### PR TITLE
Map vendor IDs when importing products

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -143,11 +143,13 @@ class InventoryManager:
 
         # Productos
         for p in data.get("productos", []):
+            vend = vendedor_id_map.get(p.get("vendedor_id"))
+            dist = Distribuidor_id_map.get(p.get("Distribuidor_id"))
             self.db.add_producto(
                 p.get("nombre", ""),
                 p.get("codigo", ""),
-                None,  # vendedor_id
-                None,  # Distribuidor_id
+                vend,
+                dist,
                 p.get("precio_compra", 0),
                 p.get("precio_venta_minorista", 0),
                 p.get("precio_venta_mayorista", 0),

--- a/tests/test_import_products_vendor.py
+++ b/tests/test_import_products_vendor.py
@@ -1,0 +1,40 @@
+import json
+import inventory_manager as im
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+def test_import_product_vendor_mapping(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+
+    data = {
+        "Distribuidores": [{"id": 1, "nombre": "D1"}],
+        "vendedores": [{"id": 5, "nombre": "V1", "Distribuidor_id": 1, "codigo": "V001"}],
+        "productos": [
+            {
+                "id": 10,
+                "nombre": "P1",
+                "codigo": "C1",
+                "vendedor_id": 5,
+                "Distribuidor_id": 1,
+                "precio_compra": 0,
+                "precio_venta_minorista": 0,
+                "precio_venta_mayorista": 0,
+                "stock": 3,
+            }
+        ],
+    }
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data))
+
+    manager.importar_inventario_json(str(path))
+
+    productos = manager.db.get_productos()
+    assert len(productos) == 1
+    prod = productos[0]
+    vend_id = manager.db.get_vendedores()[0]["id"]
+    dist_id = manager.db.get_Distribuidores()[0]["id"]
+    assert prod["vendedor_id"] == vend_id
+    assert prod["Distribuidor_id"] == dist_id


### PR DESCRIPTION
## Summary
- map `vendedor_id` and `Distribuidor_id` when importing products
- add regression test covering product vendor/distributor mapping

## Testing
- `pytest tests/test_import_products_vendor.py -q`
- `pytest tests/test_venta_extra.py -q`
- `pytest tests/test_comisiones_compra.py tests/test_get_venta_credito_fiscal.py tests/test_import_vendor_mapping.py tests/test_detalle_venta_vendedor.py -q`
- `pytest tests/test_estado_cuenta_cliente.py tests/test_estado_cuenta_clientes.py tests/test_estado_cuenta_vendedores.py tests/test_monto.py -q`
- `pytest tests/test_date_parsing.py -q` *(fails: Command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686af89d4a2c8323b599a512781c3117