### PR TITLE
Reduce gap above invoice product table

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -263,7 +263,7 @@ def generar_factura_electronica_pdf(
 
     # Posición inicial para la tabla de productos
     tabla_x = x_margin
-    tabla_y = box_y - 40
+    tabla_y = box_y - 20
     row_h = 18
     tabla_columnas = ["Cantidad", "Descripción", "Precio Unitario", "No sujetas", "Exentas", "Gravadas"]
     tabla_data = [tabla_columnas]


### PR DESCRIPTION
## Summary
- move product table closer to the emitter/receiver boxes in the invoice PDF

## Testing
- `pytest -q tests/test_factura_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6877c683a4c483238249a445c8d0cf63