### PR TITLE
Support different invoice document types

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -6,7 +6,14 @@ from reportlab.graphics.barcode import qr
 from reportlab.platypus import Table, TableStyle
 from reportlab.lib import colors
 
-def generar_factura_electronica_pdf(venta, detalles, cliente, distribuidor, archivo="factura_electronica.pdf"):
+def generar_factura_electronica_pdf(
+    venta,
+    detalles,
+    cliente,
+    distribuidor,
+    tipo_documento="Crédito Fiscal",
+    archivo="factura_electronica.pdf",
+):
     from datetime import datetime
 
     c = canvas.Canvas(archivo, pagesize=letter)
@@ -34,7 +41,7 @@ def generar_factura_electronica_pdf(venta, detalles, cliente, distribuidor, arch
     c.setFont("Helvetica-Bold", 11)
     c.drawString(doc_x, doc_y, "DOCUMENTO TRIBUTARIO ELECTRÓNICO")
     c.setFont("Helvetica-Bold", 9)
-    c.drawString(doc_x, doc_y - 18, "COMPROBANTE DE CRÉDITO FISCAL")
+    c.drawString(doc_x, doc_y - 18, str(tipo_documento))
     c.setFont("Helvetica", 7)
     c.drawRightString(width - x_margin, doc_y, f"Ver. {venta.get('version', '3')}")
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -488,11 +488,13 @@ class SalesTab(QWidget):
         with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_pdf:
             pdf_path = tmp_pdf.name
 
+        tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
         generar_factura_electronica_pdf(
             venta_data,
             detalles,
             cliente or {},
             distribuidor or {},
+            tipo_doc,
             archivo=pdf_path,
         )
 
@@ -621,13 +623,14 @@ class SalesTab(QWidget):
             )
 
         cliente_nombre = cliente.get("nombre", "cliente") if cliente else "cliente"
-        tipo = "credito fiscal" if credito_info else "consumidor final"
-        filename = f"{cliente_nombre} {venta_id} {tipo}.pdf"
+        tipo = "Crédito Fiscal" if credito_info else "Consumidor Final"
+        filename = f"{cliente_nombre} {venta_id} {tipo.lower()}.pdf"
         generar_factura_electronica_pdf(
             venta_data,
             detalles,
             cliente or {},
             distribuidor or {},
+            tipo,
             archivo=filename,
         )
         QMessageBox.information(self, "Guardar PDF", f"Factura guardada en {filename}")
@@ -708,13 +711,15 @@ class SalesTab(QWidget):
             )
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
-
             temp_file = tmp.name
+
+        tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
         generar_factura_electronica_pdf(
             venta_data,
             detalles,
             cliente or {},
             distribuidor or {},
+            tipo_doc,
             archivo=temp_file,
         )
         QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(temp_file)))
@@ -826,7 +831,14 @@ class SalesTab(QWidget):
             cliente = data.get("cliente", {})
             with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
                 temp_file = tmp.name
-            generar_factura_electronica_pdf(venta, detalles, cliente, {}, archivo=temp_file)
+            generar_factura_electronica_pdf(
+                venta,
+                detalles,
+                cliente,
+                {},
+                tipo.title(),
+                archivo=temp_file,
+            )
             QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(temp_file)))
 
 


### PR DESCRIPTION
## Summary
- add `tipo_documento` parameter to `generar_factura_electronica_pdf`
- render provided document type text in invoice header
- pass the selected document type from `SalesTab`

## Testing
- `pip install PyQt5`
- `pip install -r requirements.txt`
- `timeout 10 pytest -q` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686df6acf77083239797b775ea88a87a