### PR TITLE
Add field for DUI/NIT in credit sales

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1922,6 +1922,10 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         self.venta_a_cuenta_de_edit = QLineEdit()
         self.venta_a_cuenta_de_edit.setPlaceholderText("Venta a cuenta de")
         right_layout.addWidget(self.venta_a_cuenta_de_edit)
+        right_layout.addWidget(QLabel("DUI/NIT:"))
+        self.venta_documento_edit = QLineEdit()
+        self.venta_documento_edit.setPlaceholderText("Documento")
+        right_layout.addWidget(self.venta_documento_edit)
 
         right_layout.addWidget(QLabel("Fecha nota de remisión anterior:"))
         self.fecha_remision_anterior = QDateEdit(QDate.currentDate())

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -209,7 +209,7 @@ def generar_factura_electronica_pdf(
     doc = venta.get('documento_venta_a_cuenta')
     if doc:
         text_y -= 12
-        c.drawString(receptor_x + 5, text_y, f"DUI: {doc}")
+        c.drawString(receptor_x + 5, text_y, f"DUI/NIT: {doc}")
 
     # Posición inicial para la tabla de productos
     tabla_x = x_margin


### PR DESCRIPTION
## Summary
- allow entering client document info for credit fiscal sales
- include DUI/NIT on credit invoice PDF

## Testing
- `pytest tests/test_generar_dte_json.py -q`
- `pytest tests/test_factura_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6876f79bf05c8323a41f9511a4dcc617