### PR TITLE
Fix date filtering with timestamps

### DIFF
--- a/db.py
+++ b/db.py
@@ -702,10 +702,10 @@ class DB:
         )
         params = [persona_id]
         if fecha_inicio:
-            query += " AND fecha >= ?"
+            query += " AND date(fecha) >= date(?)"
             params.append(fecha_inicio)
         if fecha_fin:
-            query += " AND fecha <= ?"
+            query += " AND date(fecha) <= date(?)"
             params.append(fecha_fin)
         query += " ORDER BY fecha"
         self.cursor.execute(query, params)
@@ -729,10 +729,10 @@ class DB:
             )
             params = []
             if fecha_inicio:
-                query += " AND fecha >= ?"
+                query += " AND date(fecha) >= date(?)"
                 params.append(fecha_inicio)
             if fecha_fin:
-                query += " AND fecha <= ?"
+                query += " AND date(fecha) <= date(?)"
                 params.append(fecha_fin)
             query += " GROUP BY vendedor_id ORDER BY vendedor_id"
             self.cursor.execute(query, params)
@@ -741,10 +741,10 @@ class DB:
         query = "SELECT id, fecha, total FROM ventas WHERE vendedor_id=?"
         params = [vendedor_id]
         if fecha_inicio:
-            query += " AND fecha >= ?"
+            query += " AND date(fecha) >= date(?)"
             params.append(fecha_inicio)
         if fecha_fin:
-            query += " AND fecha <= ?"
+            query += " AND date(fecha) <= date(?)"
             params.append(fecha_fin)
         query += " ORDER BY fecha"
         self.cursor.execute(query, params)
@@ -765,10 +765,10 @@ class DB:
             )
             params = []
             if fecha_inicio:
-                query += " AND fecha >= ?"
+                query += " AND date(fecha) >= date(?)"
                 params.append(fecha_inicio)
             if fecha_fin:
-                query += " AND fecha <= ?"
+                query += " AND date(fecha) <= date(?)"
                 params.append(fecha_fin)
             query += " GROUP BY cliente_id ORDER BY cliente_id"
             self.cursor.execute(query, params)
@@ -777,10 +777,10 @@ class DB:
         query = "SELECT id, fecha, total FROM ventas WHERE cliente_id=?"
         params = [cliente_id]
         if fecha_inicio:
-            query += " AND fecha >= ?"
+            query += " AND date(fecha) >= date(?)"
             params.append(fecha_inicio)
         if fecha_fin:
-            query += " AND fecha <= ?"
+            query += " AND date(fecha) <= date(?)"
             params.append(fecha_fin)
         query += " ORDER BY fecha"
         self.cursor.execute(query, params)
@@ -917,10 +917,10 @@ class DB:
         query = "SELECT fecha, monto FROM pagos WHERE cliente_id=?"
         params = [cliente_id]
         if fecha_inicio:
-            query += " AND fecha >= ?"
+            query += " AND date(fecha) >= date(?)"
             params.append(fecha_inicio)
         if fecha_fin:
-            query += " AND fecha <= ?"
+            query += " AND date(fecha) <= date(?)"
             params.append(fecha_fin)
         query += " ORDER BY fecha"
         self.cursor.execute(query, params)

--- a/tests/test_estado_cuenta_cliente.py
+++ b/tests/test_estado_cuenta_cliente.py
@@ -25,3 +25,20 @@ def test_estado_cuenta_cliente_exclusive():
     assert estado["saldo"] == 170
     assert len(estado["historial_compras"]) == 2
     assert len(estado["pagos_aplicados"]) == 1
+
+
+def test_estado_cuenta_cliente_timestamp_filter():
+    db = create_db()
+    db.add_cliente("Pedro", "", "", "", "", "", "", "", "", "")
+    cid = db.cursor.lastrowid
+
+    db.add_venta("2025-07-06 10:00:00", 75, cliente_id=cid)
+    db.add_pago(cid, 25, "2025-07-06 18:30:00")
+
+    estado = db.get_estado_cuenta_cliente(
+        cid, fecha_inicio="2025-07-06", fecha_fin="2025-07-06"
+    )
+    assert len(estado["historial_compras"]) == 1
+    assert estado["historial_compras"][0]["total"] == 75
+    assert len(estado["pagos_aplicados"]) == 1
+    assert estado["pagos_aplicados"][0]["monto"] == 25


### PR DESCRIPTION
## Summary
- ensure date comparisons ignore time by wrapping columns in `date()`
- add regression test for timestamp filtering in customer account

## Testing
- `pytest tests/test_estado_cuenta_cliente.py -q`
- `pytest tests/test_estado_cuenta_clientes.py tests/test_estado_cuenta_vendedores.py -q`

Some tests could not be run due to environment limitations.

------
https://chatgpt.com/codex/tasks/task_e_686b1921cf988323837c3533a708c31d