### PR TITLE
Add ticket PDF generation and notas support

### DIFF
--- a/db.py
+++ b/db.py
@@ -123,6 +123,17 @@ class DB:
             )
         """)
         self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS notas (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venta_id INTEGER,
+                tipo TEXT,
+                fecha TEXT,
+                monto REAL,
+                motivo TEXT,
+                FOREIGN KEY (venta_id) REFERENCES ventas(id)
+            )
+        """)
+        self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS compras (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 fecha TEXT,
@@ -931,6 +942,23 @@ class DB:
             params.append(fecha_fin)
         query += " ORDER BY fecha"
         self.cursor.execute(query, params)
+        return [dict(row) for row in self.cursor.fetchall()]
+
+    def add_nota(self, venta_id, tipo, fecha, monto, motivo):
+        """Registra una nota de crédito o débito."""
+        self.cursor.execute(
+            "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, ?, ?, ?, ?)",
+            (venta_id, tipo, fecha, monto, motivo),
+        )
+        self.conn.commit()
+        return self.cursor.lastrowid
+
+    def get_notas_by_venta(self, venta_id):
+        """Devuelve las notas asociadas a una venta."""
+        self.cursor.execute(
+            "SELECT * FROM notas WHERE venta_id=? ORDER BY fecha",
+            (venta_id,),
+        )
         return [dict(row) for row in self.cursor.fetchall()]
 
     def get_estado_cuenta_cliente(self, cliente_id, fecha_inicio=None, fecha_fin=None):

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -25,8 +25,11 @@ def generar_factura_electronica_pdf(
     if datos_negocio is None:
         datos_negocio = {}
         if os.path.exists(DATOS_NEGOCIO_PATH):
-            with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
-                datos_negocio = json.load(f)
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    datos_negocio = json.load(f)
+            except Exception:
+                datos_negocio = {}
 
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1,0 +1,96 @@
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QTableWidget,
+    QTableWidgetItem,
+    QPushButton,
+    QFileDialog,
+    QInputDialog,
+    QMessageBox,
+)
+from PyQt5.QtCore import QDate
+
+from ticket_pdf import generar_ticket_pdf
+
+
+class FacturacionTab(QWidget):
+    """Tab para gestionar facturas y notas."""
+
+    def __init__(self, manager, parent=None):
+        super().__init__(parent)
+        self.manager = manager
+        self._setup_ui()
+        self.load_invoices()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        self.table = QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels(["ID", "Fecha", "Cliente", "Total"])
+        layout.addWidget(self.table)
+
+        btns = QHBoxLayout()
+        self.btn_ticket = QPushButton("Generar ticket virtual")
+        self.btn_credito = QPushButton("Nota de crédito")
+        self.btn_debito = QPushButton("Nota de débito")
+        btns.addWidget(self.btn_ticket)
+        btns.addWidget(self.btn_credito)
+        btns.addWidget(self.btn_debito)
+        btns.addStretch(1)
+        layout.addLayout(btns)
+
+        self.btn_ticket.clicked.connect(self.create_ticket)
+        self.btn_credito.clicked.connect(lambda: self.create_nota("credito"))
+        self.btn_debito.clicked.connect(lambda: self.create_nota("debito"))
+
+    def load_invoices(self):
+        ventas = self.manager.db.get_ventas()
+        clientes = {c["id"]: c["nombre"] for c in self.manager._clientes}
+        self.table.setRowCount(len(ventas))
+        for row, v in enumerate(ventas):
+            self.table.setItem(row, 0, QTableWidgetItem(str(v.get("id"))))
+            self.table.setItem(row, 1, QTableWidgetItem(v.get("fecha", "")))
+            self.table.setItem(row, 2, QTableWidgetItem(clientes.get(v.get("cliente_id"), "")))
+            self.table.setItem(row, 3, QTableWidgetItem(f"${v.get('total', 0):.2f}"))
+        if ventas:
+            self.table.selectRow(0)
+
+    def _selected_venta(self):
+        if self.table.currentRow() < 0:
+            return None
+        item = self.table.item(self.table.currentRow(), 0)
+        if item:
+            try:
+                return int(item.text())
+            except ValueError:
+                return None
+        return None
+
+    def create_ticket(self):
+        venta_id = self._selected_venta()
+        if venta_id is None:
+            QMessageBox.warning(self, "Ticket", "Seleccione una venta")
+            return
+        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
+        detalles = self.manager.db.get_detalles_venta(venta_id)
+        fname, _ = QFileDialog.getSaveFileName(self, "Guardar ticket", "ticket.pdf", "PDF (*.pdf)")
+        if not fname:
+            return
+        generar_ticket_pdf(venta, detalles, fname)
+        QMessageBox.information(self, "Ticket", "Ticket generado correctamente")
+
+    def create_nota(self, tipo):
+        venta_id = self._selected_venta()
+        if venta_id is None:
+            QMessageBox.warning(self, "Nota", "Seleccione una venta")
+            return
+        monto, ok = QInputDialog.getDouble(self, "Monto", "Monto de la nota", 0, decimals=2)
+        if not ok:
+            return
+        motivo, ok2 = QInputDialog.getText(self, "Motivo", "Motivo")
+        if not ok2:
+            return
+        fecha = QDate.currentDate().toString("yyyy-MM-dd")
+        self.manager.db.add_nota(venta_id, tipo, fecha, monto, motivo)
+        QMessageBox.information(self, "Nota", "Nota registrada")
+        self.load_invoices()

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QDateEdit,
     QTextEdit,
     QMessageBox,
+    QFileDialog,
     QAbstractItemView,
 
     QHeaderView,
@@ -24,6 +25,7 @@ from PyQt5.QtCore import Qt, QDate, QUrl, QThread, pyqtSignal
 from PyQt5.QtGui import QDesktopServices, QPixmap
 from datetime import datetime
 from factura_sv import generar_factura_electronica_pdf
+from ticket_pdf import generar_ticket_pdf
 from dialogs import ManualInvoiceDialog
 import tempfile
 import subprocess
@@ -159,12 +161,15 @@ class SalesTab(QWidget):
         self.btn_enviar = QPushButton("Enviar por correo")
         self.btn_imprimir = QPushButton("Imprimir PDF")
         self.btn_editar = QPushButton("Editar factura")
+        self.btn_ticket = QPushButton("Ticket")
         btn_layout.addWidget(self.btn_guardar)
         btn_layout.addWidget(self.btn_enviar)
         btn_layout.addWidget(self.btn_imprimir)
         btn_layout.addWidget(self.btn_editar)
+        btn_layout.addWidget(self.btn_ticket)
         self.btn_guardar.clicked.connect(self.save_pdf)
         self.btn_enviar.clicked.connect(self.send_email)
+        self.btn_ticket.clicked.connect(self.save_ticket)
         preview_layout.addLayout(btn_layout)
 
         preview_widget = QWidget()
@@ -634,6 +639,27 @@ class SalesTab(QWidget):
             archivo=filename,
         )
         QMessageBox.information(self, "Guardar PDF", f"Factura guardada en {filename}")
