### PR TITLE
Add document naming and storage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ archivo. En su lugar, define la variable de entorno `INVENTARIO_EMAIL_PASSWORD`
 con la contraseña correspondiente antes de ejecutar la aplicación.
 
 Las facturas generadas desde la pestaña **Ventas** se guardan automáticamente en
-`facturas/consumidor_final` o `facturas/credito_fiscal` dependiendo del tipo de
+`facturas_consumidor_final` o `facturas_credito_fiscal` dependiendo del tipo de
 documento. Los tickets se almacenan en la carpeta `tickets`. Al imprimir,
 previsualizar o enviar por correo se reutilizan estos PDFs si están disponibles.
-Las notas de débito creadas desde la pestaña **Facturación** se guardan como
-archivos de texto en la carpeta `notas_debito`.
+Las notas de débito creadas desde la pestaña **Facturación** se guardan en la
+carpeta `notas_debito`.
 
 ### Generar ticket en formato personalizado
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -22,6 +22,7 @@ import os
 from ticket_pdf import generar_ticket_personalizado
 from factura_sv import generar_factura_electronica_pdf
 from utils.monto import monto_a_texto_sv
+from utils.docs import get_document_paths, build_invoice_json
 import tempfile
 import subprocess
 import shutil
@@ -31,9 +32,8 @@ NOTAS_DEBITO_DIR = os.path.join(os.path.dirname(__file__), "notas_debito")
 import json
 from datetime import datetime
 
-FACTURAS_DIR = os.path.join(os.path.dirname(__file__), "facturas")
-CF_DIR = os.path.join(FACTURAS_DIR, "consumidor_final")
-CREDITO_DIR = os.path.join(FACTURAS_DIR, "credito_fiscal")
+CF_DIR = os.path.join(os.path.dirname(__file__), "facturas_consumidor_final")
+CREDITO_DIR = os.path.join(os.path.dirname(__file__), "facturas_credito_fiscal")
 
 
 class FacturacionTab(QWidget):
@@ -407,9 +407,11 @@ class FacturacionTab(QWidget):
         fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
 
         tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
-        dest_dir = CREDITO_DIR if credito_info else CF_DIR
-        os.makedirs(dest_dir, exist_ok=True)
-        file_path = os.path.join(dest_dir, f"factura_{venta_id}.pdf")
+        doc_key = "CreditoFiscal" if credito_info else "ConsumidorFinal"
+        cliente_nombre = cliente.get("nombre") if cliente else ""
+        file_path, json_path = get_document_paths(
+            venta_data.get("fecha"), cliente_nombre, numero_control or venta_id, doc_key
+        )
 
         generar_factura_electronica_pdf(
             venta_data,
@@ -425,6 +427,9 @@ class FacturacionTab(QWidget):
             tipo_transmision=tipo_transmision,
             fecha_generacion=fecha_generacion,
         )
+        json_data = build_invoice_json(venta_data, cliente or {}, detalles)
+        with open(json_path, 'w', encoding='utf-8') as fh:
+            json.dump(json_data, fh, ensure_ascii=False, indent=2)
         self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
         return file_path
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -26,6 +26,7 @@ from PyQt5.QtGui import QDesktopServices, QPixmap
 from datetime import datetime
 from factura_sv import generar_factura_electronica_pdf
 from utils.monto import monto_a_texto_sv
+from utils.docs import get_document_paths, build_invoice_json
 from ticket_pdf import generar_ticket_personalizado
 from dialogs import ManualInvoiceDialog
 import tempfile
@@ -41,9 +42,8 @@ from email import encoders
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
-FACTURAS_DIR = os.path.join(os.path.dirname(__file__), "facturas")
-CF_DIR = os.path.join(FACTURAS_DIR, "consumidor_final")
-CREDITO_DIR = os.path.join(FACTURAS_DIR, "credito_fiscal")
+CF_DIR = os.path.join(os.path.dirname(__file__), "facturas_consumidor_final")
+CREDITO_DIR = os.path.join(os.path.dirname(__file__), "facturas_credito_fiscal")
 TICKETS_DIR = os.path.join(os.path.dirname(__file__), "tickets")
 
 
