### PR TITLE
Improve estado_cuenta_pdf ID handling

### DIFF
--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -121,38 +121,64 @@ def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", *
     fecha_fin = kwargs.get("fecha_fin")
     if modo == "cliente":
         cid = kwargs.get("cliente_id")
-        cliente = db.get_cliente(cid) if cid else {}
-        if cliente is None:
-            cliente = {}
-        c.setFont("Courier", 10)
-        c.drawString(40, y, f"Cliente: {cliente.get('nombre','')}")
-        y -= 14
-        facturas = db.get_estado_cuenta(cid, "cliente", fecha_inicio, fecha_fin)
-        c.drawString(40, y, "Fecha       Factura    Total")
-        y -= 14
-        for f in facturas:
-            c.drawString(40, y, f.get("fecha", "")[:10])
-            c.drawString(120, y, str(f.get("id")))
-            c.drawRightString(width - 40, y, f"{f.get('total',0):.2f}")
+        if cid is None:
+            resumen = db.get_estado_cuenta_clientes(
+                fecha_inicio=fecha_inicio, fecha_fin=fecha_fin
+            )
+            c.drawString(40, y, "Cliente            Total Compras")
             y -= 14
+            for r in resumen:
+                cli = db.get_cliente(r.get("cliente_id"))
+                nombre = cli.get("nombre", "") if cli else str(r.get("cliente_id"))
+                c.drawString(40, y, nombre)
+                c.drawRightString(width - 40, y, f"{r.get('total_compras',0):.2f}")
+                y -= 14
+        else:
+            cliente = db.get_cliente(cid) or {}
+            if not cliente:
+                raise ValueError("Cliente no encontrado")
+            c.setFont("Courier", 10)
+            c.drawString(40, y, f"Cliente: {cliente.get('nombre','')}")
+            y -= 14
+            facturas = db.get_estado_cuenta(cid, "cliente", fecha_inicio, fecha_fin)
+            c.drawString(40, y, "Fecha       Factura    Total")
+            y -= 14
+            for f in facturas:
+                c.drawString(40, y, f.get("fecha", "")[:10])
+                c.drawString(120, y, str(f.get("id")))
+                c.drawRightString(width - 40, y, f"{f.get('total',0):.2f}")
+                y -= 14
     elif modo == "vendedor":
         vid = kwargs.get("vendedor_id")
-        vendedor = db.get_trabajador(vid) if vid else None
-        if vendedor is None and vid is not None:
-            vendedor = db.get_vendedor(vid)
-        if vendedor is None:
-            vendedor = {}
-        c.setFont("Courier", 10)
-        c.drawString(40, y, f"Vendedor: {vendedor.get('nombre','')}")
-        y -= 14
-        ventas = db.get_estado_cuenta(vid, "vendedor", fecha_inicio, fecha_fin)
-        c.drawString(40, y, "Fecha       Factura    Total")
-        y -= 14
-        for v in ventas:
-            c.drawString(40, y, v.get("fecha", "")[:10])
-            c.drawString(120, y, str(v.get("id")))
-            c.drawRightString(width - 40, y, f"{v.get('total',0):.2f}")
+        if vid is None:
+            resumen = db.get_estado_cuenta_vendedores(
+                fecha_inicio=fecha_inicio, fecha_fin=fecha_fin
+            )
+            c.drawString(40, y, "Vendedor            Total Ventas")
             y -= 14
+            for r in resumen:
+                vend = db.get_trabajador(r.get("vendedor_id"))
+                if vend is None:
+                    vend = db.get_vendedor(r.get("vendedor_id"))
+                nombre = vend.get("nombre", "") if vend else str(r.get("vendedor_id"))
+                c.drawString(40, y, nombre)
+                c.drawRightString(width - 40, y, f"{r.get('total_ventas',0):.2f}")
+                y -= 14
+        else:
+            vendedor = db.get_trabajador(vid) or db.get_vendedor(vid)
+            if vendedor is None:
+                raise ValueError("Vendedor no encontrado")
+            c.setFont("Courier", 10)
+            c.drawString(40, y, f"Vendedor: {vendedor.get('nombre','')}")
+            y -= 14
+            ventas = db.get_estado_cuenta(vid, "vendedor", fecha_inicio, fecha_fin)
+            c.drawString(40, y, "Fecha       Factura    Total")
+            y -= 14
+            for v in ventas:
+                c.drawString(40, y, v.get("fecha", "")[:10])
+                c.drawString(120, y, str(v.get("id")))
+                c.drawRightString(width - 40, y, f"{v.get('total',0):.2f}")
+                y -= 14
     else:
         resumen = db.get_estado_cuenta_vendedores(fecha_inicio=fecha_inicio, fecha_fin=fecha_fin)
         c.drawString(40, y, "Vendedor            Total Ventas")

--- a/tests/test_generar_estado_cuenta_pdf.py
+++ b/tests/test_generar_estado_cuenta_pdf.py
@@ -1,0 +1,47 @@
+import pytest
+from db import DB
+from estado_cuenta_pdf import generar_estado_cuenta_pdf
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_generar_estado_cuenta_pdf_cliente_detalle(tmp_path):
+    db = create_db()
+    db.add_cliente("Juan", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+    db.add_venta("2024-01-01", 100, cliente_id=cid)
+    pdf_path = tmp_path / "cliente_detalle.pdf"
+    generar_estado_cuenta_pdf(db, modo="cliente", archivo=str(pdf_path), cliente_id=cid)
+    assert pdf_path.exists() and pdf_path.stat().st_size > 0
+
+
+def test_generar_estado_cuenta_pdf_cliente_summary(tmp_path):
+    db = create_db()
+    db.add_cliente("Juan", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+    db.add_venta("2024-01-01", 100, cliente_id=cid)
+    pdf_path = tmp_path / "cliente_summary.pdf"
+    generar_estado_cuenta_pdf(db, modo="cliente", archivo=str(pdf_path))
+    assert pdf_path.exists() and pdf_path.stat().st_size > 0
+
+
+def test_generar_estado_cuenta_pdf_vendedor_detalle(tmp_path):
+    db = create_db()
+    db.add_vendedor("Ana")
+    vid = db.cursor.lastrowid
+    db.add_venta("2024-01-01", 100, vendedor_id=vid)
+    pdf_path = tmp_path / "vendedor_detalle.pdf"
+    generar_estado_cuenta_pdf(db, modo="vendedor", archivo=str(pdf_path), vendedor_id=vid)
+    assert pdf_path.exists() and pdf_path.stat().st_size > 0
+
+
+def test_generar_estado_cuenta_pdf_vendedor_summary(tmp_path):
+    db = create_db()
+    db.add_vendedor("Ana")
+    vid = db.cursor.lastrowid
+    db.add_venta("2024-01-01", 100, vendedor_id=vid)
+    pdf_path = tmp_path / "vendedor_summary.pdf"
+    generar_estado_cuenta_pdf(db, modo="vendedor", archivo=str(pdf_path))
+    assert pdf_path.exists() and pdf_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- handle missing `cliente_id`/`vendedor_id` in `generar_estado_cuenta_pdf`
- return summaries when IDs are absent and raise when invalid
- test PDF generation for both detailed and summary modes

## Testing
- `pytest tests/test_generar_estado_cuenta_pdf.py -q`
- `pytest -q` *(failed: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6866f823feb88323bdc8b48057a8e530