### PR TITLE
Update account statement dialog UI

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1307,13 +1307,14 @@ class MainWindow(QMainWindow):
             if tipo_idx == 0:
                 for i, c in enumerate(dialog.clientes):
                     if c.get("id") == persona.get("id"):
-                        dialog.cliente_combo.setCurrentIndex(i)
+                        dialog.cliente_table.selectRow(i)
+                        dialog.selected_cliente = c
                         break
             else:
-                vends = dialog.db.get_vendedores()
-                for i, v in enumerate(vends):
+                for i, v in enumerate(dialog.vendedores):
                     if v.get("id") == persona.get("id"):
-                        dialog.vendedor_combo.setCurrentIndex(i)
+                        dialog.vendedor_table.selectRow(i)
+                        dialog.selected_vendedor = v
                         break
         dialog.exec_()
 


### PR DESCRIPTION
## Summary
- replace comboboxes with tables in EstadoCuentaDialog
- keep selection synchronized in main window when opening the dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686188c6dc908323b95f57dd8d7bed97