### PR TITLE
Add debit note storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Las facturas generadas desde la pestaña **Ventas** se guardan automáticamente 
 `facturas/consumidor_final` o `facturas/credito_fiscal` dependiendo del tipo de
 documento. Los tickets se almacenan en la carpeta `tickets`. Al imprimir,
 previsualizar o enviar por correo se reutilizan estos PDFs si están disponibles.
+Las notas de débito creadas desde la pestaña **Facturación** se guardan como
+archivos de texto en la carpeta `notas_debito`.
 
 ### Generar ticket en formato personalizado
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -14,8 +14,12 @@ from PyQt5.QtWidgets import (
     QHeaderView,
 )
 from PyQt5.QtCore import QDate
+import os
 
 from ticket_pdf import generar_ticket_personalizado
+
+# Directory where debit notes will be stored
+NOTAS_DEBITO_DIR = os.path.join(os.path.dirname(__file__), "notas_debito")
 import json
 from datetime import datetime
 
@@ -153,7 +157,16 @@ class FacturacionTab(QWidget):
         if not ok2:
             return
         fecha = QDate.currentDate().toString("yyyy-MM-dd")
-        self.manager.db.add_nota(venta_id, tipo, fecha, monto, motivo)
+        nota_id = self.manager.db.add_nota(venta_id, tipo, fecha, monto, motivo)
+
+        if tipo == "debito":
+            os.makedirs(NOTAS_DEBITO_DIR, exist_ok=True)
+            fname = os.path.join(NOTAS_DEBITO_DIR, f"nota_{nota_id}.txt")
+            with open(fname, "w", encoding="utf-8") as f:
+                f.write(
+                    f"Venta ID: {venta_id}\nFecha: {fecha}\nMonto: {monto}\nMotivo: {motivo}"
+                )
+
         QMessageBox.information(self, "Nota", "Nota registrada")
         self.load_invoices()
 


### PR DESCRIPTION
## Summary
- generate a `notas_debito` directory
- save debit note info as text files
- document debit note folder in README

## Testing
- `pytest tests/test_notas.py::test_agregar_y_obtener_notas -q` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68740855f4d4832383563b79b3541682