### PR TITLE
Improve table responsiveness

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
     QDoubleSpinBox, QPushButton, QListWidget, QListWidgetItem, QMessageBox, QCheckBox, QRadioButton, QComboBox,
     QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
-    QAbstractItemView, QTextEdit, QStackedLayout, QWidget
+    QAbstractItemView, QTextEdit, QStackedLayout, QWidget, QHeaderView, QSizePolicy
 )
 from PyQt5.QtCore import Qt, QDate, QUrl
 from PyQt5.QtGui import QColor, QDesktopServices
@@ -194,6 +194,8 @@ class EstadoCuentaDialog(QDialog):
         self.cliente_table.setHorizontalHeaderLabels(["Código", "Nombre"])
         self.cliente_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.cliente_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.cliente_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.cliente_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.clientes = self.db.get_clientes()
         self.clientes_mostrados = list(self.clientes)
         self._mostrar_clientes(self.clientes)
@@ -214,6 +216,8 @@ class EstadoCuentaDialog(QDialog):
         self.vendedor_table.setHorizontalHeaderLabels(["Código", "Nombre"])
         self.vendedor_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.vendedor_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.vendedor_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.vendedor_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.vendedores = self.db.get_vendedores()
         self.vendedores_mostrados = list(self.vendedores)
         self._mostrar_vendedores(self.vendedores)
@@ -229,6 +233,8 @@ class EstadoCuentaDialog(QDialog):
         self.vendedor_table_all.setHorizontalHeaderLabels(["Código", "Nombre"])
         self.vendedor_table_all.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.vendedor_table_all.setSelectionBehavior(QTableWidget.SelectRows)
+        self.vendedor_table_all.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.vendedor_table_all.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._mostrar_vendedores_all(self.vendedores)
         todos_layout.addWidget(self.vendedor_table_all)
         self.stack.addWidget(todos_widget)
@@ -574,6 +580,8 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         ])
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         left_layout.addWidget(self.table)
         self.btn_agregar.clicked.connect(self._agregar_a_venta)
         self.table.cellClicked.connect(self._eliminar_fila)
@@ -1166,6 +1174,8 @@ class RegisterPurchaseDialog(QDialog):
         ])
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         layout.addWidget(self.table)
 
         # Total general de la compra
@@ -1702,6 +1712,8 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         ])
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         left_layout.addWidget(self.table)
         self.table.cellClicked.connect(self._eliminar_fila)
 
@@ -2413,7 +2425,9 @@ class CompraDetalleDialog(QDialog):
             "IVA", "Comisión", "Vencimiento"
         ])
         table.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        table.setSelectionBehavior(QTableWidget.SelectRows)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         for i, d in enumerate(detalles):
             nombre_producto = productos_dict.get(d.get("producto_id"), "Desconocido")
             precio_unitario = d.get("precio_unitario", d.get("precio", 0))

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QTableWidget, QTableWidgetItem,
-    QPushButton, QLabel, QDateEdit, QComboBox, QAbstractItemView
+    QPushButton, QLabel, QDateEdit, QComboBox, QAbstractItemView, QHeaderView, QSizePolicy
 )
 from PyQt5.QtCore import Qt, QDate
 from PyQt5.QtGui import QColor
@@ -97,6 +97,8 @@ class PurchasesTab(QWidget):
         self.table.verticalHeader().setDefaultSectionSize(60)
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         content_layout.addWidget(self.table)
 
         side_layout = QVBoxLayout()

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -13,6 +13,9 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QAbstractItemView,
 
+    QHeaderView,
+    QSizePolicy,
+
     QInputDialog,
     QDialog,
 
@@ -126,6 +129,8 @@ class SalesTab(QWidget):
         ])
         self.sales_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.sales_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.sales_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.sales_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.sales_table.itemSelectionChanged.connect(self.show_sale)
         left_layout.addWidget(self.sales_table)
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -2,7 +2,7 @@ from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QTableView, QLineEdit,
     QPushButton, QTabWidget, QMessageBox, QSplitter, QMenuBar, QAction, QFileDialog,
     QListWidget, QInputDialog, QLabel, QComboBox, QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QDialog,
-    QDateEdit, QCheckBox, QTextEdit, QAbstractItemView
+    QDateEdit, QCheckBox, QTextEdit, QAbstractItemView, QHeaderView, QSizePolicy
 )
 from PyQt5.QtCore import Qt, QDate
 from PyQt5.QtGui import QColor
@@ -154,6 +154,8 @@ class MainWindow(QMainWindow):
         self.product_table.setSelectionMode(QTableView.SingleSelection)
         self.product_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.product_table.clicked.connect(self._on_table_clicked)
+        self.product_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.product_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.selected_row = None
         main_layout.addWidget(self.product_table)
 
@@ -249,6 +251,8 @@ class MainWindow(QMainWindow):
         ])
         self.clientes_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.clientes_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.clientes_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.clientes_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         clientes_layout.addWidget(self.clientes_table)
 
         # Botones
@@ -288,6 +292,8 @@ class MainWindow(QMainWindow):
         ])
         self.inventario_actual_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.inventario_actual_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.inventario_actual_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.inventario_actual_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         inventario_actual_layout.addWidget(self.inventario_actual_table)
 
         inventario_actual_tab.setLayout(inventario_actual_layout)
@@ -324,6 +330,8 @@ class MainWindow(QMainWindow):
         ])
         self.trabajadores_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.trabajadores_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.trabajadores_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.trabajadores_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         trabajadores_layout.addWidget(self.trabajadores_table)
 
         # Botones
@@ -370,6 +378,8 @@ class MainWindow(QMainWindow):
         self.estado_table.setHorizontalHeaderLabels(["Código", "Nombre"])
         self.estado_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.estado_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.estado_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.estado_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         self.estado_table.itemSelectionChanged.connect(self._on_estado_row_selected)
 


### PR DESCRIPTION
## Summary
- expand all tables horizontally using `QHeaderView.Stretch`
- make tables grow and shrink with the window via `QSizePolicy`

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_date_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6868445aa1dc8323b5a40b9c6cfe7d10