### PR TITLE
Add DTE header to invoice PDF

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -2,6 +2,10 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from reportlab.platypus import Table, TableStyle
 from reportlab.lib import colors
+from reportlab.graphics import renderPDF
+from reportlab.graphics.barcode import qr
+from reportlab.graphics.shapes import Drawing
+from reportlab.lib.units import mm
 import json
 import os
 
@@ -16,6 +20,12 @@ def generar_factura_electronica_pdf(
     tipo_documento="Crédito Fiscal",
     archivo="factura_electronica.pdf",
     datos_negocio=None,
+    codigo_generacion="",
+    numero_control="",
+    sello_recepcion="",
+    modelo_facturacion="",
+    tipo_transmision="",
+    fecha_generacion="",
 ):
 
     if datos_negocio is None:
@@ -32,8 +42,45 @@ def generar_factura_electronica_pdf(
     x_margin = 30
     y_margin = 30
 
+    # --- Cabecera Documento Tributario Electrónico ---
+    top = height - 50
+    c.setFont("Helvetica-Bold", 16)
+    c.drawCentredString(width / 2, top, "DOCUMENTO TRIBUTARIO ELECTRÓNICO")
+
+    top -= 20
+    c.setFont("Helvetica-Bold", 12)
+    c.drawCentredString(width / 2, top, tipo_documento.upper())
+
+    row_y = top - 40
+    c.setFont("Helvetica", 10)
+    left_x = 40
+    y = row_y
+    c.drawString(left_x, y, f"Código Generación: {codigo_generacion}")
+    y -= 14
+    c.drawString(left_x, y, f"Número Control: {numero_control}")
+    y -= 14
+    c.drawString(left_x, y, f"Sello Recepción: {sello_recepcion}")
+
+    right_x = width - 40
+    y = row_y
+    c.drawRightString(right_x, y, f"Modelo Facturación: {modelo_facturacion}")
+    y -= 14
+    c.drawRightString(right_x, y, f"Tipo Transmisión: {tipo_transmision}")
+    y -= 14
+    c.drawRightString(right_x, y, f"Fecha Generación: {fecha_generacion}")
+
+    qr_value = codigo_generacion
+    qr_code = qr.QrCodeWidget(qr_value)
+    bounds = qr_code.getBounds()
+    size = 40 * mm
+    w = bounds[2] - bounds[0]
+    h = bounds[3] - bounds[1]
+    d = Drawing(size, size, transform=[size / w, 0, 0, size / h, 0, 0])
+    d.add(qr_code)
+    renderPDF.draw(d, c, (width - size) / 2, row_y - size + 10)
+
     # Posiciones base para los cuadros de emisor y receptor
-    encabezado_y = height - y_margin
+    encabezado_y = row_y - size - 20
 
     # --- Datos del EMISOR (izquierda) y RECEPTOR (derecha) ---
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -382,6 +382,21 @@ class FacturacionTab(QWidget):
                 None,
             )
 
+        extra = venta_data.get("extra") or {}
+        if isinstance(extra, str):
+            try:
+                extra = json.loads(extra)
+            except Exception:
+                extra = {}
+        dte_json = extra.get("dteJson") or extra.get("dte_json") or {}
+        ident = dte_json.get("identificacion", {})
+        codigo_generacion = venta_data.get("codigo_generacion") or ident.get("codigoGeneracion", "")
+        numero_control = venta_data.get("numero_control") or dte_json.get("numeroControl", "")
+        sello_recepcion = venta_data.get("sello_recepcion") or extra.get("selloRecibido", "")
+        modelo_facturacion = venta_data.get("modelo_facturacion") or ident.get("modeloFacturacion", "")
+        tipo_transmision = venta_data.get("tipo_transmision") or ident.get("tipoTransmision", "")
+        fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
+
         tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
         dest_dir = CREDITO_DIR if credito_info else CF_DIR
         os.makedirs(dest_dir, exist_ok=True)
@@ -394,6 +409,12 @@ class FacturacionTab(QWidget):
             distribuidor or {},
             tipo_doc,
             archivo=file_path,
