### PR TITLE
Add invoice type prompt

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -407,7 +407,21 @@ class SalesTab(QWidget):
                 "No has seleccionado ninguna venta",
             )
             return
+        tipo, ok = QInputDialog.getItem(
+            self,
+            "Tipo de factura",
+            "¿Qué tipo de factura desea generar?",
+            ["Consumidor final", "Crédito fiscal"],
+            0,
+            False,
+        )
+        if not ok:
+            return
         dialog = ManualInvoiceDialog(self)
+        if tipo == "Crédito fiscal":
+            dialog.type_combo.setCurrentIndex(1)
+        else:
+            dialog.type_combo.setCurrentIndex(0)
         if dialog.exec_() == QDialog.Accepted:
             data = dialog.get_data()
             venta = {k: v for k, v in data.items() if k not in {"cliente", "detalles", "tipo"}}


### PR DESCRIPTION
## Summary
- prompt user for invoice type when generating manual invoice

## Testing
- `pytest tests/test_date_parsing.py -q`
- `pytest tests/test_manual_invoice.py -q` *(fails: environment stuck)*

------
https://chatgpt.com/codex/tasks/task_e_685eda3a2e288323a574d4c1c8153310