### PR TITLE
Clear credito fiscal data on import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -104,6 +104,7 @@ class InventoryManager:
             self.db.cursor.execute("DELETE FROM compras")
             self.db.cursor.execute("DELETE FROM detalles_compra")
             self.db.cursor.execute("DELETE FROM movimientos")
+            self.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
             self.db.cursor.execute("DELETE FROM trabajadores")
             self.db.conn.commit()
         except Exception:


### PR DESCRIPTION
## Summary
- clear the ventas_credito_fiscal table during inventory JSON import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683450206c8323a557a0f17c721988