### PR TITLE
Implement ticket PDF storage and reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,18 @@ contraseña de la cuenta utilizada para enviar correos ya **no** se guarda en el
 archivo. En su lugar, define la variable de entorno `INVENTARIO_EMAIL_PASSWORD`
 con la contraseña correspondiente antes de ejecutar la aplicación.
 
+Las facturas generadas desde la pestaña **Ventas** se guardan automáticamente en
+`facturas/consumidor_final` o `facturas/credito_fiscal` dependiendo del tipo de
+documento. Los tickets se almacenan en la carpeta `tickets`. Al imprimir,
+previsualizar o enviar por correo se reutilizan estos PDFs si están disponibles.
+
 ### Generar ticket en formato personalizado
 
 En las pestañas **Ventas** y **Facturación** hay un botón `Ticket`.
-Al pulsarlo se abre un cuadro de diálogo para elegir dónde guardar el PDF.
-El ticket utiliza un formato básico y lee los datos de `datos_negocio.json`.
-Modifica ese archivo para personalizar nombre, dirección y otros datos.
+Al pulsarlo se genera automáticamente un archivo `ticket_{id}.pdf` dentro de la
+carpeta `tickets`. El ticket utiliza un formato básico y lee los datos de
+`datos_negocio.json`. Modifica ese archivo para personalizar nombre, dirección y
+otros datos.
 
 Si quieres mostrar tu logo, reemplaza `logoinventario.jpg` por tu imagen.
 

--- a/db.py
+++ b/db.py
@@ -249,6 +249,17 @@ class DB:
             )
         """
         )
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tickets_pdf (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venta_id INTEGER,
+                ruta TEXT,
+                fecha_creacion TEXT,
+                FOREIGN KEY (venta_id) REFERENCES ventas(id)
+            )
+        """
+        )
         self.conn.commit()
 
 
@@ -1006,6 +1017,34 @@ class DB:
         )
         self.conn.commit()
         return self.cursor.lastrowid
+
+    def add_ticket_pdf(self, venta_id, ruta):
+        """Almacena la ruta de un ticket generado para una venta."""
+        fecha = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.cursor.execute(
+            "INSERT INTO tickets_pdf (venta_id, ruta, fecha_creacion) VALUES (?, ?, ?)",
+            (venta_id, ruta, fecha),
+        )
+        self.conn.commit()
+        return self.cursor.lastrowid
+
+    def get_ticket_pdf(self, venta_id):
+        """Devuelve la ruta del ticket más reciente asociado a una venta."""
+        self.cursor.execute(
+            "SELECT ruta FROM tickets_pdf WHERE venta_id=? ORDER BY fecha_creacion DESC LIMIT 1",
+            (venta_id,),
+        )
+        row = self.cursor.fetchone()
+        return row["ruta"] if row else None
+
+    def get_factura_pdf(self, venta_id):
+        """Devuelve la ruta de la factura PDF más reciente de una venta."""
+        self.cursor.execute(
+            "SELECT ruta FROM facturas_pdf WHERE venta_id=? ORDER BY fecha_creacion DESC LIMIT 1",
+            (venta_id,),
+        )
+        row = self.cursor.fetchone()
+        return row["ruta"] if row else None
 
     def get_notas_by_venta(self, venta_id):
         """Devuelve las notas asociadas a una venta."""

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -43,6 +43,7 @@ DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json
 FACTURAS_DIR = os.path.join(os.path.dirname(__file__), "facturas")
 CF_DIR = os.path.join(FACTURAS_DIR, "consumidor_final")
 CREDITO_DIR = os.path.join(FACTURAS_DIR, "credito_fiscal")
+TICKETS_DIR = os.path.join(os.path.dirname(__file__), "tickets")
 
 
 class EmailSender(QThread):
@@ -438,73 +439,12 @@ class SalesTab(QWidget):
 
         self._clear_preview_files()
 
