### PR TITLE
Improve vendor PDF output

### DIFF
--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -89,7 +89,21 @@ def generar_reporte_vendedor_pdf(db, vendedor_id, fecha_inicio, fecha_fin, archi
 
 
 def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", **kwargs):
-    """Genera un PDF básico para distintos modos de estado de cuenta."""
+    """Genera un PDF para estados de cuenta.
+
+    Cuando ``modo`` es ``"vendedor"`` y se solicita ``incluir_detalles`` se
+    delega a :func:`generar_reporte_vendedor_pdf` para producir el formato
+    detallado por cliente y producto.
+    """
+
+    # -- Atajo para el reporte detallado de vendedor -----------------------
+    if modo == "vendedor" and kwargs.get("incluir_detalles"):
+        vid = kwargs.get("vendedor_id")
+        fecha_inicio = kwargs.get("fecha_inicio")
+        fecha_fin = kwargs.get("fecha_fin")
+        generar_reporte_vendedor_pdf(db, vid, fecha_inicio, fecha_fin, archivo)
+        return
+
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter
     y = height - 40


### PR DESCRIPTION
## Summary
- allow `generar_estado_cuenta_pdf` to delegate to the detailed
  vendor report when `modo="vendedor"` and `incluir_detalles` is set
- this uses the existing `generar_reporte_vendedor_pdf` function

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: command timed out in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6866b84eefe08323b1fe507ce0badd3e