### PR TITLE
Add save dialog and empty table support

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -7,7 +7,8 @@ from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
     QDoubleSpinBox, QPushButton, QListWidget, QListWidgetItem, QMessageBox, QCheckBox, QRadioButton, QComboBox,
     QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
-    QAbstractItemView, QTextEdit, QStackedLayout, QWidget, QHeaderView, QSizePolicy
+    QAbstractItemView, QTextEdit, QStackedLayout, QWidget, QHeaderView, QSizePolicy,
+    QFileDialog
 )
 from PyQt5.QtCore import Qt, QDate, QUrl
 from PyQt5.QtGui import QColor, QDesktopServices
@@ -363,7 +364,14 @@ class EstadoCuentaDialog(QDialog):
 
     def _generar_pdf(self):
         params = self._collect_params()
-        filename = "estado_cuenta.pdf"
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Guardar PDF",
+            "estado_cuenta.pdf",
+            "PDF Files (*.pdf)"
+        )
+        if not filename:
+            return
         from estado_cuenta_pdf import generar_estado_cuenta_pdf
         try:
             generar_estado_cuenta_pdf(self.db, archivo=filename, **params)
@@ -372,10 +380,21 @@ class EstadoCuentaDialog(QDialog):
             QMessageBox.warning(self, "Estado de cuenta", f"Error: {e}")
 
     def _generar_e_imprimir_pdf(self):
-        self._generar_pdf()
-        # Intentar abrir el PDF para imprimir/visualizar
-        filename = "estado_cuenta.pdf"
-        QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(filename)))
+        params = self._collect_params()
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Guardar PDF",
+            "estado_cuenta.pdf",
+            "PDF Files (*.pdf)"
+        )
+        if not filename:
+            return
+        from estado_cuenta_pdf import generar_estado_cuenta_pdf
+        try:
+            generar_estado_cuenta_pdf(self.db, archivo=filename, **params)
+            QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(filename)))
+        except Exception as e:
+            QMessageBox.warning(self, "Estado de cuenta", f"Error: {e}")
 
 
 class ProductDialogBase:

--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -209,6 +209,28 @@ def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", *
                     }
                 )
 
+        if not grupos:
+            data = [headers, ["" for _ in headers]]
+            table = Table(data, colWidths=col_widths, repeatRows=1)
+            table.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#f5f5f5")),
+                        ("TEXTCOLOR", (0, 0), (-1, 0), colors.HexColor("#222")),
+                        ("ALIGN", (0, 0), (3, -1), "LEFT"),
+                        ("ALIGN", (4, 1), (-1, -1), "RIGHT"),
+                        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                        ("FONTSIZE", (0, 0), (-1, 0), 9),
+                        ("FONTSIZE", (0, 1), (-1, -1), 8),
+                        ("BOTTOMPADDING", (0, 0), (-1, 0), 5),
+                        ("TOPPADDING", (0, 0), (-1, 0), 3),
+                        ("GRID", (0, 0), (-1, -1), 0.4, colors.grey),
+                        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ]
+                )
+            )
+            elements.append(table)
+
         for g in grupos.values():
             elements.append(
                 Paragraph(
@@ -330,6 +352,28 @@ def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", *
                     }
                 )
 
+        if not grupos:
+            data = [headers, ["" for _ in headers]]
+            table = Table(data, colWidths=col_widths, repeatRows=1)
+            table.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#f5f5f5")),
+                        ("TEXTCOLOR", (0, 0), (-1, 0), colors.HexColor("#222")),
+                        ("ALIGN", (0, 0), (3, -1), "LEFT"),
+                        ("ALIGN", (4, 1), (-1, -1), "RIGHT"),
+                        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                        ("FONTSIZE", (0, 0), (-1, 0), 9),
+                        ("FONTSIZE", (0, 1), (-1, -1), 8),
+                        ("BOTTOMPADDING", (0, 0), (-1, 0), 5),
+                        ("TOPPADDING", (0, 0), (-1, 0), 3),
+                        ("GRID", (0, 0), (-1, -1), 0.4, colors.grey),
+                        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ]
+                )
+            )
+            elements.append(table)
+
         for g in grupos.values():
             elements.append(
                 Paragraph(
@@ -417,6 +461,8 @@ def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", *
             vend = db.get_trabajador(r.get("vendedor_id"))
             nombre = vend.get("nombre", "") if vend else str(r.get("vendedor_id"))
             data.append([nombre, f"{r.get('total_ventas',0):.2f}"])
+        if len(data) == 1:
+            data.append(["", ""])
         table = Table(data, colWidths=[200, 80])
         table.setStyle(
             TableStyle(

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1399,10 +1399,20 @@ class MainWindow(QMainWindow):
         inicio_str = inicio.toString("yyyy-MM-dd")
         fin_str = fin.toString("yyyy-MM-dd")
         codigo = persona.get("codigo", persona.get("id"))
-        filename = f"reporte_vendedor_{codigo}.pdf"
+        suggested = f"reporte_vendedor_{codigo}.pdf"
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Guardar PDF",
+            suggested,
+            "PDF Files (*.pdf)"
+        )
+        if not filename:
+            return
         try:
             from estado_cuenta_pdf import generar_reporte_vendedor_pdf
-            generar_reporte_vendedor_pdf(self.manager.db, persona["id"], inicio_str, fin_str, archivo=filename)
+            generar_reporte_vendedor_pdf(
+                self.manager.db, persona["id"], inicio_str, fin_str, archivo=filename
+            )
             QMessageBox.information(self, "Imprimir", f"Reporte guardado en {filename}")
         except Exception as e:
             QMessageBox.warning(self, "Imprimir", f"Error al generar PDF: {e}")


### PR DESCRIPTION
## Summary
- add a file save dialog when exporting account status PDFs
- allow user to choose file path when exporting vendor report
- keep table layout when there is no data in account status reports

## Testing
- `pip install PyQt5`
- `pip install reportlab`
- `pytest -q` *(fails: testing interrupted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_686b1e40f74c8323b5b7abbe8cd69f18