### PR TITLE
Add get_venta_credito_fiscal method and tests

### DIFF
--- a/db.py
+++ b/db.py
@@ -621,6 +621,15 @@ class DB:
         self.cursor.execute("SELECT * FROM detalles_compra WHERE compra_id=?", (compra_id,))
         return [dict(row) for row in self.cursor.fetchall()]
 
+    def get_venta_credito_fiscal(self, venta_id):
+        """Retrieve a venta_credito_fiscal row by the associated venta_id."""
+        self.cursor.execute(
+            "SELECT * FROM ventas_credito_fiscal WHERE venta_id=?",
+            (venta_id,)
+        )
+        row = self.cursor.fetchone()
+        return dict(row) if row else None
+
     def get_estado_cuenta(self, persona_id, tipo="cliente", fecha_inicio=None, fecha_fin=None):
         """Obtiene las facturas de un cliente o vendedor en un rango de fechas.
 

--- a/tests/test_get_venta_credito_fiscal.py
+++ b/tests/test_get_venta_credito_fiscal.py
@@ -1,0 +1,25 @@
+import pytest
+from db import DB
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_get_venta_credito_fiscal():
+    db = create_db()
+    db.add_cliente("Cliente", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+
+    venta_id = db.add_venta_credito_fiscal(cid, "2024-01-01", 100, "NRC", "NIT", "GIRO")
+
+    row = db.get_venta_credito_fiscal(venta_id)
+    assert row is not None
+    assert row["venta_id"] == venta_id
+    assert row["cliente_id"] == cid
+
+
+def test_get_venta_credito_fiscal_none():
+    db = create_db()
+    assert db.get_venta_credito_fiscal(1) is None
+


### PR DESCRIPTION
## Summary
- implement `get_venta_credito_fiscal` in `db.py`
- add tests for retrieving credito fiscal sales

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dadc9553883239d5e3009a53c356f