### PR TITLE
Add rounding and validation for DTE numbers

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2,9 +2,18 @@ import json
 import os
 import uuid
 from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
 from db import DB
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+
+
+def _round(value, digits):
+    """Round ``value`` to ``digits`` decimal places using HALF_UP."""
+    if value is None:
+        value = 0
+    fmt = "0." + "0" * digits
+    return float(Decimal(str(value)).quantize(Decimal(fmt), rounding=ROUND_HALF_UP))
 
 
 def _load_datos_negocio():
@@ -106,18 +115,25 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
             receptor["ordenNo"] = fiscal.get("orden_no")
 
     cuerpo = []
+    items_total = Decimal("0")
     for idx, d in enumerate(detalles, 1):
+        cant = Decimal(str(d.get("cantidad", 0)))
+        price = Decimal(str(d.get("precio_unitario", 0)))
+        cant_r = cant.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP)
+        price_r = price.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP)
+        items_total += cant_r * price_r
         cuerpo.append({
             "numItem": idx,
             "descripcion": d.get("descripcion"),
-            "cantidad": d.get("cantidad"),
-            "precioUnitario": d.get("precio_unitario"),
+            "cantidad": float(cant_r),
+            "precioUnitario": float(price_r),
         })
 
-    total = sum(d.get("cantidad", 0) * d.get("precio_unitario", 0) for d in detalles)
+    total = float(items_total)
     sumas_val = fiscal.get("sumas", total) if fiscal else total
     descuentos_val = fiscal.get("descuentos", 0) if fiscal else 0
     iva_val = fiscal.get("iva") if fiscal else 0
+
     resumen = {
         "totalNoSuj": fiscal.get("ventas_no_sujetas") if fiscal else 0,
         "totalExenta": fiscal.get("ventas_exentas") if fiscal else 0,
@@ -127,6 +143,27 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
         "subTotal": (sumas_val - descuentos_val) + iva_val,
         "totalPagar": venta.get("total", total),
     }
+
+    # Round resumen values to two decimals
+    for k, v in resumen.items():
+        resumen[k] = _round(v, 2)
+
+    # Validate totals within tolerance
+    items_total_2 = _round(items_total, 2)
+    if abs(items_total_2 - resumen["sumas"]) > 0.01:
+        print(
+            f"Advertencia: la suma de los ítems {items_total_2:.2f} difiere del resumen {resumen['sumas']:.2f}"
+        )
+
+    calc_sub = _round(resumen["sumas"] - resumen["descuentos"] + resumen["iva"], 2)
+    if abs(calc_sub - resumen["subTotal"]) > 0.01:
+        print(
+            f"Advertencia: el subtotal calculado {calc_sub:.2f} difiere del resumen {resumen['subTotal']:.2f}"
+        )
+    if abs(calc_sub - resumen["totalPagar"]) > 0.01:
+        print(
+            f"Advertencia: el total a pagar {resumen['totalPagar']:.2f} difiere del subtotal calculado {calc_sub:.2f}"
+        )
 
     result = {
         "identificacion": identificacion,

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -36,3 +36,60 @@ def test_generar_dte_json_basic():
     assert data["identificacion"].get("codigoGeneracion")
     assert data["receptor"].get("noRemision") is None
     assert data["receptor"].get("ordenNo") is None
+
+
+def test_dte_rounding_and_validation(capsys):
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    precio = 1.123456789
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-01-01",
+        precio * 2,
+        "123",
+        "nit1",
+        "giro",
+        sumas=precio * 2,
+        descuentos=0,
+        iva=0,
+    )
+    db.add_detalle_venta(venta_id, prod_id, 2, precio, vendedor_id=vend_id)
+
+    data = generar_dte_json(db, venta_id)
+    out = capsys.readouterr().out
+    # Values rounded
+    assert data["cuerpoDocumento"][0]["precioUnitario"] == 1.12345679
+    assert data["resumen"]["sumas"] == 2.25
+    # No warnings printed
+    assert out.strip() == ""
+
+
+def test_dte_sum_mismatch_warning(capsys):
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-01-01",
+        10,
+        "123",
+        "nit1",
+        "giro",
+        sumas=10,
+        descuentos=0,
+        iva=0,
+    )
+    db.add_detalle_venta(venta_id, prod_id, 1, 5, vendedor_id=vend_id)
+
+    generar_dte_json(db, venta_id)
+    out = capsys.readouterr().out
+    assert "Advertencia" in out


### PR DESCRIPTION
## Summary
- round item and summary values in DTE JSON generation
- warn when totals differ by more than 0.01
- test rounding rules
- test mismatch warning

## Testing
- `pytest tests/test_generar_dte_json.py::test_dte_rounding_and_validation -q`
- `pytest tests/test_generar_dte_json.py::test_dte_sum_mismatch_warning -q`
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_68803180f1488323a0a490254228d9a0