### PR TITLE
Enable uploading DTE signature files

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ Para firmar electrónicamente los DTE define los archivos de firma en
 {
   "firma_electronica": {
     "certificado": "ruta/al/certificado.crt",
+    "certificado_data": "PEM_O_BASE64",
     "clave_privada": "ruta/al/clave.key",
+    "clave_privada_data": "PEM_O_BASE64",
+    "llave_publica": "ruta/opcional/public.key",
+    "llave_publica_data": "PEM_O_BASE64",
     "frase_acceso": "PASSWORD_EN_BASE64"
   }
 }

--- a/config_negocio.json
+++ b/config_negocio.json
@@ -2,6 +2,10 @@
   "firma_electronica": {
     "certificado": "",
     "clave_privada": "",
-    "frase_acceso": ""
+    "frase_acceso": "",
+    "certificado_data": "",
+    "clave_privada_data": "",
+    "llave_publica": "",
+    "llave_publica_data": ""
   }
 }

--- a/dialogs.py
+++ b/dialogs.py
@@ -2,6 +2,8 @@ from decimal import Decimal, getcontext, ROUND_HALF_UP
 import json
 import logging
 import base64
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography import x509
 
 logger = logging.getLogger(__name__)
 from PyQt5.QtWidgets import (
@@ -2769,11 +2771,31 @@ class DatosNegocioDialog(QDialog):
         self.email.textChanged.connect(self._update_user_field)
         self._update_smtp_fields()
 
+        self.btn_load_cert.clicked.connect(self._load_cert_file)
+        self.btn_load_key.clicked.connect(self._load_key_file)
+        self.btn_load_pub.clicked.connect(self._load_pub_file)
+
         # --- Grupo 5: Configuraci\u00f3n de Facturaci\u00f3n Electr\u00f3nica ---
         grupo5 = QGroupBox("\ud83d\udcc3 Configuraci\u00f3n de Facturaci\u00f3n Electr\u00f3nica")
         form5 = QFormLayout()
         self.dte_certificado = QLineEdit()
+        self.btn_load_cert = QPushButton("...")
+        cert_row = QHBoxLayout()
+        cert_row.addWidget(self.dte_certificado)
+        cert_row.addWidget(self.btn_load_cert)
+
         self.dte_key = QLineEdit()
+        self.btn_load_key = QPushButton("...")
+        key_row = QHBoxLayout()
+        key_row.addWidget(self.dte_key)
+        key_row.addWidget(self.btn_load_key)
+
+        self.dte_public_key = QLineEdit()
+        self.btn_load_pub = QPushButton("...")
+        pub_row = QHBoxLayout()
+        pub_row.addWidget(self.dte_public_key)
+        pub_row.addWidget(self.btn_load_pub)
+
         self.dte_pass = QLineEdit()
         self.dte_pass.setEchoMode(QLineEdit.Password)
         self.tipo_contribuyente = QComboBox()
@@ -2790,8 +2812,9 @@ class DatosNegocioDialog(QDialog):
         self.incluir_sello_pdf = QCheckBox("Incluir sello de recepci\u00f3n en el PDF (si existe)")
         self.guardar_respuesta_bd = QCheckBox("Guardar respuesta de Hacienda en base de datos")
 
-        form5.addRow("Certificado (.crt):", self.dte_certificado)
-        form5.addRow("Llave privada (.key):", self.dte_key)
+        form5.addRow("Certificado (.crt):", cert_row)
+        form5.addRow("Llave privada (.key):", key_row)
+        form5.addRow("Llave p\xC3\xBAblica (.key):", pub_row)
         form5.addRow("Contrase\u00f1a clave privada:", self.dte_pass)
         form5.addRow("Tipo contribuyente:", self.tipo_contribuyente)
         form5.addRow("Prefijo n\u00famero control:", self.prefijo_control)
@@ -2873,14 +2896,38 @@ class DatosNegocioDialog(QDialog):
             "tipo_contribuyente": self.tipo_contribuyente.currentText(),
         }
 
