### PR TITLE
Fix invoice PDF duplication handling

### DIFF
--- a/db.py
+++ b/db.py
@@ -1038,6 +1038,15 @@ class DB:
 
     def add_factura_pdf(self, venta_id, tipo, ruta):
         """Guarda la ruta de un PDF generado para una venta."""
+        # Check if a record with the same file path already exists
+        self.cursor.execute(
+            "SELECT id FROM facturas_pdf WHERE ruta=?",
+            (ruta,),
+        )
+        row = self.cursor.fetchone()
+        if row:
+            return row["id"]
+
         fecha = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.cursor.execute(
             "INSERT INTO facturas_pdf (venta_id, tipo, ruta, fecha_creacion) VALUES (?, ?, ?, ?)",

--- a/tests/test_facturas_pdf_unique.py
+++ b/tests/test_facturas_pdf_unique.py
@@ -1,0 +1,16 @@
+from db import DB
+
+
+def test_add_factura_pdf_deduplicates(tmp_path):
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 10)
+    pdf_path = tmp_path / "fact.pdf"
+    pdf_path.write_text("pdf")
+
+    first = db.add_factura_pdf(venta_id, "CF", str(pdf_path))
+    second = db.add_factura_pdf(venta_id, "CF", str(pdf_path))
+
+    assert first == second
+    count = db.cursor.execute("SELECT COUNT(*) FROM facturas_pdf").fetchone()[0]
+    assert count == 1
+


### PR DESCRIPTION
## Summary
- deduplicate invoice PDFs in `add_factura_pdf`
- test that duplicate invoice creation only stores one record

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eca2d3b5c8323ae6a328b689db41a