### PR TITLE
Remove duplicate get_venta_credito_fiscal implementations

### DIFF
--- a/db.py
+++ b/db.py
@@ -605,14 +605,6 @@ class DB:
             logger.exception("Error al agregar venta a crédito fiscal: %s", e)
             return None
 
-    def get_venta_credito_fiscal(self, venta_id):
-        """Retrieve a single record from ventas_credito_fiscal by venta_id."""
-        self.cursor.execute(
-            "SELECT * FROM ventas_credito_fiscal WHERE venta_id=?",
-            (venta_id,),
-        )
-        row = self.cursor.fetchone()
-        return dict(row) if row else None
 
     def get_ventas(self):
         self.cursor.execute("SELECT * FROM ventas")
@@ -656,14 +648,6 @@ class DB:
         self.cursor.execute("SELECT * FROM detalles_compra WHERE compra_id=?", (compra_id,))
         return [dict(row) for row in self.cursor.fetchall()]
 
-    def get_venta_credito_fiscal(self, venta_id):
-        """Retrieve a venta_credito_fiscal row by the associated venta_id."""
-        self.cursor.execute(
-            "SELECT * FROM ventas_credito_fiscal WHERE venta_id=?",
-            (venta_id,)
-        )
-        row = self.cursor.fetchone()
-        return dict(row) if row else None
 
     def get_estado_cuenta(self, persona_id, tipo="cliente", fecha_inicio=None, fecha_fin=None):
         """Obtiene las facturas de un cliente o vendedor en un rango de fechas.


### PR DESCRIPTION
## Summary
- clean up `db.py` by keeping a single version of `get_venta_credito_fiscal`
- ensure this implementation parses the `extra` column as JSON

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_6868345192008323bad97b4f20154a01