### PR TITLE
Implement detailed invoice totals

### DIFF
--- a/db.py
+++ b/db.py
@@ -433,6 +433,7 @@ class DB:
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN iva REAL DEFAULT 0")
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN subtotal REAL DEFAULT 0")
             self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN total_letras TEXT")
+            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN descuentos REAL DEFAULT 0")
             self.cursor.execute("ALTER TABLE ventas ADD COLUMN extra TEXT")
             self.cursor.execute("ALTER TABLE ventas ADD COLUMN estado TEXT DEFAULT 'Pagada'")
             self.conn.commit()
@@ -629,6 +630,7 @@ class DB:
         fecha_remision_anterior="",
         fecha_remision="",
         sumas=0,
+        descuentos=0,
         iva=0,
         subtotal=0,
         ventas_exentas=0,
@@ -678,13 +680,13 @@ class DB:
                     venta_id, cliente_id, nrc, nit, giro,
                     no_remision, orden_no, condicion_pago, venta_a_cuenta_de,
                     documento_venta_a_cuenta, fecha_remision_anterior, fecha_remision,
-                    sumas, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    sumas, descuentos, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 venta_id, cliente_id, nrc, nit, giro,
                 no_remision, orden_no, condicion_pago, venta_a_cuenta_de,
                 documento_venta_a_cuenta, fecha_remision_anterior, fecha_remision,
-                sumas, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra_json
+                sumas, descuentos, iva, subtotal, ventas_exentas, ventas_no_sujetas, total_letras, extra_json
             ))
             self.conn.commit()
             return venta_id

--- a/dialogs.py
+++ b/dialogs.py
@@ -909,6 +909,7 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             vendedor_id = self.vendedores_trabajadores[vendedor_idx - 1]["id"]
 
         sumas = 0
+        descuentos = 0
         ventas_exentas = 0
         ventas_no_sujetas = 0
         total = 0
@@ -917,7 +918,8 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         for item in self.venta_items:
             tipo_fiscal = item.get("tipo_fiscal", "").lower()
             if tipo_fiscal == "venta gravada":
-                sumas += item["subtotal_con_descuento"]
+                sumas += item["subtotal"]
+                descuentos += item.get("descuento_monto", 0)
                 iva += item.get("iva", 0)  # <-- Suma el IVA real de cada producto gravado
             elif tipo_fiscal == "venta exenta":
                 ventas_exentas += item["subtotal_con_descuento"]
@@ -938,11 +940,12 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             "venta_a_cuenta_de": self.venta_a_cuenta_de_edit.text(),
             "documento_venta_a_cuenta": self.venta_documento_edit.text(),
             "sumas": sumas,
+            "descuentos": descuentos,
             "iva": iva,
             "ventas_exentas": ventas_exentas,
             "ventas_no_sujetas": ventas_no_sujetas,
-            "subtotal": sumas + ventas_exentas + ventas_no_sujetas,
-            "total": sumas + ventas_exentas + ventas_no_sujetas + iva,
+            "subtotal": (sumas - descuentos) + iva,
+            "total": (sumas - descuentos) + iva + ventas_exentas + ventas_no_sujetas,
             "fecha": QDate.currentDate().toString("yyyy-MM-dd"),
             "Distribuidor_id": (
                 self.Distribuidor_combo.currentIndex()
@@ -2224,6 +2227,7 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
             vendedor_id = self.vendedores_trabajadores[vendedor_idx - 1]["id"]
 
         sumas = 0
+        descuentos = 0
         ventas_exentas = 0
         ventas_no_sujetas = 0
         total = 0
@@ -2236,7 +2240,8 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
                 base = item.get("subtotal", base)
 
             if tipo_fiscal == "venta gravada":
-                sumas += base
+                sumas += item["subtotal"]
+                descuentos += item.get("descuento_monto", 0)
                 iva += item.get("iva", 0)
             elif tipo_fiscal == "venta exenta":
                 ventas_exentas += base
@@ -2266,11 +2271,12 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
             "fecha_remision_anterior": self.fecha_remision_anterior.date().toString("yyyy-MM-dd"),
             "fecha_remision": self.fecha_remision.date().toString("yyyy-MM-dd"),
             "sumas": sumas,
+            "descuentos": descuentos,
             "iva": iva,
-            "subtotal": sumas + ventas_exentas + ventas_no_sujetas,
+            "subtotal": (sumas - descuentos) + iva,
             "ventas_exentas": ventas_exentas,
             "ventas_no_sujetas": ventas_no_sujetas,
-            "total": sumas + ventas_exentas + ventas_no_sujetas + iva,
+            "total": (sumas - descuentos) + iva + ventas_exentas + ventas_no_sujetas,
             "fecha": QDate.currentDate().toString("yyyy-MM-dd"),
             "Distribuidor_id": (
                 self.Distribuidor_combo.currentIndex()

--- a/dte.py
+++ b/dte.py
@@ -110,11 +110,16 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         })
 
     total = sum(d.get("cantidad", 0) * d.get("precio_unitario", 0) for d in detalles)
