### PR TITLE
Extend invoice scan paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ documento. Los tickets se almacenan en la carpeta `tickets`. Al imprimir,
 previsualizar o enviar por correo se reutilizan estos PDFs si están disponibles.
 Las notas de débito creadas desde la pestaña **Facturación** se guardan en la
 carpeta `notas_debito`.
+Además, la pestaña **Facturación** buscará archivos también en las rutas
+`facturas/consumidor_final` y `facturas/credito_fiscal` si existen, de modo que
+las facturas almacenadas manualmente en esas carpetas se muestren incluso si no
+están vinculadas a una venta.
 
 ### Generar ticket en formato personalizado
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -34,6 +34,11 @@ from datetime import datetime
 
 CF_DIR = os.path.join(os.path.dirname(__file__), "facturas_consumidor_final")
 CREDITO_DIR = os.path.join(os.path.dirname(__file__), "facturas_credito_fiscal")
+# Additional locations where invoices may be stored
+ADDITIONAL_DIRS = [
+    os.path.join(os.path.dirname(__file__), "facturas", "consumidor_final"),
+    os.path.join(os.path.dirname(__file__), "facturas", "credito_fiscal"),
+]
 
 
 class FacturacionTab(QWidget):
@@ -201,7 +206,8 @@ class FacturacionTab(QWidget):
     def _find_orphan_documents(self):
         db_pdfs = set(r["ruta"] for r in self.manager.db.cursor.execute("SELECT ruta FROM facturas_pdf"))
         result = []
-        for folder in (CF_DIR, CREDITO_DIR):
+        folders = [CF_DIR, CREDITO_DIR] + ADDITIONAL_DIRS
+        for folder in folders:
             if not os.path.isdir(folder):
                 continue
             files = {}

--- a/tests/test_orphan_dirs.py
+++ b/tests/test_orphan_dirs.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+from types import SimpleNamespace
+
+import facturacion_tab
+from db import DB
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+def test_find_orphan_in_additional_dirs(qt_app, tmp_path, monkeypatch):
+    cf_alt = tmp_path / "facturas" / "consumidor_final"
+    cf_alt.mkdir(parents=True)
+    json_path = cf_alt / "orphan.json"
+    json_path.write_text("{}")
+
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(tmp_path / "facturas_consumidor_final"))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "facturas_credito_fiscal"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [str(cf_alt)])
+
+    tab = facturacion_tab.FacturacionTab(man)
+    orphans = tab._find_orphan_documents()
+    assert any(o.get("json") == str(json_path) for o in orphans)


### PR DESCRIPTION
## Summary
- search for invoices in additional folders
- document additional scan paths in README
- test new orphan scanning logic

## Testing
- `pytest tests/test_orphan_dirs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879762a105c8323ab5c89c0d39c3521