### PR TITLE
Add email provider auto fill

### DIFF
--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -23,6 +23,7 @@
   "ciiu": "",
   "contador_nombre": "",
   "contador_nit": "",
+  "email_provider": "Gmail",
   "smtp_server": "",
   "smtp_port": 587,
   "email_usuario": "",


### PR DESCRIPTION
## Summary
- add combo box for choosing SMTP provider
- auto fill SMTP server, port and user values
- include provider field in `datos_negocio.json`

## Testing
- `pytest -q tests/test_date_parsing.py`
- `pytest -q tests/test_import_vendor_mapping.py`
- `pytest -q tests/test_manual_invoice.py` *(failed to complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6861f4add7908323a8e670045f526947