-        credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
-        detalles = self.manager.db.get_detalles_venta(venta_id)
-
-        venta_data = dict(venta)
-        if credito_info:
-            venta_data.update(credito_info)
-
-        if venta_data.get("vendedor_id"):
-            trabajador = self.manager.db.get_trabajador(venta_data["vendedor_id"])
-            if trabajador:
-                venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
-
-        sumas = ventas_exentas = ventas_no_sujetas = iva = 0
-        for d in detalles:
-            base = d.get("precio_unitario", 0) * d.get("cantidad", 0)
-            if d.get("descuento_tipo") == "%":
-                base -= base * d.get("descuento", 0) / 100
-            else:
-                base -= d.get("descuento", 0)
-            iva_item = d.get("iva", 0)
-            tipo = d.get("tipo_fiscal", "").lower()
-            if tipo == "venta exenta":
-                d["ventas_exentas"] = base
-                ventas_exentas += base
-            elif tipo == "venta no sujeta":
-                d["ventas_no_sujetas"] = base
-                ventas_no_sujetas += base
-            else:
-                d["ventas_gravadas"] = base
-                sumas += base
-                iva += iva_item
-
-        subtotal = sumas + ventas_exentas + ventas_no_sujetas
-        total = subtotal + iva
-        venta_data.update(
-            {
-                "sumas": sumas,
-                "iva": iva,
-                "ventas_exentas": ventas_exentas,
-                "ventas_no_sujetas": ventas_no_sujetas,
-                "subtotal": subtotal,
-                "total": total,
-            }
-        )
-
-        cliente = None
-        if venta.get("cliente_id"):
-            cliente = next((c for c in self.manager._clientes if c["id"] == venta["cliente_id"]), None)
-        distribuidor = None
-        if venta.get("Distribuidor_id"):
-            distribuidor = next(
-                (d for d in self.manager._Distribuidores if d["id"] == venta["Distribuidor_id"]),
-                None,
-            )
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_pdf:
-            pdf_path = tmp_pdf.name
-
-        tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
-        generar_factura_electronica_pdf(
-            venta_data,
-            detalles,
-            cliente or {},
-            distribuidor or {},
-            tipo_doc,
-            archivo=pdf_path,
-        )
+        pdf_path = self.manager.db.get_factura_pdf(venta_id)
+        if not pdf_path or not os.path.exists(pdf_path):
+            pdf_path = self._generate_invoice_pdf(venta_id)
+            if not pdf_path:
+                self.preview_label.setText("No se pudo generar previsualización")
+                return
 
         prefix = tempfile.mktemp()
         try:
@@ -673,11 +613,10 @@ class SalesTab(QWidget):
                 extra = json.loads(raw_extra)
             except Exception:
                 extra = {}
-        filename, _ = QFileDialog.getSaveFileName(self, "Guardar ticket", "ticket.pdf", "PDF (*.pdf)")
-        if not filename:
-            return
-
+        os.makedirs(TICKETS_DIR, exist_ok=True)
+        filename = os.path.join(TICKETS_DIR, f"ticket_{venta_id}.pdf")
         generar_ticket_personalizado(venta, detalles, filename, dte_data=extra)
+        self.manager.db.add_ticket_pdf(venta_id, filename)
         QMessageBox.information(self, "Ticket", f"Ticket guardado en {filename}")
 
     def preview_pdf(self):
@@ -695,79 +634,13 @@ class SalesTab(QWidget):
 
             return
 
-        credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
-        detalles = self.manager.db.get_detalles_venta(venta_id)
-
-        venta_data = dict(venta)
-        if credito_info:
-            venta_data.update(credito_info)
-
-        if venta_data.get("vendedor_id"):
-            trabajador = self.manager.db.get_trabajador(venta_data["vendedor_id"])
-            if trabajador:
-                venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
-
-
-        sumas = 0
-        ventas_exentas = 0
-        ventas_no_sujetas = 0
-        iva = 0
-        for d in detalles:
-            base = d.get("precio_unitario", 0) * d.get("cantidad", 0)
-            if d.get("descuento_tipo") == "%":
-                base -= base * d.get("descuento", 0) / 100
-            else:
-                base -= d.get("descuento", 0)
-            iva_item = d.get("iva", 0)
-            tipo = d.get("tipo_fiscal", "").lower()
-            if tipo == "venta exenta":
-                d["ventas_exentas"] = base
-                ventas_exentas += base
-            elif tipo == "venta no sujeta":
-                d["ventas_no_sujetas"] = base
-                ventas_no_sujetas += base
-            else:
-                d["ventas_gravadas"] = base
-                sumas += base
-                iva += iva_item
-
-        subtotal = sumas + ventas_exentas + ventas_no_sujetas
-        total = subtotal + iva
-        venta_data.update(
-            {
-                "sumas": sumas,
-                "iva": iva,
-                "ventas_exentas": ventas_exentas,
-                "ventas_no_sujetas": ventas_no_sujetas,
-                "subtotal": subtotal,
-                "total": total,
-            }
-        )
-
-
-        cliente = None
-        if venta.get("cliente_id"):
-            cliente = next((c for c in self.manager._clientes if c["id"] == venta["cliente_id"]), None)
-        distribuidor = None
-        if venta.get("Distribuidor_id"):
-            distribuidor = next(
-                (d for d in self.manager._Distribuidores if d["id"] == venta["Distribuidor_id"]),
-                None,
-            )
-
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
-            temp_file = tmp.name
-
-        tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
-        generar_factura_electronica_pdf(
-            venta_data,
-            detalles,
-            cliente or {},
-            distribuidor or {},
-            tipo_doc,
-            archivo=temp_file,
-        )
-        QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(temp_file)))
+        pdf_path = self.manager.db.get_factura_pdf(venta_id)
+        if not pdf_path or not os.path.exists(pdf_path):
+            pdf_path = self._generate_invoice_pdf(venta_id)
+        if not pdf_path or not os.path.exists(pdf_path):
+            QMessageBox.warning(self, "Previsualizar", "No se pudo generar el PDF.")
+            return
+        QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(pdf_path)))
 
     def print_pdf(self):
         """Print the selected sale by first generating a temporary PDF."""