@@ -575,9 +575,11 @@ class SalesTab(QWidget):
         fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
 
         tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
-        dest_dir = CREDITO_DIR if credito_info else CF_DIR
-        os.makedirs(dest_dir, exist_ok=True)
-        file_path = os.path.join(dest_dir, f"factura_{venta_id}.pdf")
+        doc_key = "CreditoFiscal" if credito_info else "ConsumidorFinal"
+        cliente_nombre = cliente.get("nombre") if cliente else ""
+        file_path, json_path = get_document_paths(
+            venta_data.get("fecha"), cliente_nombre, numero_control or venta_id, doc_key
+        )
 
         generar_factura_electronica_pdf(
             venta_data,
@@ -593,6 +595,9 @@ class SalesTab(QWidget):
             tipo_transmision=tipo_transmision,
             fecha_generacion=fecha_generacion,
         )
+        json_data = build_invoice_json(venta_data, cliente or {}, detalles)
+        with open(json_path, 'w', encoding='utf-8') as fh:
+            json.dump(json_data, fh, ensure_ascii=False, indent=2)
         self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
         return file_path
 
@@ -649,9 +654,16 @@ class SalesTab(QWidget):
                 extra = json.loads(raw_extra)
             except Exception:
                 extra = {}
-        os.makedirs(TICKETS_DIR, exist_ok=True)
-        filename = os.path.join(TICKETS_DIR, f"ticket_{venta_id}.pdf")
+        cliente = None
+        if venta.get("cliente_id"):
+            cliente = next((c for c in self.manager._clientes if c["id"] == venta["cliente_id"]), None)
+        cliente_nombre = cliente.get("nombre") if cliente else ""
+        filename, json_path = get_document_paths(
+            venta.get("fecha"), cliente_nombre, venta_id, "Ticket"
+        )
         generar_ticket_personalizado(venta, detalles, filename, dte_data=extra)
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump({"venta": venta, "detalles": detalles}, fh, ensure_ascii=False, indent=2)
         self.manager.db.add_ticket_pdf(venta_id, filename)
         QMessageBox.information(self, "Ticket", f"Ticket guardado en {filename}")
 

