### PR TITLE
Fix vendor mapping on JSON import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -175,22 +175,15 @@ class InventoryManager:
         for v in data.get("ventas", []):
             cliente_id = cliente_id_map.get(v.get("cliente_id"))
             Distribuidor_id = Distribuidor_id_map.get(v.get("Distribuidor_id"))
-            if cliente_id is not None and Distribuidor_id is not None:
-                self.db.cursor.execute(
-                    "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id) VALUES (?, ?, ?, ?)",
-                    (v.get("fecha", ""), v.get("total", 0), cliente_id, Distribuidor_id)
-                )
-            elif cliente_id is not None:
-                self.db.cursor.execute(
-                    "INSERT INTO ventas (fecha, total, cliente_id) VALUES (?, ?, ?)",
-                    (v.get("fecha", ""), v.get("total", 0), cliente_id)
-                )
-            else:
-                self.db.cursor.execute(
-                    "INSERT INTO ventas (fecha, total) VALUES (?, ?)",
-                    (v.get("fecha", ""), v.get("total", 0))
-                )
-            new_id = self.db.cursor.lastrowid
+            vendedor_id = vendedor_id_map.get(v.get("vendedor_id")) if v.get("vendedor_id") is not None else None
+
+            new_id = self.db.add_venta(
+                v.get("fecha", ""),
+                v.get("total", 0),
+                cliente_id=cliente_id,
+                Distribuidor_id=Distribuidor_id,
+                vendedor_id=vendedor_id,
+            )
             venta_id_map[v["id"]] = new_id
 
         # Compras

--- a/tests/test_import_vendor_mapping.py
+++ b/tests/test_import_vendor_mapping.py
@@ -1,0 +1,28 @@
+import json
+import pytest
+import inventory_manager as im
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+def test_import_maps_vendors(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+
+    data = {
+        "Distribuidores": [{"id": 1, "nombre": "D1"}],
+        "vendedores": [{"id": 99, "nombre": "V1", "Distribuidor_id": 1, "codigo": "V001"}],
+        "clientes": [{"id": 2, "nombre": "C1", "codigo": "C001"}],
+        "ventas": [{"id": 5, "fecha": "2024-01-01", "total": 10, "cliente_id": 2, "Distribuidor_id": 1, "vendedor_id": 99}],
+    }
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data))
+
+    manager.importar_inventario_json(str(path))
+
+    ventas = manager.db.get_ventas()
+    assert len(ventas) == 1
+    venta = ventas[0]
+    vend = manager.db.get_vendedores()[0]
+    assert venta["vendedor_id"] == vend["id"]


### PR DESCRIPTION
## Summary
- map original `vendedor_id` to new IDs in importer
- add regression test covering vendor mapping

## Testing
- `pytest tests/test_import_vendor_mapping.py -q`
- `timeout 30s pytest -q` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6861a279ad5c832393f988a0a61d3c00