### PR TITLE
Fix duplicate refresh_filters method

### DIFF
--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -120,15 +120,6 @@ class PurchasesTab(QWidget):
         self.btn_ver.clicked.connect(self.show_selected_detail)
         self.btn_pdf.clicked.connect(self.save_selected_pdf)
 
-    def refresh_filters(self):
-        """Reload vendor and distributor filter options from manager data."""
-        self.distribuidor_combo.clear()
-        self.distribuidor_combo.addItem("Todos")
-        self.distribuidor_combo.addItems([d["nombre"] for d in self.manager._Distribuidores])
-        self.vendedor_combo.clear()
-        self.vendedor_combo.addItem("Todos")
-        self.vendedor_combo.addItems([v["nombre"] for v in self.manager._vendedores])
-
     def _selected_compra_id(self):
         if self.table.currentRow() < 0:
             return None


### PR DESCRIPTION
## Summary
- delete the second `refresh_filters` definition in `purchases_tab.py`
- keep the detailed version defined earlier

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_date_parsing.py::test_load_purchases_date_formats -q`


------
https://chatgpt.com/codex/tasks/task_e_686af07063d083238dce7fc6db725ba2