### PR TITLE
Default billing model update

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -23,7 +23,7 @@ def generar_factura_electronica_pdf(
     codigo_generacion="",
     numero_control="",
     sello_recepcion="",
-    modelo_facturacion="",
+    modelo_facturacion="1 - Facturación previo",
     tipo_transmision="",
     fecha_generacion="",
 ):

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -394,6 +394,8 @@ class FacturacionTab(QWidget):
         numero_control = venta_data.get("numero_control") or dte_json.get("numeroControl", "")
         sello_recepcion = venta_data.get("sello_recepcion") or extra.get("selloRecibido", "")
         modelo_facturacion = venta_data.get("modelo_facturacion") or ident.get("modeloFacturacion", "")
+        if not modelo_facturacion:
+            modelo_facturacion = "1 - Facturación previo"
         tipo_transmision = venta_data.get("tipo_transmision") or ident.get("tipoTransmision", "")
         fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -562,6 +562,8 @@ class SalesTab(QWidget):
         numero_control = venta_data.get("numero_control") or dte_json.get("numeroControl", "")
         sello_recepcion = venta_data.get("sello_recepcion") or extra.get("selloRecibido", "")
         modelo_facturacion = venta_data.get("modelo_facturacion") or ident.get("modeloFacturacion", "")
+        if not modelo_facturacion:
+            modelo_facturacion = "1 - Facturación previo"
         tipo_transmision = venta_data.get("tipo_transmision") or ident.get("tipoTransmision", "")
         fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
 


### PR DESCRIPTION
## Summary
- set default `modelo_facturacion` to `1 - Facturación previo`
- ensure generated invoices fall back to this billing model when empty

## Testing
- `pytest -q` *(fails: hangs without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68757d6e2a0c83239dabae38ac9904f6