### PR TITLE
Fix datos_negocio.json syntax

### DIFF
--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -25,5 +25,5 @@
   "contador_nit": "",
   "smtp_server": "smtp.gmail.com",
   "smtp_port": "587",
-  "email_usuario": "arieliosefrosales@gmail.com",
+  "email_usuario": "arieliosefrosales@gmail.com"
 }


### PR DESCRIPTION
## Summary
- remove trailing comma in `datos_negocio.json`
- ensure file ends with newline

## Testing
- `python - <<'PY'
import json
with open('datos_negocio.json') as f:
    json.load(f)
print('OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_687025d529ec8323b3c606649ebdad30