@@ -802,7 +675,9 @@ class SalesTab(QWidget):
         subject = self.email_subject_edit.text().strip()
         body = self.email_body_edit.toPlainText()
 
-        pdf_path = self._generate_invoice_pdf(venta_id)
+        pdf_path = self.manager.db.get_factura_pdf(venta_id)
+        if not pdf_path or not os.path.exists(pdf_path):
+            pdf_path = self._generate_invoice_pdf(venta_id)
         if not pdf_path or not os.path.exists(pdf_path):
             QMessageBox.warning(self, "Enviar por correo", "No se pudo generar el PDF.")
             return

--- a/tests/test_manual_invoice.py
+++ b/tests/test_manual_invoice.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from PyQt5.QtWidgets import QApplication, QDialog, QTableWidgetItem, QMessageBox
+from PyQt5.QtGui import QDesktopServices
 
 from sales_tab import SalesTab
 from dialogs import ManualInvoiceDialog
@@ -69,3 +70,27 @@ def test_manual_invoice_consumidor_final_fields(qt_app):
 
     for name in required:
         assert hasattr(dialog, name), f"Dialog missing field {name}"
+
+
+def test_preview_uses_stored_pdf(qt_app, tmp_path, monkeypatch):
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 5)
+    man = Manager(db)
+    tab = SalesTab(man)
+    tab.sales_table.setRowCount(1)
+    tab.sales_table.setItem(0, 0, QTableWidgetItem(str(venta_id)))
+    tab.sales_table.selectRow(0)
+
+    pdf = tmp_path / "fact.pdf"
+    pdf.write_text("x")
+    db.add_factura_pdf(venta_id, "CF", str(pdf))
+
+    called = {"gen": False}
+    def fake_generate(vid):
+        called["gen"] = True
+        return str(pdf)
+    monkeypatch.setattr(tab, "_generate_invoice_pdf", fake_generate)
+    monkeypatch.setattr(QDesktopServices, "openUrl", lambda *a, **k: None)
+
+    tab.preview_pdf()
+    assert called["gen"] is False

--- a/tests/test_ticket_and_nota.py
+++ b/tests/test_ticket_and_nota.py
@@ -3,6 +3,15 @@ from ticket_pdf import generar_ticket_pdf, generar_ticket_personalizado
 import fitz
 
 
+def test_ticket_path_storage(tmp_path):
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 50)
+    path = tmp_path / "ticket.pdf"
+    path.write_text("data")
+    db.add_ticket_pdf(venta_id, str(path))
+    assert db.get_ticket_pdf(venta_id) == str(path)
+
+
 def test_add_nota_and_retrieve(tmp_path):
     db = DB(":memory:")
     venta_id = db.add_venta("2024-01-01", 100)


### PR DESCRIPTION
## Summary
- extend database with `tickets_pdf` table and helper methods
- automatically store invoices and tickets in dedicated folders
- reuse stored PDFs for preview, printing and email when available
- add ticket PDF tests and preview reuse test
- document automatic PDF storage in README

## Testing
- `pytest tests/test_manual_invoice.py::test_preview_uses_stored_pdf -q`
- `pytest tests/test_ticket_and_nota.py::test_ticket_path_storage -q`
- `pytest -q` *(fails: runtime exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68716e1bef348323bdefd85e4119e952