### PR TITLE
Disable SMTP warning on startup

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -94,7 +94,6 @@ class SalesTab(QWidget):
         self.email_thread = None
         self._setup_ui()
         self._load_email_config()
-        self._check_smtp_credentials()
         self.load_sales()
 
     def _setup_ui(self):


### PR DESCRIPTION
## Summary
- avoid showing an SMTP credentials warning when the sales tab opens

## Testing
- `pytest -q` *(fails: tests hang and require GUI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b7741f0688323a6cdbec99ca5fb3e