### PR TITLE
Fix price defaults for fiscal sales

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1626,7 +1626,8 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         prod = None
         if self.productos_data:
             for p in self.productos_data:
-                if get_field(p, "nombre", "") == nombre:
+                nombre_prod = get_field(p, "nombre", "")
+                if nombre.startswith(nombre_prod):
                     prod = p
                     break
         precio = 0


### PR DESCRIPTION
## Summary
- ensure fiscal sales default to predefined unit price

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d2d1d8208323bb6ea9a0a3f001d7