### PR TITLE
Fix vendor account dialog to use trabajadores

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -219,7 +219,8 @@ class EstadoCuentaDialog(QDialog):
         self.vendedor_table.setSelectionBehavior(QTableWidget.SelectRows)
         self.vendedor_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.vendedor_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.vendedores = self.db.get_vendedores()
+        # Use trabajadores marked as vendedores when listing available sellers
+        self.vendedores = self.db.get_trabajadores(solo_vendedores=True)
         self.vendedores_mostrados = list(self.vendedores)
         self._mostrar_vendedores(self.vendedores)
         vend_layout.addWidget(self.vendedor_table)

--- a/tests/test_estado_cuenta_dialog.py
+++ b/tests/test_estado_cuenta_dialog.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from dialogs import EstadoCuentaDialog
+from db import DB
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    return app
+
+def test_dialog_uses_trabajadores_for_vendedores(qt_app):
+    db = DB(":memory:")
+    db.add_trabajador({"nombre": "Vend1", "codigo": "T1", "es_vendedor": True})
+    db.add_trabajador({"nombre": "Vend2", "codigo": "T2", "es_vendedor": True})
+
+    dialog = EstadoCuentaDialog(db)
+
+    assert dialog.vendedor_table.rowCount() == 2
+    codes = [dialog.vendedor_table.item(i, 0).text() for i in range(2)]
+    assert "T1" in codes and "T2" in codes


### PR DESCRIPTION
## Summary
- display worker-vendors in EstadoCuentaDialog
- test that vendor dialog lists trabajadores

## Testing
- `pytest tests/test_estado_cuenta_vendedores.py tests/test_estado_cuenta_clientes.py tests/test_detalle_venta_vendedor.py tests/test_estado_cuenta_dialog.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5f68de648323b499ef8a29aac0af