### PR TITLE
Fix schema creation for credit sales

### DIFF
--- a/db.py
+++ b/db.py
@@ -234,6 +234,14 @@ class DB:
                 documento_venta_a_cuenta TEXT,
                 fecha_remision_anterior TEXT,
                 fecha_remision TEXT,
+                sumas REAL DEFAULT 0,
+                descuentos REAL DEFAULT 0,
+                iva REAL DEFAULT 0,
+                subtotal REAL DEFAULT 0,
+                ventas_exentas REAL DEFAULT 0,
+                ventas_no_sujetas REAL DEFAULT 0,
+                total_letras TEXT,
+                extra TEXT,
                 FOREIGN KEY (venta_id) REFERENCES ventas(id),
                 FOREIGN KEY (cliente_id) REFERENCES clientes(id)
             )
@@ -670,6 +678,14 @@ class DB:
                     documento_venta_a_cuenta TEXT,
                     fecha_remision_anterior TEXT,
                     fecha_remision TEXT,
+                    sumas REAL DEFAULT 0,
+                    descuentos REAL DEFAULT 0,
+                    iva REAL DEFAULT 0,
+                    subtotal REAL DEFAULT 0,
+                    ventas_exentas REAL DEFAULT 0,
+                    ventas_no_sujetas REAL DEFAULT 0,
+                    total_letras TEXT,
+                    extra TEXT,
                     FOREIGN KEY (venta_id) REFERENCES ventas(id),
                     FOREIGN KEY (cliente_id) REFERENCES clientes(id)
                 )

--- a/fitz.py
+++ b/fitz.py
@@ -1,2 +1,15 @@
-from PyMuPDF import fitz as _fitz  # type: ignore
+"""Compatibility wrapper for the :mod:`fitz` bindings from PyMuPDF.
+
+PyMuPDF changed its top level package name from ``PyMuPDF`` to
+``pymupdf`` starting with version 1.22. Older installations still export
+the bindings via ``PyMuPDF``.  This small wrapper tries the new import
+first and falls back to the legacy location so the rest of the code can
+simply ``import fitz`` regardless of the installed version.
+"""
+
+try:  # PyMuPDF >= 1.22
+    import pymupdf as _fitz  # type: ignore
+except ModuleNotFoundError:  # Older versions
+    from PyMuPDF import fitz as _fitz  # type: ignore
+
 globals().update(_fitz.__dict__)


### PR DESCRIPTION
## Summary
- create `descuentos` and other fiscal fields at table creation
- allow fitz wrapper to import newer `pymupdf`

## Testing
- `pytest tests/test_get_venta_credito_fiscal.py::test_get_venta_credito_fiscal_basic -q` *(fails: ModuleNotFoundError due to PyQt)*

------
https://chatgpt.com/codex/tasks/task_e_687730bbfe68832392dd1944bd82e465