### PR TITLE
Add default email configuration

### DIFF
--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -26,5 +26,7 @@
   "smtp_server": "",
   "smtp_port": 587,
   "email_usuario": "",
-  "email_contraseña": ""
+  "email_contraseña": "",
+  "default_email_subject": "",
+  "default_email_body": ""
 }


### PR DESCRIPTION
## Summary
- add default email subject & body fields to `datos_negocio.json`
- allow setting default invoice email text in Sales tab
- load/save the default email text for each email

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f50ee73c832382ce4257846c5e41