### PR TITLE
Add payment fields to DTE and invoice

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -95,6 +95,10 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
             "nrc": fiscal.get("nrc") or receptor.get("nrc"),
             "giro": fiscal.get("giro") or receptor.get("giro"),
         })
+        if fiscal.get("no_remision"):
+            receptor["noRemision"] = fiscal.get("no_remision")
+        if fiscal.get("orden_no"):
+            receptor["ordenNo"] = fiscal.get("orden_no")
 
     cuerpo = []
     for idx, d in enumerate(detalles, 1):
@@ -122,6 +126,7 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         "resumen": resumen,
         "firmaElectronica": None,
         "selloRecibido": None,
+        "condicionPago": fiscal.get("condicion_pago") if fiscal else None,
     }
 
     if fiscal:

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -203,6 +203,12 @@ def generar_factura_electronica_pdf(
     c.drawString(receptor_x + 5, text_y, f"Giro: {cliente.get('giro', '')}")
     text_y -= 12
     c.drawString(receptor_x + 5, text_y, f"Dirección: {cliente.get('direccion', '')}")
+    text_y -= 12
+    c.drawString(receptor_x + 5, text_y, f"No. Remisión: {venta.get('no_remision', '')}")
+    text_y -= 12
+    c.drawString(receptor_x + 5, text_y, f"Orden No.: {venta.get('orden_no', '')}")
+    text_y -= 12
+    c.drawString(receptor_x + 5, text_y, f"Condición pago: {venta.get('condicion_pago', '')}")
     if venta.get('venta_a_cuenta_de'):
         text_y -= 12
         c.drawString(receptor_x + 5, text_y, f"Venta a cuenta de: {venta.get('venta_a_cuenta_de')}")

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -27,9 +27,12 @@ def test_generar_dte_json_basic():
         "resumen",
         "firmaElectronica",
         "selloRecibido",
+        "condicionPago",
     ]
     for key in required:
         assert key in data
     assert data["firmaElectronica"] is None
     assert data["selloRecibido"] is None
     assert data["identificacion"].get("codigoGeneracion")
+    assert data["receptor"].get("noRemision") is None
+    assert data["receptor"].get("ordenNo") is None


### PR DESCRIPTION
## Summary
- capture additional payment fields in generated DTE
- display payment information on PDF invoices
- expect new key in DTE unit tests

## Testing
- `pytest tests/test_generar_dte_json.py -q`
- `pytest tests/test_factura_pdf.py -q`
- `pytest -q` *(fails: Qt-based tests require GUI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68770a9baba08323b22cd2a975f9572e