### PR TITLE
Make emitter/receiver boxes invisible

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -161,8 +161,10 @@ def generar_factura_electronica_pdf(
     receptor_x = emisor_x + box_w + 10
 
     c.setLineWidth(0.7)
+    c.setStrokeColor(colors.white)
     c.roundRect(emisor_x, box_y, box_w, box_h, 6, stroke=1, fill=0)
     c.roundRect(receptor_x, box_y, box_w, box_h, 6, stroke=1, fill=0)
+    c.setStrokeColor(colors.black)
 
     text_y = box_y + box_h - 14
     c.setFont("Helvetica-Bold", 8)


### PR DESCRIPTION
## Summary
- change the borders around *emisor* and *receptor* sections so they are not visible
- run factura PDF test

## Testing
- `pytest tests/test_factura_pdf.py::test_factura_header_contains_doc_type -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b96d8f1c8323838bd6be82e02879