### PR TITLE
Add vendor commission reporting

### DIFF
--- a/db.py
+++ b/db.py
@@ -781,6 +781,25 @@ class DB:
         self.cursor.execute(query, params)
         return [dict(row) for row in self.cursor.fetchall()]
 
+    def get_comision_vendedores(self, fecha_inicio=None, fecha_fin=None):
+        """Return total commission per vendor within an optional date range."""
+        query = (
+            "SELECT dv.vendedor_id, SUM(dv.comision) AS total_comision "
+            "FROM detalles_venta dv "
+            "JOIN ventas v ON v.id = dv.venta_id "
+            "WHERE dv.vendedor_id IS NOT NULL"
+        )
+        params = []
+        if fecha_inicio:
+            query += " AND date(v.fecha) >= date(?)"
+            params.append(fecha_inicio)
+        if fecha_fin:
+            query += " AND date(v.fecha) <= date(?)"
+            params.append(fecha_fin)
+        query += " GROUP BY dv.vendedor_id ORDER BY dv.vendedor_id"
+        self.cursor.execute(query, params)
+        return [dict(row) for row in self.cursor.fetchall()]
+
     def get_estado_cuenta_clientes(self, cliente_id=None, fecha_inicio=None, fecha_fin=None):
         """Genera el estado de cuenta de los clientes.
 

--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -491,14 +491,20 @@ def generar_estado_cuenta_pdf(
         resumen = db.get_estado_cuenta_vendedores(
             fecha_inicio=fecha_inicio, fecha_fin=fecha_fin
         )
-        data = [["Vendedor", "Total Ventas"]]
+        comisiones = db.get_comision_vendedores(
+            fecha_inicio=fecha_inicio, fecha_fin=fecha_fin
+        )
+        com_map = {c["vendedor_id"]: c["total_comision"] for c in comisiones}
+        data = [["Vendedor", "Total Ventas", "Comisión"]]
         for r in resumen:
-            vend = db.get_trabajador(r.get("vendedor_id"))
-            nombre = vend.get("nombre", "") if vend else str(r.get("vendedor_id"))
-            data.append([nombre, f"{r.get('total_ventas',0):.2f}"])
+            vid = r.get("vendedor_id")
+            vend = db.get_trabajador(vid)
+            nombre = vend.get("nombre", "") if vend else str(vid)
+            comision = com_map.get(vid, 0)
+            data.append([nombre, f"{r.get('total_ventas',0):.2f}", f"{comision:.2f}"])
         if len(data) == 1:
-            data.append(["", ""])
-        table = Table(data, colWidths=[200, 80])
+            data.append(["", "", ""])
+        table = Table(data, colWidths=[200, 80, 80])
         table.setStyle(
             TableStyle(
                 [

--- a/tests/test_comision_vendedores.py
+++ b/tests/test_comision_vendedores.py
@@ -1,0 +1,35 @@
+import pytest
+from db import DB
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_get_comision_vendedores():
+    db = create_db()
+    db.add_vendedor("V1")
+    vid1 = db.cursor.lastrowid
+    db.add_vendedor("V2")
+    vid2 = db.cursor.lastrowid
+    db.add_producto("P1", "C1", vid1, None, 0, 0, 0, 10)
+    pid1 = db.cursor.lastrowid
+    db.add_producto("P2", "C2", vid2, None, 0, 0, 0, 10)
+    pid2 = db.cursor.lastrowid
+
+    v1 = db.add_venta("2024-01-01", 100, vendedor_id=vid1)
+    db.add_detalle_venta(v1, pid1, 1, 100, comision=10, vendedor_id=vid1)
+    v2 = db.add_venta("2024-01-02", 50, vendedor_id=vid2)
+    db.add_detalle_venta(v2, pid2, 1, 50, comision=5, vendedor_id=vid2)
+    v3 = db.add_venta("2024-01-03", 150, vendedor_id=vid1)
+    db.add_detalle_venta(v3, pid1, 1, 150, comision=15, vendedor_id=vid1)
+
+    resumen = db.get_comision_vendedores()
+    resumen_dict = {r["vendedor_id"]: r["total_comision"] for r in resumen}
+    assert resumen_dict[vid1] == 25
+    assert resumen_dict[vid2] == 5
+
+    rango = db.get_comision_vendedores(fecha_inicio="2024-01-03", fecha_fin="2024-01-03")
+    assert len(rango) == 1
+    assert rango[0]["vendedor_id"] == vid1
+    assert rango[0]["total_comision"] == 15


### PR DESCRIPTION
## Summary
- add `get_comision_vendedores` in `db.py`
- update sales report PDF to display commission totals
- test commission totals across multiple vendors

## Testing
- `pytest tests/test_comision_vendedores.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68706da5faac83239ccef02b78d90f08