### PR TITLE
Fix credit fiscal sale validation

### DIFF
--- a/db.py
+++ b/db.py
@@ -692,7 +692,8 @@ class DB:
             return venta_id
         except Exception as e:
             logger.exception("Error al agregar venta a crédito fiscal: %s", e)
-            return None
+            self.conn.rollback()
+            raise
 
 
     def get_ventas(self):

--- a/fitz.py
+++ b/fitz.py
@@ -1,1 +1,2 @@
-from pymupdf import *  # type: ignore
+from PyMuPDF import fitz as _fitz  # type: ignore
+globals().update(_fitz.__dict__)

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -752,9 +752,13 @@ class MainWindow(QMainWindow):
                     iva=iva,
                     subtotal=subtotal,
                     ventas_exentas=data.get("ventas_exentas", 0),
-                    ventas_no_sujetas=data.get("ventas_no_sujetas", 0),   
+                    ventas_no_sujetas=data.get("ventas_no_sujetas", 0),
                     total_letras=total_letras
                 )
+                if not venta_id:
+                    raise ValueError(
+                        "No se pudo registrar la venta a cr\xE9dito fiscal."
+                    )
                 logger.debug("IVA guardado en la venta: %s", iva)
 
                 for item in items:


### PR DESCRIPTION
## Summary
- validate venta_id when creating credit fiscal sales
- rollback and raise on DB insertion failures
- adjust PyMuPDF shim

## Testing
- `pytest tests/test_get_venta_credito_fiscal.py tests/test_generar_dte_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68772c5705b08323bdabadc61f1e5965