### PR TITLE
Add DTE sandbox transmission support

### DIFF
--- a/db.py
+++ b/db.py
@@ -280,6 +280,7 @@ class DB:
                 estado TEXT,
                 sello TEXT,
                 fecha_hora TEXT,
+                respuesta TEXT,
 
                 FOREIGN KEY (venta_id) REFERENCES ventas(id)
             )
@@ -1432,15 +1433,16 @@ class DB:
                     pass
         return rows
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello):
+    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
         """Guarda un registro del estado de transmisión de un DTE."""
+        self.ensure_column("dte_envios", "respuesta", "TEXT")
         fecha_hora = datetime.now().isoformat()
         self.cursor.execute(
             """
-            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (venta_id, modo, estado, sello, fecha_hora),
+            (venta_id, modo, estado, sello, fecha_hora, respuesta_json),
         )
         self.conn.commit()
 

--- a/dte.py
+++ b/dte.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP, getcontext
 from db import DB
 import requests
+from utils import jws
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
@@ -209,6 +210,51 @@ def generar_dte_json(
     return result
 
 
+def validate_dte_json(data: dict) -> None:
+    """Basic validation for DTE payload before signing."""
+    required = ["identificacion", "emisor", "receptor", "cuerpoDocumento", "resumen"]
+    for key in required:
+        if key not in data:
+            raise ValueError(f"Falta el campo obligatorio: {key}")
+
+    cuerpo = data.get("cuerpoDocumento", [])
+    items_total = Decimal("0")
+    for item in cuerpo:
+        cantidad = Decimal(str(item.get("cantidad", 0)))
+        precio = Decimal(str(item.get("precioUnitario", 0)))
+        item["cantidad"] = float(cantidad.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP))
+        item["precioUnitario"] = float(precio.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP))
+        items_total += cantidad * precio
+
+    resumen = data.get("resumen", {})
+    for k, v in resumen.items():
+        if isinstance(v, (int, float, str)):
+            resumen[k] = _round(v, 2)
+
+    sumas = Decimal(str(resumen.get("sumas", 0)))
+    descuentos = Decimal(str(resumen.get("descuentos", 0)))
+    iva = Decimal(str(resumen.get("iva", 0)))
+    sub_total = Decimal(str(resumen.get("subTotal", 0)))
+    total = Decimal(str(resumen.get("totalPagar", 0)))
+
+    items_total_2 = Decimal(str(_round(items_total, 2)))
+    if abs(items_total_2 - sumas) > Decimal("0.01"):
+        print(
+            f"Advertencia: la suma de los ítems {items_total_2:.2f} difiere del resumen {sumas:.2f}"
+        )
+
+    calc_sub = sumas - descuentos + iva
+    calc_sub = Decimal(str(_round(calc_sub, 2)))
+    if abs(calc_sub - sub_total) > Decimal("0.01"):
+        print(
+            f"Advertencia: el subtotal calculado {calc_sub:.2f} difiere del resumen {sub_total:.2f}"
+        )
+    if abs(calc_sub - total) > Decimal("0.01"):
+        print(
+            f"Advertencia: el total a pagar {total:.2f} difiere del subtotal calculado {calc_sub:.2f}"
+        )
+
+
 def generar_ticket_json(
     db: DB,
     venta_id: int,
@@ -260,11 +306,12 @@ def _load_dte_api_config():
     return datos.get("dte_api", {})
 
 
-def _post_dte(url: str, token: str, data: dict) -> dict:
+def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
     if token:
-        headers["Authorization"] = f"Bearer {token}"
-    resp = requests.post(url, json=data, headers=headers, timeout=20)
+        headers["Authorization"] = f"FIRMANTE {token}"
+    payload = {"dte": jws_token}
+    resp = requests.post(url, json=payload, headers=headers, timeout=20)
     resp.raise_for_status()
     try:
         return resp.json()
@@ -289,20 +336,21 @@ def transmitir_dte(
         dte_data = generar_ticket_json(db, venta_id)
     else:
         dte_data = generar_dte_json(db, venta_id)
-    url = config.get("url")
-    token = config.get("token")
-    if not url:
-        raise ValueError("URL de API no configurada")
+    validate_dte_json(dte_data)
+    url = config.get("url") or "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+    cert, key, phrase = jws.get_cert_config()
+    signed = jws.sign_json(dte_data, cert, phrase, key)
+    token = jws.create_auth_jwt("inventario", cert, phrase, key)
 
     try:
-        respuesta = _post_dte(url, token, dte_data)
+        respuesta = _post_dte(url, token, signed)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = respuesta.get("estado") or "Transmitido"
     except Exception:
         db.registrar_envio_dte(venta_id, modo, "Rechazado", "")
         raise
 
-    db.registrar_envio_dte(venta_id, modo, estado, sello)
+    db.registrar_envio_dte(venta_id, modo, estado, sello, json.dumps(respuesta, ensure_ascii=False))
     if sello:
         db.update_venta_extra(venta_id, {"selloRecibido": sello})
     return {"estado": estado, "sello": sello}
@@ -310,10 +358,11 @@ def transmitir_dte(
 
 def enviar_dte_a_hacienda(dte_json_firmado: dict) -> dict:
     """Envía un DTE firmado al entorno de pruebas de Hacienda."""
-    url = "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"
-    config = _load_dte_api_config()
-    token = config.get("token")
-    respuesta = _post_dte(url, token, dte_json_firmado)
+    url = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+    cert, key, phrase = jws.get_cert_config()
+    jws_token = jws.sign_json(dte_json_firmado, cert, phrase, key)
+    jwt_token = jws.create_auth_jwt("inventario", cert, phrase, key)
+    respuesta = _post_dte(url, jwt_token, jws_token)
     estado = respuesta.get("estado") or respuesta.get("estadoDte") or respuesta.get("descripcionEstado")
     if estado:
         respuesta["estado"] = estado

--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -83,12 +83,10 @@ def generar_cabecera_dte(
     qr_x = 40 + box_w + col_margin + 3
     qr_y = box_y + (box_h - qr_size) / 2
     qr_value = build_qr_value(
+        1 if ambiente == "produccion" else 2,
         codigo_generacion,
+        tipo_dte,
         numero_control,
-        nit_emisor=nit_emisor,
-        tipo_dte=tipo_dte,
-        fecha_emision=fecha_emision,
-        ambiente=ambiente,
     )
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -17,33 +17,23 @@ DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json
 
 
 def build_qr_value(
+    ambiente: int,
     codigo_generacion: str,
-    numero_control: str,
-    nit_emisor: str = "",
-    tipo_dte: str = "01",
-    ambiente: str = "pruebas",
-    fecha_emision: str | None = None,
-    total: float | None = None,
+    tipo_dte: str,
+    numero_documento: str,
 ) -> str:
     """Return the URL used for the DTE QR code."""
 
     base_url = (
-        "https://www.mh.gob.sv/consulta-dte"
-        if ambiente == "produccion"
-        else "https://sandbox.mh.gob.sv/consulta-dte"
+        "https://www.mh.gob.sv/consulta-dte" if ambiente == 1 else "https://sandbox.mh.gob.sv/consulta-dte"
     )
 
     params = {
-        "tipoDte": tipo_dte,
-        "numeroControl": numero_control,
+        "ambiente": ambiente,
         "codigoGeneracion": codigo_generacion,
+        "tipoDte": tipo_dte,
+        "numeroDocumento": numero_documento,
     }
-    if nit_emisor:
-        params["nitEmisor"] = nit_emisor
-    if fecha_emision:
-        params["fechaEmision"] = fecha_emision
-    if total is not None:
-        params["montoTotal"] = f"{total:.2f}"
 
     return base_url + "?" + urlencode(params)
 
@@ -147,15 +137,11 @@ def generar_factura_electronica_pdf(
     # --- Código QR ---
     qr_x = x_margin + box_w + col_margin + 5
     qr_y = box_y + (box_h - qr_size) / 2
-    nit_emisor = datos_negocio.get("nit", "")
     qr_value = build_qr_value(
+        1 if ambiente == "produccion" else 2,
         codigo_generacion,
+        "01" if tipo_documento.upper() == "CONSUMIDOR FINAL" else "03",
         numero_control,
-        nit_emisor=nit_emisor,
-        tipo_dte="01" if tipo_documento.upper() == "CONSUMIDOR FINAL" else "03",
-        fecha_emision=venta.get("fecha"),
-        total=venta.get("total"),
-        ambiente=ambiente,
     )
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -28,6 +28,10 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
 
+    monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
+    monkeypatch.setattr("utils.jws.sign_json", lambda data, cert, p, key: "SIGNED")
+    monkeypatch.setattr("utils.jws.create_auth_jwt", lambda sub, cert, p, key: "JWT")
+
     def fake_post(url, json=None, headers=None, timeout=20):
         class R:
             status_code = 200

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -79,17 +79,16 @@ def test_values_are_rounded(tmp_path):
 
 def test_qr_value_contains_params():
     url = build_qr_value(
+        2,
         'ABC',
+        '01',
         'NC-1',
-        nit_emisor='0614',
-        ambiente='pruebas',
-        fecha_emision='2025-07-30',
     )
     assert url.startswith('https://sandbox.mh.gob.sv/consulta-dte?')
     assert 'codigoGeneracion=ABC' in url
-    assert 'numeroControl=NC-1' in url
-    assert 'nitEmisor=0614' in url
-    assert 'fechaEmision=2025-07-30' in url
+    assert 'numeroDocumento=NC-1' in url
+    assert 'tipoDte=01' in url
+    assert 'ambiente=2' in url
 
 
 def test_contingencia_draws_message(tmp_path):

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -185,3 +185,34 @@ def test_get_cert_config_embedded(tmp_path, monkeypatch):
     )
     data = jwt.decode(token, public_pem, algorithms=["RS256"])
     assert data == payload
+
+
+def test_sign_json_adds_header(tmp_path):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "SV")]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "SV")]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    cert_file = tmp_path / "cert.crt"
+    key_file = tmp_path / "key.pem"
+    cert_file.write_bytes(cert_pem)
+    key_file.write_bytes(key_pem)
+    payload = {"a": 1}
+    token = jws.sign_json(payload, str(cert_file), None, str(key_file))
+    header = jwt.get_unverified_header(token)
+    assert header["alg"] == "RS256"
+    assert header["typ"] == "JWT"
+    assert "x5c" in header
+

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -1,8 +1,7 @@
 import os
 import json
 import base64
-import os
-import json
+import time
 from cryptography.hazmat.primitives.serialization import (
     pkcs12,
     Encoding,
@@ -122,15 +121,37 @@ def sign_json(
             with open(key_path, "rb") as fh:
                 key_bytes = fh.read()
         key = load_pem_private_key(key_bytes, password.encode() if password else None)
+        cert_bytes = None
+        if cert_path and os.path.exists(cert_path):
+            with open(cert_path, "rb") as fh:
+                cert_data = fh.read()
+            if b"-----BEGIN" in cert_data:
+                cert = x509.load_pem_x509_certificate(cert_data)
+            else:
+                _k, cert, _ = pkcs12.load_key_and_certificates(cert_data, password.encode() if password else None)
+            cert_bytes = cert.public_bytes(Encoding.DER)
     elif cert_path:
         if isinstance(cert_path, bytes):
             key = _load_p12_key_bytes(cert_path, password)
+            _k, cert, _ = pkcs12.load_key_and_certificates(cert_path, password.encode() if password else None)
+            cert_bytes = cert.public_bytes(Encoding.DER) if cert else None
         else:
             key = _load_p12_key(cert_path, password)
+            with open(cert_path, "rb") as fh:
+                cert_data = fh.read()
+            if b"-----BEGIN" in cert_data:
+                cert_obj = x509.load_pem_x509_certificate(cert_data)
+            else:
+                _k, cert_obj, _ = pkcs12.load_key_and_certificates(cert_data, password.encode() if password else None)
+            cert_bytes = cert_obj.public_bytes(Encoding.DER)
     else:
         raise ValueError("Missing certificate information")
+
     pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
-    token = jwt.encode(payload, pem, algorithm="RS256")
+    header = {"alg": "RS256", "typ": "JWT"}
+    if cert_bytes:
+        header["x5c"] = [base64.b64encode(cert_bytes).decode()]
+    token = jwt.encode(payload, pem, algorithm="RS256", headers=header)
     return token
 
 
@@ -147,3 +168,18 @@ def sign_and_save(
     with open(jws_path, "w", encoding="utf-8") as fh:
         fh.write(token)
     return jws_path
+
+
+def create_auth_jwt(
+    subject: str,
+    cert_path: str | None = None,
+    password: str | None = None,
+    key_path: str | None = None,
+) -> str:
+    """Return a short-lived JWT for API authentication."""
+    payload = {
+        "sub": subject,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300,
+    }
+    return sign_json(payload, cert_path, password, key_path)


### PR DESCRIPTION
## Summary
- validate DTE JSON before sending
- sign DTE payload with RS256 including certificate chain
- generate short-lived JWT for Hacienda API
- store Hacienda response in database
- update QR generation parameters
- adjust tests for new behaviour

## Testing
- `pytest tests/test_jws.py::test_sign_and_save_pem tests/test_jws.py::test_sign_json_adds_header tests/test_dte_transmision.py::test_transmitir_dte_normal tests/test_dte_transmision.py::test_transmitir_dte_contingencia tests/test_factura_pdf.py::test_qr_value_contains_params -q`

------
https://chatgpt.com/codex/tasks/task_e_68895a68d82883239d0ff4cd78d59639