### PR TITLE
Add QR verification link to DTE PDFs

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -7,6 +7,7 @@ from reportlab.lib.units import mm
 from reportlab.lib import colors
 
 from utils.pdf_utils import draw_wrapped_text
+from factura_sv import build_qr_value
 
 
 def generar_cabecera_dte(
@@ -16,6 +17,10 @@ def generar_cabecera_dte(
     modelo_facturacion: str,
     tipo_transmision: str,
     fecha_generacion: str,
+    nit_emisor: str = "",
+    fecha_emision: str | None = None,
+    tipo_dte: str = "01",
+    ambiente: str = "pruebas",
     tipo_documento: str = "CONSUMIDOR FINAL",
     archivo: str = "cabecera_dte.pdf",
 ):
@@ -77,7 +82,15 @@ def generar_cabecera_dte(
     # QR en el centro
     qr_x = 40 + box_w + col_margin + 3
     qr_y = box_y + (box_h - qr_size) / 2
-    qr_code = qr.QrCodeWidget(codigo_generacion)
+    qr_value = build_qr_value(
+        codigo_generacion,
+        numero_control,
+        nit_emisor=nit_emisor,
+        tipo_dte=tipo_dte,
+        fecha_emision=fecha_emision,
+        ambiente=ambiente,
+    )
+    qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()
     w = bounds[2] - bounds[0]
     h = bounds[3] - bounds[1]
@@ -128,6 +141,8 @@ if __name__ == "__main__":
         modelo_facturacion="1 - Facturación previo",
         tipo_transmision="1 - Transmisión normal",
         fecha_generacion="01/07/2025, 11:15 AM",
+        nit_emisor="06140020001001",
+        fecha_emision="2025-07-30",
         tipo_documento="CONSUMIDOR FINAL",
         archivo="cabecera_consumidor_final.pdf",
     )
@@ -138,6 +153,8 @@ if __name__ == "__main__":
         modelo_facturacion="1 - Facturación previo",
         tipo_transmision="1 - Transmisión normal",
         fecha_generacion="01/07/2025, 11:15 AM",
+        nit_emisor="06140020001001",
+        fecha_emision="2025-07-30",
         tipo_documento="CREDITO FISCAL",
         archivo="cabecera_credito_fiscal.pdf",
     )

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -21,24 +21,31 @@ def build_qr_value(
     numero_control: str,
     nit_emisor: str = "",
     tipo_dte: str = "01",
-    ambiente: str = "00",
+    ambiente: str = "pruebas",
     fecha_emision: str | None = None,
     total: float | None = None,
 ) -> str:
-    """Return the URL encoded string for the DTE QR code."""
+    """Return the URL used for the DTE QR code."""
+
+    base_url = (
+        "https://www.mh.gob.sv/consulta-dte"
+        if ambiente == "produccion"
+        else "https://sandbox.mh.gob.sv/consulta-dte"
+    )
+
     params = {
-        "ambiente": ambiente,
-        "codGen": codigo_generacion,
         "tipoDte": tipo_dte,
         "numeroControl": numero_control,
+        "codigoGeneracion": codigo_generacion,
     }
     if nit_emisor:
         params["nitEmisor"] = nit_emisor
     if fecha_emision:
-        params["fechaEmi"] = fecha_emision
+        params["fechaEmision"] = fecha_emision
     if total is not None:
         params["montoTotal"] = f"{total:.2f}"
-    return "https://portaldgii.mh.gob.sv/consulta?" + urlencode(params)
+
+    return base_url + "?" + urlencode(params)
 
 
 def generar_factura_electronica_pdf(
@@ -55,6 +62,7 @@ def generar_factura_electronica_pdf(
     modelo_facturacion="1 - Facturación previo",
     tipo_transmision="1 - Transmisión normal",
     fecha_generacion="",
+    ambiente="pruebas",
 ):
 
     if datos_negocio is None:
@@ -65,6 +73,8 @@ def generar_factura_electronica_pdf(
                     datos_negocio = json.load(f)
             except Exception:
                 datos_negocio = {}
+    if ambiente == "pruebas" and datos_negocio.get("dte_api", {}).get("ambiente"):
+        ambiente = datos_negocio["dte_api"].get("ambiente")
 
     if not codigo_generacion or not numero_control or not fecha_generacion:
         cab = generar_cabecera_dte_data(modelo_facturacion, tipo_transmision)
@@ -145,6 +155,7 @@ def generar_factura_electronica_pdf(
         tipo_dte="01" if tipo_documento.upper() == "CONSUMIDOR FINAL" else "03",
         fecha_emision=venta.get("fecha"),
         total=venta.get("total"),
+        ambiente=ambiente,
     )
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -78,10 +78,18 @@ def test_values_are_rounded(tmp_path):
 
 
 def test_qr_value_contains_params():
-    url = build_qr_value('ABC', 'NC-1', nit_emisor='0614', ambiente='01')
-    assert 'codGen=ABC' in url
+    url = build_qr_value(
+        'ABC',
+        'NC-1',
+        nit_emisor='0614',
+        ambiente='pruebas',
+        fecha_emision='2025-07-30',
+    )
+    assert url.startswith('https://sandbox.mh.gob.sv/consulta-dte?')
+    assert 'codigoGeneracion=ABC' in url
     assert 'numeroControl=NC-1' in url
     assert 'nitEmisor=0614' in url
+    assert 'fechaEmision=2025-07-30' in url
 
 
 def test_contingencia_draws_message(tmp_path):


### PR DESCRIPTION
## Summary
- generate QR codes with Hacienda URL
- include QR code in DTE header PDF
- update tests for new QR format

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6887afa2550483238b88c84e86598a1c