### PR TITLE
Add empty Facturacion tab

### DIFF
--- a/db.py
+++ b/db.py
@@ -1213,7 +1213,8 @@ class DB:
         self.cursor.execute(
             "UPDATE productos SET stock=? WHERE id=?",
             (total, producto_id)
-        )        self.conn.commit()
+        )
+        self.conn.commit()
 
     # --- NOTAS DE CRÉDITO Y DÉBITO ---
     def agregar_nota(self, tipo, venta_id, fecha, monto, motivo, detalles=None):

--- a/facturacion_vacia_tab.py
+++ b/facturacion_vacia_tab.py
@@ -1,0 +1,9 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+class FacturacionVaciaTab(QWidget):
+    """Pestaña vacía de facturación para futuras ampliaciones."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Pestaña de facturación en construcción"))

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -24,6 +24,7 @@ DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json
 LAST_INVENTORY_PATH = os.path.join(os.path.dirname(__file__), "ultimo_inventario.json")
 from sales_tab import SalesTab
 from facturacion_tab import FacturacionTab
+from facturacion_vacia_tab import FacturacionVaciaTab
 from datetime import datetime
 
 from num2words import num2words  # Instala las dependencias con: pip install -r requirements.txt
@@ -312,6 +313,8 @@ class MainWindow(QMainWindow):
         self.facturacion_tab.setObjectName("Facturación")
         self.compras_tab.setObjectName("Compras")
         inventario_actual_tab.setObjectName("Inventario actual")
+        self.facturacion_vacia_tab = FacturacionVaciaTab(self)
+        self.facturacion_vacia_tab.setObjectName("Facturacion")
 
         self.tabs.addTab(tab_widget, "Inventario")
         self.tabs.addTab(vend_dist_tab, "Vendedores y Distribuidores")
@@ -320,6 +323,7 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(self.facturacion_tab, "Facturación")
         self.tabs.addTab(self.compras_tab, "Compras")
         self.tabs.addTab(inventario_actual_tab, "Inventario actual")
+        self.tabs.addTab(self.facturacion_vacia_tab, "Facturacion")
         self.setCentralWidget(self.tabs)
 
         # --- PESTAÑA DE TRABAJADORES ---


### PR DESCRIPTION
## Summary
- create a placeholder `FacturacionVaciaTab` widget
- include the new tab in the main window
- fix a syntax error in `db.py`

## Testing
- `pytest tests/test_monto.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f056990f08323b889c7d05c5eb39f