### PR TITLE
Enable movable tabs with saved order

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -70,7 +70,7 @@ class InventoryManager:
         self.db.aumentar_stock(producto_id, cantidad)
         self.refresh_data()
 
-    def exportar_inventario_json(self, filename):
+    def exportar_inventario_json(self, filename, tab_order=None):
         datos_negocio = {}
         if os.path.exists(DATOS_NEGOCIO_PATH):
             with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
@@ -89,6 +89,7 @@ class InventoryManager:
             "datos_negocio": datos_negocio,
             "trabajadores": [dict(t) for t in self.db.get_trabajadores()],
             "ventas_credito_fiscal": ventas_credito_fiscal,
+            "tab_order": tab_order,
         }
         with open(filename, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
@@ -313,6 +314,8 @@ class InventoryManager:
                 ),
             )
         self.db.conn.commit()
+        self.refresh_data()
+        return data
 
     def add_Distribuidor(self, nombre):
         self.db.add_Distribuidor(nombre)

--- a/main.py
+++ b/main.py
@@ -25,7 +25,9 @@ if __name__ == "__main__":
     ultimo_archivo = cargar_ultimo_archivo()
     if ultimo_archivo and os.path.exists(ultimo_archivo):
         try:
-            window.manager.importar_inventario_json(ultimo_archivo)
+            data = window.manager.importar_inventario_json(ultimo_archivo)
+            if isinstance(data, dict) and data.get("tab_order"):
+                window.set_tab_order(data["tab_order"])
             window.ultimo_archivo_json = ultimo_archivo
             window.compras_tab.refresh_filters()
             window.filter_products()


### PR DESCRIPTION
## Summary
- allow moving QTabWidget tabs
- store tab order in exported inventory JSON
- restore saved tab order when loading inventory

## Testing
- `pip install -r requirements.txt`
- `pytest -vv` *(fails: tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_686844631c9c832387cf5f5f2842ac37