### PR TITLE
Fix credit fiscal import duplication

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -107,6 +107,7 @@ class InventoryManager:
             self.db.cursor.execute("DELETE FROM detalles_compra")
             self.db.cursor.execute("DELETE FROM movimientos")
             self.db.cursor.execute("DELETE FROM trabajadores")
+            self.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
             self.db.conn.commit()
         except Exception:
             pass

--- a/tests/test_import_cleans_fiscal.py
+++ b/tests/test_import_cleans_fiscal.py
@@ -1,0 +1,31 @@
+import json
+import inventory_manager as im
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+def test_import_resets_credito_fiscal(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+
+    data = {
+        "vendedores": [],
+        "Distribuidores": [],
+        "productos": [],
+        "clientes": [{"id": 1, "nombre": "C"}],
+        "ventas": [{"id": 1, "fecha": "2024-01-01", "total": 1, "cliente_id": 1}],
+        "ventas_credito_fiscal": [
+            {"venta_id": 1, "cliente_id": 1, "nrc": "1", "nit": "1", "giro": "g"}
+        ],
+    }
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data))
+
+    manager.importar_inventario_json(str(path))
+    assert len(manager.db.cursor.execute("SELECT * FROM ventas_credito_fiscal").fetchall()) == 1
+
+    # Import again to check that table is cleared
+    manager.importar_inventario_json(str(path))
+    rows = manager.db.cursor.execute("SELECT * FROM ventas_credito_fiscal").fetchall()
+    assert len(rows) == 1


### PR DESCRIPTION
## Summary
- clear `ventas_credito_fiscal` table during inventory import
- add regression test ensuring repeated imports don't accumulate credit fiscal records

## Testing
- `pytest tests/test_import_cleans_fiscal.py tests/test_get_venta_credito_fiscal.py tests/test_detalle_venta_vendedor.py tests/test_monto.py tests/test_estado_cuenta_vendedores.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6868288d0a348323a1715c08a823560d