### PR TITLE
Fix purchase calculation bug and add tests

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1153,19 +1153,19 @@ class RegisterPurchaseDialog(QDialog):
         iva_tipo = "ninguno"
         if self.iva_checkbox.isChecked():
             if self.iva_desglosado_radio.isChecked():
-                iva = subtotal * 13 / 113  # o el cálculo que uses
+                iva = subtotal_con_descuento * 13 / 113
                 iva_tipo = "desglosado"
-                total = subtotal  # <--- El total es el precio ingresado, NO se suma el IVA
+                total = subtotal_con_descuento
             elif self.iva_añadido_radio.isChecked():
-                iva = subtotal * 0.13
+                iva = subtotal_con_descuento * 0.13
                 iva_tipo = "añadido"
-                total = subtotal + iva  # <--- Aquí sí se suma el IVA
+                total = subtotal_con_descuento + iva
             else:
-                total = subtotal
+                total = subtotal_con_descuento
                 iva = 0
                 iva_tipo = "ninguno"
         else:
-            total = subtotal
+            total = subtotal_con_descuento
             iva = 0
             iva_tipo = "ninguno"
             
@@ -1173,10 +1173,10 @@ class RegisterPurchaseDialog(QDialog):
         comision_pct = self.comision_pct_spin.value()
         comision_tipo = self.comision_tipo_combo.currentText()
         if comision_tipo == "Añadida al total":
-            comision_monto = subtotal * (comision_pct / 100)
+            comision_monto = subtotal_con_descuento * (comision_pct / 100)
             total_con_comision = total + comision_monto
         elif comision_tipo == "Desglosada (incluida en el precio)":
-            comision_monto = subtotal * (comision_pct / (100 + comision_pct)) if comision_pct > 0 else 0
+            comision_monto = subtotal_con_descuento * (comision_pct / (100 + comision_pct)) if comision_pct > 0 else 0
             total_con_comision = total  # El total ya incluye la comisión
         else:
             comision_monto = 0

--- a/tests/test_monto.py
+++ b/tests/test_monto.py
@@ -1,0 +1,28 @@
+import ast
+
+def num2words(n, lang='es'):
+    mapping = {0: 'cero', 174: 'ciento setenta y cuatro'}
+    return mapping.get(n, str(n))
+
+with open('ui_mainwindow.py', 'r', encoding='utf-8') as f:
+    source = f.read()
+
+module = ast.parse(source)
+func_code = None
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == 'monto_a_texto_sv':
+        func_code = ast.unparse(node)
+        break
+
+namespace = {'num2words': num2words}
+exec(func_code, namespace)
+
+monto_a_texto_sv = namespace['monto_a_texto_sv']
+
+
+def test_monto_a_texto_sv_basic():
+    assert monto_a_texto_sv(174.50) == "CIENTO SETENTA Y CUATRO 50/100 D\u00d3LARES"
+
+
+def test_monto_a_texto_sv_cents():
+    assert monto_a_texto_sv(0.99) == "CERO 99/100 D\u00d3LARES"

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -348,7 +348,7 @@ class MainWindow(QMainWindow):
         vend_dist_tab = QWidget()
         vend_dist_layout = QHBoxLayout()
 
-        # vendegorías
+        # Vendedores
         vend_layout = QVBoxLayout()
         vend_layout.addWidget(QLabel("Vendedores"))
         self.vendedores_tree = QTreeWidget()
@@ -517,7 +517,7 @@ class MainWindow(QMainWindow):
         inventario_actual_tab = QWidget()
         inventario_actual_layout = QVBoxLayout()
 
-        # Filtros (opcional, puedes agregar por vendegoría, Distribuidor, búsqueda, etc.)
+        # Filtros (opcional, puedes agregar por vendedor, categoría, Distribuidor, búsqueda, etc.)
         filtros_actual_layout = QHBoxLayout()
         self.actual_search_bar = QLineEdit()
         self.actual_search_bar.setPlaceholderText("Buscar por nombre o código...")


### PR DESCRIPTION
## Summary
- correct price and tax calculations when adding purchase items
- fix typo in inventory filter comment
- add simple tests for `monto_a_texto_sv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587d32267c83239bed4772a3bc51b5