### PR TITLE
Fix duplicate DUI field in Vendedor dialog

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2540,7 +2540,6 @@ class VendedorDialog(QDialog):
         self.nombre_edit = QLineEdit()
         self.dui_edit = QLineEdit()
         self.descripcion_edit = QLineEdit()
-        self.dui_edit = QLineEdit()
         self.Distribuidor_combo = QComboBox()
         self.Distribuidores = Distribuidores
         self.Distribuidor_combo.addItem("Sin Distribuidor")
@@ -2554,8 +2553,6 @@ class VendedorDialog(QDialog):
         layout.addWidget(self.dui_edit)
         layout.addWidget(QLabel("Descripción:"))
         layout.addWidget(self.descripcion_edit)
-        layout.addWidget(QLabel("DUI:"))
-        layout.addWidget(self.dui_edit)
         layout.addWidget(QLabel("Distribuidor:"))
         layout.addWidget(self.Distribuidor_combo)
 
@@ -2578,7 +2575,6 @@ class VendedorDialog(QDialog):
             self.nombre_edit.setText(vendedor.get("nombre", ""))
             self.dui_edit.setText(vendedor.get("dui", ""))
             self.descripcion_edit.setText(vendedor.get("descripcion", ""))
-            self.dui_edit.setText(vendedor.get("dui", ""))
             Distribuidor_id = vendedor.get("Distribuidor_id")
             if Distribuidor_id:
                 for i, d in enumerate(self.Distribuidores):
@@ -2596,7 +2592,6 @@ class VendedorDialog(QDialog):
             "nombre": self.nombre_edit.text(),
             "dui": self.dui_edit.text(),
             "descripcion": self.descripcion_edit.text(),
-            "dui": self.dui_edit.text(),
             "Distribuidor_id": Distribuidor_id,
         }
 class CompraDetalleDialog(QDialog):


### PR DESCRIPTION
## Summary
- cleanup duplicate DUI input in `VendedorDialog`
- remove extra key from returned data

## Testing
- `pytest tests/test_date_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687069b38ef08323b192876a5a24516d