### PR TITLE
Fix IVA rounding in PDF invoices

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -241,7 +241,7 @@ def generar_factura_electronica_pdf(
         tabla_data.append([
             str(d.get("cantidad", "")),
             d.get("descripcion", ""),
-            f"{d.get('precio_unitario', 0):.2f}",
+            f"{d.get('precio_unitario', 0):.4f}",
             f"{d.get('ventas_no_sujetas', 0):.2f}",
             f"{d.get('ventas_exentas', 0):.2f}",
             f"{d.get('ventas_gravadas', 0):.2f}",
@@ -302,7 +302,7 @@ def generar_factura_electronica_pdf(
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "IVA 13%:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('iva', '')}")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('iva', 0):.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
@@ -326,7 +326,7 @@ def generar_factura_electronica_pdf(
     c.setFont("Helvetica-Bold", 10)
     c.drawString(x_linea + 10, texto_y, "Total a pagar:")
     c.setFont("Helvetica-Bold", 10)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('total', '')}")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('total', 0):.2f}")
 
     # --- Valor en letras (columna izquierda del cuadro, texto más grande y solo el label en negrita) ---
     c.setFont("Helvetica-Bold", 11)

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -66,3 +66,13 @@ def test_header_boxes_and_qr(tmp_path):
     assert 'Tipo Transmisión:' in text
     assert 'Fecha Generación:' in text
 
+
+def test_values_are_rounded(tmp_path):
+    out = _generate(tmp_path, 'Crédito Fiscal')
+    with fitz.open(out) as doc:
+        text = ''.join(p.get_text() for p in doc)
+    # IVA should be shown with two decimal places
+    assert '1.30' in text
+    # Precio unitario is shown with four decimals
+    assert '10.0000' in text
+


### PR DESCRIPTION
## Summary
- round IVA and total amounts to two decimals in factura PDF
- keep unit price with four decimal precision
- add regression test for rounded values

## Testing
- `pytest tests/test_factura_pdf.py::test_values_are_rounded -q`


------
https://chatgpt.com/codex/tasks/task_e_6877b2c7d0648323b26d3b0603690511