--- a/tests/test_doc_utils.py
+++ b/tests/test_doc_utils.py
@@ -1,0 +1,19 @@
+import os
+from utils import docs
+
+
+def test_generate_document_name():
+    name = docs.generate_document_name('2024-07-03', 'Cliente #1', 5, 'CreditoFiscal')
+    assert name.startswith('20240703_Cliente_1_5_CreditoFiscal')
+
+
+def test_get_document_paths_and_list(tmp_path):
+    pdf, js = docs.get_document_paths('2024-07-03', 'Acme', 1, 'Ticket', root=tmp_path)
+    assert os.path.dirname(pdf) == os.path.join(tmp_path, 'tickets')
+    # create files
+    with open(pdf, 'w') as f:
+        f.write('pdf')
+    with open(js, 'w') as f:
+        f.write('{}')
+    res = docs.list_documents(root=tmp_path)
+    assert {'tipo': 'Ticket', 'pdf': pdf, 'json': js} in res

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -1,0 +1,124 @@
+import os
+import re
+import json
+from datetime import datetime
+
+# Base path is repository root two levels up from this file
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+FOLDERS = {
+    'ConsumidorFinal': os.path.join(BASE_DIR, 'facturas_consumidor_final'),
+    'CreditoFiscal': os.path.join(BASE_DIR, 'facturas_credito_fiscal'),
+    'Ticket': os.path.join(BASE_DIR, 'tickets'),
+    'NotaDebito': os.path.join(BASE_DIR, 'notas_debito'),
+}
+
+TEMPLATE_PATH = os.path.join(BASE_DIR, 'formato_factura.json')
+
+
+def sanitize_filename(value: str) -> str:
+    """Return a filesystem friendly version of ``value``."""
+    if not value:
+        return ''
+    sanitized = re.sub(r'[^A-Za-z0-9]+', '_', value)
+    return sanitized.strip('_')
+
+
+def generate_document_name(date, cliente, identifier, doc_type) -> str:
+    """Return the base filename for a document."""
+    if isinstance(date, datetime):
+        d = date
+    else:
+        try:
+            d = datetime.strptime(str(date)[:10], '%Y-%m-%d')
+        except Exception:
+            d = datetime.now()
+    date_str = d.strftime('%Y%m%d')
+    parts = [date_str, sanitize_filename(cliente), str(identifier), sanitize_filename(doc_type)]
+    parts = [p for p in parts if p]
+    return '_'.join(parts)
+
+
+def get_document_paths(date, cliente, identifier, doc_type, root=None):
+    """Return PDF and JSON paths for the given document."""
+    base = root or BASE_DIR
+    folder = FOLDERS.get(doc_type)
+    if root:
+        # when custom root is provided, mirror folder names inside it
+        name = os.path.basename(folder)
+        folder = os.path.join(root, name)
+    os.makedirs(folder, exist_ok=True)
+    base_name = generate_document_name(date, cliente, identifier, doc_type)
+    pdf_path = os.path.join(folder, base_name + '.pdf')
+    json_path = os.path.join(folder, base_name + '.json')
+    return pdf_path, json_path
+
+
+def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
+    """Create an invoice JSON following the template structure."""
+    with open(template_path, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+
+    ident = data.get('identificacion', {})
+    if venta.get('numero_control'):
+        ident['numeroControl'] = venta['numero_control']
+    if venta.get('codigo_generacion'):
+        ident['codigoGeneracion'] = venta['codigo_generacion']
+    if venta.get('fecha'):
+        ident['fecEmi'] = venta['fecha']
+    data['identificacion'] = ident
+
+    rec = data.get('receptor', {})
+    if cliente:
+        if cliente.get('nombre'):
+            rec['nombre'] = cliente['nombre']
+        if cliente.get('direccion'):
+            rec['direccion'] = cliente['direccion']
+        if cliente.get('nit'):
+            rec['nit'] = cliente['nit']
+    data['receptor'] = rec
+
+    cuerpo = []
+    for idx, det in enumerate(detalles or [], 1):
+        cuerpo.append({
+            'numItem': idx,
+            'descripcion': det.get('descripcion'),
+            'cantidad': det.get('cantidad'),
+            'precioUnitario': det.get('precio_unitario'),
+        })
+    data['cuerpoDocumento'] = cuerpo
+
+    resumen = data.get('resumen', {})
+    if venta.get('total') is not None:
+        resumen['totalPagar'] = venta['total']
+    if venta.get('subtotal') is not None:
+        resumen['subTotalVentas'] = venta['subtotal']
+        resumen['subTotal'] = venta['subtotal']
+    if venta.get('total_letras'):
+        resumen['totalLetras'] = venta['total_letras']
+    data['resumen'] = resumen
+
+    return data
+
+
+def list_documents(root=None):
+    """Return a list of paired PDF/JSON documents found in folders."""
+    base = root or BASE_DIR
+    result = []
+    for doc_type, folder in FOLDERS.items():
+        if root:
+            folder = os.path.join(base, os.path.basename(folder))
+        if not os.path.isdir(folder):
+            continue
+        pairs = {}
+        for fname in os.listdir(folder):
+            base_name, ext = os.path.splitext(fname)
+            path = os.path.join(folder, fname)
+            if ext.lower() == '.pdf':
+                pairs.setdefault(base_name, {})['pdf'] = path
+            elif ext.lower() == '.json':
+                pairs.setdefault(base_name, {})['json'] = path
+        for name, paths in pairs.items():
+            if 'pdf' in paths and 'json' in paths:
+                result.append({'tipo': doc_type, 'pdf': paths['pdf'], 'json': paths['json']})
+    return result


### PR DESCRIPTION
## Summary
- add `docs` utilities for generating filenames and listing stored docs
- store invoice/ticket JSON files next to PDFs and use new directories
- update invoice generation in sales and facturación tabs to use helpers
- document new paths in README
- add unit tests for doc utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f1d724348323aa718edad724a7b3