### PR TITLE
Load datos_negocio in PDF reports

### DIFF
--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -11,9 +11,20 @@ from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 from datetime import datetime
+import json
+import os
+
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
 
-def generar_reporte_vendedor_pdf(db, vendedor_id, fecha_inicio, fecha_fin, archivo="reporte_vendedor.pdf"):
+def generar_reporte_vendedor_pdf(
+    db,
+    vendedor_id,
+    fecha_inicio,
+    fecha_fin,
+    archivo="reporte_vendedor.pdf",
+    datos_negocio=None,
+):
     """Genera un PDF con el detalle de ventas por vendedor."""
     vendedor = db.get_trabajador(vendedor_id)
     if not vendedor:
@@ -32,12 +43,21 @@ def generar_reporte_vendedor_pdf(db, vendedor_id, fecha_inicio, fecha_fin, archi
             d["cliente_id"] = cid
             grouped.setdefault(cid, []).append(d)
 
+    if datos_negocio is None:
+        datos_negocio = {}
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    datos_negocio = json.load(f)
+            except Exception:
+                datos_negocio = {}
+
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter
     y = height - 40
 
     c.setFont("Courier-Bold", 12)
-    c.drawCentredString(width / 2, y, "FARMACIA SANTA CATALINA")
+    c.drawCentredString(width / 2, y, datos_negocio.get("nombre_comercial", ""))
     y -= 14
     c.setFont("Courier", 10)
     titulo = f"Reporte de VENTAS por VENDEDOR desde: {fecha_inicio} al {fecha_fin}"
@@ -98,10 +118,25 @@ def generar_reporte_vendedor_pdf(db, vendedor_id, fecha_inicio, fecha_fin, archi
     c.save()
 
 
-def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", **kwargs):
+def generar_estado_cuenta_pdf(
+    db,
+    modo="cliente",
+    archivo="estado_cuenta.pdf",
+    datos_negocio=None,
+    **kwargs,
+):
     """Genera un PDF de estado de cuenta similar al ejemplo de ventas."""
     fecha_inicio = kwargs.get("fecha_inicio", "")
     fecha_fin = kwargs.get("fecha_fin", "")
+
+    if datos_negocio is None:
+        datos_negocio = {}
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    datos_negocio = json.load(f)
+            except Exception:
+                datos_negocio = {}
 
     doc = SimpleDocTemplate(
         archivo,
@@ -146,7 +181,7 @@ def generar_estado_cuenta_pdf(db, modo="cliente", archivo="estado_cuenta.pdf", *
     )
 
     elements = [
-        Paragraph("FARMACIA SANTA CATALINA", style_title),
+        Paragraph(datos_negocio.get("nombre_comercial", ""), style_title),
         Paragraph(
             f"Estado de cuenta desde: {fecha_inicio} al {fecha_fin}", style_subtitle
         ),

--- a/estado_ventas_pdf.py
+++ b/estado_ventas_pdf.py
@@ -3,13 +3,17 @@ from reportlab.pdfgen import canvas
 from reportlab.platypus import Table, TableStyle
 from reportlab.lib import colors
 from datetime import datetime
+import json
+import os
+
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
 
-def _draw_header(c, width, height, vendedor, fecha_inicio, fecha_fin):
+def _draw_header(c, width, height, vendedor, fecha_inicio, fecha_fin, datos_negocio):
     """Dibuja el encabezado principal y retorna la coordenada y inicial."""
     y = height - 40
     c.setFont("Helvetica-Bold", 14)
-    c.drawCentredString(width / 2, y, "FARMACIA SANTA CATALINA")
+    c.drawCentredString(width / 2, y, datos_negocio.get("nombre_comercial", ""))
     y -= 16
     c.setFont("Helvetica-Bold", 10)
     titulo = f"Reporte de VENTAS por VENDEDOR desde: {fecha_inicio} al {fecha_fin}"
@@ -30,13 +34,29 @@ def _draw_footer(c, width, page_number):
     c.drawRightString(width - 40, 30, f"Página {page_number}")
 
 
-def generar_estado_ventas_pdf(vendedor, fecha_inicio, fecha_fin, ventas_por_cliente, archivo):
+def generar_estado_ventas_pdf(
+    vendedor,
+    fecha_inicio,
+    fecha_fin,
+    ventas_por_cliente,
+    archivo,
+    datos_negocio=None,
+):
     """Genera un reporte de ventas por vendedor en formato PDF."""
+    if datos_negocio is None:
+        datos_negocio = {}
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    datos_negocio = json.load(f)
+            except Exception:
+                datos_negocio = {}
+
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter
 
     page = 1
-    y = _draw_header(c, width, height, vendedor, fecha_inicio, fecha_fin)
+    y = _draw_header(c, width, height, vendedor, fecha_inicio, fecha_fin, datos_negocio)
 
     margin_bottom = 50
     row_height = 14
@@ -53,7 +73,15 @@ def generar_estado_ventas_pdf(vendedor, fecha_inicio, fecha_fin, ventas_por_clie
             _draw_footer(c, width, page)
             c.showPage()
             page += 1
-            y = _draw_header(c, width, height, vendedor, fecha_inicio, fecha_fin)
+            y = _draw_header(
+                c,
+                width,
+                height,
+                vendedor,
+                fecha_inicio,
+                fecha_fin,
+                datos_negocio,
+            )
 
         c.setFont("Helvetica-Bold", 9)
         c.drawString(40, y, f"CLIENTE: {nombre_cli} - {dui_cli}")

--- a/prueba de estado de ventas.py
+++ b/prueba de estado de ventas.py
@@ -8,6 +8,10 @@ from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, 
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfbase import pdfmetrics
+import json
+import os
+
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
 # Puedes registrar Arial si tienes el archivo, si no, Helvetica es suficiente
 # pdfmetrics.registerFont(TTFont('Arial', 'arial.ttf'))
@@ -22,12 +26,21 @@ def calcular_comision(total, porc):
         porc_val = 0
     return round(total * (porc_val / 100), 2)
 
-def generar_estado_ventas_pdf(filename):
+def generar_estado_ventas_pdf(filename, datos_negocio=None):
     # Datos de ejemplo (exactamente como en la foto, con cálculos corregidos)
     fecha_reporte = "20/06/2025"
     fecha_inicio = "01/01/2025"
     fecha_fin = "31/12/2025"
     vendedor = {"nombre": "JAVIER PORTILLO", "codigo": "005"}
+
+    if datos_negocio is None:
+        datos_negocio = {}
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    datos_negocio = json.load(f)
+            except Exception:
+                datos_negocio = {}
 
     clientes = [
         {
@@ -226,7 +239,7 @@ def generar_estado_ventas_pdf(filename):
     style_normal = ParagraphStyle('normal', parent=styles['Normal'], fontSize=8, fontName='Helvetica')
 
     # Encabezado
-    elements.append(Paragraph("FARMACIA SANTA CATALINA", style_title))
+    elements.append(Paragraph(datos_negocio.get("nombre_comercial", ""), style_title))
     elements.append(Paragraph(f"Reporte de VENTAS por VENDEDOR desde: {fecha_inicio} al {fecha_fin}", style_subtitle))
     elements.append(Spacer(1, 2))
     elements.append(Paragraph(f"{vendedor['nombre']} — {vendedor['codigo']}", style_vendedor))


### PR DESCRIPTION
## Summary
- read datos_negocio.json in report modules
- remove hard coded business name
- adjust page-break header call

## Testing
- `pytest tests/test_date_parsing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870012f13d08323a48f303fa0c8d909