### PR TITLE
Handle duplicate invoices by name

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -243,6 +243,7 @@ class FacturacionTab(QWidget):
 
     def _find_orphan_documents(self):
         db_pdfs = set(r["ruta"] for r in self.manager.db.cursor.execute("SELECT ruta FROM facturas_pdf"))
+        db_bases = {os.path.splitext(os.path.basename(p))[0] for p in db_pdfs}
         result = []
         folders = [CF_DIR, CREDITO_DIR] + ADDITIONAL_DIRS
         files = {}
@@ -264,6 +265,8 @@ class FacturacionTab(QWidget):
             pdf = paths.get('.pdf')
             js = paths.get('.json')
             if pdf and pdf in db_pdfs:
+                continue
+            if base in db_bases:
                 continue
             mtime = None
             if pdf and os.path.exists(pdf):

--- a/tests/test_orphan_dirs.py
+++ b/tests/test_orphan_dirs.py
@@ -55,3 +55,30 @@ def test_pair_across_directories(qt_app, tmp_path, monkeypatch):
     assert match
     assert match.get("pdf") == str(pdf_path)
     assert match.get("json") == str(json_path)
+
+
+def test_orphans_skip_duplicates_by_name(qt_app, tmp_path, monkeypatch):
+    inv_dir = tmp_path / "facturas_consumidor_final"
+    inv_dir.mkdir()
+    pdf_path = inv_dir / "20240103_Test_3_ConsumidorFinal.pdf"
+    pdf_path.write_text("pdf")
+    json_path = inv_dir / "20240103_Test_3_ConsumidorFinal.json"
+    json_path.write_text("{}")
+
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-03", 5)
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    other_pdf = other_dir / "20240103_Test_3_ConsumidorFinal.pdf"
+    other_pdf.write_text("pdf")
+    db.add_factura_pdf(venta_id, "CF", str(other_pdf))
+
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "facturas_credito_fiscal"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    tab = facturacion_tab.FacturacionTab(man)
+    orphans = tab._find_orphan_documents()
+    assert not any(o.get("name") == "20240103_Test_3_ConsumidorFinal" for o in orphans)


### PR DESCRIPTION
## Summary
- avoid duplicate entries in FacturacionTab when a PDF already exists in the DB by comparing base names
- test that orphan documents skip duplicates

## Testing
- `pytest tests/test_orphan_dirs.py -q`
- `pytest tests/test_orphan_dirs.py::test_orphans_skip_duplicates_by_name -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec00cdacc8323bafffbb34dd46f7a