### PR TITLE
Implementación de envío y registro de DTEs

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -11,6 +11,9 @@ import json
 import os
 from jsonschema import validate as _jsonschema_validate
 from utils import catalogos
+import logging
+
+logger = logging.getLogger(__name__)
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.json")
@@ -424,4 +427,121 @@ def enviar_dte_a_hacienda(dte_json_firmado: dict) -> dict:
     if estado:
         respuesta["estado"] = estado
     return respuesta
+
+
+def _parse_error_response(respuesta: dict) -> str:
+    """Construye un mensaje de error a partir de ``descripcionMsg`` y ``observaciones``."""
+    partes = []
+    desc = respuesta.get("descripcionMsg")
+    if desc:
+        partes.append(str(desc))
+    obs = respuesta.get("observaciones")
+    if isinstance(obs, dict):
+        for k, v in obs.items():
+            partes.append(f"{k}: {v}")
+    elif isinstance(obs, list):
+        partes.extend(str(o) for o in obs)
+    elif obs:
+        partes.append(str(obs))
+    mensaje = "; ".join(partes)
+    if mensaje:
+        logger.error(mensaje)
+    return mensaje
+
+
+def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> dict:
+    """Firma y envía ``data`` a la API de Hacienda registrando el envío."""
+    config = _load_dte_api_config()
+    if modo == "contingencia":
+        db.registrar_envio_dte(doc_id, modo, "Pendiente", "")
+        return {"estado": "Pendiente"}
+
+    url = config.get("url") or DEFAULT_RECEPCION_URL
+    cert, key, phrase = jws.get_cert_config()
+    signed = jws.sign_json(data, cert, phrase, key)
+    token = auth.get_token()
+
+    try:
+        respuesta = _post_dte(url, token, signed)
+        sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
+        estado = (
+            respuesta.get("estado")
+            or respuesta.get("estadoDte")
+            or respuesta.get("descripcionEstado")
+            or "Transmitido"
+        )
+    except Exception:
+        db.registrar_envio_dte(doc_id, modo, "Rechazado", "")
+        raise
+
+    db.registrar_envio_dte(
+        doc_id,
+        modo,
+        estado,
+        sello,
+        json.dumps(respuesta, ensure_ascii=False),
+    )
+    if estado == "Rechazado":
+        respuesta["errores"] = _parse_error_response(respuesta)
+    return {"estado": estado, "sello": sello}
+
+
+def enviar_factura(db: DB, venta_id: int, modo: str = "normal") -> dict:
+    """Genera y transmite una factura electrónica."""
+    data = generar_dte_json(db, venta_id)
+    validate_dte_json(data)
+    resp = _enviar_documento(db, venta_id, data, modo)
+    if resp.get("sello"):
+        db.update_venta_extra(venta_id, {"selloRecibido": resp["sello"]})
+    return resp
+
+
+def enviar_nota_credito(db: DB, nota_id: int, modo: str = "normal") -> dict:
+    """Genera y transmite una nota de crédito."""
+    data = generar_nota_credito_json(db, nota_id)
+    validate_dte_json(data)
+    return _enviar_documento(db, nota_id, data, modo)
+
+
+def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
+    """Firma y envía un evento a Hacienda."""
+    config = _load_dte_api_config()
+    url = config.get("url") or DEFAULT_RECEPCION_URL
+    cert, key, phrase = jws.get_cert_config()
+    signed = jws.sign_json(data, cert, phrase, key)
+    token = auth.get_token()
+
+    try:
+        respuesta = _post_dte(url, token, signed)
+        sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
+        estado = (
+            respuesta.get("estado")
+            or respuesta.get("estadoEvento")
+            or respuesta.get("descripcionEstado")
+            or "Transmitido"
+        )
+    except Exception:
+        db.registrar_envio_dte(evento_id, "evento", "Rechazado", "")
+        raise
+
+    db.registrar_envio_dte(
+        evento_id,
+        "evento",
+        estado,
+        sello,
+        json.dumps(respuesta, ensure_ascii=False),
+    )
+    if estado == "Rechazado":
+        respuesta["errores"] = _parse_error_response(respuesta)
+    return {"estado": estado, "sello": sello}
+
+
+def enviar_evento_contingencia(db: DB, evento_id: int, data: dict) -> dict:
+    """Envía un evento de contingencia."""
+    return _enviar_evento(db, evento_id, data)
+
+
+def enviar_evento_anulacion(db: DB, evento_id: int, data: dict) -> dict:
+    """Envía un evento de anulación."""
+    return _enviar_evento(db, evento_id, data)
 

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -1,0 +1,158 @@
+import json
+import logging
+
+from db import DB
+from dte import (
+    enviar_factura,
+    enviar_nota_credito,
+    enviar_evento_contingencia,
+    enviar_evento_anulacion,
+)
+
+
+def create_sale(db):
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "X", vid, None, 0, 0, 0, 1)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id
+
+
+def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+
+    monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
+    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
+
+    responses = [
+        {"estado": "Rechazado", "descripcionMsg": "Error", "observaciones": ["campo"]},
+        {"estado": "Transmitido", "sello": "ABC"},
+    ]
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        data = responses.pop(0)
+        class R:
+            status_code = 200
+            def json(self):
+                return data
+            def raise_for_status(self):
+                pass
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+
+    caplog.set_level(logging.ERROR)
+    res = enviar_factura(db, venta)
+    assert res["estado"] == "Rechazado"
+    assert "Error" in caplog.text and "campo" in caplog.text
+    row = db.cursor.execute("SELECT count(*) c FROM dte_envios WHERE venta_id=?", (venta,)).fetchone()
+    assert row["c"] == 1
+
+    caplog.clear()
+    res = enviar_factura(db, venta)
+    assert res["estado"] == "Transmitido"
+    row = db.cursor.execute("SELECT count(*) c FROM dte_envios WHERE venta_id=?", (venta,)).fetchone()
+    assert row["c"] == 2
+
+
+def test_enviar_nota_credito(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+    nota_id = db.add_nota(venta, "credito", "2024-01-02", 10, "motivo")
+
+    monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
+    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            def json(self):
+                return {"estado": "Transmitido", "sello": "XYZ"}
+            def raise_for_status(self):
+                pass
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+
+    res = enviar_nota_credito(db, nota_id)
+    assert res["estado"] == "Transmitido"
+    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (nota_id,)).fetchone()
+    assert row["estado"] == "Transmitido"
+
+
+def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
+    db = DB(":memory:")
+
+    monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
+    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            def json(self):
+                return {
+                    "estado": "Rechazado",
+                    "descripcionMsg": "Fallo",
+                    "observaciones": {"campo": "invalido"},
+                }
+            def raise_for_status(self):
+                pass
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+
+    caplog.set_level(logging.ERROR)
+    res = enviar_evento_contingencia(db, 1, {"id": 1})
+    assert res["estado"] == "Rechazado"
+    assert "Fallo" in caplog.text and "campo: invalido" in caplog.text
+    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (1,)).fetchone()
+    assert row["estado"] == "Rechazado"
+
+
+def test_enviar_evento_anulacion(monkeypatch, tmp_path):
+    db = DB(":memory:")
+
+    monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
+    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            def json(self):
+                return {"estado": "Transmitido", "sello": "SSS"}
+            def raise_for_status(self):
+                pass
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+
+    res = enviar_evento_anulacion(db, 2, {"id": 2})
+    assert res["estado"] == "Transmitido"
+    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (2,)).fetchone()
+    assert row["estado"] == "Transmitido"
+


### PR DESCRIPTION
## Summary
- Añade helpers para transmitir facturas, notas de crédito y eventos, registrando cada envío y analizando errores
- Incluye funciones para enviar eventos de contingencia y anulación con registro y manejo de errores
- Agrega pruebas con mocks para validar reenvío tras rechazo y transmisión de distintos documentos

## Testing
- `pytest tests/test_envio_documentos.py tests/test_dte_transmision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689133ccf7e48323acbdb685f0959cbe