### PR TITLE
Reduce spacing between header and emitter/receiver boxes

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -149,8 +149,8 @@ def generar_factura_electronica_pdf(
     )
 
     # Posiciones base para los cuadros de emisor y receptor
-    # Mantenemos un espacio de 40 puntos debajo del código QR
-    encabezado_y = qr_y - 40
+    # Mantenemos un espacio de 20 puntos debajo del código QR para acercarlos al encabezado
+    encabezado_y = qr_y - 20
 
     # --- Datos del EMISOR (izquierda) y RECEPTOR (derecha) ---
 


### PR DESCRIPTION
## Summary
- tweak PDF layout so emitter/receiver blocks sit closer to the header

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: output truncated due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68767b9ffa688323a2febebc366c3d3b