### PR TITLE
Add DTE signing with JWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ contraseña de la cuenta utilizada para enviar correos ya **no** se guarda en el
 archivo. En su lugar, define la variable de entorno `INVENTARIO_EMAIL_PASSWORD`
 con la contraseña correspondiente antes de ejecutar la aplicación.
 
+Para firmar electrónicamente los DTE puedes especificar un certificado en
+`datos_negocio.json`. Agrega las claves `certificado_digital_path` con la ruta
+al archivo `.p12` de Hacienda y `certificado_digital_password` con la contraseña
+codificada en Base64. Al generar facturas o tickets se creará junto al PDF un
+archivo `.jws` con el JSON firmado.
+
 Las facturas generadas desde la pestaña **Ventas** se guardan automáticamente en
 `facturas_consumidor_final` o `facturas_credito_fiscal` dependiendo del tipo de
 documento. Los tickets se almacenan en la carpeta `tickets`. Al imprimir,

--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -27,5 +27,7 @@
   "smtp_server": "smtp.gmail.com",
   "smtp_port": "587",
   "email_usuario": "contacto@tiendademo.com",
-  "email_contrasena": ""
+  "email_contrasena": "",
+  "certificado_digital_path": "",
+  "certificado_digital_password": ""
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pyinstaller
 dbfread
 PyMuPDF
+PyJWT[crypto]

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from factura_sv import generar_factura_electronica_pdf
 from utils.monto import monto_a_texto_sv
 from utils.docs import get_document_paths, build_invoice_json
+from utils.jws import get_cert_config, sign_and_save
 from ticket_pdf import generar_ticket_personalizado
 from dialogs import ManualInvoiceDialog
 import tempfile
@@ -600,6 +601,12 @@ class SalesTab(QWidget):
             json.dump(json_data, fh, ensure_ascii=False, indent=2)
         if not os.path.exists(json_path):
             raise IOError(f"No se pudo guardar JSON en {json_path}")
+        cert_path, cert_pass = get_cert_config(DATOS_NEGOCIO_PATH)
+        if cert_path:
+            try:
+                sign_and_save(json_data, json_path, cert_path, cert_pass)
+            except Exception:
+                pass
         self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
         return file_path
 
@@ -632,6 +639,12 @@ class SalesTab(QWidget):
             json.dump({"venta": venta, "detalles": detalles}, fh, ensure_ascii=False, indent=2)
         if not os.path.exists(json_path):
             raise IOError(f"No se pudo guardar JSON en {json_path}")
+        cert_path, cert_pass = get_cert_config(DATOS_NEGOCIO_PATH)
+        if cert_path:
+            try:
+                sign_and_save({"venta": venta, "detalles": detalles}, json_path, cert_path, cert_pass)
+            except Exception:
+                pass
         self.manager.db.add_ticket_pdf(venta_id, filename)
         return filename
 
@@ -700,6 +713,12 @@ class SalesTab(QWidget):
             json.dump({"venta": venta, "detalles": detalles}, fh, ensure_ascii=False, indent=2)
         if not os.path.exists(json_path):
             raise IOError(f"No se pudo guardar JSON en {json_path}")
+        cert_path, cert_pass = get_cert_config(DATOS_NEGOCIO_PATH)
+        if cert_path:
+            try:
+                sign_and_save({"venta": venta, "detalles": detalles}, json_path, cert_path, cert_pass)
+            except Exception:
+                pass
         self.manager.db.add_ticket_pdf(venta_id, filename)
         QMessageBox.information(self, "Ticket", f"Ticket guardado en {filename}")
 

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -1,0 +1,74 @@
+import json
+import base64
+from utils import jws
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+import datetime
+import jwt
+
+
+def create_p12(path, password):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "SV"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Test"),
+        x509.NameAttribute(NameOID.COMMON_NAME, "Test Cert"),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    p12 = pkcs12.serialize_key_and_certificates(
+        b"test",
+        key,
+        cert,
+        None,
+        serialization.BestAvailableEncryption(password.encode()),
+    )
+    with open(path, "wb") as fh:
+        fh.write(p12)
+
+
+def test_sign_and_save(tmp_path, monkeypatch):
+    cert_file = tmp_path / "cert.p12"
+    password = "secret"
+    create_p12(cert_file, password)
+
+    datos_path = tmp_path / "datos.json"
+    with open(datos_path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "certificado_digital_path": str(cert_file),
+                "certificado_digital_password": base64.b64encode(password.encode()).decode(),
+            },
+            fh,
+        )
+
+    monkeypatch.setattr(jws, "DATOS_NEGOCIO_PATH", str(datos_path))
+
+    payload = {"foo": "bar"}
+    json_file = tmp_path / "dte.json"
+    with open(json_file, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+    cert_path, cert_pass = jws.get_cert_config(str(datos_path))
+    jws_path = jws.sign_and_save(payload, str(json_file), cert_path, cert_pass)
+    assert jws_path
+    token = open(jws_path).read()
+    # verify
+    _priv_key, cert, _ = pkcs12.load_key_and_certificates(open(cert_file, "rb").read(), password.encode())
+    public_pem = cert.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    data = jwt.decode(token, public_pem, algorithms=["RS256"])
+    assert data == payload

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -1,0 +1,55 @@
+import os
+import json
+import base64
+from cryptography.hazmat.primitives.serialization import (
+    pkcs12,
+    Encoding,
+    PrivateFormat,
+    NoEncryption,
+)
+import jwt
+
+DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "datos_negocio.json")
+
+
+def get_cert_config(path: str = DATOS_NEGOCIO_PATH):
+    """Return certificate path and password from business config."""
+    if not os.path.exists(path):
+        return None, None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        cert_path = data.get("certificado_digital_path")
+        password = data.get("certificado_digital_password")
+        if password:
+            try:
+                password = base64.b64decode(password).decode("utf-8")
+            except Exception:
+                pass
+        return cert_path, password
+    except Exception:
+        return None, None
+
+
+def _load_private_key(cert_path: str, password: str | None):
+    with open(cert_path, "rb") as fh:
+        data = fh.read()
+    key, _cert, _ = pkcs12.load_key_and_certificates(data, password.encode() if password else None)
+    return key
+
+
+def sign_json(payload: dict, cert_path: str, password: str | None = None) -> str:
+    """Return a JWS token (compact serialization) for ``payload``."""
+    key = _load_private_key(cert_path, password)
+    pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    token = jwt.encode(payload, pem, algorithm="RS256")
+    return token
+
+
+def sign_and_save(payload: dict, json_path: str, cert_path: str, password: str | None = None) -> str:
+    """Sign ``payload`` and store the JWS next to ``json_path``."""
+    token = sign_json(payload, cert_path, password)
+    jws_path = os.path.splitext(json_path)[0] + "_signed.jws"
+    with open(jws_path, "w", encoding="utf-8") as fh:
+        fh.write(token)
+    return jws_path


### PR DESCRIPTION
## Summary
- store digital certificate path and password in `datos_negocio.json`
- document certificate usage in README
- add PyJWT dependency
- implement certificate handling and JSON Web Signature utilities
- sign invoice and ticket JSON using stored certificate
- test JWS signing logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_doc_utils.py tests/test_jws.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880322492ec83238cde26c7091e0bbc