### PR TITLE
Fix missing column migrations

### DIFF
--- a/db.py
+++ b/db.py
@@ -436,17 +436,21 @@ class DB:
             self.conn.commit()
         except Exception:
             pass  # Ya existe la columna
-        try:
-            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN sumas REAL DEFAULT 0")
-            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN iva REAL DEFAULT 0")
-            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN subtotal REAL DEFAULT 0")
-            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN total_letras TEXT")
-            self.cursor.execute("ALTER TABLE ventas_credito_fiscal ADD COLUMN descuentos REAL DEFAULT 0")
-            self.cursor.execute("ALTER TABLE ventas ADD COLUMN extra TEXT")
-            self.cursor.execute("ALTER TABLE ventas ADD COLUMN estado TEXT DEFAULT 'Pagada'")
-            self.conn.commit()
-        except Exception:
-            pass  # Ya existen
+        # Asegura columnas adicionales en ventas_credito_fiscal y ventas
+        for stmt in [
+            "ALTER TABLE ventas_credito_fiscal ADD COLUMN sumas REAL DEFAULT 0",
+            "ALTER TABLE ventas_credito_fiscal ADD COLUMN iva REAL DEFAULT 0",
+            "ALTER TABLE ventas_credito_fiscal ADD COLUMN subtotal REAL DEFAULT 0",
+            "ALTER TABLE ventas_credito_fiscal ADD COLUMN total_letras TEXT",
+            "ALTER TABLE ventas_credito_fiscal ADD COLUMN descuentos REAL DEFAULT 0",
+            "ALTER TABLE ventas ADD COLUMN extra TEXT",
+            "ALTER TABLE ventas ADD COLUMN estado TEXT DEFAULT 'Pagada'",
+        ]:
+            try:
+                self.cursor.execute(stmt)
+                self.conn.commit()
+            except Exception:
+                pass  # La columna ya existe o no se pudo crear
         try:
             self.cursor.execute("ALTER TABLE detalles_venta ADD COLUMN extra TEXT")
             self.conn.commit()


### PR DESCRIPTION
## Summary
- ensure optional columns like `descuentos` are added even when earlier `ALTER TABLE` statements fail

## Testing
- `pytest tests/test_fiscal_sales_cleanup.py::test_import_resets_fiscal_sales -q`
- `pytest tests/test_factura_pdf.py -q`
- `pytest tests/test_ticket_format.py -q`
- `pytest tests/test_generar_dte_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687736686b7c83239c9f0d31a0c404b5