-        config = {
-            "firma_electronica": {
-                "certificado": self.dte_certificado.text(),
-                "clave_privada": self.dte_key.text(),
-                "frase_acceso": base64.b64encode(self.dte_pass.text().encode()).decode()
-                if self.dte_pass.text() else "",
-            }
+        fe_config = {
+            "certificado": self.dte_certificado.text(),
+            "clave_privada": self.dte_key.text(),
+            "llave_publica": self.dte_public_key.text(),
+            "frase_acceso": base64.b64encode(self.dte_pass.text().encode()).decode()
+            if self.dte_pass.text() else "",
+            "certificado_data": "",
+            "clave_privada_data": "",
+            "llave_publica_data": "",
         }
+
+        for path, key in [
+            (self.dte_certificado.text(), "certificado_data"),
+            (self.dte_key.text(), "clave_privada_data"),
+            (self.dte_public_key.text(), "llave_publica_data"),
+        ]:
+            if path:
+                try:
+                    with open(path, "rb") as fh:
+                        data_f = fh.read()
+                    if key == "certificado_data":
+                        x509.load_pem_x509_certificate(data_f)
+                    elif key == "clave_privada_data":
+                        load_pem_private_key(
+                            data_f,
+                            self.dte_pass.text().encode() if self.dte_pass.text() else None,
+                        )
+                    fe_config[key] = base64.b64encode(data_f).decode()
+                except Exception as e:
+                    QMessageBox.warning(self, "Archivo de firma", f"Error al leer {path}: {e}")
+
+        config = {"firma_electronica": fe_config}
 
         return datos, config
 
@@ -2924,6 +2971,7 @@ class DatosNegocioDialog(QDialog):
         fe = config.get("firma_electronica", {})
         self.dte_certificado.setText(fe.get("certificado", ""))
         self.dte_key.setText(fe.get("clave_privada", ""))
+        self.dte_public_key.setText(fe.get("llave_publica", ""))
         frase = fe.get("frase_acceso", "")
         if frase:
             try:
@@ -2974,6 +3022,27 @@ class DatosNegocioDialog(QDialog):
         self.smtp_port.setReadOnly(True)
         self.email_usuario.setText(self.email.text())
         self.email_usuario.setReadOnly(True)
+
+    def _load_cert_file(self):
+        fname, _ = QFileDialog.getOpenFileName(
+            self, "Seleccionar certificado", "", "Cert Files (*.crt *.pem *.cer)"
+        )
+        if fname:
+            self.dte_certificado.setText(fname)
+
+    def _load_key_file(self):
+        fname, _ = QFileDialog.getOpenFileName(
+            self, "Seleccionar llave privada", "", "Key Files (*.key *.pem)"
+        )
+        if fname:
+            self.dte_key.setText(fname)
+
+    def _load_pub_file(self):
+        fname, _ = QFileDialog.getOpenFileName(
+            self, "Seleccionar llave publica", "", "Key Files (*.key *.pem)"
+        )
+        if fname:
+            self.dte_public_key.setText(fname)
 class TrabajadorDialog(QDialog):
     def __init__(self, trabajador=None, parent=None):
         super().__init__(parent)

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -142,3 +142,46 @@ def test_sign_and_save_p12(tmp_path, monkeypatch):
     )
     data = jwt.decode(token, public_pem, algorithms=["RS256"])
     assert data == payload
