### PR TITLE
Relax certificate validation in test mode

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2907,6 +2907,8 @@ class DatosNegocioDialog(QDialog):
             "llave_publica_data": "",
         }
 
+        verificar = self.ambiente_hacienda.currentText().lower() == "producción" or self.ambiente_hacienda.currentText().lower() == "produccion"
+
         for path, key in [
             (self.dte_certificado.text(), "certificado_data"),
             (self.dte_key.text(), "clave_privada_data"),
@@ -2916,15 +2918,16 @@ class DatosNegocioDialog(QDialog):
                 try:
                     with open(path, "rb") as fh:
                         data_f = fh.read()
-                    if key == "certificado_data":
-                        x509.load_pem_x509_certificate(data_f)
-                    elif key == "clave_privada_data":
-                        if b"-----BEGIN" not in data_f:
-                            raise ValueError("El archivo no parece ser una clave privada PEM")
-                        load_pem_private_key(
-                            data_f,
-                            self.dte_pass.text().encode() if self.dte_pass.text() else None,
-                        )
+                    if verificar:
+                        if key == "certificado_data":
+                            x509.load_pem_x509_certificate(data_f)
+                        elif key == "clave_privada_data":
+                            if b"-----BEGIN" not in data_f:
+                                raise ValueError("El archivo no parece ser una clave privada PEM")
+                            load_pem_private_key(
+                                data_f,
+                                self.dte_pass.text().encode() if self.dte_pass.text() else None,
+                            )
                     fe_config[key] = base64.b64encode(data_f).decode()
                 except Exception as e:
                     QMessageBox.warning(self, "Archivo de firma", f"Error al leer {path}: {e}")

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -22,8 +22,22 @@ DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "d
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config_negocio.json")
 
 
+def _get_ambiente() -> str:
+    """Return configured DTE environment or ``"pruebas"`` by default."""
+    if os.path.exists(DATOS_NEGOCIO_PATH):
+        try:
+            with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+                datos = json.load(fh)
+            return datos.get("dte_api", {}).get("ambiente", "pruebas").lower()
+        except Exception:
+            pass
+    return "pruebas"
+
+
 def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
     """Return certificate (.crt), key (.key) and password from config."""
+    ambiente = _get_ambiente()
+    verificar = ambiente == "produccion"
     if os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as fh:
@@ -40,21 +54,23 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
                 except Exception:
                     pass
             if cert and os.path.exists(cert) and key and os.path.exists(key):
-                with open(cert, "rb") as fh:
-                    x509.load_pem_x509_certificate(fh.read())
-                with open(key, "rb") as fh:
-                    key_bytes = fh.read()
-                if b"-----BEGIN" not in key_bytes:
-                    raise ValueError("La clave privada no parece ser PEM")
-                load_pem_private_key(key_bytes, password.encode() if password else None)
+                if verificar:
+                    with open(cert, "rb") as fh:
+                        x509.load_pem_x509_certificate(fh.read())
+                    with open(key, "rb") as fh:
+                        key_bytes = fh.read()
+                    if b"-----BEGIN" not in key_bytes:
+                        raise ValueError("La clave privada no parece ser PEM")
+                    load_pem_private_key(key_bytes, password.encode() if password else None)
                 return cert, key, password
             if cert_data_b64 and key_data_b64:
                 cert_bytes = base64.b64decode(cert_data_b64)
                 key_bytes = base64.b64decode(key_data_b64)
-                x509.load_pem_x509_certificate(cert_bytes)
-                if b"-----BEGIN" not in key_bytes:
-                    raise ValueError("La clave privada no parece ser PEM")
-                load_pem_private_key(key_bytes, password.encode() if password else None)
+                if verificar:
+                    x509.load_pem_x509_certificate(cert_bytes)
+                    if b"-----BEGIN" not in key_bytes:
+                        raise ValueError("La clave privada no parece ser PEM")
+                    load_pem_private_key(key_bytes, password.encode() if password else None)
                 return cert_bytes, key_bytes, password
         except Exception:
             return None, None, None
@@ -71,6 +87,8 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
                 except Exception:
                     pass
             if cert_path and os.path.exists(cert_path):
+                if verificar:
+                    _load_p12_key(cert_path, password)
                 return cert_path, None, password
         except Exception:
             return None, None, None


### PR DESCRIPTION
## Summary
- allow utils.get_cert_config to skip certificate validation in non-production
- only verify DTE signing files when production is selected in the dialog

## Testing
- `pip install -r requirements.txt`
- `timeout 60 pytest -q` *(fails: one test failure)*

------
https://chatgpt.com/codex/tasks/task_e_688943b723008323b75e37eaf33d9ece