### PR TITLE
Fix stale invoice table entries

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -294,9 +294,16 @@ class FacturacionTab(QWidget):
         clientes = {c["id"]: c.get("nombre", "") for c in self.manager._clientes}
         result = []
         for row in self.manager.db.cursor.execute("SELECT venta_id, ruta FROM facturas_pdf"):
-            venta = ventas.get(row["venta_id"])
+            venta_id = row["venta_id"]
+            venta = ventas.get(venta_id)
             pdf = row["ruta"]
             js = os.path.splitext(pdf)[0] + ".json"
+
+            # Remove stale DB records if both files are missing
+            if not os.path.exists(pdf) and not os.path.exists(js):
+                self.manager.db.delete_factura_pdf(venta_id)
+                continue
+
             estado = venta.get("estado", "") if venta else "Sin venta"
             if not os.path.exists(pdf) or not os.path.exists(js):
                 estado = "Incompleta"

--- a/tests/test_stale_invoice_records.py
+++ b/tests/test_stale_invoice_records.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+from types import SimpleNamespace
+
+import facturacion_tab
+from db import DB
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+
+def test_missing_invoice_records_removed(qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 10)
+    # add reference to non existing pdf
+    db.add_factura_pdf(venta_id, "CF", str(tmp_path / "missing.pdf"))
+
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+
+    rows = tab._get_invoices_from_db()
+    assert rows == []
+    count = db.cursor.execute("SELECT COUNT(*) FROM facturas_pdf").fetchone()[0]
+    assert count == 0


### PR DESCRIPTION
## Summary
- clean up invoice records with missing PDFs/JSONs
- add regression test for stale invoice cleanup

## Testing
- `pytest -k stale_invoice_records -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac20b5224832388bf366046ce4159