### PR TITLE
Add green stock highlighting for items >25

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -180,6 +180,8 @@ class ProductDialogBase:
                 item.setBackground(QColor("orange"))
             elif stock < 25:
                 item.setBackground(QColor("yellow"))
+            else:
+                item.setBackground(QColor("green"))
             self.product_list.addItem(item)
         self.productos = productos
 

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -376,6 +376,8 @@ class ProductTableModel(QAbstractTableModel):
                 return QColor("orange")
             elif stock < 25:
                 return QColor("yellow")
+            else:
+                return QColor("green")
         return None
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1131,6 +1131,8 @@ class MainWindow(QMainWindow):
                 item_cantidad.setBackground(QColor("orange"))
             elif stock < 25:
                 item_cantidad.setBackground(QColor("yellow"))
+            else:
+                item_cantidad.setBackground(QColor("green"))
             self.inventario_actual_table.setItem(row, 2, item_cantidad)
             self.inventario_actual_table.setItem(row, 3, QTableWidgetItem(f"${d['precio_compra']:.2f}"))
             self.inventario_actual_table.setItem(row, 4, QTableWidgetItem(d["fecha_compra"]))


### PR DESCRIPTION
## Summary
- show green background when stock is greater than 25
- apply the same rule in inventory tables and selection dialogs

## Testing
- `python -m py_compile inventory_manager.py dialogs.py ui_mainwindow.py`
- `pytest -k "not manual_invoice" -q`
- `timeout 15s pytest tests/test_manual_invoice.py -vv -s` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685ef4edd5ac832380d6a5d5cc5c0ced