### PR TITLE
Add email validation for clients

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2286,7 +2286,21 @@ class ClienteDialog(QDialog):
         if not self.nombre_edit.text().strip():
             QMessageBox.warning(self, "Validación", "El nombre es obligatorio.")
             return
-        # Elimina toda validación de NIT y correo
+        email = self.email_edit.text().strip()
+        if not email:
+            QMessageBox.warning(
+                self,
+                "Validación",
+                "El correo electrónico es obligatorio."
+            )
+            return
+        if not validar_email(email):
+            QMessageBox.warning(
+                self,
+                "Validación",
+                "Ingrese un correo electrónico válido."
+            )
+            return
         self.accept()
 
     def get_data(self):


### PR DESCRIPTION
## Summary
- require valid email when creating or editing a client

## Testing
- `pytest tests/test_manual_invoice.py::test_manual_invoice_requires_selection -q` *(fails: process hangs due to PyQt GUI requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6861964a5a348323a80cdbf849222a50