### PR TITLE
Rename invoice PDF button

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -3080,7 +3080,7 @@ class ManualInvoiceDialog(QDialog):
         main_layout.addLayout(self.stack)
 
         btns = QHBoxLayout()
-        self.btn_ok = QPushButton("Generar PDF")
+        self.btn_ok = QPushButton("Guardar factura")
         self.btn_cancel = QPushButton("Cancelar")
         btns.addWidget(self.btn_ok)
         btns.addWidget(self.btn_cancel)

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -163,7 +163,7 @@ class SalesTab(QWidget):
         preview_layout.addWidget(self.info_label)
 
         btn_layout = QHBoxLayout()
-        self.btn_guardar = QPushButton("Guardar PDF")
+        self.btn_guardar = QPushButton("Guardar factura")
         self.btn_enviar = QPushButton("Enviar por correo")
         self.btn_imprimir = QPushButton("Imprimir PDF")
         self.btn_ticket = QPushButton("Ticket")
@@ -598,13 +598,15 @@ class SalesTab(QWidget):
         json_data = build_invoice_json(venta_data, cliente or {}, detalles)
         with open(json_path, 'w', encoding='utf-8') as fh:
             json.dump(json_data, fh, ensure_ascii=False, indent=2)
+        if not os.path.exists(json_path):
+            raise IOError(f"No se pudo guardar JSON en {json_path}")
         self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
         return file_path
 
     def save_pdf(self):
         """Generate a PDF for the selected sale after user confirmation."""
         if self.sales_table.currentRow() < 0:
-            QMessageBox.warning(self, "Guardar PDF", "Seleccione una factura primero.")
+            QMessageBox.warning(self, "Guardar factura", "Seleccione una factura primero.")
             return
 
         row = self.sales_table.currentRow()
@@ -612,7 +614,7 @@ class SalesTab(QWidget):
 
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
         if not venta:
-            QMessageBox.warning(self, "Guardar PDF", "No se encontró la venta seleccionada.")
+            QMessageBox.warning(self, "Guardar factura", "No se encontró la venta seleccionada.")
             return
 
         credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
@@ -621,17 +623,17 @@ class SalesTab(QWidget):
             if credito_info
             else "Esta venta está registrada como consumidor final, ¿desea continuar?"
         )
-        reply = QMessageBox.question(self, "Guardar PDF", mensaje, QMessageBox.Yes | QMessageBox.No)
+        reply = QMessageBox.question(self, "Guardar factura", mensaje, QMessageBox.Yes | QMessageBox.No)
         if reply != QMessageBox.Yes:
             QMessageBox.information(
                 self,
-                "Guardar PDF",
+                "Guardar factura",
                 "Si desea modificar esta factura presione generar nueva factura manual",
             )
             return
         file_path = self._generate_invoice_pdf(venta_id)
         if file_path:
-            QMessageBox.information(self, "Guardar PDF", f"Factura guardada en {file_path}")
+            QMessageBox.information(self, "Guardar factura", f"Factura guardada en {file_path}")
 
     def save_ticket(self):
         """Generate a simple ticket PDF for the selected sale."""
@@ -664,6 +666,8 @@ class SalesTab(QWidget):
         generar_ticket_personalizado(venta, detalles, filename, dte_data=extra)
         with open(json_path, "w", encoding="utf-8") as fh:
             json.dump({"venta": venta, "detalles": detalles}, fh, ensure_ascii=False, indent=2)
+        if not os.path.exists(json_path):
+            raise IOError(f"No se pudo guardar JSON en {json_path}")
         self.manager.db.add_ticket_pdf(venta_id, filename)
         QMessageBox.information(self, "Ticket", f"Ticket guardado en {filename}")
 

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -1,0 +1,91 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication, QTableWidgetItem, QMessageBox
+
+from sales_tab import SalesTab
+from utils import docs
+
+class FakeDB:
+    def __init__(self):
+        self._ventas = []
+        self.detalles = {}
+    def get_ventas(self):
+        return self._ventas
+    def get_venta_credito_fiscal(self, vid):
+        return None
+    def get_detalles_venta(self, vid):
+        return self.detalles.get(vid, [])
+    def get_trabajador(self, vid):
+        return None
+    def add_factura_pdf(self, *a):
+        pass
+    def add_ticket_pdf(self, *a):
+        pass
+    def get_ticket_pdf(self, vid):
+        return None
+    def get_factura_pdf(self, vid):
+        return None
+
+class Manager:
+    def __init__(self, db):
+        self.db = db
+        self._Distribuidores = []
+        self._clientes = []
+        self._vendedores = []
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_generate_invoice_creates_json(qt_app, tmp_path):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    man = Manager(db)
+    tab = SalesTab(man)
+
+    pdf_path = tmp_path / "fact.pdf"
+    json_path = tmp_path / "fact.json"
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf_path), str(json_path)
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("sales_tab.get_document_paths", fake_paths)
+
+    tab._generate_invoice_pdf(1)
+    monkeypatch.undo()
+
+    assert pdf_path.exists()
+    assert json_path.exists()
+
+
+def test_save_ticket_creates_json(qt_app, tmp_path):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    man = Manager(db)
+    tab = SalesTab(man)
+    tab.sales_table.setRowCount(1)
+    tab.sales_table.setItem(0, 0, QTableWidgetItem("1"))
+    tab.sales_table.selectRow(0)
+
+    pdf_path = tmp_path / "ticket.pdf"
+    json_path = tmp_path / "ticket.json"
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf_path), str(json_path)
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("sales_tab.get_document_paths", fake_paths)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+    tab.save_ticket()
+    monkeypatch.undo()
+
+    assert pdf_path.exists()
+    assert json_path.exists()


### PR DESCRIPTION
## Summary
- rename invoice PDF generation button to 'Guardar factura'
- ensure JSON files for invoices and tickets are stored
- test saving JSON for invoices and tickets

## Testing
- `pytest tests/test_invoice_json_save.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68780387b4508323ad8194413338a69f