### PR TITLE
Fix client list updates

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -320,6 +320,76 @@ class InventoryManager:
         self.db.add_vendedor(nombre, Distribuidor_id=Distribuidor_id, codigo=codigo)
         self.refresh_data()
 
+    def add_cliente(
+        self,
+        nombre,
+        nrc,
+        nit,
+        dui,
+        giro,
+        telefono,
+        email,
+        direccion,
+        departamento,
+        municipio,
+        codigo=None,
+    ):
+        """Add a new client and refresh the cached lists."""
+
+        self.db.add_cliente(
+            nombre,
+            nrc,
+            nit,
+            dui,
+            giro,
+            telefono,
+            email,
+            direccion,
+            departamento,
+            municipio,
+            codigo=codigo,
+        )
+        self.refresh_data()
+
+    def update_cliente(
+        self,
+        cliente_id,
+        codigo,
+        nombre,
+        nrc,
+        nit,
+        dui,
+        giro,
+        telefono,
+        email,
+        direccion,
+        departamento,
+        municipio,
+    ):
+        """Update an existing client and refresh the cached lists."""
+
+        self.db.update_cliente(
+            cliente_id,
+            codigo,
+            nombre,
+            nrc,
+            nit,
+            dui,
+            giro,
+            telefono,
+            email,
+            direccion,
+            departamento,
+            municipio,
+        )
+        self.refresh_data()
+
+    def delete_cliente(self, cliente_id):
+        """Delete a client and refresh the cached lists."""
+
+        self.db.delete_cliente(cliente_id)
+        self.refresh_data()
+
     def limpiar_inventario(self):
         self.db.limpiar_productos()
         self.db.limpiar_vendedores()

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1040,9 +1040,18 @@ class MainWindow(QMainWindow):
         dialog = ClienteDialog(self, codigo_sugerido=codigo)
         if dialog.exec_():
             data = dialog.get_data()
-            self.manager.db.add_cliente(
-                data["nombre"], data["nrc"], data["nit"], data["dui"], data["giro"],
-                data["telefono"], data["email"], data["direccion"], data["departamento"], data["municipio"], data["codigo"]
+            self.manager.add_cliente(
+                data["nombre"],
+                data["nrc"],
+                data["nit"],
+                data["dui"],
+                data["giro"],
+                data["telefono"],
+                data["email"],
+                data["direccion"],
+                data["departamento"],
+                data["municipio"],
+                data["codigo"],
             )
             self._actualizar_tabla_clientes()
             QMessageBox.information(self, "Cliente", "Cliente agregado correctamente.")
@@ -1055,9 +1064,19 @@ class MainWindow(QMainWindow):
         dialog = ClienteDialog(self, cliente=cli)
         if dialog.exec_():
             data = dialog.get_data()
-            self.manager.db.update_cliente(
-                cli["id"], data["codigo"], data["nombre"], data["nrc"], data["nit"], data["dui"], data["giro"],
-                data["telefono"], data["email"], data["direccion"], data["departamento"], data["municipio"]
+            self.manager.update_cliente(
+                cli["id"],
+                data["codigo"],
+                data["nombre"],
+                data["nrc"],
+                data["nit"],
+                data["dui"],
+                data["giro"],
+                data["telefono"],
+                data["email"],
+                data["direccion"],
+                data["departamento"],
+                data["municipio"],
             )
             self._actualizar_tabla_clientes()
             QMessageBox.information(self, "Cliente", "Cliente editado correctamente.")
@@ -1069,7 +1088,7 @@ class MainWindow(QMainWindow):
             return
         confirm = QMessageBox.question(self, "Eliminar", f"¿Eliminar cliente '{cli['nombre']}'?", QMessageBox.Yes | QMessageBox.No)
         if confirm == QMessageBox.Yes:
-            self.manager.db.delete_cliente(cli["id"])
+            self.manager.delete_cliente(cli["id"])
             self._actualizar_tabla_clientes()
             QMessageBox.information(self, "Cliente eliminado", f"El cliente '{cli['nombre']}' ha sido eliminado.")
 


### PR DESCRIPTION
## Summary
- add methods in inventory_manager to manage clients and refresh cached data
- use the new methods from the UI when adding, editing, or deleting clients

## Testing
- `pytest -q` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6861ec1297448323b74e080811a5dd1a