### PR TITLE
Improve EstadoCuentaDialog selection handling

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -235,6 +235,7 @@ class EstadoCuentaDialog(QDialog):
         self.vendedor_table_all.setHorizontalHeaderLabels(["Código", "Nombre"])
         self.vendedor_table_all.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.vendedor_table_all.setSelectionBehavior(QTableWidget.SelectRows)
+        self.vendedor_table_all.setSelectionMode(QAbstractItemView.NoSelection)
         self.vendedor_table_all.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.vendedor_table_all.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._mostrar_vendedores_all(self.vendedores)
@@ -353,18 +354,24 @@ class EstadoCuentaDialog(QDialog):
             "agrupar_factura": self.agrupar_factura.isChecked(),
             "incluir_detalles": self.incluir_detalles.isChecked(),
         }
-        if modo == "cliente" and self.clientes_mostrados:
+        if modo == "cliente":
             idx = self.cliente_table.currentRow()
-            if 0 <= idx < len(self.clientes_mostrados):
-                params["cliente_id"] = self.clientes_mostrados[idx].get("id")
-        if modo == "vendedor" and self.vendedores_mostrados:
+            if idx < 0 or idx >= len(self.clientes_mostrados):
+                QMessageBox.warning(self, "Validación", "No se ha seleccionado ningún cliente.")
+                return None
+            params["cliente_id"] = self.clientes_mostrados[idx].get("id")
+        if modo == "vendedor":
             idx = self.vendedor_table.currentRow()
-            if 0 <= idx < len(self.vendedores_mostrados):
-                params["vendedor_id"] = self.vendedores_mostrados[idx].get("id")
+            if idx < 0 or idx >= len(self.vendedores_mostrados):
+                QMessageBox.warning(self, "Validación", "No se ha seleccionado ningún vendedor.")
+                return None
+            params["vendedor_id"] = self.vendedores_mostrados[idx].get("id")
         return params
 
     def _generar_pdf(self):
         params = self._collect_params()
+        if params is None:
+            return
         filename, _ = QFileDialog.getSaveFileName(
             self,
             "Guardar PDF",
@@ -382,6 +389,8 @@ class EstadoCuentaDialog(QDialog):
 
     def _generar_e_imprimir_pdf(self):
         params = self._collect_params()
+        if params is None:
+            return
         filename, _ = QFileDialog.getSaveFileName(
             self,
             "Guardar PDF",

--- a/tests/test_estado_cuenta_dialog.py
+++ b/tests/test_estado_cuenta_dialog.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QAbstractItemView, QMessageBox
 
 from dialogs import EstadoCuentaDialog
 from db import DB
@@ -21,3 +21,42 @@ def test_dialog_uses_trabajadores_for_vendedores(qt_app):
     assert dialog.vendedor_table.rowCount() == 2
     codes = [dialog.vendedor_table.item(i, 0).text() for i in range(2)]
     assert "T1" in codes and "T2" in codes
+
+
+def test_dialog_requires_vendedor_selection(qt_app, monkeypatch):
+    db = DB(":memory:")
+    db.add_trabajador({"nombre": "Vend1", "codigo": "V1", "es_vendedor": True})
+    dialog = EstadoCuentaDialog(db)
+    dialog.modo_combo.setCurrentIndex(1)
+    warnings = {}
+
+    def fake_warning(parent, title, msg):
+        warnings["msg"] = msg
+
+    monkeypatch.setattr(QMessageBox, "warning", fake_warning)
+    params = dialog._collect_params()
+    assert params is None
+    assert "ningún vendedor" in warnings.get("msg", "")
+
+
+def test_dialog_requires_cliente_selection(qt_app, monkeypatch):
+    db = DB(":memory:")
+    db.add_cliente("Cli", "", "", "", "", "", "", "", "", "")
+    dialog = EstadoCuentaDialog(db)
+    dialog.modo_combo.setCurrentIndex(0)
+    warnings = {}
+
+    def fake_warning(parent, title, msg):
+        warnings["msg"] = msg
+
+    monkeypatch.setattr(QMessageBox, "warning", fake_warning)
+    params = dialog._collect_params()
+    assert params is None
+    assert "ningún cliente" in warnings.get("msg", "")
+
+
+def test_vendedor_table_all_no_selection(qt_app):
+    db = DB(":memory:")
+    db.add_trabajador({"nombre": "Vend", "codigo": "V1", "es_vendedor": True})
+    dialog = EstadoCuentaDialog(db)
+    assert dialog.vendedor_table_all.selectionMode() == QAbstractItemView.NoSelection


### PR DESCRIPTION
## Summary
- disable row selection in the vendor list for the "All vendors" mode
- validate that a vendor or client is selected before generating an account statement
- update `_generar_pdf` methods to exit when no selection is made
- extend tests for `EstadoCuentaDialog`

## Testing
- `pytest tests/test_estado_cuenta_dialog.py -q`
- `pytest -k estado_cuenta -q`


------
https://chatgpt.com/codex/tasks/task_e_686b73d6f9f88323b3679495aa3812c2