### PR TITLE
Ensure optional 'venta a cuenta' fields persist across sales

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -51,6 +51,13 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
 
     detalles = db.get_detalles_venta(venta_id)
     fiscal = db.get_venta_credito_fiscal(venta_id)
+    extra = {}
+    raw_extra = venta.get("extra")
+    if raw_extra:
+        try:
+            extra = json.loads(raw_extra)
+        except Exception:
+            extra = {}
 
     cliente = None
     if venta.get("cliente_id"):
@@ -138,5 +145,10 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
             result["ventaACuentaDe"] = fiscal.get("venta_a_cuenta_de")
         if fiscal.get("documento_venta_a_cuenta"):
             result["documentoVentaACuenta"] = fiscal.get("documento_venta_a_cuenta")
+    else:
+        if extra.get("venta_a_cuenta_de"):
+            result["ventaACuentaDe"] = extra.get("venta_a_cuenta_de")
+        if extra.get("documento_venta_a_cuenta"):
+            result["documentoVentaACuenta"] = extra.get("documento_venta_a_cuenta")
 
     return result

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -391,6 +391,10 @@ class FacturacionTab(QWidget):
                 extra = json.loads(extra)
             except Exception:
                 extra = {}
+        if not venta_data.get("venta_a_cuenta_de"):
+            venta_data["venta_a_cuenta_de"] = extra.get("venta_a_cuenta_de", "")
+        if not venta_data.get("documento_venta_a_cuenta"):
+            venta_data["documento_venta_a_cuenta"] = extra.get("documento_venta_a_cuenta", "")
         dte_json = extra.get("dteJson") or extra.get("dte_json") or {}
         ident = dte_json.get("identificacion", {})
         codigo_generacion = venta_data.get("codigo_generacion") or ident.get("codigoGeneracion", "")

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -559,6 +559,10 @@ class SalesTab(QWidget):
                 extra = json.loads(extra)
             except Exception:
                 extra = {}
+        if not venta_data.get("venta_a_cuenta_de"):
+            venta_data["venta_a_cuenta_de"] = extra.get("venta_a_cuenta_de", "")
+        if not venta_data.get("documento_venta_a_cuenta"):
+            venta_data["documento_venta_a_cuenta"] = extra.get("documento_venta_a_cuenta", "")
         dte_json = extra.get("dteJson") or extra.get("dte_json") or {}
         ident = dte_json.get("identificacion", {})
         codigo_generacion = venta_data.get("codigo_generacion") or ident.get("codigoGeneracion", "")

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -603,12 +603,18 @@ class MainWindow(QMainWindow):
                 Distribuidor_id = Distribuidor["id"] if Distribuidor else None
                 vendedor_id = data.get("vendedor_id")
                 estado = data.get("estado", "Pagada")
+                extra = {}
+                if data.get("venta_a_cuenta_de") or data.get("documento_venta_a_cuenta"):
+                    extra["venta_a_cuenta_de"] = data.get("venta_a_cuenta_de", "")
+                    extra["documento_venta_a_cuenta"] = data.get("documento_venta_a_cuenta", "")
+
                 venta_id = self.manager.db.add_venta(
                     fecha,
                     total,
                     cliente_id=cliente_id,
                     Distribuidor_id=Distribuidor_id,
                     vendedor_id=vendedor_id,
+                    extra=extra or None,
                     estado=estado,
                 )
                 # Agrega todos los productos de la venta


### PR DESCRIPTION
## Summary
- preserve `venta_a_cuenta_de` and `documento_venta_a_cuenta` when registering
  consumidor final sales
- load those fields from `extra` data when generating PDFs
- include optional fields from `extra` when creating DTE JSON

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_dte_header_pdf.py::test_generar_cabecera_consumidor_final -q` *(fails: Command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6877aa68e95c83239e7578522d1cd088