### PR TITLE
Add DTE transmission features

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ db = DB()
 dte = db.generar_dte_json(venta_id=1)
 ```
 
+Para transmitir los DTE hacia la API de Hacienda añade en `datos_negocio.json` un
+bloque de configuración similar al siguiente:
+
+```json
+{
+  "dte_api": {
+    "url": "https://api.hacienda.test/dtes",
+    "ambiente": "produccion" | "pruebas",
+    "token": "TOKEN_O_CREDENCIAL"
+  }
+}
+```
+La función `transmitir_dte(db, venta_id)` utilizará estos datos para enviar el
+DTE inmediatamente después de firmarlo en modo normal, o registrará un evento
+pendiente en modo de contingencia.
+
 ### Datos del negocio y correo
 
 La configuración general se almacena en `datos_negocio.json`. Para que el envío

--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -27,5 +27,10 @@
   "smtp_server": "smtp.gmail.com",
   "smtp_port": "587",
   "email_usuario": "contacto@tiendademo.com",
-  "email_contrasena": ""
+  "email_contrasena": "",
+  "dte_api": {
+    "url": "https://api.hacienda.test/dtes",
+    "ambiente": "pruebas",
+    "token": ""
+  }
 }

--- a/db.py
+++ b/db.py
@@ -270,6 +270,19 @@ class DB:
             )
         """
         )
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS dte_envios (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venta_id INTEGER,
+                modo TEXT,
+                estado TEXT,
+                sello TEXT,
+                fecha_hora TEXT,
+                FOREIGN KEY (venta_id) REFERENCES ventas(id)
+            )
+        """
+        )
         self.conn.commit()
 
 
@@ -1395,3 +1408,33 @@ class DB:
                 except Exception:
                     pass
         return rows
+
+    def registrar_envio_dte(self, venta_id, modo, estado, sello):
+        """Guarda un registro del estado de transmisión de un DTE."""
+        fecha_hora = datetime.now().isoformat()
+        self.cursor.execute(
+            """
+            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (venta_id, modo, estado, sello, fecha_hora),
+        )
+        self.conn.commit()
+
+    def update_venta_extra(self, venta_id, extra_dict):
+        """Actualiza el campo ``extra`` de la venta, fusionando los datos."""
+        self.ensure_column("ventas", "extra", "TEXT")
+        self.cursor.execute("SELECT extra FROM ventas WHERE id=?", (venta_id,))
+        row = self.cursor.fetchone()
+        current = {}
+        if row and row[0]:
+            try:
+                current = json.loads(row[0])
+            except Exception:
+                current = {}
+        current.update(extra_dict)
+        self.cursor.execute(
+            "UPDATE ventas SET extra=? WHERE id=?",
+            (json.dumps(current, ensure_ascii=False), venta_id),
+        )
+        self.conn.commit()

--- a/dte.py
+++ b/dte.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from datetime import datetime
 from db import DB
+import requests
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
@@ -152,3 +153,47 @@ def generar_dte_json(db: DB, venta_id: int) -> dict:
             result["documentoVentaACuenta"] = extra.get("documento_venta_a_cuenta")
 
     return result
+
+
+def _load_dte_api_config():
+    datos = _load_datos_negocio()
+    return datos.get("dte_api", {})
+
+
+def _post_dte(url: str, token: str, data: dict) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.post(url, json=data, headers=headers, timeout=20)
+    resp.raise_for_status()
+    try:
+        return resp.json()
+    except Exception:
+        return {"estado": "Transmitido", "sello": ""}
+
+
+def transmitir_dte(db: DB, venta_id: int, modo: str = "normal") -> dict:
+    """Envía un DTE a la API configurada y registra su estado."""
+    config = _load_dte_api_config()
+    if modo == "contingencia":
+        db.registrar_envio_dte(venta_id, modo, "Pendiente", "")
+        return {"estado": "Pendiente"}
+
+    dte_data = generar_dte_json(db, venta_id)
+    url = config.get("url")
+    token = config.get("token")
+    if not url:
+        raise ValueError("URL de API no configurada")
+
+    try:
+        respuesta = _post_dte(url, token, dte_data)
+        sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
+        estado = respuesta.get("estado") or "Transmitido"
+    except Exception:
+        db.registrar_envio_dte(venta_id, modo, "Rechazado", "")
+        raise
+
+    db.registrar_envio_dte(venta_id, modo, estado, sello)
+    if sello:
+        db.update_venta_extra(venta_id, {"selloRecibido": sello})
+    return {"estado": estado, "sello": sello}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pyinstaller
 dbfread
 PyMuPDF
+requests

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -1,0 +1,55 @@
+from db import DB
+from dte import transmitir_dte
+import json
+
+
+def create_sale(db):
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "X", vid, None, 0, 0, 0, 1)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id
+
+
+def test_transmitir_dte_contingencia(tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+    res = transmitir_dte(db, venta, modo="contingencia")
+    assert res["estado"] == "Pendiente"
+    row = db.cursor.execute(
+        "SELECT estado FROM dte_envios WHERE venta_id=?", (venta,)
+    ).fetchone()
+    assert row["estado"] == "Pendiente"
+
+
+def test_transmitir_dte_normal(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            def json(self):
+                return {"estado": "Transmitido", "sello": "ABC123"}
+            def raise_for_status(self):
+                pass
+        return R()
+
+    from dte import _post_dte
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    config = {
+        "dte_api": {"url": "http://example.com", "ambiente": "pruebas", "token": "t"}
+    }
+    with open("datos_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+
+    res = transmitir_dte(db, venta)
+    assert res["estado"] == "Transmitido"
+    row = db.cursor.execute(
+        "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
+    ).fetchone()
+    assert row["estado"] == "Transmitido"
+    assert row["sello"] == "ABC123"


### PR DESCRIPTION
## Summary
- create table to track DTE transmissions
- support updating sale extras
- add API configuration and sending helpers
- document new API options in README
- add tests for DTE transmission

## Testing
- `pytest tests/test_dte_transmision.py tests/test_generar_dte_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688035064880832386520321a65deeb9