### PR TITLE
Align QR code with header

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -61,7 +61,9 @@ def generar_cabecera_dte(
     h = bounds[3] - bounds[1]
     d = Drawing(size, size, transform=[size / w, 0, 0, size / h, 0, 0])
     d.add(qr_code)
-    renderPDF.draw(d, c, (width - size) / 2, row_y - size + 10)
+    # Align QR vertically with the header information
+    qr_y = row_y - size - 23
+    renderPDF.draw(d, c, (width - size) / 2, qr_y)
 
     c.save()
 

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -98,7 +98,11 @@ def generar_factura_electronica_pdf(
     d = Drawing(size, size, transform=[size / w, 0, 0, size / h, 0, 0])
     d.add(qr_code)
     qr_x = x_margin + left_col_w + col_margin + 5
-    qr_y = row_y - size - 50
+    # Align QR vertically with the header lines (Código Generación,
+    # Número Control y Sello Recepción) so it sits next to them
+    # instead of below them.
+    # Position the QR so its top aligns with the header lines
+    qr_y = row_y - size - 23
     # ensure background so text does not bleed into the QR image
     c.setFillColor(colors.white)
     c.rect(qr_x - 2, qr_y - 2, size + 4, size + 4, fill=1, stroke=0)
@@ -107,7 +111,8 @@ def generar_factura_electronica_pdf(
 
 
     # Posiciones base para los cuadros de emisor y receptor
-    encabezado_y = row_y - size - 10
+    # Keep roughly the same gap between the QR code and the info boxes
+    encabezado_y = qr_y - 40
 
     # --- Datos del EMISOR (izquierda) y RECEPTOR (derecha) ---
 

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -71,12 +71,12 @@ def test_qr_position_and_boxes_spacing(tmp_path):
     left_col_w = available_w / 2
     size = 30 * mm
     qr_x = x_margin + left_col_w + col_margin + 5
-    qr_y = (height - 50 - 40) - size - 50
+    qr_y = (height - 50 - 40) - size - 23
     qr_top = height - (qr_y + size)
     qr_bottom = height - qr_y
 
-    # QR should be below the header lines
-    assert qr_top >= numero.y1
+    # QR should align vertically with the header lines
+    assert abs(qr_top - numero.y0) < 5
 
     # Boxes should sit close to the QR code
     gap = qr_bottom - emisor.y0


### PR DESCRIPTION
## Summary
- keep QR code aligned with header info
- update tests for new QR positioning

## Testing
- `pytest -q tests/test_factura_pdf.py::test_qr_position_and_boxes_spacing`


------
https://chatgpt.com/codex/tasks/task_e_6875afc0af648323a070c79071a303e5