+
+    def save_ticket(self):
+        """Generate a simple ticket PDF for the selected sale."""
+        if self.sales_table.currentRow() < 0:
+            QMessageBox.warning(self, "Ticket", "Seleccione una factura primero.")
+            return
+
+        row = self.sales_table.currentRow()
+        venta_id = int(self.sales_table.item(row, 0).text())
+        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
+        if not venta:
+            QMessageBox.warning(self, "Ticket", "No se encontró la venta seleccionada.")
+            return
+
+        detalles = self.manager.db.get_detalles_venta(venta_id)
+        filename, _ = QFileDialog.getSaveFileName(self, "Guardar ticket", "ticket.pdf", "PDF (*.pdf)")
+        if not filename:
+            return
+
+        generar_ticket_pdf(venta, detalles, filename)
+        QMessageBox.information(self, "Ticket", f"Ticket guardado en {filename}")
 
     def preview_pdf(self):
         """Generate a temporary PDF and open it with the default viewer."""

--- a/tests/test_ticket_and_nota.py
+++ b/tests/test_ticket_and_nota.py
@@ -1,0 +1,23 @@
+from db import DB
+from ticket_pdf import generar_ticket_pdf
+import os
+
+
+def test_add_nota_and_retrieve(tmp_path):
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 100)
+    db.add_nota(venta_id, "credito", "2024-01-02", 10.0, "devolucion")
+    notas = db.get_notas_by_venta(venta_id)
+    assert len(notas) == 1
+    n = notas[0]
+    assert n["tipo"] == "credito"
+    assert n["monto"] == 10.0
+
+
+def test_generar_ticket_pdf(tmp_path):
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "precio_unitario": 10}]
+    archivo = tmp_path / "ticket.pdf"
+    generar_ticket_pdf(venta, detalles, str(archivo))
+    assert archivo.exists()
+    assert archivo.stat().st_size > 0

