### PR TITLE
Fix JSON storage for ventas_credito_fiscal extra

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -282,33 +282,38 @@ class InventoryManager:
 
         # --- AGREGA DESPUÉS DE IMPORTAR VENTAS ---
         for vcf in data.get("ventas_credito_fiscal", []):
-            self.db.cursor.execute("""
+            extra = vcf.get("extra")
+            extra_json = json.dumps(extra) if extra is not None else None
+            self.db.cursor.execute(
+                """
                 INSERT INTO ventas_credito_fiscal (
                     venta_id, cliente_id, nrc, nit, giro, no_remision, orden_no, condicion_pago,
                     venta_a_cuenta_de, fecha_remision_anterior, fecha_remision,
                     sumas, iva, subtotal, total_letras,
                     ventas_exentas, ventas_no_sujetas, extra
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                venta_id_map.get(vcf.get("venta_id")),      # <-- Usa el nuevo ID de la venta
-                cliente_id_map.get(vcf.get("cliente_id")),  # <-- Usa el nuevo ID del cliente
-                vcf.get("nrc"),
-                vcf.get("nit"),
-                vcf.get("giro"),
-                vcf.get("no_remision"),
-                vcf.get("orden_no"),
-                vcf.get("condicion_pago"),
-                vcf.get("venta_a_cuenta_de"),
-                vcf.get("fecha_remision_anterior"),
-                vcf.get("fecha_remision"),
-                vcf.get("sumas", 0),
-                vcf.get("iva", 0),
-                vcf.get("subtotal", 0),
-                vcf.get("total_letras", ""),
-                vcf.get("ventas_exentas", 0),
-                vcf.get("ventas_no_sujetas", 0),
-                vcf.get("extra", None)
-            ))
+                """,
+                (
+                    venta_id_map.get(vcf.get("venta_id")),
+                    cliente_id_map.get(vcf.get("cliente_id")),
+                    vcf.get("nrc"),
+                    vcf.get("nit"),
+                    vcf.get("giro"),
+                    vcf.get("no_remision"),
+                    vcf.get("orden_no"),
+                    vcf.get("condicion_pago"),
+                    vcf.get("venta_a_cuenta_de"),
+                    vcf.get("fecha_remision_anterior"),
+                    vcf.get("fecha_remision"),
+                    vcf.get("sumas", 0),
+                    vcf.get("iva", 0),
+                    vcf.get("subtotal", 0),
+                    vcf.get("total_letras", ""),
+                    vcf.get("ventas_exentas", 0),
+                    vcf.get("ventas_no_sujetas", 0),
+                    extra_json,
+                ),
+            )
         self.db.conn.commit()
 
     def add_Distribuidor(self, nombre):

--- a/tests/test_get_venta_credito_fiscal.py
+++ b/tests/test_get_venta_credito_fiscal.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from db import DB
 
 
@@ -26,5 +27,29 @@ def test_get_venta_credito_fiscal_basic():
     assert record["venta_id"] == venta_id
     assert record["cliente_id"] == cliente_id
     assert record["nrc"] == "123"
+
+
+def test_extra_is_json_string():
+    db = create_db()
+    db.add_cliente("Maria", "456", "nit2", "", "giro2", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+
+    extra = {"foo": "bar", "num": 1}
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-02-01",
+        50.0,
+        "456",
+        "nit2",
+        "giro2",
+        extra=extra,
+    )
+
+    db.cursor.execute(
+        "SELECT extra FROM ventas_credito_fiscal WHERE venta_id=?",
+        (venta_id,),
+    )
+    stored = db.cursor.fetchone()["extra"]
+    assert stored == json.dumps(extra)
 
    


### PR DESCRIPTION
## Summary
- ensure imported credit invoices store `extra` column as JSON
- test that `extra` is serialized to JSON when using `add_venta_credito_fiscal`

## Testing
- `pytest tests/test_get_venta_credito_fiscal.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a27adc1083238fc0e74ffaca3357