### PR TITLE
Improve 'Venta a cuenta de' handling

### DIFF
--- a/db.py
+++ b/db.py
@@ -231,6 +231,7 @@ class DB:
                 orden_no TEXT,
                 condicion_pago TEXT,
                 venta_a_cuenta_de TEXT,
+                documento_venta_a_cuenta TEXT,
                 fecha_remision_anterior TEXT,
                 fecha_remision TEXT,
                 FOREIGN KEY (venta_id) REFERENCES ventas(id),
@@ -249,6 +250,7 @@ class DB:
             )
         """
         )
+        self.ensure_column("ventas_credito_fiscal", "documento_venta_a_cuenta", "TEXT")
         self.cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS tickets_pdf (
@@ -623,6 +625,7 @@ class DB:
         orden_no="",
         condicion_pago="",
         venta_a_cuenta_de="",
+        documento_venta_a_cuenta="",
         fecha_remision_anterior="",
         fecha_remision="",
         sumas=0,
@@ -636,6 +639,7 @@ class DB:
     ):
         # Asegura que la columna estado exista antes de insertar
         self.ensure_column("ventas", "estado", "TEXT DEFAULT 'Pagada'")
+        self.ensure_column("ventas_credito_fiscal", "documento_venta_a_cuenta", "TEXT")
         try:
             cols = ["fecha", "total", "cliente_id", "estado"]
             vals = [fecha, total, cliente_id, estado]
@@ -661,6 +665,7 @@ class DB:
                     orden_no TEXT,
                     condicion_pago TEXT,
                     venta_a_cuenta_de TEXT,
+                    documento_venta_a_cuenta TEXT,
                     fecha_remision_anterior TEXT,
                     fecha_remision TEXT,
                     FOREIGN KEY (venta_id) REFERENCES ventas(id),
@@ -672,13 +677,13 @@ class DB:
                 INSERT INTO ventas_credito_fiscal (
                     venta_id, cliente_id, nrc, nit, giro,
                     no_remision, orden_no, condicion_pago, venta_a_cuenta_de,
-                    fecha_remision_anterior, fecha_remision,
+                    documento_venta_a_cuenta, fecha_remision_anterior, fecha_remision,
                     sumas, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 venta_id, cliente_id, nrc, nit, giro,
                 no_remision, orden_no, condicion_pago, venta_a_cuenta_de,
-                fecha_remision_anterior, fecha_remision,
+                documento_venta_a_cuenta, fecha_remision_anterior, fecha_remision,
                 sumas, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra_json
             ))
             self.conn.commit()

--- a/dialogs.py
+++ b/dialogs.py
@@ -680,8 +680,12 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         # Campo "Venta a cuenta de"
         right_layout.addWidget(QLabel("Venta a cuenta de:"))
         self.venta_a_cuenta_de_edit = QLineEdit()
-        self.venta_a_cuenta_de_edit.setPlaceholderText("Venta a cuenta de")
+        self.venta_a_cuenta_de_edit.setPlaceholderText("Nombre")
         right_layout.addWidget(self.venta_a_cuenta_de_edit)
+        right_layout.addWidget(QLabel("DUI/NIT:"))
+        self.venta_documento_edit = QLineEdit()
+        self.venta_documento_edit.setPlaceholderText("Documento")
+        right_layout.addWidget(self.venta_documento_edit)
 
         # Distribuidor
         right_layout.addWidget(QLabel("Distribuidor:"))
@@ -932,6 +936,7 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             "precio_total_manual": float(self.precio_total_spin.value()),
             "iva_agregado": self.iva_agregado_radio.isChecked(),
             "venta_a_cuenta_de": self.venta_a_cuenta_de_edit.text(),
+            "documento_venta_a_cuenta": self.venta_documento_edit.text(),
             "sumas": sumas,
             "iva": iva,
             "ventas_exentas": ventas_exentas,
@@ -2253,6 +2258,7 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
             "orden_no": self.orden_no_edit.text(),
             "condicion_pago": self.condicion_pago_combo.currentText(),
             "venta_a_cuenta_de": self.venta_a_cuenta_de_edit.text(),
+            "documento_venta_a_cuenta": self.venta_documento_edit.text(),
             "fecha_remision_anterior": self.fecha_remision_anterior.date().toString("yyyy-MM-dd"),
             "fecha_remision": self.fecha_remision.date().toString("yyyy-MM-dd"),
             "sumas": sumas,
@@ -2984,6 +2990,7 @@ class ManualInvoiceDialog(QDialog):
         self.cf_orden_no = QLineEdit()
         self.cf_vendedor = QLineEdit()
         self.cf_venta_cuenta = QLineEdit()
+        self.cf_documento_cuenta = QLineEdit()
         self.cf_fecha = QDateEdit(QDate.currentDate())
         self.cf_fecha.setCalendarPopup(True)
         self.cf_nombre = QLineEdit()
@@ -3000,6 +3007,7 @@ class ManualInvoiceDialog(QDialog):
             ("Orden No:", self.cf_orden_no),
             ("Vendedor:", self.cf_vendedor),
             ("Venta a cuenta de:", self.cf_venta_cuenta),
+            ("DUI/NIT:", self.cf_documento_cuenta),
             ("Fecha:", self.cf_fecha),
             ("Nombre:", self.cf_nombre),
             ("Dirección:", self.cf_direccion),
@@ -3023,6 +3031,7 @@ class ManualInvoiceDialog(QDialog):
         self.cr_orden_no = QLineEdit()
         self.cr_vendedor = QLineEdit()
         self.cr_venta_cuenta = QLineEdit()
+        self.cr_documento_cuenta = QLineEdit()
         self.cr_fecha = QDateEdit(QDate.currentDate())
         self.cr_fecha.setCalendarPopup(True)
         self.cr_cliente_nombre = QLineEdit()
@@ -3042,6 +3051,7 @@ class ManualInvoiceDialog(QDialog):
             ("Orden No:", self.cr_orden_no),
             ("Vendedor:", self.cr_vendedor),
             ("Venta a cuenta de:", self.cr_venta_cuenta),
+            ("DUI/NIT:", self.cr_documento_cuenta),
             ("Fecha:", self.cr_fecha),
             ("Cliente:", self.cr_cliente_nombre),
             ("Dirección:", self.cr_cliente_direccion),
@@ -3082,6 +3092,7 @@ class ManualInvoiceDialog(QDialog):
                 "orden_no": self.cf_orden_no.text(),
                 "vendedor_nombre": self.cf_vendedor.text(),
                 "venta_a_cuenta_de": self.cf_venta_cuenta.text(),
+                "documento_venta_a_cuenta": self.cf_documento_cuenta.text(),
                 "fecha": self.cf_fecha.date().toString("yyyy-MM-dd"),
                 "total_letras": self.cf_total_letras.text(),
                 "observaciones": self.cf_observaciones.toPlainText(),
@@ -3102,6 +3113,7 @@ class ManualInvoiceDialog(QDialog):
                 "orden_no": self.cr_orden_no.text(),
                 "vendedor_nombre": self.cr_vendedor.text(),
                 "venta_a_cuenta_de": self.cr_venta_cuenta.text(),
+                "documento_venta_a_cuenta": self.cr_documento_cuenta.text(),
                 "fecha": self.cr_fecha.date().toString("yyyy-MM-dd"),
                 "total_letras": self.cr_total_letras.text(),
                 "observaciones": self.cr_observaciones.toPlainText(),

--- a/dte.py
+++ b/dte.py
@@ -114,7 +114,7 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         "totalPagar": venta.get("total", total),
     }
 
-    return {
+    result = {
         "identificacion": identificacion,
         "emisor": emisor,
         "receptor": receptor,
@@ -123,3 +123,11 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         "firmaElectronica": None,
         "selloRecibido": None,
     }
+
+    if fiscal:
+        if fiscal.get("venta_a_cuenta_de"):
+            result["ventaACuentaDe"] = fiscal.get("venta_a_cuenta_de")
+        if fiscal.get("documento_venta_a_cuenta"):
+            result["documentoVentaACuenta"] = fiscal.get("documento_venta_a_cuenta")
+
+    return result

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -203,6 +203,13 @@ def generar_factura_electronica_pdf(
     c.drawString(receptor_x + 5, text_y, f"Giro: {cliente.get('giro', '')}")
     text_y -= 12
     c.drawString(receptor_x + 5, text_y, f"Dirección: {cliente.get('direccion', '')}")
+    if venta.get('venta_a_cuenta_de'):
+        text_y -= 12
+        c.drawString(receptor_x + 5, text_y, f"Venta a cuenta de: {venta.get('venta_a_cuenta_de')}")
+    doc = venta.get('documento_venta_a_cuenta')
+    if doc:
+        text_y -= 12
+        c.drawString(receptor_x + 5, text_y, f"DUI: {doc}")
 
     # Posición inicial para la tabla de productos
     tabla_x = x_margin

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -329,10 +329,10 @@ class InventoryManager:
                 """
                 INSERT INTO ventas_credito_fiscal (
                     venta_id, cliente_id, nrc, nit, giro, no_remision, orden_no, condicion_pago,
-                    venta_a_cuenta_de, fecha_remision_anterior, fecha_remision,
+                    venta_a_cuenta_de, documento_venta_a_cuenta, fecha_remision_anterior, fecha_remision,
                     sumas, iva, subtotal, total_letras,
                     ventas_exentas, ventas_no_sujetas, extra
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     venta_id_map.get(vcf.get("venta_id")),
@@ -344,6 +344,7 @@ class InventoryManager:
                     vcf.get("orden_no"),
                     vcf.get("condicion_pago"),
                     vcf.get("venta_a_cuenta_de"),
+                    vcf.get("documento_venta_a_cuenta"),
                     vcf.get("fecha_remision_anterior"),
                     vcf.get("fecha_remision"),
                     vcf.get("sumas", 0),

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -743,6 +743,7 @@ class MainWindow(QMainWindow):
                     orden_no=data.get("orden_no", ""),
                     condicion_pago=data.get("condicion_pago", ""),
                     venta_a_cuenta_de=data.get("venta_a_cuenta_de", ""),
+                    documento_venta_a_cuenta=data.get("documento_venta_a_cuenta", ""),
                     fecha_remision_anterior=data.get("fecha_remision_anterior", ""),
                     fecha_remision=data.get("fecha_remision", ""),
                     sumas=sumas,


### PR DESCRIPTION
## Summary
- add `documento_venta_a_cuenta` column for credit-fiscal sales
- expose document field in sales dialogs
- include new field when saving a sale and in manual invoice dialog
- output both name and document on generated PDFs
- include fields in exported DTE JSON

## Testing
- `pytest -q` *(fails: process hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6876ed850c9883239433f2fc12a73684