### PR TITLE
Improve invoice detection across directories

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -245,10 +245,10 @@ class FacturacionTab(QWidget):
         db_pdfs = set(r["ruta"] for r in self.manager.db.cursor.execute("SELECT ruta FROM facturas_pdf"))
         result = []
         folders = [CF_DIR, CREDITO_DIR] + ADDITIONAL_DIRS
+        files = {}
         for folder in folders:
             if not os.path.isdir(folder):
                 continue
-            files = {}
             for root, _dirs, fnames in os.walk(folder):
                 for fname in fnames:
                     base, ext = os.path.splitext(fname)
@@ -256,37 +256,39 @@ class FacturacionTab(QWidget):
                         continue
                     if not DOC_PATTERN.match(base):
                         continue
-                    key = os.path.join(root, base)
-                    files.setdefault(key, {})[ext.lower()] = os.path.join(root, fname)
-            for base, paths in files.items():
-                pdf = paths.get('.pdf')
-                js = paths.get('.json')
-                if pdf and pdf in db_pdfs:
-                    continue
-                mtime = None
-                if pdf and os.path.exists(pdf):
-                    mtime = os.path.getmtime(pdf)
-                elif js and os.path.exists(js):
-                    mtime = os.path.getmtime(js)
-                fecha = datetime.fromtimestamp(mtime).strftime('%Y-%m-%d') if mtime else ''
-                estado = 'Sin venta'
-                if not pdf or not js:
+                    entry = files.setdefault(base, {})
+                    # prefer existing paths to keep deterministic order
+                    entry.setdefault(ext.lower(), os.path.join(root, fname))
+
+        for base, paths in files.items():
+            pdf = paths.get('.pdf')
+            js = paths.get('.json')
+            if pdf and pdf in db_pdfs:
+                continue
+            mtime = None
+            if pdf and os.path.exists(pdf):
+                mtime = os.path.getmtime(pdf)
+            elif js and os.path.exists(js):
+                mtime = os.path.getmtime(js)
+            fecha = datetime.fromtimestamp(mtime).strftime('%Y-%m-%d') if mtime else ''
+            estado = 'Sin venta'
+            if not pdf or not js:
+                estado = 'Incompleta'
+            else:
+                try:
+                    with open(js, 'r', encoding='utf-8') as fh:
+                        json.load(fh)
+                except Exception:
                     estado = 'Incompleta'
-                else:
-                    try:
-                        with open(js, 'r', encoding='utf-8') as fh:
-                            json.load(fh)
-                    except Exception:
-                        estado = 'Incompleta'
-                result.append({
-                    'row_type': 'orphan',
-                    'name': os.path.basename(base),
-                    'pdf': pdf,
-                    'json': js,
-                    'fecha': fecha,
-                    '_parsed_fecha': datetime.fromtimestamp(mtime).date() if mtime else None,
-                    'estado': estado,
-                })
+            result.append({
+                'row_type': 'orphan',
+                'name': base,
+                'pdf': pdf,
+                'json': js,
+                'fecha': fecha,
+                '_parsed_fecha': datetime.fromtimestamp(mtime).date() if mtime else None,
+                'estado': estado,
+            })
         return result
 
     def _get_invoices_from_db(self):

--- a/tests/test_orphan_dirs.py
+++ b/tests/test_orphan_dirs.py
@@ -29,3 +29,29 @@ def test_find_orphan_in_additional_dirs(qt_app, tmp_path, monkeypatch):
     tab = facturacion_tab.FacturacionTab(man)
     orphans = tab._find_orphan_documents()
     assert any(o.get("json") == str(json_path) for o in orphans)
+
+
+def test_pair_across_directories(qt_app, tmp_path, monkeypatch):
+    pdf_dir = tmp_path / "facturas_consumidor_final"
+    pdf_dir.mkdir()
+    json_dir = tmp_path / "facturas" / "consumidor_final"
+    json_dir.mkdir(parents=True)
+
+    pdf_path = pdf_dir / "20240102_Test_2_ConsumidorFinal.pdf"
+    pdf_path.write_text("pdf")
+    json_path = json_dir / "20240102_Test_2_ConsumidorFinal.json"
+    json_path.write_text("{}")
+
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(pdf_dir))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "facturas_credito_fiscal"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [str(json_dir)])
+
+    tab = facturacion_tab.FacturacionTab(man)
+    orphans = tab._find_orphan_documents()
+    match = next((o for o in orphans if o.get("name") == "20240102_Test_2_ConsumidorFinal"), None)
+    assert match
+    assert match.get("pdf") == str(pdf_path)
+    assert match.get("json") == str(json_path)


### PR DESCRIPTION
## Summary
- pair orphan invoice documents (pdf and json) across different folders
- test pairing logic for invoices split across directories

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_orphan_dirs.py::test_pair_across_directories -q`


------
https://chatgpt.com/codex/tasks/task_e_687dc6ca6d988323a233ac2b84240517