### PR TITLE
Remove IVA retenido support

### DIFF
--- a/db.py
+++ b/db.py
@@ -331,7 +331,6 @@ class DB:
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN sumas REAL DEFAULT 0")
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN iva REAL DEFAULT 0")
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN subtotal REAL DEFAULT 0")
-            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN iva_retenido REAL DEFAULT 0")
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN total_letras TEXT")
             self.cursor.execute("ALTER TABLE ventas ADD COLUMN extra TEXT")
             self.conn.commit()
@@ -492,8 +491,8 @@ class DB:
     def add_venta_credito_fiscal(self, cliente_id, fecha, total, nrc, nit, giro, Distribuidor_id=None, vendedor_id=None,
                                  no_remision="", orden_no="", condicion_pago="", venta_a_cuenta_de="",
                                  fecha_remision_anterior="", fecha_remision="",
-                                 sumas=0, iva=0, subtotal=0, iva_retenido=0,
-                                 ventas_exentas=0, ventas_no_sujetas=0,   # <-- AGREGA ESTOS
+                                 sumas=0, iva=0, subtotal=0,
+                                 ventas_exentas=0, ventas_no_sujetas=0,
                                  total_letras="", extra=None):
         try:
             if Distribuidor_id is not None and vendedor_id is not None:
@@ -541,13 +540,13 @@ class DB:
                     venta_id, cliente_id, nrc, nit, giro,
                     no_remision, orden_no, condicion_pago, venta_a_cuenta_de,
                     fecha_remision_anterior, fecha_remision,
-                    sumas, iva, subtotal, iva_retenido, ventas_exentas, ventas_no_sujetas, total_letras, extra
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    sumas, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 venta_id, cliente_id, nrc, nit, giro,
                 no_remision, orden_no, condicion_pago, venta_a_cuenta_de,
                 fecha_remision_anterior, fecha_remision,
