### PR TITLE
Fix PDF preview without pdftoppm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Esta aplicación permite gestionar inventarios y ventas utilizando una interfaz 
 pip install -r requirements.txt
 ```
 
+Esto instalará también **PyMuPDF**, utilizado para generar las previsualizaciones de las facturas en PDF.
+
 ## Ejecutar la aplicación
 
 Ejecuta el archivo `main.py` para iniciar la interfaz gráfica:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ reportlab
 pytest
 pyinstaller
 dbfread
+PyMuPDF

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -24,6 +24,7 @@ from factura_sv import generar_factura_electronica_pdf
 from dialogs import ManualInvoiceDialog
 import tempfile
 import subprocess
+import shutil
 import os
 
 
@@ -297,8 +298,23 @@ class SalesTab(QWidget):
 
         prefix = tempfile.mktemp()
         try:
-            subprocess.run(["pdftoppm", "-png", "-singlefile", pdf_path, prefix], check=True)
             png_path = prefix + ".png"
+            if shutil.which("pdftoppm"):
+                subprocess.run([
+                    "pdftoppm",
+                    "-png",
+                    "-singlefile",
+                    pdf_path,
+                    prefix,
+                ], check=True)
+            else:
+                import fitz
+
+                doc = fitz.open(pdf_path)
+                page = doc.load_page(0)
+                pix = page.get_pixmap()
+                pix.save(png_path)
+
             self.preview_pdf_file = pdf_path
             self.preview_image_file = png_path
             pixmap = QPixmap(png_path)


### PR DESCRIPTION
## Summary
- fallback to PyMuPDF when pdftoppm is missing
- document PyMuPDF dependency
- update requirements

## Testing
- `pytest tests/test_date_parsing.py -q`
- `pytest tests/test_manual_invoice.py -q` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6861cb7bc5f083238af0d028d0d3e6c1