### PR TITLE
Fix relative file paths

### DIFF
--- a/db.py
+++ b/db.py
@@ -2,12 +2,13 @@ import sqlite3
 from datetime import datetime
 import json
 import logging
+import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class DB:
-    def __init__(self, db_name="inventario.db"):
+    def __init__(self, db_name=os.path.join(os.path.dirname(__file__), "inventario.db")):
         self.conn = sqlite3.connect(db_name)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -5,6 +5,8 @@ import json
 from datetime import datetime, timedelta
 import os
 
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+
 class InventoryManager:
     def __init__(self):
         self.db = DB()
@@ -70,8 +72,8 @@ class InventoryManager:
 
     def exportar_inventario_json(self, filename):
         datos_negocio = {}
-        if os.path.exists("datos_negocio.json"):
-            with open("datos_negocio.json", "r", encoding="utf-8") as f:
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
                 datos_negocio = json.load(f)
         ventas_credito_fiscal = [dict(row) for row in self.db.cursor.execute("SELECT * FROM ventas_credito_fiscal")]
         data = {
@@ -268,7 +270,7 @@ class InventoryManager:
         self.refresh_data()
         # --- BLOQUE MODIFICADO PARA DATOS DEL NEGOCIO ---
         datos_negocio = data.get("datos_negocio", None)
-        datos_path = "datos_negocio.json"
+        datos_path = DATOS_NEGOCIO_PATH
         if datos_negocio:
             with open(datos_path, "w", encoding="utf-8") as f:
                 json.dump(datos_negocio, f, ensure_ascii=False, indent=2)

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -33,6 +33,8 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email import encoders
 
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+
 
 class EmailSender(QThread):
     finished = pyqtSignal(bool, str)
@@ -346,7 +348,7 @@ class SalesTab(QWidget):
             self._update_email_preview()
 
     def _load_email_config(self):
-        path = "datos_negocio.json"
+        path = DATOS_NEGOCIO_PATH
         if os.path.exists(path):
             try:
                 with open(path, "r", encoding="utf-8") as f:
@@ -358,7 +360,7 @@ class SalesTab(QWidget):
         self._update_email_preview()
 
     def _save_email_config(self):
-        path = "datos_negocio.json"
+        path = DATOS_NEGOCIO_PATH
         data = {}
         if os.path.exists(path):
             try:
@@ -376,7 +378,7 @@ class SalesTab(QWidget):
 
     def _check_smtp_credentials(self):
         """Warn user if SMTP settings are incomplete when the tab is opened."""
-        path = "datos_negocio.json"
+        path = DATOS_NEGOCIO_PATH
         if not os.path.exists(path):
             QMessageBox.warning(
                 self,
@@ -754,9 +756,9 @@ class SalesTab(QWidget):
             return
 
         creds = {}
-        if os.path.exists("datos_negocio.json"):
+        if os.path.exists(DATOS_NEGOCIO_PATH):
             try:
-                with open("datos_negocio.json", "r", encoding="utf-8") as f:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
                     creds = json.load(f)
             except Exception:
                 creds = {}

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -18,6 +18,9 @@ from dialogs import (
     ClienteDialog,
     EstadoCuentaDialog,
 )
+
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+LAST_INVENTORY_PATH = os.path.join(os.path.dirname(__file__), "ultimo_inventario.json")
 from sales_tab import SalesTab
 from datetime import datetime
 
@@ -749,7 +752,7 @@ class MainWindow(QMainWindow):
             try:
                 self.manager.exportar_inventario_json(filename)
                 self.ultimo_archivo_json = filename
-                with open("ultimo_inventario.json", "w", encoding="utf-8") as f:
+                with open(LAST_INVENTORY_PATH, "w", encoding="utf-8") as f:
                     json.dump({"ultimo": filename}, f)
                 QMessageBox.information(self, "Guardar como", "Inventario guardado correctamente.")
             except Exception as e:
@@ -762,7 +765,7 @@ class MainWindow(QMainWindow):
             try:
                 self.manager.importar_inventario_json(filename)
                 self.ultimo_archivo_json = filename
-                with open("ultimo_inventario.json", "w", encoding="utf-8") as f:
+                with open(LAST_INVENTORY_PATH, "w", encoding="utf-8") as f:
                     json.dump({"ultimo": filename}, f)
                 self.compras_tab.refresh_filters()
                 self.filter_products()
@@ -1212,7 +1215,7 @@ class MainWindow(QMainWindow):
     def _abrir_datos_negocio(self):
         # Puedes guardar/cargar los datos en un archivo JSON local, por ejemplo:
         import os, json
-        datos_path = "datos_negocio.json"
+        datos_path = DATOS_NEGOCIO_PATH
         datos = {}
         if os.path.exists(datos_path):
             try:


### PR DESCRIPTION
## Summary
- use the repo directory for the default SQLite DB
- refer to datos_negocio.json and ultimo_inventario.json using absolute paths
- keep functionality working when running from outside the repo

## Testing
- `pytest -q tests/test_get_venta_credito_fiscal.py`
- `pytest -q tests/test_comisiones_compra.py`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_686226e9c38083238a0daad68a2551e0