### PR TITLE
Handle vendor id mapping when importing sales

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -220,6 +220,9 @@ class InventoryManager:
         for d in data.get("detalles_venta", []):
             venta_id = venta_id_map.get(d.get("venta_id"))
             producto_id = producto_id_map.get(d.get("producto_id"))
+            vendedor_id = None
+            if d.get("vendedor_id") is not None:
+                vendedor_id = vendedor_id_map.get(d.get("vendedor_id"))
             if venta_id and producto_id:
                 self.db.cursor.execute(
                     "INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -236,7 +239,7 @@ class InventoryManager:
                         d.get("tipo_fiscal", "Gravada"),
                         d.get("extra", None),
                         d.get("precio_con_iva", 0),
-                        d.get("vendedor_id", None)
+                        vendedor_id
                     )
                 )
 

--- a/tests/test_detalle_venta_vendedor.py
+++ b/tests/test_detalle_venta_vendedor.py
@@ -16,3 +16,64 @@ def test_detalle_venta_con_vendedor():
     db.add_detalle_venta(venta_id, producto_id, 1, 10, vendedor_id=vendedor_id)
     detalles = db.get_detalles_venta(venta_id)
     assert detalles[0]["vendedor_id"] == vendedor_id
+
+
+def test_import_detalles_venta_uses_vendedor_map(tmp_path, monkeypatch):
+    import inventory_manager
+    monkeypatch.setattr(inventory_manager, 'DB', lambda: DB(":memory:"))
+    man = inventory_manager.InventoryManager()
+
+    data = {
+        "vendedores": [{"id": 1, "nombre": "Luis"}],
+        "Distribuidores": [],
+        "productos": [
+            {
+                "id": 1,
+                "nombre": "Prod",
+                "codigo": "P1",
+                "precio_compra": 0,
+                "precio_venta_minorista": 0,
+                "precio_venta_mayorista": 0,
+                "stock": 10,
+            }
+        ],
+        "clientes": [],
+        "ventas": [{"id": 1, "fecha": "2024-01-01", "total": 10}],
+        "compras": [],
+        "movimientos": [],
+        "detalles_compra": [],
+        "detalles_venta": [
+            {
+                "venta_id": 1,
+                "producto_id": 1,
+                "cantidad": 1,
+                "precio_unitario": 10,
+                "descuento": 0,
+                "descuento_tipo": "",
+                "iva": 0,
+                "comision": 0,
+                "iva_tipo": "",
+                "tipo_fiscal": "Gravada",
+                "extra": None,
+                "precio_con_iva": 10,
+                "vendedor_id": 1,
+            }
+        ],
+        "trabajadores": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+
+    file_path = tmp_path / "inv.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        import json
+        json.dump(data, f)
+
+    man.importar_inventario_json(str(file_path))
+
+    ventas = man.db.get_ventas()
+    assert len(ventas) == 1
+    venta_id = ventas[0]["id"]
+    detalles = man.db.get_detalles_venta(venta_id)
+    vend_id = man.db.get_vendedores()[0]["id"]
+    assert detalles[0]["vendedor_id"] == vend_id


### PR DESCRIPTION
## Summary
- map vendor ids when inserting `detalles_venta` rows
- test import of sale details so vendor references are remapped correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a27a83ec832384c866a8b63439ea