### PR TITLE
Add vendor DUI support and schema migration

### DIFF
--- a/db.py
+++ b/db.py
@@ -21,7 +21,6 @@ class DB:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 codigo TEXT,
                 nombre TEXT NOT NULL,
-                dui TEXT,
                 telefono TEXT,
                 email TEXT,
                 cargo TEXT,
@@ -46,6 +45,7 @@ class DB:
                 nombre TEXT NOT NULL,
                 descripcion TEXT,
                 Distribuidor_id INTEGER,
+                dui TEXT,
                 FOREIGN KEY (Distribuidor_id) REFERENCES Distribuidores(id)
             )
         """)
@@ -291,6 +291,11 @@ class DB:
         except Exception:
             pass  # Ya existe la columna
         try:
+            self.cursor.execute("ALTER TABLE vendedores ADD COLUMN dui TEXT")
+            self.conn.commit()
+        except Exception:
+            pass  # Ya existe la columna
+        try:
             self.cursor.execute("ALTER TABLE trabajadores ADD COLUMN codigo TEXT")
             self.conn.commit()
         except Exception:
@@ -434,12 +439,12 @@ class DB:
             logger.exception("Error al eliminar Distribuidor: %s", e)
 
     # CRUD VENDEDORES (antes vendedores)
-    def add_vendedor(self, nombre, descripcion="", Distribuidor_id=None, codigo=None):
+    def add_vendedor(self, nombre, descripcion="", Distribuidor_id=None, codigo=None, dui=None):
         if codigo is None:
             codigo = self.get_next_vendedor_codigo()
         self.cursor.execute(
-            "INSERT INTO vendedores (codigo, nombre, descripcion, Distribuidor_id) VALUES (?, ?, ?, ?)",
-            (codigo, nombre, descripcion, Distribuidor_id),
+            "INSERT INTO vendedores (codigo, nombre, descripcion, Distribuidor_id, dui) VALUES (?, ?, ?, ?, ?)",
+            (codigo, nombre, descripcion, Distribuidor_id, dui),
         )
         self.conn.commit()
 
@@ -447,11 +452,11 @@ class DB:
         self.cursor.execute("SELECT * FROM vendedores")
         return [dict(row) for row in self.cursor.fetchall()]
 
-    def update_vendedor(self, id, codigo, nombre, descripcion, Distribuidor_id):
+    def update_vendedor(self, id, codigo, nombre, descripcion, Distribuidor_id, dui=None):
         try:
             self.cursor.execute(
-                "UPDATE vendedores SET codigo=?, nombre=?, descripcion=?, Distribuidor_id=? WHERE id=?",
-                (codigo, nombre, descripcion, Distribuidor_id, id),
+                "UPDATE vendedores SET codigo=?, nombre=?, descripcion=?, Distribuidor_id=?, dui=? WHERE id=?",
+                (codigo, nombre, descripcion, Distribuidor_id, dui, id),
             )
             self.conn.commit()
         except Exception as e:
@@ -962,15 +967,14 @@ class DB:
     def add_Distribuidor_detallado(self, data):
         self.cursor.execute("""
             INSERT INTO Distribuidores (
-                codigo, nombre, dui, telefono, email, cargo, sucursal,
+                codigo, nombre, telefono, email, cargo, sucursal,
                 fecha_inicio, direccion, departamento, municipio,
                 tipo_contrato, comisiones_especificas, metodo_pago, nit, nrc,
                 cuenta_bancaria, notas
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             data.get("codigo", ""),
             data.get("nombre", ""),
-            data.get("dui", ""),
             data.get("telefono", ""),
             data.get("email", ""),
             data.get("cargo", ""),

--- a/dialogs.py
+++ b/dialogs.py
@@ -2504,6 +2504,7 @@ class VendedorDialog(QDialog):
         self.codigo_edit = QLineEdit()
         self.nombre_edit = QLineEdit()
         self.descripcion_edit = QLineEdit()
+        self.dui_edit = QLineEdit()
         self.Distribuidor_combo = QComboBox()
         self.Distribuidores = Distribuidores
         self.Distribuidor_combo.addItem("Sin Distribuidor")
@@ -2515,6 +2516,8 @@ class VendedorDialog(QDialog):
         layout.addWidget(self.nombre_edit)
         layout.addWidget(QLabel("Descripción:"))
         layout.addWidget(self.descripcion_edit)
+        layout.addWidget(QLabel("DUI:"))
+        layout.addWidget(self.dui_edit)
         layout.addWidget(QLabel("Distribuidor:"))
         layout.addWidget(self.Distribuidor_combo)
 
@@ -2536,6 +2539,7 @@ class VendedorDialog(QDialog):
             self.codigo_edit.setText(vendedor.get("codigo", ""))
             self.nombre_edit.setText(vendedor.get("nombre", ""))
             self.descripcion_edit.setText(vendedor.get("descripcion", ""))
+            self.dui_edit.setText(vendedor.get("dui", ""))
             Distribuidor_id = vendedor.get("Distribuidor_id")
             if Distribuidor_id:
                 for i, d in enumerate(self.Distribuidores):
@@ -2552,6 +2556,7 @@ class VendedorDialog(QDialog):
             "codigo": self.codigo_edit.text(),
             "nombre": self.nombre_edit.text(),
             "descripcion": self.descripcion_edit.text(),
+            "dui": self.dui_edit.text(),
             "Distribuidor_id": Distribuidor_id,
         }
 class CompraDetalleDialog(QDialog):

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -133,7 +133,7 @@ class InventoryManager:
             dist_id = vend.get("Distribuidor_id")
             new_dist_id = Distribuidor_id_map.get(dist_id) if dist_id is not None else None
             self.db.add_vendedor(
-                vend["nombre"], vend.get("descripcion", ""), new_dist_id, vend.get("codigo")
+                vend["nombre"], vend.get("descripcion", ""), new_dist_id, vend.get("codigo"), vend.get("dui")
             )
             self.db.cursor.execute("SELECT id FROM vendedores WHERE nombre=? ORDER BY id DESC LIMIT 1", (vend["nombre"],))
             new_id = self.db.cursor.fetchone()["id"]
