### PR TITLE
Use negocio settings in PDF headers

### DIFF
--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -2,6 +2,8 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from datetime import datetime
 
+from utils.negocio import get_nombre_comercial
+
 
 def generar_reporte_vendedor_pdf(db, vendedor_id, fecha_inicio, fecha_fin, archivo="reporte_vendedor.pdf"):
     """Genera un PDF con el detalle de ventas por vendedor."""
@@ -28,8 +30,9 @@ def generar_reporte_vendedor_pdf(db, vendedor_id, fecha_inicio, fecha_fin, archi
     width, height = letter
     y = height - 40
 
+    nombre_comercial = get_nombre_comercial()
     c.setFont("Courier-Bold", 12)
-    c.drawCentredString(width / 2, y, "FARMACIA SANTA CATALINA")
+    c.drawCentredString(width / 2, y, nombre_comercial)
     y -= 14
     c.setFont("Courier", 10)
     titulo = f"Reporte de VENTAS por VENDEDOR desde: {fecha_inicio} al {fecha_fin}"

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -6,6 +6,8 @@ from reportlab.graphics.barcode import qr
 from reportlab.platypus import Table, TableStyle
 from reportlab.lib import colors
 
+from utils.negocio import get_nombre_comercial
+
 def generar_factura_electronica_pdf(venta, detalles, cliente, distribuidor, archivo="factura_electronica.pdf"):
     from datetime import datetime
 
@@ -17,8 +19,9 @@ def generar_factura_electronica_pdf(venta, detalles, cliente, distribuidor, arch
     # --- ENCABEZADO SUPERIOR IZQUIERDA: DATOS FIJOS ---
     encabezado_y = height - y_margin
     encabezado_x = x_margin
+    nombre_comercial = get_nombre_comercial()
     c.setFont("Helvetica-Bold", 14)
-    c.drawString(encabezado_x, encabezado_y, "FARMACIA SANTA CATALINA")
+    c.drawString(encabezado_x, encabezado_y, nombre_comercial)
     c.setFont("Helvetica-Bold", 10)
     c.drawString(encabezado_x, encabezado_y - 16, "KAROL YAMILETH CRUZ ESCOBAR")
     c.setFont("Helvetica-Bold", 9)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,7 @@
+from .monto import monto_a_texto_sv
+from .negocio import get_nombre_comercial
+
+__all__ = [
+    "monto_a_texto_sv",
+    "get_nombre_comercial",
+]

--- a/utils/negocio.py
+++ b/utils/negocio.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+DATOS_NEGOCIO_PATH = os.path.join(ROOT_DIR, "datos_negocio.json")
+
+
+def get_nombre_comercial(default="FARMACIA SANTA CATALINA"):
+    """Return the commercial name stored in ``datos_negocio.json``.
+
+    Parameters
+    ----------
+    default: str
+        Value returned if the file or the key is missing.
+    """
+    try:
+        with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data.get("nombre_comercial", default) or default
+    except Exception:
+        return default


### PR DESCRIPTION
## Summary
- read negocio data in utils
- use the configured `nombre_comercial` when creating invoices and vendedor reports
- export helper from utils

## Testing
- `pytest -q tests/test_vendedor_pdf.py`
- `pytest -q tests/test_monto.py`
- `pytest -q tests/test_import_vendor_mapping.py`
- `pytest -q tests/test_date_parsing.py` *(fails to display output, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6866f828f6ac8323b1c94aa69afa7407