### PR TITLE
Fix delete column index in RegisterSaleDialog

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -725,7 +725,7 @@ class RegisterSaleDialog(QDialog):
             self.table.setCellWidget(i, 5, btn)
 
     def _eliminar_fila(self, row, col):
-        if col == 3:
+        if col == 5:
             self._eliminar_item(row)
 
     def _eliminar_item(self, row):


### PR DESCRIPTION
## Summary
- ensure RegisterSaleDialog only deletes when clicking the "Eliminar" column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a71c88808323b83a1e2534637414