### PR TITLE
Fix estado cuenta loops and improve PDF tests

### DIFF
--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -193,6 +193,9 @@ def generar_estado_cuenta_pdf(
         cliente = db.get_cliente(cid) if cid else {}
         if cliente is None:
             cliente = {}
+        if not cliente and cid is not None:
+            raise ValueError("Cliente no encontrado")
+
         c.setFont("Courier", 10)
         c.drawString(40, y, f"Cliente: {cliente.get('nombre','').upper()}")
         y -= 14
@@ -203,31 +206,7 @@ def generar_estado_cuenta_pdf(
             c.drawString(40, y, f.get("fecha", "")[:10])
             c.drawString(120, y, str(f.get("id")))
             c.drawRightString(width - 40, y, f"{f.get('total',0):.2f}")
-
             y -= 14
-            for r in resumen:
-                cli = db.get_cliente(r.get("cliente_id"))
-                nombre = cli.get("nombre", "") if cli else str(r.get("cliente_id"))
-                c.drawString(40, y, nombre)
-                c.drawRightString(width - 40, y, f"{r.get('total_compras',0):.2f}")
-                y -= 14
-        else:
-            cliente = db.get_cliente(cid) or {}
-            if not cliente:
-                raise ValueError("Cliente no encontrado")
-            c.setFont("Courier", 10)
-            c.drawString(40, y, f"Cliente: {cliente.get('nombre','')}")
-            y -= 14
-            facturas = db.get_estado_cuenta(cid, "cliente", fecha_inicio, fecha_fin)
-            c.drawString(40, y, "Fecha       Factura    Total")
-            y -= 14
-
-
-            for f in facturas:
-                c.drawString(40, y, f.get("fecha", "")[:10])
-                c.drawString(120, y, str(f.get("id")))
-                c.drawRightString(width - 40, y, f"{f.get('total',0):.2f}")
-                y -= 14
     elif modo == "vendedor":
         vid = kwargs.get("vendedor_id")
 
@@ -246,13 +225,7 @@ def generar_estado_cuenta_pdf(
             c.drawString(40, y, v.get("fecha", "")[:10])
             c.drawString(120, y, str(v.get("id")))
             c.drawRightString(width - 40, y, f"{v.get('total',0):.2f}")
-
             y -= 14
-            for v in ventas:
-                c.drawString(40, y, v.get("fecha", "")[:10])
-                c.drawString(120, y, str(v.get("id")))
-                c.drawRightString(width - 40, y, f"{v.get('total',0):.2f}")
-                y -= 14
     else:
         resumen = db.get_estado_cuenta_vendedores(fecha_inicio=fecha_inicio, fecha_fin=fecha_fin)
         c.drawString(40, y, "Vendedor            Total Ventas")

--- a/tests/test_generar_estado_cuenta_pdf.py
+++ b/tests/test_generar_estado_cuenta_pdf.py
@@ -1,6 +1,7 @@
 import pytest
 from db import DB
 from estado_cuenta_pdf import generar_estado_cuenta_pdf
+import fitz
 
 
 def create_db():
@@ -45,3 +46,30 @@ def test_generar_estado_cuenta_pdf_vendedor_summary(tmp_path):
     pdf_path = tmp_path / "vendedor_summary.pdf"
     generar_estado_cuenta_pdf(db, modo="vendedor", archivo=str(pdf_path))
     assert pdf_path.exists() and pdf_path.stat().st_size > 0
+
+
+def extract_text(path):
+    with fitz.open(path) as doc:
+        return "\n".join(page.get_text() for page in doc)
+
+
+def test_pdf_content_with_facturas(tmp_path):
+    db = create_db()
+    db.add_cliente("Mario", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-05", 55, cliente_id=cid)
+    pdf_path = tmp_path / "content.pdf"
+    generar_estado_cuenta_pdf(db, modo="cliente", archivo=str(pdf_path), cliente_id=cid)
+    text = extract_text(str(pdf_path))
+    assert str(venta_id) in text
+
+
+def test_pdf_content_without_facturas(tmp_path):
+    db = create_db()
+    db.add_cliente("Luis", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+    pdf_path = tmp_path / "empty.pdf"
+    generar_estado_cuenta_pdf(db, modo="cliente", archivo=str(pdf_path), cliente_id=cid)
+    text = extract_text(str(pdf_path))
+    assert "Fecha" in text and "Factura" in text
+    assert str(cid) not in text


### PR DESCRIPTION
## Summary
- clean up invoice listing logic in `estado_cuenta_pdf.py`
- add PDF extraction helper in tests
- verify PDF content for invoices and empty lists

## Testing
- `pytest tests/test_generar_estado_cuenta_pdf.py::test_pdf_content_with_facturas -q`
- `pytest -q` *(fails: PyQt5 GUI tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_68670c08e79c8323823bf43cd0e27c91