### PR TITLE
Fix sales table refresh on new inventory

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -874,6 +874,8 @@ class MainWindow(QMainWindow):
 
             self.compras_tab.load_purchases()
 
+            self.sales_tab.load_sales()  # <-- AGREGA ESTA LÍNEA
+
             self._actualizar_tabla_trabajadores()  # <-- AGREGA ESTA LÍNEA
             self.filter_products()
             self._actualizar_arbol_vendedores()


### PR DESCRIPTION
## Summary
- refresh the sales tab when creating a new inventory

## Testing
- `pytest tests/test_fiscal_sales_cleanup.py::test_import_resets_fiscal_sales -q`
- `pytest tests/test_date_parsing.py::test_load_purchases_date_formats -q`
- `pytest tests/test_comisiones_compra.py -q`
- `pytest tests/test_detalle_venta_vendedor.py -q`
- `pytest tests/test_get_venta_credito_fiscal.py -q`
- `pytest tests/test_import_products_vendor.py -q`
- `pytest tests/test_import_vendor_mapping.py -q`
- `pytest tests/test_monto.py -q`
- `pytest tests/test_estado_cuenta_cliente.py -q`
- `pytest tests/test_estado_cuenta_clientes.py -q`
- `pytest tests/test_estado_cuenta_vendedores.py -q`
- `pytest tests/test_venta_extra.py -q`

Two tests involving GUI interactions (`test_manual_invoice.py` and one from `test_date_parsing.py`) could not complete in this environment.

------
https://chatgpt.com/codex/tasks/task_e_686b332b75f48323b8ab5e450d6df11e