### PR TITLE
Improve private key validation

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2919,6 +2919,8 @@ class DatosNegocioDialog(QDialog):
                     if key == "certificado_data":
                         x509.load_pem_x509_certificate(data_f)
                     elif key == "clave_privada_data":
+                        if b"-----BEGIN" not in data_f:
+                            raise ValueError("El archivo no parece ser una clave privada PEM")
                         load_pem_private_key(
                             data_f,
                             self.dte_pass.text().encode() if self.dte_pass.text() else None,

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -43,12 +43,17 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
                 with open(cert, "rb") as fh:
                     x509.load_pem_x509_certificate(fh.read())
                 with open(key, "rb") as fh:
-                    load_pem_private_key(fh.read(), password.encode() if password else None)
+                    key_bytes = fh.read()
+                if b"-----BEGIN" not in key_bytes:
+                    raise ValueError("La clave privada no parece ser PEM")
+                load_pem_private_key(key_bytes, password.encode() if password else None)
                 return cert, key, password
             if cert_data_b64 and key_data_b64:
                 cert_bytes = base64.b64decode(cert_data_b64)
                 key_bytes = base64.b64decode(key_data_b64)
                 x509.load_pem_x509_certificate(cert_bytes)
+                if b"-----BEGIN" not in key_bytes:
+                    raise ValueError("La clave privada no parece ser PEM")
                 load_pem_private_key(key_bytes, password.encode() if password else None)
                 return cert_bytes, key_bytes, password
         except Exception:


### PR DESCRIPTION
## Summary
- better private key validations when loading certificate files
- warn if the private key file does not look like PEM data

## Testing
- `pytest tests/test_jws.py::test_sign_and_save_pem -q`
- `pytest -q` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688941eab1d08323a55c53e426b23921