+    sumas_val = fiscal.get("sumas", total) if fiscal else total
+    descuentos_val = fiscal.get("descuentos", 0) if fiscal else 0
+    iva_val = fiscal.get("iva") if fiscal else 0
     resumen = {
         "totalNoSuj": fiscal.get("ventas_no_sujetas") if fiscal else 0,
         "totalExenta": fiscal.get("ventas_exentas") if fiscal else 0,
-        "subTotalVentas": fiscal.get("sumas", total) if fiscal else total,
-        "iva": fiscal.get("iva") if fiscal else 0,
+        "sumas": sumas_val,
+        "descuentos": descuentos_val,
+        "iva": iva_val,
+        "subTotal": (sumas_val - descuentos_val) + iva_val,
         "totalPagar": venta.get("total", total),
     }
 

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -280,21 +280,33 @@ def generar_factura_electronica_pdf(
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
-    c.drawString(x_linea + 10, texto_y, "Descuentos y rebajas globales:")
+    c.drawString(x_linea + 10, texto_y, "Descuentos y rebajas:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('descuentos_globales', '')}")
-
-    texto_y -= salto
-    c.setFont("Helvetica-Bold", 9)
-    c.drawString(x_linea + 10, texto_y, "Subtotal:")
-    c.setFont("Helvetica", 9)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('subtotal', '')}")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('descuentos', 0):.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "IVA 13%:")
     c.setFont("Helvetica", 9)
     c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('iva', '')}")
+
+    texto_y -= salto
+    c.setFont("Helvetica-Bold", 9)
+    c.drawString(x_linea + 10, texto_y, "Subtotal:")
+    c.setFont("Helvetica", 9)
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('subtotal', 0):.2f}")
+
+    texto_y -= salto
+    c.setFont("Helvetica-Bold", 9)
+    c.drawString(x_linea + 10, texto_y, "Exentas:")
+    c.setFont("Helvetica", 9)
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('ventas_exentas', 0):.2f}")
+
+    texto_y -= salto
+    c.setFont("Helvetica-Bold", 9)
+    c.drawString(x_linea + 10, texto_y, "No sujetas:")
+    c.setFont("Helvetica", 9)
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('ventas_no_sujetas', 0):.2f}")
 
     texto_y -= salto + 10  # Más espacio antes de "Total a pagar"
     c.setFont("Helvetica-Bold", 10)

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -334,13 +334,14 @@ class FacturacionTab(QWidget):
             if trabajador:
                 venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
 
-        sumas = ventas_exentas = ventas_no_sujetas = iva = 0
+        sumas = descuentos = 0
+        ventas_exentas = ventas_no_sujetas = iva = 0
         for d in detalles:
-            base = d.get("precio_unitario", 0) * d.get("cantidad", 0)
+            base_total = d.get("precio_unitario", 0) * d.get("cantidad", 0)
+            desc = d.get("descuento", 0)
             if d.get("descuento_tipo") == "%":
-                base -= base * d.get("descuento", 0) / 100
-            else:
-                base -= d.get("descuento", 0)
+                desc = base_total * d.get("descuento", 0) / 100
+            base = base_total - desc
             iva_item = d.get("iva", 0)
             tipo = d.get("tipo_fiscal", "").lower()
             if tipo == "venta exenta":
@@ -351,14 +352,16 @@ class FacturacionTab(QWidget):
                 ventas_no_sujetas += base
             else:
                 d["ventas_gravadas"] = base
-                sumas += base
+                sumas += base_total
+                descuentos += desc
                 iva += iva_item
 
