### PR TITLE
Fix purchase table delete button width

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1218,6 +1218,7 @@ class RegisterPurchaseDialog(QDialog):
             self.table.setItem(i, 8, QTableWidgetItem(item.get("fecha_vencimiento", "")))
             btn = QPushButton("Eliminar")
             btn.setFixedHeight(22)
+            btn.setFixedWidth(70)
             btn.setStyleSheet("background-color: #b71c1c; color: #fff; border-radius: 6px; font-size:11px;")
             btn.clicked.connect(lambda _, row=i: self._eliminar_item(row))
             self.table.setCellWidget(i, 8, btn)


### PR DESCRIPTION
## Summary
- keep the delete button from stretching in the RegisterPurchaseDialog table by setting a fixed width

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68589c492ba8832380c75da51c4175b5