### PR TITLE
Fix fiscal sales duplication and remove stored email password

### DIFF
--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -26,5 +26,4 @@
   "smtp_server": "smtp.gmail.com",
   "smtp_port": "587",
   "email_usuario": "arieliosefrosales@gmail.com",
-  "email_contrasena": "<PASSWORD_FROM_ENV>"
 }

--- a/db.py
+++ b/db.py
@@ -956,6 +956,10 @@ class DB:
         self.cursor.execute("DELETE FROM Distribuidores")
         self.conn.commit()
 
+    def limpiar_ventas_credito_fiscal(self):
+        self.cursor.execute("DELETE FROM ventas_credito_fiscal")
+        self.conn.commit()
+
     def add_Distribuidor_detallado(self, data):
         self.cursor.execute("""
             INSERT INTO Distribuidores (

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -100,6 +100,7 @@ class InventoryManager:
         self.db.limpiar_productos()
         self.db.limpiar_vendedores()
         self.db.limpiar_Distribuidores()
+        self.db.limpiar_ventas_credito_fiscal()
         try:
             self.db.cursor.execute("DELETE FROM clientes")
             self.db.cursor.execute("DELETE FROM ventas")

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -405,11 +405,7 @@ class SalesTab(QWidget):
         server = data.get("smtp_server")
         port = data.get("smtp_port")
         user = data.get("email_usuario") or data.get("email")
-        password = (
-            os.getenv("INVENTARIO_EMAIL_PASSWORD")
-            or data.get("email_contrasena")
-            or data.get("email_contraseña")
-        )
+        password = os.getenv("INVENTARIO_EMAIL_PASSWORD")
 
         if not data.get("email_usuario") and user:
             data["email_usuario"] = user
@@ -774,11 +770,7 @@ class SalesTab(QWidget):
         server = creds.get("smtp_server")
         port = creds.get("smtp_port")
         user = creds.get("email_usuario")
-        password = (
-            os.getenv("INVENTARIO_EMAIL_PASSWORD")
-            or creds.get("email_contrasena")
-            or creds.get("email_contraseña")
-        )
+        password = os.getenv("INVENTARIO_EMAIL_PASSWORD")
         if not all([server, port, user, password]):
             QMessageBox.warning(self, "Enviar por correo", "Credenciales SMTP incompletas.")
             return

--- a/tests/test_fiscal_sales_cleanup.py
+++ b/tests/test_fiscal_sales_cleanup.py
@@ -1,0 +1,47 @@
+import json
+import inventory_manager as im
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+def make_inv(path):
+    data = {
+        "Distribuidores": [],
+        "vendedores": [],
+        "productos": [],
+        "clientes": [{"id": 1, "nombre": "C1", "codigo": "C001"}],
+        "ventas": [{"id": 1, "fecha": "2024-01-01", "total": 5, "cliente_id": 1}],
+        "compras": [],
+        "movimientos": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "trabajadores": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [
+            {"venta_id": 1, "cliente_id": 1, "nrc": "123", "nit": "n1", "giro": "g"}
+        ],
+    }
+    p = path / "inv.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_import_resets_fiscal_sales(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    man = im.InventoryManager()
+    path = make_inv(tmp_path)
+
+    man.importar_inventario_json(str(path))
+    count1 = man.db.cursor.execute(
+        "SELECT COUNT(*) FROM ventas_credito_fiscal"
+    ).fetchone()[0]
+
+    man.importar_inventario_json(str(path))
+    count2 = man.db.cursor.execute(
+        "SELECT COUNT(*) FROM ventas_credito_fiscal"
+    ).fetchone()[0]
+
+    assert count1 == 1
+    assert count2 == 1

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -849,6 +849,7 @@ class MainWindow(QMainWindow):
             self.manager.db.limpiar_productos()
             self.manager.db.limpiar_vendedores()
             self.manager.db.limpiar_Distribuidores()
+            self.manager.db.limpiar_ventas_credito_fiscal()
             try:
                 self.manager.db.cursor.execute("DELETE FROM trabajadores")
                 self.manager.db.cursor.execute("DELETE FROM clientes")


### PR DESCRIPTION
## Summary
- add `limpiar_ventas_credito_fiscal` to DB
- call cleanup when importing or creating a new inventory
- drop SMTP password from config files and read from env instead
- add regression test for fiscal sales cleanup

## Testing
- `pytest tests/test_fiscal_sales_cleanup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68684447cb6083238c418a45666872de