### PR TITLE
Highlight low stock in tables

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -1,6 +1,8 @@
 from db import DB
 from PyQt5.QtCore import QAbstractTableModel, Qt
 from PyQt5.QtGui import QColor
+
+STOCK_THRESHOLD = 5
 import json
 from datetime import datetime, timedelta
 import os
@@ -364,6 +366,10 @@ class ProductTableModel(QAbstractTableModel):
             # Si agregas comisión:
             # elif col == 4:
             #     return f"{row.get('comision_base', 0)}%"  # O el campo que corresponda
+        elif role == Qt.BackgroundRole and col == 3:
+            cantidad_val = int(row.get("stock", 0))
+            if cantidad_val < STOCK_THRESHOLD:
+                return QColor("red") if cantidad_val == 0 else QColor("yellow")
         return None
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
@@ -423,6 +429,10 @@ class LoteTableModel(QAbstractTableModel):
                 )
             elif col == 5:
                 return row.get("fecha_vencimiento", "")
+        elif role == Qt.BackgroundRole and col == 2:
+            cantidad_val = int(row.get("cantidad", 0))
+            if cantidad_val < STOCK_THRESHOLD:
+                return QColor("red") if cantidad_val == 0 else QColor("yellow")
         return None
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -6,6 +6,8 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt, QDate
 from PyQt5.QtGui import QColor
+
+STOCK_THRESHOLD = 5
 import os
 import json
 from inventory_manager import InventoryManager
@@ -1679,7 +1681,12 @@ class MainWindow(QMainWindow):
         for row, d in enumerate(detalles):
             self.inventario_actual_table.setItem(row, 0, QTableWidgetItem(d["producto"]))
             self.inventario_actual_table.setItem(row, 1, QTableWidgetItem(d["codigo"]))
-            self.inventario_actual_table.setItem(row, 2, QTableWidgetItem(str(d["cantidad"])))
+            item_cantidad = QTableWidgetItem(str(d["cantidad"]))
+            cantidad_val = int(d.get("cantidad", 0))
+            if cantidad_val < STOCK_THRESHOLD:
+                color = QColor("red") if cantidad_val == 0 else QColor("yellow")
+                item_cantidad.setBackground(color)
+            self.inventario_actual_table.setItem(row, 2, item_cantidad)
             self.inventario_actual_table.setItem(row, 3, QTableWidgetItem(f"${d['precio_compra']:.2f}"))
             self.inventario_actual_table.setItem(row, 4, QTableWidgetItem(d["fecha_compra"]))
             # --- FECHA DE VENCIMIENTO CON COLOR ---


### PR DESCRIPTION
## Summary
- add constant STOCK_THRESHOLD to mark low inventory
- color quantity cells in inventory table when below threshold
- color stock columns in product and lot tables accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c9198c148323a7724853fd9f5d50