### PR TITLE
Load email password from env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pytest
 ### Datos del negocio y correo
 
 La configuración general se almacena en `datos_negocio.json`. Para que el envío
-de facturas por correo funcione, completa los campos SMTP de este archivo. El
-campo `email_contrasena` guarda la contraseña de la cuenta utilizada para
-enviar correos.
+de facturas por correo funcione, completa los campos SMTP de este archivo. La
+contraseña de la cuenta se toma de la variable de entorno `EMAIL_PASSWORD` y el
+campo `email_contrasena` puede dejarse como un marcador de posición.
 

--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -26,5 +26,5 @@
   "smtp_server": "smtp.gmail.com",
   "smtp_port": "587",
   "email_usuario": "arieliosefrosales@gmail.com",
-  "email_contrasena": "AmoMi1conejita"
+  "email_contrasena": "CHANGE_ME"
 }

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -402,7 +402,7 @@ class SalesTab(QWidget):
         server = data.get("smtp_server")
         port = data.get("smtp_port")
         user = data.get("email_usuario") or data.get("email")
-        password = data.get("email_contrasena") or data.get("email_contraseña")
+        password = os.getenv("EMAIL_PASSWORD") or data.get("email_contrasena") or data.get("email_contraseña")
 
         if not data.get("email_usuario") and user:
             data["email_usuario"] = user
@@ -767,7 +767,7 @@ class SalesTab(QWidget):
         server = creds.get("smtp_server")
         port = creds.get("smtp_port")
         user = creds.get("email_usuario")
-        password = creds.get("email_contrasena") or creds.get("email_contraseña")
+        password = os.getenv("EMAIL_PASSWORD") or creds.get("email_contrasena") or creds.get("email_contraseña")
         if not all([server, port, user, password]):
             QMessageBox.warning(self, "Enviar por correo", "Credenciales SMTP incompletas.")
             return


### PR DESCRIPTION
## Summary
- store a placeholder email_contrasena in JSON fixtures
- read password from EMAIL_PASSWORD environment variable in `sales_tab.py`
- document the EMAIL_PASSWORD variable in the README

## Testing
- `pytest -q` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68670c0815ac832389b55c8afed12c91