### PR TITLE
Fix misencoded accents in ticket PDF

### DIFF
--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -137,7 +137,7 @@ def generar_ticket_personalizado(
 
     # Encabezado con datos de DTE
     c.setFont("Helvetica-Bold", 8)
-    c.drawCentredString(width / 2, y, "DOCUMENTO TRIBUTARIO ELECTR\xc3\x93NICO")
+    c.drawCentredString(width / 2, y, "DOCUMENTO TRIBUTARIO ELECTRÓNICO")
     y -= 4 * mm
     c.drawCentredString(width / 2, y, "FACTURA")
     y -= 5 * mm
@@ -155,24 +155,24 @@ def generar_ticket_personalizado(
     c.drawCentredString(width / 2, y, f"NRC: {_with_falta(nrc)}")
     y -= 4 * mm
     giro = datos_negocio.get("giro")
-    c.drawCentredString(width / 2, y, f"Actividad Econ\xc3\xb3mica: {_with_falta(giro)}")
+    c.drawCentredString(width / 2, y, f"Actividad Económica: {_with_falta(giro)}")
     y -= 4 * mm
     direccion = datos_negocio.get("direccion")
-    c.drawCentredString(width / 2, y, f"Direcci\xc3\xb3n: {_with_falta(direccion)}")
+    c.drawCentredString(width / 2, y, f"Dirección: {_with_falta(direccion)}")
     y -= 5 * mm
     c.setFont("Helvetica-Bold", 7)
     c.drawCentredString(width / 2, y, "DATOS DE FACTURA")
     y -= 4 * mm
     c.setFont("Helvetica", 7)
-    c.drawCentredString(width / 2, y, "C\xc3\xb3digo de Generaci\xc3\xb3n:")
+    c.drawCentredString(width / 2, y, "Código de Generación:")
     y -= 3 * mm
-    c.drawCentredString(width / 2, y, "N\xc3\xbamero de control:")
+    c.drawCentredString(width / 2, y, "Número de control:")
     y -= 4 * mm
-    c.drawCentredString(width / 2, y, "M\xc3\xb3delo de Facturaci\xc3\xb3n: Modelo Facturaci\xc3\xb3n Previo")
+    c.drawCentredString(width / 2, y, "Módelo de Facturación: Modelo Facturación Previo")
     y -= 3 * mm
-    c.drawCentredString(width / 2, y, "Tipo de Transmisi\xc3\xb3n: Transmisi\xc3\xb3n Normal")
+    c.drawCentredString(width / 2, y, "Tipo de Transmisión: Transmisión Normal")
     y -= 3 * mm
-    c.drawCentredString(width / 2, y, f"Fecha y hora de Generaci\xc3\xb3n: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    c.drawCentredString(width / 2, y, f"Fecha y hora de Generación: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     y -= 5 * mm
     c.line(5 * mm, y, width - 5 * mm, y)
     y -= 4 * mm


### PR DESCRIPTION
## Summary
- correct accented text in `ticket_pdf.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q --maxfail=1 -vv` *(fails: test suite hangs on manual invoice test)*

------
https://chatgpt.com/codex/tasks/task_e_68706b534ce48323b5ee1d48fce7b34b