### PR TITLE
Fix invoice sort when date is missing

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -166,9 +166,14 @@ class FacturacionTab(QWidget):
 
         rows.extend(self._find_orphan_documents())
 
-        # Sort invoices by date descending; fall back to original order if
-        # the date is missing
-        rows.sort(key=lambda r: r.get("_parsed_fecha"), reverse=True)
+        # Sort invoices by date descending, leaving entries without a date in
+        # their original relative order
+        rows.sort(
+            key=lambda r: (
+                r.get("_parsed_fecha") is None,
+                -(r.get("_parsed_fecha").toordinal() if r.get("_parsed_fecha") else 0),
+            )
+        )
 
         self.table.setRowCount(len(rows))
         for row, v in enumerate(rows):


### PR DESCRIPTION
## Summary
- handle invoices without dates when sorting

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: tests hang, possibly due to GUI requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6879a26a6e408323ac20d5ab4641945e