### PR TITLE
Ensure sales table updates when inventory loads

### DIFF
--- a/tests/test_load_inventory_ui.py
+++ b/tests/test_load_inventory_ui.py
@@ -1,0 +1,47 @@
+import os
+import json
+import pytest
+
+import inventory_manager as im
+import ui_mainwindow
+from PyQt5.QtWidgets import QApplication
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+def make_inv(path):
+    data = {
+        "Distribuidores": [],
+        "vendedores": [],
+        "productos": [],
+        "clientes": [{"id": 1, "nombre": "C"}],
+        "ventas": [{"id": 1, "fecha": "2024-01-01", "total": 5, "cliente_id": 1}],
+        "compras": [],
+        "movimientos": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "trabajadores": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+    p = path / "inv.json"
+    p.write_text(json.dumps(data))
+    return str(p)
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    return app
+
+def test_sales_table_populated_after_import(qt_app, tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    inv = make_inv(tmp_path)
+    monkeypatch.setattr(ui_mainwindow, "LAST_INVENTORY_PATH", tmp_path / "last.json")
+    monkeypatch.setattr(ui_mainwindow.QFileDialog, "getOpenFileName", lambda *a, **k: (inv, ""))
+    monkeypatch.setattr(ui_mainwindow.QMessageBox, "information", lambda *a, **k: None)
+    window = ui_mainwindow.MainWindow()
+    assert window.sales_tab.sales_table.rowCount() == 0
+    window.cargar_inventario()
+    assert window.sales_tab.sales_table.rowCount() == 1

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -642,6 +642,7 @@ class MainWindow(QMainWindow):
                 self.manager.refresh_data()
                 self.compras_tab.refresh_filters()
                 self.compras_tab.load_purchases()
+                self.sales_tab.load_sales()
                 self.filter_products()
                 self._actualizar_historial()
                 self._actualizar_inventario_actual()
@@ -796,6 +797,7 @@ class MainWindow(QMainWindow):
                 self.filter_products()
                 self.compras_tab.refresh_filters()
                 self.compras_tab.load_purchases()
+                self.sales_tab.load_sales()
                 self._actualizar_tabla_clientes()
                 self._actualizar_arbol_vendedores()
                 self._actualizar_arbol_Distribuidores()
@@ -830,6 +832,7 @@ class MainWindow(QMainWindow):
                 self.compras_tab.refresh_filters()
 
                 self.compras_tab.load_purchases()
+                self.sales_tab.load_sales()
 
                 self.filter_products()
                 self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA


### PR DESCRIPTION
## Summary
- update `cargar_inventario` and `cargar_rapido` to refresh sales
- add regression test verifying that inventory load populates sales table

## Testing
- `pytest -q` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686b4146693c832398d498dfc5ace69f