### PR TITLE
Reduce action button size

### DIFF
--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -119,8 +119,8 @@ class PurchasesTab(QWidget):
         btn_detalle = QPushButton("Ver")
         btn_pdf = QPushButton("PDF")
         for btn in (btn_detalle, btn_pdf):
-            btn.setFixedSize(50, 24)
-            btn.setStyleSheet("font-size:10px;")
+            btn.setFixedSize(25, 12)
+            btn.setStyleSheet("font-size:8px;")
         btn_detalle.clicked.connect(lambda: self.show_detail(compra_id))
         layout.addWidget(btn_detalle)
         layout.addWidget(btn_pdf)


### PR DESCRIPTION
## Summary
- cut the size of the `Ver` and `PDF` buttons in half in `purchases_tab`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dccdf3eb88323a91e65946b14ca02