### PR TITLE
Improve header text layout

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -5,6 +5,8 @@ from reportlab.graphics.barcode import qr
 from reportlab.graphics.shapes import Drawing
 from reportlab.lib.units import mm
 
+from utils.pdf_utils import draw_wrapped_text
+
 
 def generar_cabecera_dte(
     codigo_generacion: str,
@@ -43,11 +45,31 @@ def generar_cabecera_dte(
     c.setLineWidth(0.7)
     c.roundRect(40, box_y, box_w, box_h, 6, stroke=1, fill=0)
     text_y = box_y + box_h - 10
-    c.drawString(45, text_y, f"Código Generación: {codigo_generacion}")
-    text_y -= 10
-    c.drawString(45, text_y, f"Número Control: {numero_control}")
-    text_y -= 10
-    c.drawString(45, text_y, f"Sello Recepción: {sello_recepcion}")
+    max_w = box_w - 10
+    text_y = draw_wrapped_text(
+        c,
+        f"Código Generación: {codigo_generacion}",
+        45,
+        text_y,
+        max_w,
+        10,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Número Control: {numero_control}",
+        45,
+        text_y,
+        max_w,
+        10,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Sello Recepción: {sello_recepcion}",
+        45,
+        text_y,
+        max_w,
+        10,
+    )
 
     # QR en el centro
     qr_x = 40 + box_w + col_margin + 3
@@ -64,11 +86,31 @@ def generar_cabecera_dte(
     right_x = 40 + box_w + col_margin + qr_size + col_margin
     c.roundRect(right_x, box_y, box_w, box_h, 6, stroke=1, fill=0)
     text_y = box_y + box_h - 10
-    c.drawString(right_x + 5, text_y, f"Modelo Facturación: {modelo_facturacion}")
-    text_y -= 10
-    c.drawString(right_x + 5, text_y, f"Tipo Transmisión: {tipo_transmision}")
-    text_y -= 10
-    c.drawString(right_x + 5, text_y, f"Fecha Generación: {fecha_generacion}")
+    max_w = box_w - 10
+    text_y = draw_wrapped_text(
+        c,
+        f"Modelo Facturación: {modelo_facturacion}",
+        right_x + 5,
+        text_y,
+        max_w,
+        10,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Tipo Transmisión: {tipo_transmision}",
+        right_x + 5,
+        text_y,
+        max_w,
+        10,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Fecha Generación: {fecha_generacion}",
+        right_x + 5,
+        text_y,
+        max_w,
+        10,
+    )
 
     c.save()
 

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -6,6 +6,8 @@ from reportlab.graphics import renderPDF
 from reportlab.graphics.barcode import qr
 from reportlab.graphics.shapes import Drawing
 from reportlab.lib.units import mm
+
+from utils.pdf_utils import draw_wrapped_text
 from dte import generar_cabecera_dte_data
 import json
 import os
@@ -78,11 +80,31 @@ def generar_factura_electronica_pdf(
     c.setLineWidth(0.7)
     c.roundRect(x_margin, box_y, box_w, box_h, 6, stroke=1, fill=0)
     text_y = box_y + box_h - 12
-    c.drawString(x_margin + 5, text_y, f"Código Generación: {codigo_generacion}")
-    text_y -= 12
-    c.drawString(x_margin + 5, text_y, f"Número Control: {numero_control}")
-    text_y -= 12
-    c.drawString(x_margin + 5, text_y, f"Sello Recepción: {sello_recepcion}")
+    max_w = box_w - 10
+    text_y = draw_wrapped_text(
+        c,
+        f"Código Generación: {codigo_generacion}",
+        x_margin + 5,
+        text_y,
+        max_w,
+        12,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Número Control: {numero_control}",
+        x_margin + 5,
+        text_y,
+        max_w,
+        12,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Sello Recepción: {sello_recepcion}",
+        x_margin + 5,
+        text_y,
+        max_w,
+        12,
+    )
 
     # --- Código QR ---
     qr_x = x_margin + box_w + col_margin + 5
@@ -100,11 +122,31 @@ def generar_factura_electronica_pdf(
     right_x = x_margin + box_w + col_margin + qr_size + col_margin
     c.roundRect(right_x, box_y, box_w, box_h, 6, stroke=1, fill=0)
     text_y = box_y + box_h - 12
-    c.drawString(right_x + 5, text_y, f"Modelo Facturación: {modelo_facturacion}")
-    text_y -= 12
-    c.drawString(right_x + 5, text_y, f"Tipo Transmisión: {tipo_transmision}")
-    text_y -= 12
-    c.drawString(right_x + 5, text_y, f"Fecha Generación: {fecha_generacion}")
+    max_w = box_w - 10
+    text_y = draw_wrapped_text(
+        c,
+        f"Modelo Facturación: {modelo_facturacion}",
+        right_x + 5,
+        text_y,
+        max_w,
+        12,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Tipo Transmisión: {tipo_transmision}",
+        right_x + 5,
+        text_y,
+        max_w,
+        12,
+    )
+    text_y = draw_wrapped_text(
+        c,
+        f"Fecha Generación: {fecha_generacion}",
+        right_x + 5,
+        text_y,
+        max_w,
+        12,
+    )
 
     # Posiciones base para los cuadros de emisor y receptor
     # Mantenemos un espacio de 40 puntos debajo del código QR

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -1,0 +1,50 @@
+from reportlab.pdfbase import pdfmetrics
+
+
+def draw_wrapped_text(c, text, x, y, max_width, line_height):
+    """Draw text at ``x,y`` wrapping lines so they don't exceed ``max_width``.
+
+    Returns the y position for the next line after drawing.
+    """
+    fontname = c._fontname
+    fontsize = c._fontsize
+    words = text.split()
+    line = ""
+    lines = []
+
+    def _split_long_word(word):
+        parts = []
+        segment = ""
+        for ch in word:
+            if pdfmetrics.stringWidth(segment + ch, fontname, fontsize) <= max_width:
+                segment += ch
+            else:
+                if segment:
+                    parts.append(segment)
+                segment = ch
+        if segment:
+            parts.append(segment)
+        return parts
+
+    for word in words:
+        segments = [word]
+        if pdfmetrics.stringWidth(word, fontname, fontsize) > max_width:
+            segments = _split_long_word(word)
+        for seg in segments:
+            candidate = seg if not line else f"{line} {seg}"
+            if pdfmetrics.stringWidth(candidate, fontname, fontsize) <= max_width:
+                line = candidate
+            else:
+                if line:
+                    lines.append(line)
+                line = seg
+        if pdfmetrics.stringWidth(line, fontname, fontsize) > max_width:
+            lines.append(line)
+            line = ""
+    if line:
+        lines.append(line)
+
+    for ln in lines:
+        c.drawString(x, y, ln)
+        y -= line_height
+    return y


### PR DESCRIPTION
## Summary
- prevent long header lines overflowing boxes
- add helper for wrapped text

## Testing
- `pytest -q` *(fails: execution timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6875db04f10c832384ff0babaead55a2