### PR TITLE
Add DTE header generation utilities

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -17,6 +17,31 @@ def _load_datos_negocio():
     return {}
 
 
+def generar_numero_control(prefijo: str = "DTE-01-S001P001") -> str:
+    """Crea un número de control único siguiendo el formato de Hacienda."""
+    secuencia = str(uuid.uuid4().int % 10**15).zfill(15)
+    return f"{prefijo}-{secuencia}"
+
+
+def generar_cabecera_dte_data(modelo_facturacion: str, tipo_transmision: str) -> dict:
+    """Genera los datos para la cabecera de un DTE.
+
+    Los campos de código de generación y número de control se crean antes de
+    enviar la factura. Los valores que envía Hacienda posteriormente (código de
+    generación y sello recibido) se dejan en ``None``.
+    """
+    codigo_generacion = uuid.uuid4().hex.upper()
+    numero_control = generar_numero_control()
+    fecha_generacion = datetime.now().strftime("%d/%m/%Y, %I:%M %p")
+    return {
+        "codigo_generacion": codigo_generacion,
+        "numero_control": numero_control,
+        "sello_recepcion": None,
+        "modelo_facturacion": modelo_facturacion,
+        "tipo_transmision": tipo_transmision,
+        "fecha_generacion": fecha_generacion,
+    }
+
 def generar_dte_json(db: DB, venta_id: int) -> dict:
     """Genera un diccionario DTE básico para una venta."""
     row = db.cursor.execute("SELECT * FROM ventas WHERE id=?", (venta_id,)).fetchone()
@@ -34,7 +59,7 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
     datos = _load_datos_negocio()
 
     codigo_generacion = uuid.uuid4().hex.upper()
-    numero_control = f"{codigo_generacion[:8]}-{codigo_generacion[8:]}"
+    numero_control = generar_numero_control()
 
     fecha = venta.get("fecha") or datetime.now().strftime("%Y-%m-%d")
     hora = datetime.now().strftime("%H:%M:%S")

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -6,6 +6,7 @@ from reportlab.graphics import renderPDF
 from reportlab.graphics.barcode import qr
 from reportlab.graphics.shapes import Drawing
 from reportlab.lib.units import mm
+from dte import generar_cabecera_dte_data
 import json
 import os
 
@@ -36,6 +37,13 @@ def generar_factura_electronica_pdf(
                     datos_negocio = json.load(f)
             except Exception:
                 datos_negocio = {}
+
+    if not codigo_generacion or not numero_control or not fecha_generacion:
+        cab = generar_cabecera_dte_data(modelo_facturacion, tipo_transmision)
+        codigo_generacion = codigo_generacion or cab["codigo_generacion"]
+        numero_control = numero_control or cab["numero_control"]
+        fecha_generacion = fecha_generacion or cab["fecha_generacion"]
+        sello_recepcion = sello_recepcion or cab["sello_recepcion"]
 
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter
@@ -70,7 +78,7 @@ def generar_factura_electronica_pdf(
     y -= 14
     c.drawRightString(right_x, y, f"Fecha Generación: {fecha_generacion}")
 
-    qr_value = codigo_generacion
+    qr_value = f"{numero_control}|{codigo_generacion}"
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()
     size = 40 * mm


### PR DESCRIPTION
## Summary
- add helpers to create DTE header information
- create automatic header when generating invoice PDFs
- include control number in QR code

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757e901214832396b6e05349ec77cb