### PR TITLE
Add ticket format comparison test

### DIFF
--- a/tests/fixtures/ticket_fixture.json
+++ b/tests/fixtures/ticket_fixture.json
@@ -1,0 +1,19 @@
+{
+  "venta": {"fecha": "2025-07-03", "total": 21.08},
+  "detalles": [
+    {"descripcion": "Bencobal X 30 Capsulas (G)", "cantidad": 1, "precio_unitario": 29.68}
+  ],
+  "datos_negocio": {
+    "nombre_comercial": "Farmacia San Nicolas S.A. de C.V.",
+    "giro": "Venta de productos farmaceuticos y medicinales",
+    "direccion": "2° Calle Pte. #L-1-13, LA LIBERTAD SUR, La Libertad"
+  },
+  "dte_data": {
+    "selloRecibido": "202558120A7ABA2D4533B92916AD1D0F1EABJ1YW",
+    "firmaElectronica": "",
+    "dteJson": {
+      "codigoGeneracion": "13C694DE-DDA1-499A-B265-4BD5B01CF323",
+      "numeroControl": "DTE-01-S011P005-250000000061675"
+    }
+  }
+}

--- a/tests/test_ticket_format.py
+++ b/tests/test_ticket_format.py
@@ -1,0 +1,31 @@
+import json
+import fitz
+from ticket_pdf import generar_ticket_personalizado
+
+
+def test_custom_ticket_matches_example(tmp_path):
+    with open('tests/fixtures/ticket_fixture.json', 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+
+    out_file = tmp_path / 'ticket.pdf'
+    generar_ticket_personalizado(
+        data['venta'],
+        data['detalles'],
+        archivo=str(out_file),
+        datos_negocio=data['datos_negocio'],
+        dte_data=data['dte_data'],
+    )
+
+    with fitz.open(out_file) as doc:
+        generated_text = "\n".join(p.get_text() for p in doc)
+    with fitz.open('ticket_example.pdf') as doc:
+        example_text = "\n".join(p.get_text() for p in doc)
+
+    subset = [
+        data['datos_negocio']['nombre_comercial'],
+        'Bencobal',
+        '21.08',
+    ]
+    for fragment in subset:
+        assert fragment in generated_text
+        assert fragment in example_text


### PR DESCRIPTION
## Summary
- add fixture with sample data
- generate ticket with sample data and compare with existing PDF

## Testing
- `pytest tests/test_ticket_format.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68704ede78f883239900b64534554341