### PR TITLE
Fix QR placement in factura

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -97,13 +97,17 @@ def generar_factura_electronica_pdf(
     h = bounds[3] - bounds[1]
     d = Drawing(size, size, transform=[size / w, 0, 0, size / h, 0, 0])
     d.add(qr_code)
-    qr_x = x_margin + left_col_w + col_margin + (qr_col_w - size) / 2
-    qr_y = row_y - 14 - size / 2
+    qr_x = x_margin + left_col_w + col_margin + 5
+    qr_y = row_y - size - 50
+    # ensure background so text does not bleed into the QR image
+    c.setFillColor(colors.white)
+    c.rect(qr_x - 2, qr_y - 2, size + 4, size + 4, fill=1, stroke=0)
+    c.setFillColor(colors.black)
     renderPDF.draw(d, c, qr_x, qr_y)
 
 
     # Posiciones base para los cuadros de emisor y receptor
-    encabezado_y = row_y - size - 20
+    encabezado_y = row_y - size - 10
 
     # --- Datos del EMISOR (izquierda) y RECEPTOR (derecha) ---
 

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -51,3 +51,34 @@ def test_factura_header_contains_doc_type(tmp_path, tipo):
     assert 'DOCUMENTO TRIBUTARIO ELECTRÓNICO' in text
     assert tipo.upper() in text
 
+
+def test_qr_position_and_boxes_spacing(tmp_path):
+    out = _generate(tmp_path, 'Crédito Fiscal')
+    with fitz.open(out) as doc:
+        page = doc[0]
+        numero = page.search_for('Número Control')[0]
+        emisor = page.search_for('EMISOR:')[0]
+
+    # QR position computed using same constants as in factura_sv
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.units import mm
+
+    width, height = letter
+    x_margin = 30
+    qr_col_w = 30 * mm
+    col_margin = 15
+    available_w = width - 2 * x_margin - qr_col_w - 2 * col_margin
+    left_col_w = available_w / 2
+    size = 30 * mm
+    qr_x = x_margin + left_col_w + col_margin + 5
+    qr_y = (height - 50 - 40) - size - 50
+    qr_top = height - (qr_y + size)
+    qr_bottom = height - qr_y
+
+    # QR should be below the header lines
+    assert qr_top >= numero.y1
+
+    # Boxes should sit close to the QR code
+    gap = qr_bottom - emisor.y0
+    assert gap < 45
+


### PR DESCRIPTION
## Summary
- avoid header overlap by adjusting QR `x` and `y`
- tighten spacing of sender/receiver boxes
- add regression test for QR header spacing

## Testing
- `pytest tests/test_factura_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68759c096ad88323af122af96e351978