--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -1,0 +1,50 @@
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+import json
+import os
+
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+
+
+def generar_ticket_pdf(venta, detalles, archivo="ticket.pdf", datos_negocio=None):
+    """Genera un PDF sencillo tipo ticket para una venta."""
+    if datos_negocio is None:
+        datos_negocio = {}
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    datos_negocio = json.load(f)
+            except Exception:
+                datos_negocio = {}
+
+    c = canvas.Canvas(archivo, pagesize=letter)
+    width, height = letter
+    y = height - 40
+
+    c.setFont("Helvetica-Bold", 12)
+    c.drawCentredString(width / 2, y, datos_negocio.get("nombre_comercial", "TICKET"))
+    y -= 20
+    c.setFont("Helvetica", 10)
+    c.drawString(40, y, f"Fecha: {venta.get('fecha', '')}")
+    y -= 20
+    c.drawString(40, y, "Detalles:")
+    y -= 14
+
+    for d in detalles:
+        desc = d.get("descripcion", "")
+        qty = d.get("cantidad", 0)
+        pu = d.get("precio_unitario", 0)
+        total = qty * pu
+        c.drawString(40, y, f"{desc} x{qty} @ {pu:.2f}")
+        c.drawRightString(width - 40, y, f"{total:.2f}")
+        y -= 14
+        if y < 60:
+            c.showPage()
+            y = height - 40
+
+    y -= 10
+    c.setFont("Helvetica-Bold", 12)
+    c.drawRightString(width - 40, y, f"Total: {venta.get('total', 0):.2f}")
+
+    c.showPage()
+    c.save()

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -23,6 +23,7 @@ from dialogs import (
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 LAST_INVENTORY_PATH = os.path.join(os.path.dirname(__file__), "ultimo_inventario.json")
 from sales_tab import SalesTab
+from facturacion_tab import FacturacionTab
 from datetime import datetime
 
 from num2words import num2words  # Instala las dependencias con: pip install -r requirements.txt
@@ -270,6 +271,9 @@ class MainWindow(QMainWindow):
         # --- PESTAÑA DE VENTAS ---
         self.sales_tab = SalesTab(self.manager, self)
 
+        # --- PESTAÑA DE FACTURACIÓN ---
+        self.facturacion_tab = FacturacionTab(self.manager, self)
+
         # --- PESTAÑA DE COMPRAS ---
         from purchases_tab import PurchasesTab
         self.compras_tab = PurchasesTab(self.manager, self)
@@ -305,6 +309,7 @@ class MainWindow(QMainWindow):
         vend_dist_tab.setObjectName("Vendedores y Distribuidores")
         clientes_tab.setObjectName("Clientes")
         self.sales_tab.setObjectName("Ventas")
+        self.facturacion_tab.setObjectName("Facturación")
         self.compras_tab.setObjectName("Compras")
         inventario_actual_tab.setObjectName("Inventario actual")
 
@@ -312,6 +317,7 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(vend_dist_tab, "Vendedores y Distribuidores")
         self.tabs.addTab(clientes_tab, "Clientes")
         self.tabs.addTab(self.sales_tab, "Ventas")
+        self.tabs.addTab(self.facturacion_tab, "Facturación")
         self.tabs.addTab(self.compras_tab, "Compras")
         self.tabs.addTab(inventario_actual_tab, "Inventario actual")
         self.setCentralWidget(self.tabs)


### PR DESCRIPTION
## Summary
- create a table for notas and CRUD helpers
- add ticket PDF generation module
- implement FacturacionTab and wire into main window
- expose ticket generation in SalesTab
- provide unit tests for notes and ticket generation
- handle invalid `datos_negocio.json`

## Testing
- `pytest tests/test_ticket_and_nota.py -q`
- `python -m pytest -q` *(shows dots for all tests)*

------
https://chatgpt.com/codex/tasks/task_e_686efd85786083239019b9c58f128514