### PR TITLE
Make tables read‑only and select whole rows

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -6,7 +6,8 @@ logger = logging.getLogger(__name__)
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
     QDoubleSpinBox, QPushButton, QListWidget, QMessageBox, QCheckBox, QRadioButton, QComboBox,
-    QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup
+    QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
+    QAbstractItemView
 )
 from PyQt5.QtCore import Qt, QDate
 
@@ -363,6 +364,8 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         self.table.setHorizontalHeaderLabels([
             "Producto", "Cantidad", "Precio U.", "Descuento", "Tipo fiscal", "Eliminar"
         ])
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
         left_layout.addWidget(self.table)
         self.btn_agregar.clicked.connect(self._agregar_a_venta)
         self.table.cellClicked.connect(self._eliminar_fila)
@@ -973,6 +976,8 @@ class RegisterPurchaseDialog(QDialog):
         self.table.setHorizontalHeaderLabels([
             "Producto", "Cantidad", "Precio U.", "Subtotal", "IVA", "Comisión", "Total", "Vencimiento", "Eliminar"
         ])
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
         layout.addWidget(self.table)
 
         # Total general de la compra
@@ -1517,6 +1522,8 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         self.table.setHorizontalHeaderLabels([
             "Producto", "Cantidad", "Precio U.", "Descuento", "IVA", "Tipo fiscal", "Eliminar"
         ])
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
         left_layout.addWidget(self.table)
         self.table.cellClicked.connect(self._eliminar_fila)
         self.table.cellClicked.connect(lambda *_: self._actualizar_iva_retenido())
@@ -2233,6 +2240,8 @@ class CompraDetalleDialog(QDialog):
             "Producto", "Cantidad", "Precio U.", "Subtotal", "Descuento",
             "IVA", "Comisión", "Vencimiento"
         ])
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setSelectionBehavior(QAbstractItemView.SelectRows)
         for i, d in enumerate(detalles):
             nombre_producto = productos_dict.get(d.get("producto_id"), "Desconocido")
             precio_unitario = d.get("precio_unitario", d.get("precio", 0))

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QTableWidget, QTableWidgetItem,
-    QPushButton, QLabel, QDateEdit, QComboBox
+    QPushButton, QLabel, QDateEdit, QComboBox, QAbstractItemView
 )
 from PyQt5.QtCore import Qt, QDate
 from PyQt5.QtGui import QColor
@@ -95,6 +95,8 @@ class PurchasesTab(QWidget):
             "Total", "Comisión"
         ])
         self.table.verticalHeader().setDefaultSectionSize(60)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
         content_layout.addWidget(self.table)
 
         side_layout = QVBoxLayout()

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QDateEdit,
     QTextEdit,
     QMessageBox,
+    QAbstractItemView,
 )
 from PyQt5.QtCore import Qt, QDate
 from datetime import datetime
@@ -56,6 +57,8 @@ class SalesTab(QWidget):
         self.sales_table.setHorizontalHeaderLabels([
             "Nº Factura", "Cliente", "Fecha", "Total", "Estado"
         ])
+        self.sales_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.sales_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.sales_table.itemSelectionChanged.connect(self.show_sale)
         left_layout.addWidget(self.sales_table)
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -2,7 +2,7 @@ from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QTableView, QLineEdit,
     QPushButton, QTabWidget, QMessageBox, QSplitter, QMenuBar, QAction, QFileDialog,
     QListWidget, QInputDialog, QLabel, QComboBox, QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QDialog,
-    QDateEdit, QCheckBox, QTextEdit
+    QDateEdit, QCheckBox, QTextEdit, QAbstractItemView
 )
 from PyQt5.QtCore import Qt, QDate
 from PyQt5.QtGui import QColor
@@ -141,6 +141,7 @@ class MainWindow(QMainWindow):
         self.product_table.setModel(self.manager.get_products_model())
         self.product_table.setSelectionBehavior(QTableView.SelectRows)
         self.product_table.setSelectionMode(QTableView.SingleSelection)
+        self.product_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.product_table.clicked.connect(self._on_table_clicked)
         self.selected_row = None
         main_layout.addWidget(self.product_table)
@@ -235,6 +236,8 @@ class MainWindow(QMainWindow):
         self.clientes_table.setHorizontalHeaderLabels([
             "Código", "Nombre", "NRC", "NIT", "DUI", "Giro", "Teléfono", "Correo", "Departamento", "Municipio"
         ])
+        self.clientes_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.clientes_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         clientes_layout.addWidget(self.clientes_table)
 
         # Botones
@@ -272,6 +275,8 @@ class MainWindow(QMainWindow):
         self.inventario_actual_table.setHorizontalHeaderLabels([
             "Producto", "Código", "Cantidad", "Precio compra", "Fecha compra", "Fecha vencimiento", "Distribuidor"  # <--- Cambia aquí
         ])
+        self.inventario_actual_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.inventario_actual_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         inventario_actual_layout.addWidget(self.inventario_actual_table)
 
         inventario_actual_tab.setLayout(inventario_actual_layout)
@@ -306,6 +311,8 @@ class MainWindow(QMainWindow):
         self.trabajadores_table.setHorizontalHeaderLabels([
             "Código", "Nombre", "DUI", "NIT", "Nacimiento", "Cargo", "Área", "Teléfono", "Email", "¿Vendedor?"
         ])
+        self.trabajadores_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.trabajadores_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         trabajadores_layout.addWidget(self.trabajadores_table)
 
         # Botones
@@ -348,6 +355,8 @@ class MainWindow(QMainWindow):
 
         self.estado_table = QTableWidget(0, 2)
         self.estado_table.setHorizontalHeaderLabels(["Código", "Nombre"])
+        self.estado_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.estado_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         estado_layout.addWidget(self.estado_table)
 
         estado_tab.setLayout(estado_layout)


### PR DESCRIPTION
## Summary
- disable editing for all `QTableWidget` and the product `QTableView`
- set selection behaviour to select rows instead of individual cells

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd515fba08323b0d98c7900266a3f