-                sumas, iva, subtotal, iva_retenido, ventas_exentas, ventas_no_sujetas, total_letras, extra_json
+                sumas, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra_json
             ))
             self.conn.commit()
             return venta_id

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -229,12 +229,6 @@ def generar_factura_electronica_pdf(venta, detalles, cliente, distribuidor, arch
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
-    c.drawString(x_linea + 10, texto_y, "IVA retenido:")
-    c.setFont("Helvetica", 9)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('iva_retenido', '')}")
-
-    texto_y -= salto
-    c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "Subtotal:")
     c.setFont("Helvetica", 9)
     c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('subtotal', '')}")

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -283,9 +283,9 @@ class InventoryManager:
                 INSERT INTO ventas_credito_fiscal (
                     venta_id, cliente_id, nrc, nit, giro, no_remision, orden_no, condicion_pago,
                     venta_a_cuenta_de, fecha_remision_anterior, fecha_remision,
-                    sumas, iva, subtotal, iva_retenido, total_letras,
+                    sumas, iva, subtotal, total_letras,
                     ventas_exentas, ventas_no_sujetas, extra
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 venta_id_map.get(vcf.get("venta_id")),      # <-- Usa el nuevo ID de la venta
                 cliente_id_map.get(vcf.get("cliente_id")),  # <-- Usa el nuevo ID del cliente
@@ -301,7 +301,6 @@ class InventoryManager:
                 vcf.get("sumas", 0),
                 vcf.get("iva", 0),
                 vcf.get("subtotal", 0),
-                vcf.get("iva_retenido", 0),
                 vcf.get("total_letras", ""),
                 vcf.get("ventas_exentas", 0),
                 vcf.get("ventas_no_sujetas", 0),

--- a/remove_iva_retenido_column.py
+++ b/remove_iva_retenido_column.py
@@ -1,0 +1,27 @@
+import sqlite3
+import sys
+
+def main(db_path):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    try:
+        c.execute("PRAGMA foreign_keys=off")
+        c.execute("BEGIN")
+        # Check if column exists
+        c.execute("PRAGMA table_info(ventas_credito_fiscal)")
+        cols = [row[1] for row in c.fetchall()]
+        if 'iva_retenido' in cols:
+            columns_without = [col for col in cols if col != 'iva_retenido']
+            col_list = ','.join(columns_without)
+            c.execute(f"CREATE TABLE IF NOT EXISTS ventas_credito_fiscal_tmp AS SELECT {col_list} FROM ventas_credito_fiscal")
+            c.execute("DROP TABLE ventas_credito_fiscal")
+            c.execute(f"ALTER TABLE ventas_credito_fiscal_tmp RENAME TO ventas_credito_fiscal")
+        conn.commit()
+    finally:
+        conn.close()
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python remove_iva_retenido_column.py <database>')
+        sys.exit(1)
+    main(sys.argv[1])

--- a/tests/test_factura_texto.py
+++ b/tests/test_factura_texto.py
@@ -26,7 +26,6 @@ def test_factura_texto_contains_client_and_total():
         'sumas': 5.00,
         'iva': 0.65,
         'subtotal': 5.65,
-        'iva_retenido': 0.0,
         'ventas_exentas': 0.0,
         'ventas_no_sujetas': 0.0,
         'total': 5.65,
@@ -48,7 +47,7 @@ def test_factura_texto_contains_client_and_total():
     cliente = {'nombre': 'Juan Perez', 'direccion': 'Calle 1', 'nit': '0614-010101-101-1', 'nrc': '1234-5', 'giro': 'Comercio'}
     distribuidor = {'nombre': 'Distribuidor', 'direccion': 'Direc', 'nit': '0000-0', 'nrc': '0'}
 
-    texto = generar(venta, detalles, cliente, distribuidor)
+    texto = generar(None, venta, detalles, cliente, distribuidor)
 
     assert 'Juan Perez' in texto
     assert '5.65' in texto

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -128,15 +128,13 @@ class MainWindow(QMainWindow):
         iva = round(sum(d.get("iva", 0) for d in detalles_pdf), 2)
         subtotal = round(sumas + ventas_exentas + ventas_no_sujetas, 2)
 
-        iva_retenido = float(venta.get("iva_retenido", 0) or 0)
-        total = round(sumas + iva + ventas_exentas + ventas_no_sujetas - iva_retenido, 2)
+        total = round(sumas + iva + ventas_exentas + ventas_no_sujetas, 2)
 
         venta["sumas"] = sumas
         venta["ventas_exentas"] = ventas_exentas
         venta["ventas_no_sujetas"] = ventas_no_sujetas
         venta["iva"] = iva
         venta["subtotal"] = subtotal
-        venta["iva_retenido"] = iva_retenido
         venta["total"] = total
         venta["total_operacion"] = total  # Para el PDF
         venta["descuentos_globales"] = 0  # Si tienes descuentos globales, cámbialo aquí
@@ -208,7 +206,6 @@ class MainWindow(QMainWindow):
                 "totales": {
                     "sumas": venta.get("sumas", 0),
                     "subtotal": venta.get("subtotal", 0),
-                    "iva_retenido": venta.get("iva_retenido", 0),
                     "total_operacion": venta.get("total", 0),
                     "total_a_pagar": venta.get("total", 0),
                     "valor_letras": venta.get("total_letras", "")
@@ -296,7 +293,6 @@ class MainWindow(QMainWindow):
             "sumas": 34.00,
             "iva": 4.42,
             "subtotal": 38.42,
-            "iva_retenido": 0.00,
             "ventas_no_sujetas": 0.00,
             "ventas_exentas": 0.00,
             "total": 38.42,
@@ -1058,7 +1054,6 @@ class MainWindow(QMainWindow):
                 sumas = data.get("sumas", 0)
                 iva = data.get("iva", 0)
                 subtotal = data.get("subtotal", 0)
-                iva_retenido = data.get("iva_retenido", 0)
                 venta_total = data.get("total", 0)
                 total_letras = monto_a_texto_sv(venta_total)
                 # ---------------------------------------------------
@@ -1086,9 +1081,8 @@ class MainWindow(QMainWindow):
                     sumas=sumas,
                     iva=iva,
                     subtotal=subtotal,
-                    iva_retenido=iva_retenido,
-                    ventas_exentas=data.get("ventas_exentas", 0),         
-                    ventas_no_sujetas=data.get("ventas_no_sujetas", 0),   
+                    ventas_exentas=data.get("ventas_exentas", 0),
+                    ventas_no_sujetas=data.get("ventas_no_sujetas", 0),
                     total_letras=total_letras
                 )
                 logger.debug("IVA guardado en la venta: %s", iva)


### PR DESCRIPTION
## Summary
- drop all IVA retenido UI and logic in dialogs
- stop storing IVA retenido in DB and persistence layers
- adjust main window calculations
- omit IVA retenido in PDF output
- update inventory import/export
- provide migration script to drop iva_retenido column
- update tests to new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c557f5f08323aca0b990c282ba24