### PR TITLE
Add test for manual invoice dialog

### DIFF
--- a/tests/test_manual_invoice.py
+++ b/tests/test_manual_invoice.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication, QDialog
+
+from sales_tab import SalesTab
+from dialogs import ManualInvoiceDialog
+from db import DB
+
+class Manager:
+    def __init__(self, db):
+        self.db = db
+        self._Distribuidores = []
+        self._vendedores = []
+        self._clientes = []
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    return app
+
+def test_manual_invoice_button_opens_dialog(qt_app, monkeypatch):
+    db = DB(":memory:")
+    man = Manager(db)
+    tab = SalesTab(man)
+
+    opened = {}
+    def fake_exec(self):
+        opened['called'] = True
+        return QDialog.Rejected
+    monkeypatch.setattr(ManualInvoiceDialog, 'exec_', fake_exec)
+
+    tab.new_invoice_btn.click()
+    assert opened.get('called') is True


### PR DESCRIPTION
## Summary
- ensure that the "Generar nueva factura manual" button opens the manual invoice dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dfc24f374832391a96514523562eb