### PR TITLE
Remove credit-fiscal data when creating new inventory

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -815,6 +815,7 @@ class MainWindow(QMainWindow):
                 self.manager.db.cursor.execute("DELETE FROM detalles_venta")
                 self.manager.db.cursor.execute("DELETE FROM compras")
                 self.manager.db.cursor.execute("DELETE FROM detalles_compra")
+                self.manager.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
                 self.manager.db.cursor.execute("DELETE FROM movimientos")
                 self.manager.db.conn.commit()
             except Exception:


### PR DESCRIPTION
## Summary
- ensure `Nuevo inventario` also removes previous credit-fiscal sales

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683450eab48323a6c09d00d0af5e64