### PR TITLE
Refresh purchases tab filters

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,8 +27,9 @@ if __name__ == "__main__":
         try:
             window.manager.importar_inventario_json(ultimo_archivo)
             window.ultimo_archivo_json = ultimo_archivo
+            window.compras_tab.refresh_filters()
             window.filter_products()
-            window._actualizar_arbol_vendedores()   
+            window._actualizar_arbol_vendedores()
             window._actualizar_arbol_Distribuidores()   
             window._actualizar_tabla_clientes()    
             window._actualizar_tabla_trabajadores() 

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -68,6 +68,15 @@ class PurchasesTab(QWidget):
         self.vendedor_combo.currentIndexChanged.connect(self.load_purchases)
         self.search_bar.textChanged.connect(self.load_purchases)
 
+    def refresh_filters(self):
+        """Reload vendor and distributor filter options from manager data."""
+        self.distribuidor_combo.clear()
+        self.distribuidor_combo.addItem("Todos")
+        self.distribuidor_combo.addItems([d["nombre"] for d in self.manager._Distribuidores])
+        self.vendedor_combo.clear()
+        self.vendedor_combo.addItem("Todos")
+        self.vendedor_combo.addItems([v["nombre"] for v in self.manager._vendedores])
+
     def _add_action_buttons(self, row, compra_id):
         widget = QWidget()
         layout = QHBoxLayout(widget)

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -254,7 +254,7 @@ class MainWindow(QMainWindow):
 
         # --- PESTAÑA DE COMPRAS ---
         from purchases_tab import PurchasesTab
-        compras_tab = PurchasesTab(self.manager, self)
+        self.compras_tab = PurchasesTab(self.manager, self)
 
         # --- PESTAÑA DE INVENTARIO ACTUAL ---
         inventario_actual_tab = QWidget()
@@ -282,7 +282,7 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(vend_dist_tab, "Vendedores y Distribuidores")  # <-- Esta línea es clave
         self.tabs.addTab(clientes_tab, "Clientes")
         self.tabs.addTab(self.sales_tab, "Ventas")
-        self.tabs.addTab(compras_tab, "Compras")
+        self.tabs.addTab(self.compras_tab, "Compras")
         self.tabs.addTab(inventario_actual_tab, "Inventario actual")
         self.setCentralWidget(self.tabs)
 
@@ -741,6 +741,7 @@ class MainWindow(QMainWindow):
                 self.ultimo_archivo_json = filename
                 with open("ultimo_inventario.json", "w", encoding="utf-8") as f:
                     json.dump({"ultimo": filename}, f)
+                self.compras_tab.refresh_filters()
                 self.filter_products()
                 self._actualizar_tabla_clientes()
                 self._actualizar_arbol_vendedores()     
@@ -769,6 +770,7 @@ class MainWindow(QMainWindow):
         if self.ultimo_archivo_json and os.path.exists(self.ultimo_archivo_json):
             try:
                 self.manager.importar_inventario_json(self.ultimo_archivo_json)
+                self.compras_tab.refresh_filters()
                 self.filter_products()
                 self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA
                 QMessageBox.information(self, "Cargar rápido", f"Inventario cargado de:\n{self.ultimo_archivo_json}")
@@ -800,6 +802,7 @@ class MainWindow(QMainWindow):
             except Exception:
                 pass
             self.manager.refresh_data()
+            self.compras_tab.refresh_filters()
             self._actualizar_tabla_trabajadores()  # <-- AGREGA ESTA LÍNEA
             self.filter_products()
             self._actualizar_arbol_vendedores()
@@ -848,6 +851,7 @@ class MainWindow(QMainWindow):
                 data["codigo"]
             )
             self.manager.refresh_data()
+            self.compras_tab.refresh_filters()
             self._actualizar_arbol_vendedores()
             QMessageBox.information(self, "Vendedor", "Vendedor agregado correctamente.")
 
@@ -873,6 +877,7 @@ class MainWindow(QMainWindow):
                 data["Distribuidor_id"]
             )
             self.manager.refresh_data()
+            self.compras_tab.refresh_filters()
             self._actualizar_arbol_vendedores()
             QMessageBox.information(self, "Vendedor", "Vendedor editado correctamente.")
 
@@ -882,6 +887,7 @@ class MainWindow(QMainWindow):
             data = dialog.get_data()
             self.manager.db.add_Distribuidor_detallado(data)
             self.manager.refresh_data()
+            self.compras_tab.refresh_filters()
             self._actualizar_arbol_Distribuidores()
             QMessageBox.information(self, "Distribuidor", "Distribuidor agregado correctamente.")
 
@@ -931,6 +937,7 @@ class MainWindow(QMainWindow):
             ))
             self.manager.db.conn.commit()
             self.manager.refresh_data()
+            self.compras_tab.refresh_filters()
             self._actualizar_arbol_Distribuidores()
             QMessageBox.information(self, "Distribuidor", "Distribuidor editado correctamente.")
         self.selected_row = None


### PR DESCRIPTION
## Summary
- add `refresh_filters` to refresh combo boxes in `PurchasesTab`
- keep purchases tab instance on `MainWindow`
- refresh combo boxes after modifying vendor/distributor data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db286ed488323afbeba8e6d27b3f0