### PR TITLE
Fix amount in words in invoices

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -25,6 +25,7 @@ from PyQt5.QtCore import Qt, QDate, QUrl, QThread, pyqtSignal
 from PyQt5.QtGui import QDesktopServices, QPixmap
 from datetime import datetime
 from factura_sv import generar_factura_electronica_pdf
+from utils.monto import monto_a_texto_sv
 from ticket_pdf import generar_ticket_personalizado
 from dialogs import ManualInvoiceDialog
 import tempfile
@@ -533,6 +534,11 @@ class SalesTab(QWidget):
                 "total": total,
             }
         )
+        if not venta_data.get("total_letras"):
+            try:
+                venta_data["total_letras"] = monto_a_texto_sv(total)
+            except Exception:
+                venta_data["total_letras"] = ""
 
         cliente = None
         if venta.get("cliente_id"):


### PR DESCRIPTION
## Summary
- ensure invoices display amounts in words by default

## Testing
- `pytest tests/test_monto.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687485c3d9b883238294861703cbff4a