### PR TITLE
Add doc type header in invoice PDF

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -32,6 +32,13 @@ def generar_factura_electronica_pdf(
     x_margin = 30
     y_margin = 30
 
+    top = height - 50
+    c.setFont("Helvetica-Bold", 16)
+    c.drawCentredString(width / 2, top, "DOCUMENTO TRIBUTARIO ELECTRÓNICO")
+    top -= 20
+    c.setFont("Helvetica-Bold", 12)
+    c.drawCentredString(width / 2, top, tipo_documento.upper())
+
     # Posiciones base para los cuadros de emisor y receptor
     encabezado_y = height - y_margin
 

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -1,0 +1,53 @@
+import pytest
+import fitz
+from factura_sv import generar_factura_electronica_pdf
+
+
+def _sample_data(tipo):
+    venta = {
+        'sumas': 10,
+        'descuentos_globales': 0,
+        'subtotal': 10,
+        'iva': 1.3,
+        'total': 11.3,
+        'ventas_exentas': 0,
+        'ventas_no_sujetas': 0,
+        'total_letras': 'ONCE CON 30/100 DOLARES',
+    }
+    detalles = [
+        {
+            'cantidad': 1,
+            'descripcion': 'Prod',
+            'precio_unitario': 10,
+            'ventas_no_sujetas': 0,
+            'ventas_exentas': 0,
+            'ventas_gravadas': 10,
+        }
+    ]
+    return venta, detalles
+
+
+def _generate(tmp_path, tipo):
+    venta, detalles = _sample_data(tipo)
+    out = tmp_path / 'fact.pdf'
+    generar_factura_electronica_pdf(
+        venta,
+        detalles,
+        {},
+        {},
+        tipo,
+        archivo=str(out),
+        datos_negocio={},
+    )
+    return out
+
+
+@pytest.mark.parametrize('tipo', ['Crédito Fiscal', 'Consumidor Final'])
+def test_factura_header_contains_doc_type(tmp_path, tipo):
+    out = _generate(tmp_path, tipo)
+    assert out.exists()
+    with fitz.open(out) as doc:
+        text = ''.join(p.get_text() for p in doc)
+    assert 'DOCUMENTO TRIBUTARIO ELECTRÓNICO' in text
+    assert tipo.upper() in text
+


### PR DESCRIPTION
## Summary
- show DTE document type in generated invoices
- add regression test ensuring document type appears in PDFs

## Testing
- `pytest tests/test_factura_pdf.py -q`
- `pytest -q` *(fails: process hung or truncated output)*

------
https://chatgpt.com/codex/tasks/task_e_6875754205c48323bf21bd70c4ae4ab6