@@ -350,8 +350,8 @@ class InventoryManager:
         self.db.add_Distribuidor(nombre)
         self.refresh_data()
 
-    def add_vendedor(self, nombre, Distribuidor_id=None, codigo=None):
-        self.db.add_vendedor(nombre, Distribuidor_id=Distribuidor_id, codigo=codigo)
+    def add_vendedor(self, nombre, Distribuidor_id=None, codigo=None, dui=None):
+        self.db.add_vendedor(nombre, Distribuidor_id=Distribuidor_id, codigo=codigo, dui=dui)
         self.refresh_data()
 
     def add_cliente(

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -943,7 +943,8 @@ class MainWindow(QMainWindow):
                 data["nombre"],
                 data["descripcion"],
                 data["Distribuidor_id"],
-                data["codigo"]
+                data["codigo"],
+                data.get("dui")
             )
             self.manager.refresh_data()
             self.compras_tab.refresh_filters()
@@ -970,7 +971,8 @@ class MainWindow(QMainWindow):
                 data["codigo"],
                 data["nombre"],
                 data["descripcion"],
-                data["Distribuidor_id"]
+                data["Distribuidor_id"],
+                data.get("dui")
             )
             self.manager.refresh_data()
             self.compras_tab.refresh_filters()
@@ -1009,7 +1011,7 @@ class MainWindow(QMainWindow):
             # Actualiza el Distribuidor en la base de datos
             self.manager.db.cursor.execute("""
                 UPDATE Distribuidores SET
-                    codigo=?, nombre=?, dui=?, telefono=?, email=?, cargo=?, sucursal=?,
+                    codigo=?, nombre=?, telefono=?, email=?, cargo=?, sucursal=?,
                     comision_base=?, fecha_inicio=?, direccion=?, departamento=?, municipio=?,
                     tipo_contrato=?, comisiones_especificas=?, metodo_pago=?, nit=?, nrc=?,
                     cuenta_bancaria=?, notas=?
@@ -1017,7 +1019,6 @@ class MainWindow(QMainWindow):
             """, (
                 data.get("codigo", ""),
                 data.get("nombre", ""),
-                data.get("dui", ""),
                 data.get("telefono", ""),
                 data.get("email", ""),
                 data.get("cargo", ""),


### PR DESCRIPTION
## Summary
- drop `dui` from `Distribuidores` table
- add `dui` column for `vendedores` and migrate existing DBs
- handle DUI in vendor CRUD methods and import logic
- extend vendor dialog/UI to edit DUI

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Qt platform plugin not available)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5c843d88323b09637eb51641348