### PR TITLE
Fix manual invoice dependencies

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -17,7 +17,8 @@ from PyQt5.QtWidgets import (
     QDialog,
 
 )
-from PyQt5.QtCore import Qt, QDate
+from PyQt5.QtCore import Qt, QDate, QUrl
+from PyQt5.QtGui import QDesktopServices
 from datetime import datetime
 from factura_sv import generar_factura_electronica_pdf
 from dialogs import ManualInvoiceDialog
@@ -72,6 +73,7 @@ class SalesTab(QWidget):
         left_layout.addWidget(self.sales_table)
 
         self.new_invoice_btn = QPushButton("+ Generar nueva factura manual")
+        self.new_invoice_btn.clicked.connect(self.generate_manual_invoice)
         left_layout.addWidget(self.new_invoice_btn)
 
         left_widget = QWidget()


### PR DESCRIPTION
## Summary
- fix NameError in `SalesTab.generate_manual_invoice` by importing `QDesktopServices` and `QUrl`
- connect the manual invoice button to the handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0901cb9883239520396955f4075c