+            codigo_generacion=codigo_generacion,
+            numero_control=numero_control,
+            sello_recepcion=sello_recepcion,
+            modelo_facturacion=modelo_facturacion,
+            tipo_transmision=tipo_transmision,
+            fecha_generacion=fecha_generacion,
         )
         self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
         return file_path

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -550,6 +550,21 @@ class SalesTab(QWidget):
                 None,
             )
 
+        extra = venta_data.get("extra") or {}
+        if isinstance(extra, str):
+            try:
+                extra = json.loads(extra)
+            except Exception:
+                extra = {}
+        dte_json = extra.get("dteJson") or extra.get("dte_json") or {}
+        ident = dte_json.get("identificacion", {})
+        codigo_generacion = venta_data.get("codigo_generacion") or ident.get("codigoGeneracion", "")
+        numero_control = venta_data.get("numero_control") or dte_json.get("numeroControl", "")
+        sello_recepcion = venta_data.get("sello_recepcion") or extra.get("selloRecibido", "")
+        modelo_facturacion = venta_data.get("modelo_facturacion") or ident.get("modeloFacturacion", "")
+        tipo_transmision = venta_data.get("tipo_transmision") or ident.get("tipoTransmision", "")
+        fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
+
         tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
         dest_dir = CREDITO_DIR if credito_info else CF_DIR
         os.makedirs(dest_dir, exist_ok=True)
@@ -562,6 +577,12 @@ class SalesTab(QWidget):
             distribuidor or {},
             tipo_doc,
             archivo=file_path,
+            codigo_generacion=codigo_generacion,
+            numero_control=numero_control,
+            sello_recepcion=sello_recepcion,
+            modelo_facturacion=modelo_facturacion,
+            tipo_transmision=tipo_transmision,
+            fecha_generacion=fecha_generacion,
         )
         self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
         return file_path
@@ -762,6 +783,9 @@ class SalesTab(QWidget):
                 {},
                 tipo.title(),
                 archivo=temp_file,
+                codigo_generacion=venta.get("codigo_generacion", ""),
+                numero_control=venta.get("numero_control", ""),
+                sello_recepcion=venta.get("sello_recepcion", ""),
             )
             QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(temp_file)))
 

--- a/tests/test_manual_invoice.py
+++ b/tests/test_manual_invoice.py
@@ -6,6 +6,7 @@ from PyQt5.QtGui import QDesktopServices
 from sales_tab import SalesTab
 from dialogs import ManualInvoiceDialog
 from db import DB
+import fitz
 
 class Manager:
     def __init__(self, db):
@@ -94,3 +95,28 @@ def test_preview_uses_stored_pdf(qt_app, tmp_path, monkeypatch):
 
     tab.preview_pdf()
     assert called["gen"] is False
+
+
+def test_factura_pdf_contains_header(tmp_path):
+    pdf_path = tmp_path / "fact.pdf"
+    from factura_sv import generar_factura_electronica_pdf
+
+    generar_factura_electronica_pdf(
+        {},
+        [],
+        {},
+        {},
+        "CONSUMIDOR FINAL",
+        archivo=str(pdf_path),
+        codigo_generacion="ABC123",
+        numero_control="NC-42",
+        sello_recepcion="SELLO1",
+        modelo_facturacion="1 - Facturaci\u00f3n previo",
+        tipo_transmision="1 - Transmisi\u00f3n normal",
+        fecha_generacion="01/07/2025",
+    )
+
+    with fitz.open(pdf_path) as doc:
+        text = "".join(p.get_text() for p in doc)
+    assert "DOCUMENTO TRIBUTARIO ELECTR\u00d3NICO" in text
+    assert "NC-42" in text


### PR DESCRIPTION
## Summary
- support extended header in factura PDF generator
- pass DTE header fields from sales and facturacion tabs
- include header info when generating manual invoices
- test header text and control number in generated PDF

## Testing
- `pytest tests/test_manual_invoice.py::test_factura_pdf_contains_header -q`


------
https://chatgpt.com/codex/tasks/task_e_68757541eb0c83239c93af3f4ced6e36