### PR TITLE
Fix invoice field visibility

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -86,14 +86,12 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         "nombre": rec.get("nombre"),
         "direccion": rec.get("direccion"),
         "nit": rec.get("nit"),
-        "nrc": rec.get("nrc"),
-        "giro": rec.get("giro"),
     }
     if fiscal:
         receptor.update({
-            "nit": fiscal.get("nit") or receptor.get("nit"),
-            "nrc": fiscal.get("nrc") or receptor.get("nrc"),
-            "giro": fiscal.get("giro") or receptor.get("giro"),
+            "nrc": fiscal.get("nrc") or rec.get("nrc"),
+            "giro": fiscal.get("giro") or rec.get("giro"),
+            "nit": fiscal.get("nit") or rec.get("nit"),
         })
         if fiscal.get("no_remision"):
             receptor["noRemision"] = fiscal.get("no_remision")
@@ -131,8 +129,9 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         "resumen": resumen,
         "firmaElectronica": None,
         "selloRecibido": None,
-        "condicionPago": fiscal.get("condicion_pago") if fiscal else None,
     }
+    if fiscal:
+        result["condicionPago"] = fiscal.get("condicion_pago")
 
     if fiscal:
         if fiscal.get("venta_a_cuenta_de"):

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -203,18 +203,23 @@ def generar_factura_electronica_pdf(
 
     text_y -= line_h
     c.drawString(left_x, text_y, f"DUI: {cliente.get('dui', '')}")
-    c.drawString(right_x, text_y, f"NRC: {cliente.get('nrc', '')}")
+    if tipo_documento == "Crédito Fiscal":
+        c.drawString(right_x, text_y, f"NRC: {cliente.get('nrc', '')}")
 
     text_y -= line_h
     c.drawString(left_x, text_y, f"NIT: {cliente.get('nit', '')}")
-    c.drawString(right_x, text_y, f"No. Remisión: {venta.get('no_remision', '')}")
+    if tipo_documento == "Crédito Fiscal":
+        c.drawString(right_x, text_y, f"No. Remisión: {venta.get('no_remision', '')}")
 
-    text_y -= line_h
-    c.drawString(left_x, text_y, f"Giro: {cliente.get('giro', '')}")
-    c.drawString(right_x, text_y, f"Orden No.: {venta.get('orden_no', '')}")
+    if tipo_documento == "Crédito Fiscal":
+        text_y -= line_h
+        c.drawString(left_x, text_y, f"Giro: {cliente.get('giro', '')}")
+        c.drawString(right_x, text_y, f"Orden No.: {venta.get('orden_no', '')}")
 
-    text_y -= line_h
-    c.drawString(left_x, text_y, f"Condición pago: {venta.get('condicion_pago', '')}")
+        text_y -= line_h
+        c.drawString(left_x, text_y, f"Condición pago: {venta.get('condicion_pago', '')}")
+    else:
+        text_y -= line_h
 
     text_y -= line_h
     c.drawString(left_x, text_y, f"Dirección: {cliente.get('direccion', '')}")


### PR DESCRIPTION
## Summary
- show NRC, giro, número de remisión, orden y condición de pago only for crédito fiscal invoices in the PDF
- omit these fields from generated DTE JSON for consumidor final invoices
- keep `condicionPago` field in JSON for crédito fiscal invoices

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic -q`
- `pytest tests/test_factura_pdf.py -q`
- `pytest -k 'dte_json or factura_pdf' -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a20929048323ab01e9e4f6f6cf3b