### PR TITLE
Fix ventas import to preserve extra field

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -181,12 +181,19 @@ class InventoryManager:
             Distribuidor_id = Distribuidor_id_map.get(v.get("Distribuidor_id"))
             vendedor_id = vendedor_id_map.get(v.get("vendedor_id")) if v.get("vendedor_id") is not None else None
 
+            extra = v.get("extra")
+            if isinstance(extra, str):
+                try:
+                    extra = json.loads(extra)
+                except Exception:
+                    pass
             new_id = self.db.add_venta(
                 v.get("fecha", ""),
                 v.get("total", 0),
                 cliente_id=cliente_id,
                 Distribuidor_id=Distribuidor_id,
                 vendedor_id=vendedor_id,
+                extra=extra,
             )
             venta_id_map[v["id"]] = new_id
 


### PR DESCRIPTION
## Summary
- preserve `extra` info when importing ventas
- decode JSON strings before persisting

## Testing
- `pytest tests/test_venta_extra.py -q`
- `pytest tests/test_detalle_venta_vendedor.py -q`
- `pytest tests/test_import_vendor_mapping.py -q`
- `pytest tests/test_comisiones_compra.py -q`
- `pytest tests/test_get_venta_credito_fiscal.py -q`
- `pytest tests/test_estado_cuenta_cliente.py -q`
- `pytest tests/test_estado_cuenta_clientes.py -q`
- `pytest tests/test_estado_cuenta_vendedores.py -q`
- `pytest tests/test_fiscal_sales_cleanup.py -q`
- `pytest tests/test_monto.py -q`
- `pytest tests/test_date_parsing.py -vv` *(fails: hangs due to Qt)*
- `pytest tests/test_manual_invoice.py -vv` *(fails: hangs due to Qt)*

------
https://chatgpt.com/codex/tasks/task_e_686af07074588323b082b28e81c66d6f