### PR TITLE
Fix clearing sales when starting new inventory

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -861,6 +861,13 @@ class MainWindow(QMainWindow):
                 self.manager.db.conn.commit()
             except Exception:
                 pass
+            # Reset last loaded inventory so old data is not reimported
+            self.ultimo_archivo_json = None
+            try:
+                if os.path.exists(LAST_INVENTORY_PATH):
+                    os.remove(LAST_INVENTORY_PATH)
+            except OSError:
+                pass
             self.manager.refresh_data()
             self.compras_tab.refresh_filters()
 


### PR DESCRIPTION
## Summary
- clear stored `ultimo_inventario.json` when starting a new inventory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_686b2c8aa48483238cf7df91e4d7c4e8