### PR TITLE
Fix email password key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ Las pruebas unitarias se ejecutan con **pytest**. Para lanzarlas usa:
 pytest
 ```
 
+### Datos del negocio y correo
+
+La configuración general se almacena en `datos_negocio.json`. Para que el envío
+de facturas por correo funcione, completa los campos SMTP de este archivo. El
+campo `email_contrasena` guarda la contraseña de la cuenta utilizada para
+enviar correos.
+

--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -27,7 +27,7 @@
   "smtp_server": "",
   "smtp_port": 587,
   "email_usuario": "",
-  "email_contraseña": "",
+  "email_contrasena": "",
   "default_email_subject": "",
   "default_email_body": ""
 }

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -398,7 +398,7 @@ class SalesTab(QWidget):
         server = data.get("smtp_server")
         port = data.get("smtp_port")
         user = data.get("email_usuario") or data.get("email")
-        password = data.get("email_contraseña")
+        password = data.get("email_contrasena") or data.get("email_contraseña")
 
         if not data.get("email_usuario") and user:
             data["email_usuario"] = user
@@ -763,7 +763,7 @@ class SalesTab(QWidget):
         server = creds.get("smtp_server")
         port = creds.get("smtp_port")
         user = creds.get("email_usuario")
-        password = creds.get("email_contraseña")
+        password = creds.get("email_contrasena") or creds.get("email_contraseña")
         if not all([server, port, user, password]):
             QMessageBox.warning(self, "Enviar por correo", "Credenciales SMTP incompletas.")
             return


### PR DESCRIPTION
## Summary
- expect both `email_contrasena` and `email_contraseña` when sending mail
- update default `datos_negocio.json` to use `email_contrasena`
- document the `email_contrasena` field in the README

## Testing
- `pytest -k "" -q` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68621bd7a4a88323a2c68c296cdd496f