-        subtotal = sumas + ventas_exentas + ventas_no_sujetas
-        total = subtotal + iva
+        subtotal = (sumas - descuentos) + iva
+        total = subtotal + ventas_exentas + ventas_no_sujetas
         venta_data.update(
             {
                 "sumas": sumas,
+                "descuentos": descuentos,
                 "iva": iva,
                 "ventas_exentas": ventas_exentas,
                 "ventas_no_sujetas": ventas_no_sujetas,

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -502,13 +502,14 @@ class SalesTab(QWidget):
             if trabajador:
                 venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
 
-        sumas = ventas_exentas = ventas_no_sujetas = iva = 0
+        sumas = descuentos = 0
+        ventas_exentas = ventas_no_sujetas = iva = 0
         for d in detalles:
-            base = d.get("precio_unitario", 0) * d.get("cantidad", 0)
+            base_total = d.get("precio_unitario", 0) * d.get("cantidad", 0)
+            desc = d.get("descuento", 0)
             if d.get("descuento_tipo") == "%":
-                base -= base * d.get("descuento", 0) / 100
-            else:
-                base -= d.get("descuento", 0)
+                desc = base_total * d.get("descuento", 0) / 100
+            base = base_total - desc
             iva_item = d.get("iva", 0)
             tipo = d.get("tipo_fiscal", "").lower()
             if tipo == "venta exenta":
@@ -519,14 +520,16 @@ class SalesTab(QWidget):
                 ventas_no_sujetas += base
             else:
                 d["ventas_gravadas"] = base
-                sumas += base
+                sumas += base_total
+                descuentos += desc
                 iva += iva_item
 
-        subtotal = sumas + ventas_exentas + ventas_no_sujetas
-        total = subtotal + iva
+        subtotal = (sumas - descuentos) + iva
+        total = subtotal + ventas_exentas + ventas_no_sujetas
         venta_data.update(
             {
                 "sumas": sumas,
+                "descuentos": descuentos,
                 "iva": iva,
                 "ventas_exentas": ventas_exentas,
                 "ventas_no_sujetas": ventas_no_sujetas,

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -6,7 +6,7 @@ from factura_sv import generar_factura_electronica_pdf
 def _sample_data(tipo):
     venta = {
         'sumas': 10,
-        'descuentos_globales': 0,
+        'descuentos': 0,
         'subtotal': 10,
         'iva': 1.3,
         'total': 11.3,

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -14,7 +14,7 @@ def test_generar_dte_json_basic():
     prod_id = db.cursor.lastrowid
     db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro")
+    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
 
     data = generar_dte_json(db, venta_id)

--- a/tests/test_get_venta_credito_fiscal.py
+++ b/tests/test_get_venta_credito_fiscal.py
@@ -20,6 +20,7 @@ def test_get_venta_credito_fiscal_basic():
         "123",
         "nit1",
         "giro",
+        descuentos=0,
     )
 
     record = db.get_venta_credito_fiscal(venta_id)
@@ -42,6 +43,7 @@ def test_extra_is_json_string():
         "456",
         "nit2",
         "giro2",
+        descuentos=0,
         extra=extra,
     )
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -719,6 +719,7 @@ class MainWindow(QMainWindow):
                 
                 # --- CÁLCULOS FISCALES ---
                 sumas = data.get("sumas", 0)
+                descuentos = data.get("descuentos", 0)
                 iva = data.get("iva", 0)
                 subtotal = data.get("subtotal", 0)
                 venta_total = data.get("total", 0)
@@ -747,6 +748,7 @@ class MainWindow(QMainWindow):
                     fecha_remision_anterior=data.get("fecha_remision_anterior", ""),
                     fecha_remision=data.get("fecha_remision", ""),
                     sumas=sumas,
+                    descuentos=descuentos,
                     iva=iva,
                     subtotal=subtotal,
                     ventas_exentas=data.get("ventas_exentas", 0),


### PR DESCRIPTION
## Summary
- add `descuentos` field in `ventas_credito_fiscal`
- compute discounts and new totals when capturing sales
- generate invoices with sumas, descuentos, IVA, exentas and no sujetas
- expose new values in DTE JSON
- update tests for the new function signature

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_6877198a6f548323a6b94f311d5a19f8