### PR TITLE
Handle credit-fiscal info in sales tab

### DIFF
--- a/db.py
+++ b/db.py
@@ -613,6 +613,23 @@ class DB:
         self.cursor.execute("SELECT * FROM detalles_venta WHERE venta_id=?", (venta_id,))
         return [dict(row) for row in self.cursor.fetchall()]
 
+    def get_venta_credito_fiscal(self, venta_id):
+        """Return credit-fiscal record associated with a sale, if any."""
+        self.cursor.execute(
+            "SELECT * FROM ventas_credito_fiscal WHERE venta_id=?", (venta_id,)
+        )
+        row = self.cursor.fetchone()
+        if row:
+            data = dict(row)
+            extra = data.get("extra")
+            if extra:
+                try:
+                    data["extra"] = json.loads(extra)
+                except Exception:
+                    pass
+            return data
+        return None
+
     def get_compras(self):
         self.cursor.execute("SELECT * FROM compras")
         return [dict(row) for row in self.cursor.fetchall()]

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -11,6 +11,7 @@ class SalesTab(QWidget):
     def __init__(self, manager, parent=None):
         super().__init__(parent)
         self.manager = manager
+        self.current_credito_fiscal = None
         self._setup_ui()
         self.load_sales()
 
@@ -165,6 +166,14 @@ class SalesTab(QWidget):
             cli = next((c for c in self.manager._clientes if c["id"] == venta["cliente_id"]), None)
             if cli:
                 cliente = cli.get("nombre", "")
-        self.info_label.setText(f"Factura {venta_id} - Cliente: {cliente}")
+
+        # Fetch credit-fiscal information for this sale
+        self.current_credito_fiscal = self.manager.db.get_venta_credito_fiscal(venta_id)
+        if self.current_credito_fiscal:
+            self.info_label.setText(
+                f"Factura {venta_id} - Crédito Fiscal - Cliente: {cliente}"
+            )
+        else:
+            self.info_label.setText(f"Factura {venta_id} - Cliente: {cliente}")
         # In a real app we would load the PDF preview here
 

--- a/tests/test_get_venta_credito_fiscal.py
+++ b/tests/test_get_venta_credito_fiscal.py
@@ -1,0 +1,23 @@
+import pytest
+from db import DB
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_get_venta_credito_fiscal_return():
+    db = create_db()
+    db.add_cliente("Cli", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(cid, "2024-01-01", 100, "123", "456", "giro")
+    data = db.get_venta_credito_fiscal(venta_id)
+    assert data is not None
+    assert data["venta_id"] == venta_id
+    assert data["cliente_id"] == cid
+    assert data["nrc"] == "123"
+
+
+def test_get_venta_credito_fiscal_none():
+    db = create_db()
+    assert db.get_venta_credito_fiscal(1) is None


### PR DESCRIPTION
## Summary
- implement `get_venta_credito_fiscal` in db layer
- store selected credit-fiscal info in `SalesTab.show_sale`
- show credit-fiscal status on sale preview
- test retrieval of credit-fiscal info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685daddc22808323ac74bd77ba7afff5