+
+
+def test_get_cert_config_embedded(tmp_path, monkeypatch):
+    key_path = tmp_path / "key.pem"
+    cert_path = tmp_path / "cert.crt"
+    password = "abc"
+    create_key_cert(key_path, cert_path, password)
+    key_data = key_path.read_bytes()
+    cert_data = cert_path.read_bytes()
+
+    cfg_path = tmp_path / "config.json"
+    with open(cfg_path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "firma_electronica": {
+                    "certificado": "",
+                    "clave_privada": "",
+                    "frase_acceso": base64.b64encode(password.encode()).decode(),
+                    "certificado_data": base64.b64encode(cert_data).decode(),
+                    "clave_privada_data": base64.b64encode(key_data).decode(),
+                }
+            },
+            fh,
+        )
+
+    monkeypatch.setattr(jws, "CONFIG_NEGOCIO_PATH", str(cfg_path))
+
+    payload = {"foo": "bar"}
+    json_file = tmp_path / "dte.json"
+    with open(json_file, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+    cert, key, phrase = jws.get_cert_config(str(cfg_path))
+    jws_path = jws.sign_and_save(payload, str(json_file), cert, phrase, key)
+    token = open(jws_path).read()
+
+    cert_obj = x509.load_pem_x509_certificate(cert_data)
+    public_pem = cert_obj.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    data = jwt.decode(token, public_pem, algorithms=["RS256"])
+    assert data == payload

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -2,6 +2,7 @@ import os
 import json
 import base64
 import os
+import json
 from cryptography.hazmat.primitives.serialization import (
     pkcs12,
     Encoding,
@@ -30,22 +31,26 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
             fe = data.get("firma_electronica", {})
             cert = fe.get("certificado")
             key = fe.get("clave_privada")
+            cert_data_b64 = fe.get("certificado_data")
+            key_data_b64 = fe.get("clave_privada_data")
             password = fe.get("frase_acceso")
             if password:
                 try:
                     password = base64.b64decode(password).decode("utf-8")
                 except Exception:
                     pass
-            if cert and not os.path.exists(cert):
-                raise FileNotFoundError(cert)
-            if key and not os.path.exists(key):
-                raise FileNotFoundError(key)
-            if cert and key:
+            if cert and os.path.exists(cert) and key and os.path.exists(key):
                 with open(cert, "rb") as fh:
                     x509.load_pem_x509_certificate(fh.read())
                 with open(key, "rb") as fh:
                     load_pem_private_key(fh.read(), password.encode() if password else None)
                 return cert, key, password
+            if cert_data_b64 and key_data_b64:
+                cert_bytes = base64.b64decode(cert_data_b64)
+                key_bytes = base64.b64decode(key_data_b64)
+                x509.load_pem_x509_certificate(cert_bytes)
+                load_pem_private_key(key_bytes, password.encode() if password else None)
+                return cert_bytes, key_bytes, password
         except Exception:
             return None, None, None
 
@@ -75,6 +80,11 @@ def _load_p12_key(cert_path: str, password: str | None):
     return key
 
 
+def _load_p12_key_bytes(data: bytes, password: str | None):
+    key, _cert, _ = pkcs12.load_key_and_certificates(data, password.encode() if password else None)
+    return key
+
+
 def sign_json(
     payload: dict,
     cert_path: str | None = None,
@@ -83,10 +93,17 @@ def sign_json(
 ) -> str:
     """Return a JWS token (compact serialization) for ``payload``."""
     if key_path:
-        with open(key_path, "rb") as fh:
-            key = load_pem_private_key(fh.read(), password.encode() if password else None)
+        if isinstance(key_path, bytes):
+            key_bytes = key_path
+        else:
+            with open(key_path, "rb") as fh:
+                key_bytes = fh.read()
+        key = load_pem_private_key(key_bytes, password.encode() if password else None)
     elif cert_path:
-        key = _load_p12_key(cert_path, password)
+        if isinstance(cert_path, bytes):
+            key = _load_p12_key_bytes(cert_path, password)
+        else:
+            key = _load_p12_key(cert_path, password)
     else:
         raise ValueError("Missing certificate information")
     pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())


### PR DESCRIPTION
## Summary
- support uploading electronic signature files
- allow DatosNegocioDialog to load certificate, private key and public key
- embed uploaded files in `config_negocio.json`
- handle embedded data in JWS utilities
- document new fields in README
- test reading certificate data from config

## Testing
- `pytest tests/test_jws.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688919a457e483238119b578b1c1c3d3