### PR TITLE
Adjust header rectangles in DTE PDF

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -4,6 +4,7 @@ from reportlab.graphics import renderPDF
 from reportlab.graphics.barcode import qr
 from reportlab.graphics.shapes import Drawing
 from reportlab.lib.units import mm
+from reportlab.lib import colors
 
 from utils.pdf_utils import draw_wrapped_text
 
@@ -43,7 +44,9 @@ def generar_cabecera_dte(
 
     # --- Caja izquierda ---
     c.setLineWidth(0.7)
+    c.setStrokeColor(colors.white)
     c.roundRect(40, box_y, box_w, box_h, 6, stroke=1, fill=0)
+    c.setStrokeColor(colors.black)
     text_y = box_y + box_h - 10
     max_w = box_w - 10
     text_y = draw_wrapped_text(
@@ -84,7 +87,9 @@ def generar_cabecera_dte(
 
     # --- Caja derecha ---
     right_x = 40 + box_w + col_margin + qr_size + col_margin
+    c.setStrokeColor(colors.white)
     c.roundRect(right_x, box_y, box_w, box_h, 6, stroke=1, fill=0)
+    c.setStrokeColor(colors.black)
     text_y = box_y + box_h - 10
     max_w = box_w - 10
     text_y = draw_wrapped_text(


### PR DESCRIPTION
## Summary
- set stroke color to white when drawing generation and model rectangles in DTE header
- import `colors` for PDF styling
- keep stroke colour black for text

## Testing
- `pytest tests/test_dte_header_pdf.py::test_generar_cabecera_consumidor_final -q`
- `pytest tests/test_factura_pdf.py::test_header_boxes_and_qr -q`
- `pytest -k dte_header_pdf -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ccdb379c8323b07d72e0955efc5c