### PR TITLE
Adjust QR size to match header lines

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -53,7 +53,10 @@ def generar_cabecera_dte(
     qr_value = codigo_generacion
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()
-    size = 40 * mm
+    # Reduce the QR code so it matches the height of the three informational
+    # lines (Código Generación, Número Control y Sello Recepción). Using 15 mm
+    # keeps it roughly the same height as those lines combined.
+    size = 15 * mm
     w = bounds[2] - bounds[0]
     h = bounds[3] - bounds[1]
     d = Drawing(size, size, transform=[size / w, 0, 0, size / h, 0, 0])

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -73,7 +73,10 @@ def generar_factura_electronica_pdf(
     qr_value = codigo_generacion
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()
-    size = 40 * mm
+    # The QR code should match the height occupied by the three text lines
+    # ("Código Generación", "Número Control" and "Sello Recepción"). Each line
+    # is spaced 14 points apart, so 15 mm (~42 pt) approximates that height.
+    size = 15 * mm
     w = bounds[2] - bounds[0]
     h = bounds[3] - bounds[1]
     d = Drawing(size, size, transform=[size / w, 0, 0, size / h, 0, 0])


### PR DESCRIPTION
## Summary
- shrink QR code in factura SV header to match text height
- adjust QR code size in DTE header

## Testing
- `pytest -q` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68757d4452ec8323b67f30380795d16f