### PR TITLE
Support electronic credit notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -152,3 +152,42 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
             result["documentoVentaACuenta"] = extra.get("documento_venta_a_cuenta")
 
     return result
+
+
+def generar_nota_credito_json(db: DB, nota_id: int) -> dict:
+    """Genera un DTE de Nota de Crédito para la nota indicada."""
+    nota_row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
+    if not nota_row:
+        raise ValueError("Nota no encontrada")
+    nota = dict(nota_row)
+    if nota.get("tipo") != "credito":
+        raise ValueError("La nota indicada no es de cr\u00e9dito")
+
+    venta_id = nota["venta_id"]
+    base = generar_dte_json(db, venta_id)
+
+    original = base.get("identificacion", {}).copy()
+    cab = generar_cabecera_dte_data("1 - Facturaci\u00f3n previo", base["identificacion"].get("tipoTransmision", ""))
+    base["identificacion"].update({
+        "tipoDte": "05",
+        "codigoGeneracion": cab["codigo_generacion"],
+        "numeroControl": cab["numero_control"],
+        "fecEmi": nota.get("fecha"),
+    })
+
+    base["documentoRelacionado"] = [{
+        "tipoDte": original.get("tipoDte"),
+        "numeroControl": original.get("numeroControl"),
+        "codigoGeneracion": original.get("codigoGeneracion"),
+    }]
+
+    for item in base.get("cuerpoDocumento", []):
+        if "precioUnitario" in item and isinstance(item["precioUnitario"], (int, float)):
+            item["precioUnitario"] = -abs(item["precioUnitario"])
+
+    resumen = base.get("resumen", {})
+    for k, v in resumen.items():
+        if isinstance(v, (int, float)):
+            resumen[k] = -abs(v)
+
+    return base

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -367,3 +367,33 @@ def generar_factura_electronica_pdf(
     c.drawCentredString(width/2, 20, f"Página 1 de 1")
 
     c.save()
+
+
+def generar_nota_credito_pdf(
+    venta,
+    detalles,
+    cliente,
+    distribuidor,
+    archivo="nota_credito.pdf",
+    datos_negocio=None,
+    **kwargs,
+):
+    """Genera un PDF para una Nota de Cr\u00e9dito."""
+    venta_neg = {k: (-abs(v) if isinstance(v, (int, float)) else v) for k, v in venta.items()}
+    det_neg = []
+    for d in detalles:
+        dn = d.copy()
+        if "cantidad" in dn and isinstance(dn["cantidad"], (int, float)):
+            dn["cantidad"] = -abs(dn["cantidad"])
+        det_neg.append(dn)
+
+    generar_factura_electronica_pdf(
+        venta_neg,
+        det_neg,
+        cliente,
+        distribuidor,
+        "Nota de Cr\u00e9dito",
+        archivo=archivo,
+        datos_negocio=datos_negocio,
+        **kwargs,
+    )

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -1,0 +1,64 @@
+import fitz
+from db import DB
+from dte import generar_nota_credito_json
+from factura_sv import generar_nota_credito_pdf
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_generar_nota_credito_json_basic(tmp_path):
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
+        (venta_id, "credito", "2024-01-02", 10, "Dev"),
+    )
+    nota_id = db.cursor.lastrowid
+    db.conn.commit()
+
+    data = generar_nota_credito_json(db, nota_id)
+    assert data["identificacion"]["tipoDte"] == "05"
+    assert data.get("documentoRelacionado")
+    assert data["cuerpoDocumento"][0]["precioUnitario"] < 0
+    assert data["resumen"]["totalPagar"] < 0
+
+
+def _sample_data():
+    venta = {
+        "sumas": 10,
+        "descuentos": 0,
+        "subtotal": 10,
+        "iva": 1.3,
+        "total": 11.3,
+        "ventas_exentas": 0,
+        "ventas_no_sujetas": 0,
+        "total_letras": "ONCE CON 30/100 DOLARES",
+    }
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "precio_unitario": 10,
+            "ventas_no_sujetas": 0,
+            "ventas_exentas": 0,
+            "ventas_gravadas": 10,
+        }
+    ]
+    return venta, detalles
+
+
+def test_nota_credito_pdf(tmp_path):
+    venta, detalles = _sample_data()
+    out = tmp_path / "nota.pdf"
+    generar_nota_credito_pdf(venta, detalles, {}, {}, archivo=str(out), datos_negocio={})
+    assert out.exists()
+    with fitz.open(out) as doc:
+        text = "".join(p.get_text() for p in doc)
+    assert "NOTA DE CR\xc9DITO" in text

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -11,6 +11,7 @@ FOLDERS = {
     'CreditoFiscal': os.path.join(BASE_DIR, 'facturas_credito_fiscal'),
     'Ticket': os.path.join(BASE_DIR, 'tickets'),
     'NotaDebito': os.path.join(BASE_DIR, 'notas_debito'),
+    'NotaCredito': os.path.join(BASE_DIR, 'notas_credito'),
 }
 
 TEMPLATE_PATH = os.path.join(BASE_DIR, 'formato_factura.json')


### PR DESCRIPTION
## Summary
- add storage folder for `NotaCredito`
- support `generar_nota_credito_json`
- allow generating Nota de Crédito PDFs
- test credit note JSON and PDF creation

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_nota_credito.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880317950208323bc66be15f7337589