### PR TITLE
Check selection before manual invoice

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -407,6 +407,13 @@ class SalesTab(QWidget):
 
     def generate_manual_invoice(self):
         """Open dialog to create an invoice manually and preview the PDF."""
+        if self.sales_table.currentRow() < 0:
+            QMessageBox.warning(
+                self,
+                "Factura manual",
+                "No has seleccionado ninguna venta",
+            )
+            return
         dialog = ManualInvoiceDialog(self)
         if dialog.exec_() == QDialog.Accepted:
             data = dialog.get_data()

--- a/tests/test_manual_invoice.py
+++ b/tests/test_manual_invoice.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from PyQt5.QtWidgets import QApplication, QDialog
+from PyQt5.QtWidgets import QApplication, QDialog, QTableWidgetItem, QMessageBox
 
 from sales_tab import SalesTab
 from dialogs import ManualInvoiceDialog
@@ -19,7 +19,7 @@ def qt_app():
     app = QApplication.instance() or QApplication([])
     return app
 
-def test_manual_invoice_button_opens_dialog(qt_app, monkeypatch):
+def test_manual_invoice_requires_selection(qt_app, monkeypatch):
     db = DB(":memory:")
     man = Manager(db)
     tab = SalesTab(man)
@@ -30,5 +30,22 @@ def test_manual_invoice_button_opens_dialog(qt_app, monkeypatch):
         return QDialog.Rejected
     monkeypatch.setattr(ManualInvoiceDialog, 'exec_', fake_exec)
 
+    warnings = {}
+    def fake_warning(parent, title, message):
+        warnings['title'] = title
+        warnings['message'] = message
+    monkeypatch.setattr(QMessageBox, 'warning', fake_warning)
+
+    # Without selecting a sale, should show warning and not open dialog
+    tab.new_invoice_btn.click()
+    assert opened.get('called') is None
+    assert warnings.get('message') == "No has seleccionado ninguna venta"
+
+    # Add a fake sale and select it
+    tab.sales_table.setRowCount(1)
+    tab.sales_table.setItem(0, 0, QTableWidgetItem("1"))
+    tab.sales_table.selectRow(0)
+    opened.clear()
+    warnings.clear()
     tab.new_invoice_btn.click()
     assert opened.get('called') is True


### PR DESCRIPTION
## Summary
- warn if no sale is selected before opening manual invoice dialog
- adjust test to verify warning and selection behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dff8fc5d88323b08021d5efd27750