### PR TITLE
Ensure purchases tab stays in sync

### DIFF
--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -18,6 +18,39 @@ class PurchasesTab(QWidget):
         self._setup_ui()
         self.load_purchases()
 
+    def refresh_filters(self):
+        """Refresh distributor and vendor filter combos with current data."""
+        self.distribuidor_combo.blockSignals(True)
+        self.vendedor_combo.blockSignals(True)
+
+        current_dist = self.distribuidor_combo.currentText()
+        current_vend = self.vendedor_combo.currentText()
+
+        self.distribuidor_combo.clear()
+        self.distribuidor_combo.addItem("Todos")
+        self.distribuidor_combo.addItems([d["nombre"] for d in self.manager._Distribuidores])
+
+        self.vendedor_combo.clear()
+        self.vendedor_combo.addItem("Todos")
+        self.vendedor_combo.addItems([v["nombre"] for v in self.manager._vendedores])
+
+        if current_dist in [d["nombre"] for d in self.manager._Distribuidores]:
+            idx = self.distribuidor_combo.findText(current_dist)
+            if idx >= 0:
+                self.distribuidor_combo.setCurrentIndex(idx)
+        else:
+            self.distribuidor_combo.setCurrentIndex(0)
+
+        if current_vend in [v["nombre"] for v in self.manager._vendedores]:
+            idx = self.vendedor_combo.findText(current_vend)
+            if idx >= 0:
+                self.vendedor_combo.setCurrentIndex(idx)
+        else:
+            self.vendedor_combo.setCurrentIndex(0)
+
+        self.distribuidor_combo.blockSignals(False)
+        self.vendedor_combo.blockSignals(False)
+
     def _setup_ui(self):
         layout = QVBoxLayout(self)
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -254,7 +254,7 @@ class MainWindow(QMainWindow):
 
         # --- PESTAÑA DE COMPRAS ---
         from purchases_tab import PurchasesTab
-        compras_tab = PurchasesTab(self.manager, self)
+        self.compras_tab = PurchasesTab(self.manager, self)
 
         # --- PESTAÑA DE INVENTARIO ACTUAL ---
         inventario_actual_tab = QWidget()
@@ -282,7 +282,7 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(vend_dist_tab, "Vendedores y Distribuidores")  # <-- Esta línea es clave
         self.tabs.addTab(clientes_tab, "Clientes")
         self.tabs.addTab(self.sales_tab, "Ventas")
-        self.tabs.addTab(compras_tab, "Compras")
+        self.tabs.addTab(self.compras_tab, "Compras")
         self.tabs.addTab(inventario_actual_tab, "Inventario actual")
         self.setCentralWidget(self.tabs)
 
@@ -593,6 +593,9 @@ class MainWindow(QMainWindow):
             result = dialog.exec_()
             if result == QDialog.Accepted:
                 QMessageBox.information(self, "Compra", "Compra registrada correctamente.")
+                self.manager.refresh_data()
+                self.compras_tab.refresh_filters()
+                self.compras_tab.load_purchases()
                 self.filter_products()
                 self._actualizar_historial()
                 self._actualizar_inventario_actual()
@@ -742,11 +745,13 @@ class MainWindow(QMainWindow):
                 with open("ultimo_inventario.json", "w", encoding="utf-8") as f:
                     json.dump({"ultimo": filename}, f)
                 self.filter_products()
+                self.compras_tab.refresh_filters()
+                self.compras_tab.load_purchases()
                 self._actualizar_tabla_clientes()
-                self._actualizar_arbol_vendedores()     
-                self._actualizar_arbol_Distribuidores()  
+                self._actualizar_arbol_vendedores()
+                self._actualizar_arbol_Distribuidores()
                 self._actualizar_tabla_trabajadores()
-                self._actualizar_inventario_actual() 
+                self._actualizar_inventario_actual()
                 self._actualizar_historial() 
                 QMessageBox.information(self, "Cargar inventario", "Inventario cargado correctamente.")
             except Exception as e:
@@ -769,6 +774,8 @@ class MainWindow(QMainWindow):
         if self.ultimo_archivo_json and os.path.exists(self.ultimo_archivo_json):
             try:
                 self.manager.importar_inventario_json(self.ultimo_archivo_json)
+                self.compras_tab.refresh_filters()
+                self.compras_tab.load_purchases()
                 self.filter_products()
                 self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA
                 QMessageBox.information(self, "Cargar rápido", f"Inventario cargado de:\n{self.ultimo_archivo_json}")
@@ -800,6 +807,8 @@ class MainWindow(QMainWindow):
             except Exception:
                 pass
             self.manager.refresh_data()
+            self.compras_tab.refresh_filters()
+            self.compras_tab.load_purchases()
             self._actualizar_tabla_trabajadores()  # <-- AGREGA ESTA LÍNEA
             self.filter_products()
             self._actualizar_arbol_vendedores()


### PR DESCRIPTION
## Summary
- create `refresh_filters` in `PurchasesTab`
- store purchases tab as `self.compras_tab`
- reload purchases list after recording a purchase
- update purchases view when inventory is loaded or cleared

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db28844488323afe6bfd9ea761356