### PR TITLE
Add date range and year-to-date option for account statements

### DIFF
--- a/db.py
+++ b/db.py
@@ -601,7 +601,12 @@ class DB:
         return [dict(row) for row in self.cursor.fetchall()]
 
     def get_estado_cuenta(self, persona_id, tipo="cliente", fecha_inicio=None, fecha_fin=None):
-        """Obtiene las facturas asociadas a un cliente o vendedor en un rango de fechas."""
+        """Obtiene las facturas de un cliente o vendedor en un rango de fechas.
+
+        Si ``fecha_inicio`` y ``fecha_fin`` son ``None``, se devuelven todas las
+        facturas. Para filtrar el "año en curso" se puede pasar ``fecha_inicio``
+        como el 1 de enero del año actual y ``fecha_fin`` como la fecha actual.
+        """
         if tipo not in ("cliente", "vendedor"):
             raise ValueError("tipo debe ser 'cliente' o 'vendedor'")
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -610,6 +610,7 @@ class MainWindow(QMainWindow):
         self.btn_delete_trabajador.clicked.connect(self._eliminar_trabajador)
         self.estado_tipo_combo.currentIndexChanged.connect(self._cargar_personas_estado)
         self.btn_generar_estado.clicked.connect(self._generar_estado_cuenta)
+        self.estado_anio_actual.toggled.connect(self._toggle_estado_fechas)
 
         self._actualizar_tabla_trabajadores()
         self._cargar_personas_estado()
@@ -1623,6 +1624,14 @@ class MainWindow(QMainWindow):
             personas = self.manager.db.get_trabajadores(solo_vendedores=True)
         for p in personas:
             self.estado_persona_combo.addItem(p.get("nombre", ""), p.get("id"))
+
+    def _toggle_estado_fechas(self, checked: bool):
+        """Habilita o deshabilita las fechas manuales."""
+        self.estado_fecha_inicio.setEnabled(not checked)
+        self.estado_fecha_fin.setEnabled(not checked)
+        if checked:
+            self.estado_fecha_inicio.setDate(QDate(QDate.currentDate().year(), 1, 1))
+            self.estado_fecha_fin.setDate(QDate.currentDate())
 
     def _generar_estado_cuenta(self):
         persona_id = self.estado_persona_combo.currentData()


### PR DESCRIPTION
## Summary
- allow switching between manual date range and year-to-date quick filter when generating account statements
- document new behaviour in `get_estado_cuenta`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cbd06386c8323ae287cc6a76c90e1