### PR TITLE
Fix duplicate dui columns

### DIFF
--- a/db.py
+++ b/db.py
@@ -46,7 +46,6 @@ class DB:
                 dui TEXT,
                 descripcion TEXT,
                 Distribuidor_id INTEGER,
-                dui TEXT,
                 FOREIGN KEY (Distribuidor_id) REFERENCES Distribuidores(id)
             )
         """)
@@ -278,11 +277,6 @@ class DB:
         # Asegura que la columna descripcion exista en vendedores
         try:
             self.cursor.execute("ALTER TABLE vendedores ADD COLUMN descripcion TEXT")
-            self.conn.commit()
-        except Exception:
-            pass  # Ya existe la columna
-        try:
-            self.cursor.execute("ALTER TABLE vendedores ADD COLUMN dui TEXT")
             self.conn.commit()
         except Exception:
             pass  # Ya existe la columna


### PR DESCRIPTION
## Summary
- drop duplicate `dui` column from `vendedores` table creation
- remove repeated `ALTER TABLE vendedores ADD COLUMN dui` in setup

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -vv` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686ec5548cf48323bdac6ad2ca11b5d9