### PR TITLE
Fix distributor info dialog crash

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2377,6 +2377,45 @@ class DistribuidorDialog(QDialog):
             "notas": self.notas_edit.text()
         }
 
+class DistribuidorInfoDialog(QDialog):
+    def __init__(self, distribuidor, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Información de Distribuidor")
+        layout = QVBoxLayout()
+        form = QFormLayout()
+
+        fields = [
+            ("Código:", distribuidor.get("codigo", "")),
+            ("Nombre:", distribuidor.get("nombre", "")),
+            ("Teléfono:", distribuidor.get("telefono", "")),
+            ("Email:", distribuidor.get("email", "")),
+            ("Cargo:", distribuidor.get("cargo", "")),
+            ("Sucursal/Laboratorio:", distribuidor.get("sucursal", "")),
+            ("Comisión base:", str(distribuidor.get("comision_base", ""))),
+            ("Fecha de inicio:", distribuidor.get("fecha_inicio", "")),
+            ("Dirección:", distribuidor.get("direccion", "")),
+            ("Departamento:", distribuidor.get("departamento", "")),
+            ("Municipio:", distribuidor.get("municipio", "")),
+            ("Tipo de contrato:", distribuidor.get("tipo_contrato", "")),
+            ("Comisiones específicas:", distribuidor.get("comisiones_especificas", "")),
+            ("Método/periodicidad pago:", distribuidor.get("metodo_pago", "")),
+            ("NIT:", distribuidor.get("nit", "")),
+            ("NRC:", distribuidor.get("nrc", "")),
+            ("Cuenta bancaria:", distribuidor.get("cuenta_bancaria", "")),
+            ("Notas:", distribuidor.get("notas", "")),
+        ]
+
+        for label, value in fields:
+            line = QLineEdit(value)
+            line.setReadOnly(True)
+            form.addRow(label, line)
+
+        layout.addLayout(form)
+        close_btn = QPushButton("Cerrar")
+        close_btn.clicked.connect(self.accept)
+        layout.addWidget(close_btn, alignment=Qt.AlignRight)
+        self.setLayout(layout)
+
 class ClienteDialog(QDialog):
     def __init__(self, parent=None, cliente=None, codigo_sugerido=None):
         super().__init__(parent)

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -15,6 +15,7 @@ from dialogs import (
     ProductDialog,
     RegisterPurchaseDialog,
     DistribuidorDialog,
+    DistribuidorInfoDialog,
     ClienteDialog,
     EstadoCuentaDialog,
 )
@@ -1061,28 +1062,8 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "Información de Distribuidor", "No se encontró el Distribuidor seleccionado.")
             return
 
-        # Construye el texto con toda la información relevante
-        info = (
-            f"<b>Código:</b> {Distribuidor['codigo'] if 'codigo' in Distribuidor.keys() else ''}<br>"
-            f"<b>Nombre:</b> {Distribuidor['nombre'] if 'nombre' in Distribuidor.keys() else ''}<br>"
-            f"<b>Teléfono:</b> {Distribuidor['telefono'] if 'telefono' in Distribuidor.keys() else ''}<br>"
-            f"<b>Email:</b> {Distribuidor['email'] if 'email' in Distribuidor.keys() else ''}<br>"
-            f"<b>Cargo:</b> {Distribuidor['cargo'] if 'cargo' in Distribuidor.keys() else ''}<br>"
-            f"<b>Sucursal/Laboratorio:</b> {Distribuidor['sucursal'] if 'sucursal' in Distribuidor.keys() else ''}<br>"
-            f"<b>Comisión base:</b> {Distribuidor['comision_base'] if 'comision_base' in Distribuidor.keys() else ''}<br>"
-            f"<b>Fecha de inicio:</b> {Distribuidor['fecha_inicio'] if 'fecha_inicio' in Distribuidor.keys() else ''}<br>"
-            f"<b>Dirección:</b> {Distribuidor['direccion'] if 'direccion' in Distribuidor.keys() else ''}<br>"
-            f"<b>Departamento:</b> {Distribuidor['departamento'] if 'departamento' in Distribuidor.keys() else ''}<br>"
-            f"<b>Municipio:</b> {Distribuidor['municipio'] if 'municipio' in Distribuidor.keys() else ''}<br>"
-            f"<b>Tipo de contrato:</b> {Distribuidor['tipo_contrato'] if 'tipo_contrato' in Distribuidor.keys() else ''}<br>"
-            f"<b>Comisiones específicas:</b> {Distribuidor['comisiones_especificas'] if 'comisiones_especificas' in Distribuidor.keys() else ''}<br>"
-            f"<b>Método/periodicidad pago:</b> {Distribuidor['metodo_pago'] if 'metodo_pago' in Distribuidor.keys() else ''}<br>"
-            f"<b>NIT:</b> {Distribuidor['nit'] if 'nit' in Distribuidor.keys() else ''}<br>"
-            f"<b>NRC:</b> {Distribuidor['nrc'] if 'nrc' in Distribuidor.keys() else ''}<br>"
-            f"<b>Cuenta bancaria:</b> {Distribuidor['cuenta_bancaria'] if 'cuenta_bancaria' in Distribuidor.keys() else ''}<br>"
-            f"<b>Notas:</b> {Distribuidor['notas'] if 'notas' in Distribuidor.keys() else ''}"
-        )
-        QMessageBox.information(self, "Información de Distribuidor", info)
+        dialog = DistribuidorInfoDialog(Distribuidor, self)
+        dialog.exec_()
 
     def _actualizar_tabla_clientes(self):
         search = self.cliente_search.text()


### PR DESCRIPTION
## Summary
- add a dedicated dialog to display distributor information in read‑only mode
- open the new dialog from the 'Info de Distribuidor' button

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: duplicate column name: dui)*

------
https://chatgpt.com/codex/tasks/task_e_686eba0a0dc08323bbf91265cd921c85