### PR TITLE
Add search-based persona table for account statements

### DIFF
--- a/db.py
+++ b/db.py
@@ -983,7 +983,7 @@ class DB:
         )
         self.conn.commit()
 
-    def get_trabajadores(self, solo_vendedores=False, area=None):
+    def get_trabajadores(self, solo_vendedores=False, area=None, search=""):
         query = "SELECT * FROM trabajadores"
         params = []
         filtros = []
@@ -992,6 +992,9 @@ class DB:
         if area:
             filtros.append("area=?")
             params.append(area)
+        if search:
+            filtros.append("(nombre LIKE ? OR codigo LIKE ?)")
+            params.extend([f"%{search}%", f"%{search}%"])
         if filtros:
             query += " WHERE " + " AND ".join(filtros)
         self.cursor.execute(query, params)


### PR DESCRIPTION
## Summary
- make `get_trabajadores` accept a search filter
- remove persona combobox from account statement tab
- show clients or vendors directly in the table with a search box
- generate statements for the selected table row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdad84e1883238ef3262805151ba3