### PR TITLE
Add application logo as window icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Ejecuta el archivo `main.py` para iniciar la interfaz gráfica:
 python main.py
 ```
 
+La ventana principal mostrará el icono incluido en `logoinventario.jpg`. Puedes
+reemplazar este archivo con tu propia imagen para personalizar el logo de la
+aplicación.
+
 Se cargará el último inventario si está disponible y podrás comenzar a registrar compras y ventas.
 
 ## Pruebas

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import sys
 import os
 import json
 from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow
 
 LAST_FILE_PATH = "ultimo_inventario.json"
@@ -18,7 +19,13 @@ def cargar_ultimo_archivo():
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+    icon_path = os.path.join(os.path.dirname(__file__), "logoinventario.jpg")
+    if os.path.exists(icon_path):
+        app.setWindowIcon(QIcon(icon_path))
+
     window = MainWindow()
+    if os.path.exists(icon_path):
+        window.setWindowIcon(QIcon(icon_path))
     window.show()
 
     # Cargar automáticamente el último inventario usado


### PR DESCRIPTION
## Summary
- display logo image `logoinventario.jpg` as the window icon
- document new logo behavior in README

## Testing
- `pytest -q` *(fails: qt platform plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_68684479a92483238ad498b90d56d3da