### PR TITLE
Fix worker mapping on inventory import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -119,6 +119,7 @@ class InventoryManager:
         cliente_id_map = {}
         venta_id_map = {}
         compra_id_map = {}
+        trabajador_id_map = {}
 
         # --- Distribuidores primero ---
         for v in data.get("Distribuidores", []):
@@ -140,6 +141,7 @@ class InventoryManager:
 
         for t in data.get("trabajadores", []):
             self.db.add_trabajador(t)
+            trabajador_id_map[t.get("id")] = self.db.cursor.lastrowid
 
         # Productos
         for p in data.get("productos", []):
@@ -181,7 +183,9 @@ class InventoryManager:
         for v in data.get("ventas", []):
             cliente_id = cliente_id_map.get(v.get("cliente_id"))
             Distribuidor_id = Distribuidor_id_map.get(v.get("Distribuidor_id"))
-            vendedor_id = vendedor_id_map.get(v.get("vendedor_id")) if v.get("vendedor_id") is not None else None
+            vendedor_id = trabajador_id_map.get(v.get("vendedor_id")) if v.get("vendedor_id") is not None else None
+            if vendedor_id is None and v.get("vendedor_id") is not None:
+                vendedor_id = vendedor_id_map.get(v.get("vendedor_id"))
 
             extra = v.get("extra")
             if isinstance(extra, str):
@@ -228,7 +232,9 @@ class InventoryManager:
             producto_id = producto_id_map.get(d.get("producto_id"))
             vendedor_id = None
             if d.get("vendedor_id") is not None:
-                vendedor_id = vendedor_id_map.get(d.get("vendedor_id"))
+                vendedor_id = trabajador_id_map.get(d.get("vendedor_id"))
+                if vendedor_id is None:
+                    vendedor_id = vendedor_id_map.get(d.get("vendedor_id"))
             if venta_id and producto_id:
                 self.db.cursor.execute(
                     "INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/tests/test_import_trabajador_sales.py
+++ b/tests/test_import_trabajador_sales.py
@@ -1,0 +1,35 @@
+import json
+import inventory_manager as im
+import pytest
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+def test_import_maps_trabajador_sales(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+
+    data = {
+        "Distribuidores": [],
+        "vendedores": [],
+        "clientes": [{"id": 1, "nombre": "C"}],
+        "trabajadores": [{"id": 2, "nombre": "Vend", "codigo": "T1", "es_vendedor": True}],
+        "ventas": [{"id": 1, "fecha": "2024-01-01", "total": 5, "cliente_id": 1, "vendedor_id": 2}],
+        "compras": [],
+        "movimientos": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data))
+
+    manager.importar_inventario_json(str(path))
+
+    ventas = manager.db.get_ventas()
+    assert len(ventas) == 1
+    venta = ventas[0]
+    trab_id = manager.db.get_trabajadores()[0]["id"]
+    assert venta["vendedor_id"] == trab_id


### PR DESCRIPTION
## Summary
- map trabajador IDs when loading inventory
- fallback to vendor IDs for backwards compatibility
- test mapping of trabajador IDs during sales import

## Testing
- `pytest tests/test_import_trabajador_sales.py -q`
- `pytest tests/test_import_vendor_mapping.py tests/test_detalle_venta_vendedor.py tests/test_import_trabajador_sales.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6d0a1d3c8323b0c1f95767f14771