### PR TITLE
Improve error message when PyJWT is missing

### DIFF
--- a/utils/jws.py
+++ b/utils/jws.py
@@ -7,7 +7,12 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
     NoEncryption,
 )
-import jwt
+try:
+    import jwt
+except ModuleNotFoundError as exc:  # pragma: no cover - helpful runtime message
+    raise ModuleNotFoundError(
+        "PyJWT is required to sign DTE payloads. Install it with `pip install pyjwt`."
+    ) from exc
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "datos_negocio.json")
 


### PR DESCRIPTION
## Summary
- help users install PyJWT by catching the missing import in `utils/jws`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -k jws -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68805de229e88323bbe6019304f55084