### PR TITLE
feat: add configurable DTE endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ Para firmar electrónicamente los DTE define los archivos de firma en
 }
 ```
 
+Para diferenciar entre los ambientes de pruebas y producción de Hacienda,
+configura el campo `ambiente` y las URLs en `config_negocio.json`:
+
+```json
+{
+  "ambiente": "pruebas",
+  "auth_url": {
+    "pruebas": "https://apifacturatest.mh.gob.sv/auth",
+    "produccion": "https://api.factura.gob.sv/auth"
+  },
+  "recepcion_url": {
+    "pruebas": "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte",
+    "produccion": "https://api.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+  }
+}
+```
+
+Al cambiar `ambiente` a `produccion` la aplicación utilizará los servicios
+productivos.
+
 La contraseña puede dejarse vacía si la clave privada no está cifrada. Al
 generar facturas o tickets se creará junto al PDF un archivo `.jws` con el JSON
 firmado.
@@ -109,8 +129,6 @@ otros parámetros dentro de `datos_negocio.json` bajo el bloque `dte_api`:
 ```json
 {
   "dte_api": {
-    "url": "https://api.hacienda.test/dtes",
-    "ambiente": "pruebas",
     "token": "TOKEN",
     "prefijo_control": "DTE-01-S001P001",
     "modo_transmision": "1 - Normal"

--- a/auth.py
+++ b/auth.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import requests
 
-TOKEN_URL = "https://apifacturatest.mh.gob.sv/auth"
+DEFAULT_AUTH_URL = "https://apifacturatest.mh.gob.sv/auth"
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.json")
 DB_PATH = os.path.join(os.path.dirname(__file__), "inventario.db")
 
@@ -74,11 +74,25 @@ def _get_credentials() -> Tuple[str, str]:
     return nit, pwd
 
 
+def _get_auth_url() -> str:
+    """Obtiene la URL de autenticación según el ambiente configurado."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        ambiente = data.get("ambiente", "pruebas")
+        urls = data.get("auth_url", {})
+        url = urls.get(ambiente) if isinstance(urls, dict) else urls
+        return url or DEFAULT_AUTH_URL
+    except Exception:
+        return DEFAULT_AUTH_URL
+
+
 def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, float]:
     """Solicita un nuevo token de acceso a la API."""
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     data = {"user": nit, "pwd": pwd}
-    resp = requests.post(TOKEN_URL, data=data, headers=headers, timeout=20)
+    url = _get_auth_url()
+    resp = requests.post(url, data=data, headers=headers, timeout=20)
     resp.raise_for_status()
     info = resp.json()
     token = info.get("access_token")

--- a/config_negocio.json
+++ b/config_negocio.json
@@ -7,5 +7,14 @@
     "clave_privada_data": "",
     "llave_publica": "",
     "llave_publica_data": ""
+  },
+  "ambiente": "pruebas",
+  "auth_url": {
+    "pruebas": "https://apifacturatest.mh.gob.sv/auth",
+    "produccion": "https://api.factura.gob.sv/auth"
+  },
+  "recepcion_url": {
+    "pruebas": "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte",
+    "produccion": "https://api.dtes.mh.gob.sv/recepciondte/api/recepciondte"
   }
 }

--- a/db.py
+++ b/db.py
@@ -1446,6 +1446,20 @@ class DB:
         )
         self.conn.commit()
 
+    def consultar_envio_dte(self, venta_id):
+        """Devuelve el JSON almacenado en ``dte_envios.respuesta``."""
+        self.ensure_column("dte_envios", "respuesta", "TEXT")
+        row = self.cursor.execute(
+            "SELECT respuesta FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+            (venta_id,),
+        ).fetchone()
+        if not row or not row[0]:
+            return {}
+        try:
+            return json.loads(row[0])
+        except Exception:
+            return {}
+
     def update_venta_extra(self, venta_id, extra_dict):
         """Actualiza el campo ``extra`` de la venta, fusionando los datos."""
         self.ensure_column("ventas", "extra", "TEXT")

--- a/dte.py
+++ b/dte.py
@@ -13,6 +13,8 @@ from jsonschema import validate as _jsonschema_validate
 from utils import catalogos
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.json")
+DEFAULT_RECEPCION_URL = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
 
 # Ensure enough precision when other modules modify the global decimal context
 getcontext().prec = 28
@@ -349,14 +351,22 @@ def generar_nota_credito_json(db: DB, nota_id: int) -> dict:
 
 
 def _load_dte_api_config():
-    datos = _load_datos_negocio()
-    return datos.get("dte_api", {})
+    """Lee configuración de URLs y ambiente desde ``config_negocio.json``."""
+    try:
+        with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        ambiente = data.get("ambiente", "pruebas")
+        urls = data.get("recepcion_url", {})
+        url = urls.get(ambiente) if isinstance(urls, dict) else urls
+        return {"ambiente": ambiente, "url": url}
+    except Exception:
+        return {}
 
 
 def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
     if token:
-        headers["Authorization"] = f"FIRMANTE {token}"
+        headers["Authorization"] = f"Bearer {token}"
     payload = {"dte": jws_token}
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
     resp.raise_for_status()
@@ -384,7 +394,7 @@ def transmitir_dte(
     else:
         dte_data = generar_dte_json(db, venta_id)
     validate_dte_json(dte_data)
-    url = config.get("url") or "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+    url = config.get("url") or DEFAULT_RECEPCION_URL
     cert, key, phrase = jws.get_cert_config()
     signed = jws.sign_json(dte_data, cert, phrase, key)
     token = auth.get_token()

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -1,5 +1,5 @@
 from db import DB
-from dte import transmitir_dte
+from dte import transmitir_dte, _post_dte
 import json
 
 
@@ -42,13 +42,10 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
                 pass
         return R()
 
-    from dte import _post_dte
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {
-        "dte_api": {"url": "http://example.com", "ambiente": "pruebas", "token": "t"}
-    }
-    with open("datos_negocio.json", "w", encoding="utf-8") as fh:
+    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
     res = transmitir_dte(db, venta)
@@ -58,3 +55,28 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
     ).fetchone()
     assert row["estado"] == "Transmitido"
     assert row["sello"] == "ABC123"
+
+
+def test_post_dte_uses_bearer(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        captured["headers"] = headers
+        class R:
+            status_code = 200
+            def json(self):
+                return {}
+            def raise_for_status(self):
+                pass
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    _post_dte("http://example.com", "TOKEN", "SIGNED")
+    assert captured["headers"]["Authorization"] == "Bearer TOKEN"
+
+
+def test_consultar_envio_dte():
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(venta, "normal", "Transmitido", "S", '{"ok": true}')
+    assert db.consultar_envio_dte(venta) == {"ok": True}


### PR DESCRIPTION
## Summary
- use Bearer authorization when transmitting DTEs
- allow selecting Hacienda auth and recepcion URLs by environment
- expose DB.consultar_envio_dte for retrieving stored responses

## Testing
- `pytest tests/test_dte_transmision.py`


------
https://chatgpt.com/codex/tasks/task_e_68912f22dce883238393dbcadfa2f4e9