### PR TITLE
Fix manual invoice dialog imports

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
     QDoubleSpinBox, QPushButton, QListWidget, QMessageBox, QCheckBox, QRadioButton, QComboBox,
     QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
-    QAbstractItemView
+    QAbstractItemView, QTextEdit, QStackedLayout, QWidget
 )
 from PyQt5.QtCore import Qt, QDate
 


### PR DESCRIPTION
## Summary
- import missing PyQt5 widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df78fa7e483239c011ed2ee9cc20f