### PR TITLE
Cambiar color de alertas a verde claro

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -440,7 +440,7 @@ class ProductDialogBase:
             elif stock < 25:
                 item.setBackground(QColor("yellow"))
             else:
-                item.setBackground(QColor("green"))
+                item.setBackground(QColor("lightgreen"))
             self.product_list.addItem(item)
         self.productos = productos
 

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -495,7 +495,7 @@ class ProductTableModel(QAbstractTableModel):
             elif stock < 25:
                 return QColor("yellow")
             else:
-                return QColor("green")
+                return QColor("lightgreen")
         return None
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1228,7 +1228,7 @@ class MainWindow(QMainWindow):
             elif stock < 25:
                 item_cantidad.setBackground(QColor("yellow"))
             else:
-                item_cantidad.setBackground(QColor("green"))
+                item_cantidad.setBackground(QColor("lightgreen"))
             self.inventario_actual_table.setItem(row, 2, item_cantidad)
             self.inventario_actual_table.setItem(row, 3, QTableWidgetItem(f"${d['precio_compra']:.2f}"))
             self.inventario_actual_table.setItem(row, 4, QTableWidgetItem(d["fecha_compra"]))
@@ -1251,7 +1251,7 @@ class MainWindow(QMainWindow):
                         item_venc.setBackground(QColor("orange"))
                         item_venc.setForeground(QColor("black"))
                     elif meses > 6:
-                        item_venc.setBackground(QColor("green"))
+                        item_venc.setBackground(QColor("lightgreen"))
                         item_venc.setForeground(QColor("black"))
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- use `lightgreen` for alert background coloring in inventory views

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742114969083238a1de8e4b2305192