### PR TITLE
Fix vendedor_id missing in detalles_venta

### DIFF
--- a/db.py
+++ b/db.py
@@ -77,8 +77,10 @@ class DB:
                 producto_id INTEGER,
                 cantidad INTEGER,
                 precio_unitario REAL,
+                vendedor_id INTEGER,
                 FOREIGN KEY (venta_id) REFERENCES ventas(id),
-                FOREIGN KEY (producto_id) REFERENCES productos(id)
+                FOREIGN KEY (producto_id) REFERENCES productos(id),
+                FOREIGN KEY (vendedor_id) REFERENCES vendedores(id)
             )
         """)
         self.cursor.execute("""
@@ -391,6 +393,11 @@ class DB:
             self.conn.commit()
         except Exception:
             pass  # Ya existe la columna
+        try:
+            self.cursor.execute("ALTER TABLE detalles_venta ADD COLUMN vendedor_id INTEGER")
+            self.conn.commit()
+        except Exception:
+            pass  # Ya existe la columna
         # Índices únicos para códigos de clientes y vendedores
         self.cursor.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_clientes_codigo ON clientes(codigo)"
@@ -684,13 +691,13 @@ class DB:
             logger.exception("Error al eliminar venta: %s", e)
 
     # CRUD DETALLES_VENTA
-    def add_detalle_venta(self, venta_id, producto_id, cantidad, precio_unitario, descuento=0, descuento_tipo="", iva=0, comision=0, iva_tipo="", tipo_fiscal="", extra=None, precio_con_iva=0):
+    def add_detalle_venta(self, venta_id, producto_id, cantidad, precio_unitario, descuento=0, descuento_tipo="", iva=0, comision=0, iva_tipo="", tipo_fiscal="", extra=None, precio_con_iva=0, vendedor_id=None):
         try:
             extra_json = json.dumps(extra) if extra else None
             self.cursor.execute("""
-                INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra_json, precio_con_iva))
+                INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra_json, precio_con_iva, vendedor_id))
             self.conn.commit()
         except Exception as e:
             logger.exception("Error al agregar detalle de venta: %s", e)

--- a/tests/test_detalle_venta_vendedor.py
+++ b/tests/test_detalle_venta_vendedor.py
@@ -1,0 +1,18 @@
+import pytest
+from db import DB
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_detalle_venta_con_vendedor():
+    db = create_db()
+    db.add_vendedor("Luis")
+    vendedor_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vendedor_id, None, 0, 0, 0, 10)
+    producto_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, producto_id, 1, 10, vendedor_id=vendedor_id)
+    detalles = db.get_detalles_venta(venta_id)
+    assert detalles[0]["vendedor_id"] == vendedor_id

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -562,7 +562,9 @@ class MainWindow(QMainWindow):
                         item.get("comision_monto", 0),
                         item.get("iva_tipo", ""),
                         item.get("tipo_fiscal", "Gravada"),
-                        None
+                        None,
+                        item.get("precio_con_iva", 0),
+                        vendedor_id
                     )
                     if "lote_id" in item:
                         self.manager.db.disminuir_stock_lote(item["lote_id"], item["cantidad"])
@@ -699,8 +701,9 @@ class MainWindow(QMainWindow):
                         item.get("comision_monto", 0),
                         item.get("iva_tipo", ""),
                         item.get("tipo_fiscal", "Gravada"),
-                        item.get("extra", None), 
-                        item.get("precio_con_iva", 0)  
+                        item.get("extra", None),
+                        item.get("precio_con_iva", 0),
+                        vendedor_id
                     )
                    
                     if "lote_id" in item:


### PR DESCRIPTION
## Summary
- add `vendedor_id` column to `detalles_venta`
- migrate existing databases to include this column
- allow `add_detalle_venta` to store the vendor id
- update sales registration to pass vendor id and price with VAT
- test saving vendor id inside sales details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9e6ca4d08323ba0b3b48a95ac2c6