### PR TITLE
Fix extra column handling when saving sales

### DIFF
--- a/db.py
+++ b/db.py
@@ -506,35 +506,71 @@ class DB:
     def add_venta(self, fecha, total, cliente_id=None, Distribuidor_id=None, vendedor_id=None, extra=None):
         extra_json = json.dumps(extra) if extra else None
         if cliente_id is not None and Distribuidor_id is not None and vendedor_id is not None:
-            self.cursor.execute(
-                "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id, vendedor_id, extra) VALUES (?, ?, ?, ?, ?, ?)",
-                (fecha, total, cliente_id, Distribuidor_id, vendedor_id, extra)
-            )
+            if extra_json is not None:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id, vendedor_id, extra) VALUES (?, ?, ?, ?, ?, ?)",
+                    (fecha, total, cliente_id, Distribuidor_id, vendedor_id, extra_json)
+                )
+            else:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id, vendedor_id) VALUES (?, ?, ?, ?, ?)",
+                    (fecha, total, cliente_id, Distribuidor_id, vendedor_id)
+                )
         elif cliente_id is not None and Distribuidor_id is not None:
-            self.cursor.execute(
-                "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id) VALUES (?, ?, ?, ?)",
-                (fecha, total, cliente_id, Distribuidor_id)
-            )
+            if extra_json is not None:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id, extra) VALUES (?, ?, ?, ?, ?)",
+                    (fecha, total, cliente_id, Distribuidor_id, extra_json)
+                )
+            else:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, cliente_id, Distribuidor_id) VALUES (?, ?, ?, ?)",
+                    (fecha, total, cliente_id, Distribuidor_id)
+                )
         elif cliente_id is not None:
-            self.cursor.execute(
-                "INSERT INTO ventas (fecha, total, cliente_id, vendedor_id) VALUES (?, ?, ?, ?)",
-                (fecha, total, cliente_id, vendedor_id)
-            )
+            if extra_json is not None:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, cliente_id, vendedor_id, extra) VALUES (?, ?, ?, ?, ?)",
+                    (fecha, total, cliente_id, vendedor_id, extra_json)
+                )
+            else:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, cliente_id, vendedor_id) VALUES (?, ?, ?, ?)",
+                    (fecha, total, cliente_id, vendedor_id)
+                )
         elif Distribuidor_id is not None:
-            self.cursor.execute(
-                "INSERT INTO ventas (fecha, total, Distribuidor_id, vendedor_id) VALUES (?, ?, ?, ?)",
-                (fecha, total, Distribuidor_id, vendedor_id)
-            )
+            if extra_json is not None:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, Distribuidor_id, vendedor_id, extra) VALUES (?, ?, ?, ?, ?)",
+                    (fecha, total, Distribuidor_id, vendedor_id, extra_json)
+                )
+            else:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, Distribuidor_id, vendedor_id) VALUES (?, ?, ?, ?)",
+                    (fecha, total, Distribuidor_id, vendedor_id)
+                )
         elif vendedor_id is not None:
-            self.cursor.execute(
-                "INSERT INTO ventas (fecha, total, vendedor_id) VALUES (?, ?, ?)",
-                (fecha, total, vendedor_id)
-            )
+            if extra_json is not None:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, vendedor_id, extra) VALUES (?, ?, ?, ?)",
+                    (fecha, total, vendedor_id, extra_json)
+                )
+            else:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, vendedor_id) VALUES (?, ?, ?)",
+                    (fecha, total, vendedor_id)
+                )
         else:
-            self.cursor.execute(
-                "INSERT INTO ventas (fecha, total) VALUES (?, ?)",
-                (fecha, total)
-            )
+            if extra_json is not None:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total, extra) VALUES (?, ?, ?)",
+                    (fecha, total, extra_json)
+                )
+            else:
+                self.cursor.execute(
+                    "INSERT INTO ventas (fecha, total) VALUES (?, ?)",
+                    (fecha, total)
+                )
         self.conn.commit()
         return self.cursor.lastrowid
 

--- a/tests/test_venta_extra.py
+++ b/tests/test_venta_extra.py
@@ -1,0 +1,17 @@
+import json
+from db import DB
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_add_venta_with_extra_dict():
+    db = create_db()
+    venta_id = db.add_venta("2024-01-01", 100, extra={"note": "test", "flag": True})
+    ventas = db.get_ventas()
+    assert len(ventas) == 1
+    venta = ventas[0]
+    assert venta["id"] == venta_id
+    stored = json.loads(venta["extra"])
+    assert stored == {"note": "test", "flag": True}


### PR DESCRIPTION
## Summary
- handle `extra` correctly when inserting into `ventas`
- test saving a sale with extra info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a277f2b08323b3b5ba0a99c8a848