### PR TITLE
Fix missing account statement loader

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1458,6 +1458,13 @@ class MainWindow(QMainWindow):
             self.estado_table.setItem(row, 4, QTableWidgetItem(vend))
             self.estado_table.setItem(row, 5, QTableWidgetItem(f"${float(monto):.2f}"))
 
+    def _cargar_personas_estado(self):
+        """Carga datos para la pestaña de estados de cuenta."""
+        self._clientes_estado = self.manager.db.get_clientes()
+        self._vendedores_estado = self.manager.db.get_trabajadores(solo_vendedores=True)
+        self.estado_search_bar.clear()
+        self._mostrar_historial_general()
+
     def get_tab_order(self):
         return [self.tabs.tabText(i) for i in range(self.tabs.count())]
 


### PR DESCRIPTION
## Summary
- implement `_cargar_personas_estado` to prevent crashes when loading inventory

## Testing
- `pytest tests/test_monto.py -q`
- `pytest tests/test_estado_cuenta_dialog.py -q`
- ⚠️ `pytest tests/test_load_inventory_ui.py -q` *(failed: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_686b66a3b0008323bfbc1f969a6a91c8