### PR TITLE
Fix account tab not updating after import

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,9 +47,10 @@ if __name__ == "__main__":
             window.compras_tab.refresh_filters()
             window.filter_products()
             window._actualizar_arbol_vendedores()
-            window._actualizar_arbol_Distribuidores()   
-            window._actualizar_tabla_clientes()    
-            window._actualizar_tabla_trabajadores() 
+            window._actualizar_arbol_Distribuidores()
+            window._actualizar_tabla_clientes()
+            window._actualizar_tabla_trabajadores()
+            window._cargar_personas_estado()
             window._actualizar_historial()
             QMessageBox.information(window, "Inventario", "Inventario cargado exitosamente.")
         except Exception as e:

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -799,11 +799,12 @@ class MainWindow(QMainWindow):
                 self.compras_tab.load_purchases()
                 self.sales_tab.load_sales()
                 self._actualizar_tabla_clientes()
+                self._cargar_personas_estado()
                 self._actualizar_arbol_vendedores()
                 self._actualizar_arbol_Distribuidores()
                 self._actualizar_tabla_trabajadores()
                 self._actualizar_inventario_actual()
-                self._actualizar_historial() 
+                self._actualizar_historial()
                 QMessageBox.information(self, "Cargar inventario", "Inventario cargado correctamente.")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"No se pudo cargar el inventario:\n{e}")
@@ -836,6 +837,7 @@ class MainWindow(QMainWindow):
 
                 self.filter_products()
                 self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA
+                self._cargar_personas_estado()
                 QMessageBox.information(self, "Cargar rápido", f"Inventario cargado de:\n{self.ultimo_archivo_json}")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"No se pudo cargar el inventario:\n{e}")
@@ -884,6 +886,7 @@ class MainWindow(QMainWindow):
             self._actualizar_arbol_vendedores()
             self._actualizar_arbol_Distribuidores()
             self._actualizar_tabla_clientes()
+            self._cargar_personas_estado()
             self._actualizar_historial()
             if hasattr(self, "vendedor_combo_filtro"):
                 self.vendedor_combo_filtro.setCurrentIndex(0)


### PR DESCRIPTION
## Summary
- refresh accounts tab list after loading inventory data
- refresh accounts tab after quick load
- keep accounts tab up to date when clearing inventory
- ensure auto-load on startup populates account tab

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_estado_cuenta_clientes.py::test_estado_cuenta_clientes_summary_and_detail -q`
- `QT_QPA_PLATFORM=offscreen pytest tests/test_estado_cuenta_vendedores.py::test_estado_cuenta_vendedores_summary_and_detail -q`


------
https://chatgpt.com/codex/tasks/task_e_686b4fe01b84832399212d9ecf300cc3