### PR TITLE
Add credit/debit notes support

### DIFF
--- a/db.py
+++ b/db.py
@@ -123,6 +123,17 @@ class DB:
             )
         """)
         self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS notas (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tipo TEXT CHECK(tipo IN ('credito', 'debito')),
+                venta_id INTEGER REFERENCES ventas(id),
+                fecha TEXT,
+                monto REAL,
+                motivo TEXT,
+                detalles TEXT
+            )
+        """)
+        self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS compras (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 fecha TEXT,
@@ -1184,5 +1195,52 @@ class DB:
         self.cursor.execute(
             "UPDATE productos SET stock=? WHERE id=?",
             (total, producto_id)
+        )        self.conn.commit()
+
+    # --- NOTAS DE CRÉDITO Y DÉBITO ---
+    def agregar_nota(self, tipo, venta_id, fecha, monto, motivo, detalles=None):
+        """Registra una nota de crédito o débito asociada a una venta."""
+        if tipo not in ("credito", "debito"):
+            raise ValueError("tipo debe ser 'credito' o 'debito'")
+
+        self.cursor.execute("SELECT id FROM ventas WHERE id=?", (venta_id,))
+        if self.cursor.fetchone() is None:
+            raise ValueError("La venta indicada no existe")
+
+        detalles_json = json.dumps(detalles) if detalles is not None else None
+        self.cursor.execute(
+            """
+            INSERT INTO notas (tipo, venta_id, fecha, monto, motivo, detalles)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (tipo, venta_id, fecha, monto, motivo, detalles_json),
         )
         self.conn.commit()
+        return self.cursor.lastrowid
+
+    def obtener_notas_por_venta(self, venta_id):
+        """Devuelve todas las notas registradas para una venta."""
+        self.cursor.execute(
+            "SELECT * FROM notas WHERE venta_id=? ORDER BY fecha",
+            (venta_id,),
+        )
+        rows = [dict(row) for row in self.cursor.fetchall()]
+        for r in rows:
+            if r.get("detalles"):
+                try:
+                    r["detalles"] = json.loads(r["detalles"])
+                except Exception:
+                    pass
+        return rows
+
+    def obtener_notas(self):
+        """Devuelve todas las notas registradas en el sistema."""
+        self.cursor.execute("SELECT * FROM notas ORDER BY fecha")
+        rows = [dict(row) for row in self.cursor.fetchall()]
+        for r in rows:
+            if r.get("detalles"):
+                try:
+                    r["detalles"] = json.loads(r["detalles"])
+                except Exception:
+                    pass
+        return rows

--- a/tests/test_notas.py
+++ b/tests/test_notas.py
@@ -1,0 +1,30 @@
+import pytest
+from db import DB
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_agregar_y_obtener_notas():
+    db = create_db()
+    db.add_cliente("Juan", "", "", "", "", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 100, cliente_id=cliente_id)
+
+    note_id = db.agregar_nota("credito", venta_id, "2024-01-02", 25.0, "Devolucion", {"linea": 1})
+    assert isinstance(note_id, int)
+
+    notas = db.obtener_notas_por_venta(venta_id)
+    assert len(notas) == 1
+    nota = notas[0]
+    assert nota["tipo"] == "credito"
+    assert nota["venta_id"] == venta_id
+    assert nota["monto"] == 25.0
+    assert nota["motivo"] == "Devolucion"
+    assert nota["detalles"] == {"linea": 1}
+
+def test_agregar_nota_venta_inexistente():
+    db = create_db()
+    with pytest.raises(ValueError):
+        db.agregar_nota("debito", 999, "2024-01-03", 10, "extra")


### PR DESCRIPTION
## Summary
- create a new `notas` table to store credit/debit notes
- implement DB helpers for adding and retrieving notes
- provide basic tests covering the new API

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Aborted - PyQt initialization)*

------
https://chatgpt.com/codex/tasks/task_e_686efca4fd948323b0db3c9d57b5f308