### PR TITLE
Add header text validation in ticket PDF test

### DIFF
--- a/tests/test_ticket_and_nota.py
+++ b/tests/test_ticket_and_nota.py
@@ -1,6 +1,6 @@
 from db import DB
 from ticket_pdf import generar_ticket_pdf
-import os
+import fitz
 
 
 def test_add_nota_and_retrieve(tmp_path):
@@ -21,3 +21,15 @@ def test_generar_ticket_pdf(tmp_path):
     generar_ticket_pdf(venta, detalles, str(archivo))
     assert archivo.exists()
     assert archivo.stat().st_size > 0
+
+
+def test_generar_ticket_pdf_header(tmp_path):
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "precio_unitario": 10}]
+    datos = {"nombre_comercial": "MI NEGOCIO"}
+    archivo = tmp_path / "ticket.pdf"
+    generar_ticket_pdf(venta, detalles, str(archivo), datos_negocio=datos)
+    assert archivo.exists()
+    with fitz.open(archivo) as doc:
+        text = "".join(p.get_text() for p in doc)
+    assert "MI NEGOCIO" in text


### PR DESCRIPTION
## Summary
- extend ticket PDF tests to verify header text
- parse the generated PDF using PyMuPDF to look for business name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff4f789e48323a7fbeba3005c078a