### PR TITLE
Add sample ticket fixture and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ Si quieres mostrar tu logo, reemplaza `logoinventario.jpg` por tu imagen.
 
 Como referencia puedes revisar `ticket_example.pdf` que se
 incluye en este repositorio.
+
+Para reproducir ese ejemplo ejecuta lo siguiente:
+
+```python
+import json
+from ticket_pdf import generar_ticket_personalizado
+
+with open("tests/data/sample_ticket.json", encoding="utf-8") as f:
+    data = json.load(f)
+
+generar_ticket_personalizado(
+    data["venta"],
+    data["detalles"],
+    "mi_ticket.pdf",
+    datos_negocio=data["datos_negocio"],
+    dte_data=data["dte_data"],
+)
+```

--- a/tests/data/sample_ticket.json
+++ b/tests/data/sample_ticket.json
@@ -1,0 +1,38 @@
+{
+  "venta": {
+    "fecha": "2025-07-03 17:14:41",
+    "total": 21.08,
+    "total_letras": "VEINTIUNO CON 08/100 DOLARES",
+    "forma_pago": "TARJETA DE DEBITO",
+    "codigo_vendedor": "15290",
+    "codigo_cajero": "15290"
+  },
+  "detalles": [
+    {
+      "descripcion": "Bencobal X 30 Capsulas",
+      "cantidad": 1,
+      "precio_unitario": 29.68,
+      "descuento": 8.60,
+      "ventas_gravadas": 21.08
+    }
+  ],
+  "dte_data": {
+    "selloRecibido": "202558120A7ABA2D4533B92916AD1D0F1EABJ1YW",
+    "firmaElectronica": "",
+    "dteJson": {
+      "identificacion": {
+        "codigoGeneracion": "13C694DE-DDA1-499A-B265-4BD5B01CF323"
+      },
+      "numeroControl": "DTE-01-S011P005-250000000061675"
+    }
+  },
+  "datos_negocio": {
+    "nombre_comercial": "Farmacia San Nicolas S.A. de C.V.",
+    "nit": "06142212650014",
+    "nrc": "4065",
+    "giro": "Venta de productos farmacéuticos y medicinales",
+    "direccion": "2° Calle Pte. #L-1-13, LA LIBERTAD SUR, La Libertad",
+    "sucursal": "SANTA TECLA"
+  }
+}
+

--- a/tests/test_sample_ticket.py
+++ b/tests/test_sample_ticket.py
@@ -1,0 +1,28 @@
+import json
+import fitz
+from ticket_pdf import generar_ticket_personalizado
+
+
+def test_sample_ticket_generation(tmp_path):
+    with open('tests/data/sample_ticket.json', encoding='utf-8') as f:
+        data = json.load(f)
+
+    out = tmp_path / 'ticket.pdf'
+    generar_ticket_personalizado(
+        data['venta'],
+        data['detalles'],
+        str(out),
+        datos_negocio=data['datos_negocio'],
+        dte_data=data['dte_data'],
+    )
+
+    assert out.exists()
+
+    assert out.stat().st_size > 0
+
+    with fitz.open(out) as generated:
+        text = ''.join(p.get_text() for p in generated)
+
+    assert "Farmacia San Nicolas" in text
+    assert data["dte_data"]["selloRecibido"] in text
+


### PR DESCRIPTION
## Summary
- add JSON fixture with the data used in `ticket_example.pdf`
- document how to reproduce the sample ticket with `generar_ticket_personalizado`
- add regression test using the new fixture

## Testing
- `pytest tests/test_sample_ticket.py -q` *(fails: ModuleNotFoundError or hangs?)*

------
https://chatgpt.com/codex/tasks/task_e_68704ed7f4ec8323ad6788d1535c11a7