### PR TITLE
Guardar DTE firmado y selector de ambiente

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -80,8 +80,8 @@ def _get_auth_url() -> str:
         with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
             data = json.load(fh)
         ambiente = data.get("ambiente", "pruebas")
-        urls = data.get("auth_url", {})
-        url = urls.get(ambiente) if isinstance(urls, dict) else urls
+        env_conf = data.get(ambiente, {})
+        url = env_conf.get("auth_url")
         return url or DEFAULT_AUTH_URL
     except Exception:
         return DEFAULT_AUTH_URL

--- a/config_negocio.json
+++ b/config_negocio.json
@@ -1,20 +1,29 @@
 {
-  "firma_electronica": {
-    "certificado": "",
-    "clave_privada": "",
-    "frase_acceso": "",
-    "certificado_data": "",
-    "clave_privada_data": "",
-    "llave_publica": "",
-    "llave_publica_data": ""
-  },
   "ambiente": "pruebas",
-  "auth_url": {
-    "pruebas": "https://apifacturatest.mh.gob.sv/auth",
-    "produccion": "https://api.factura.gob.sv/auth"
+  "pruebas": {
+    "auth_url": "https://apifacturatest.mh.gob.sv/auth",
+    "recepcion_url": "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte",
+    "firma_electronica": {
+      "certificado": "",
+      "clave_privada": "",
+      "frase_acceso": "",
+      "certificado_data": "",
+      "clave_privada_data": "",
+      "llave_publica": "",
+      "llave_publica_data": ""
+    }
   },
-  "recepcion_url": {
-    "pruebas": "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte",
-    "produccion": "https://api.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+  "produccion": {
+    "auth_url": "https://api.factura.gob.sv/auth",
+    "recepcion_url": "https://api.dtes.mh.gob.sv/recepciondte/api/recepciondte",
+    "firma_electronica": {
+      "certificado": "",
+      "clave_privada": "",
+      "frase_acceso": "",
+      "certificado_data": "",
+      "clave_privada_data": "",
+      "llave_publica": "",
+      "llave_publica_data": ""
+    }
   }
 }

--- a/db.py
+++ b/db.py
@@ -1460,6 +1460,24 @@ class DB:
         except Exception:
             return {}
 
+    def listar_dtes(self, fecha_inicio=None, fecha_fin=None, estado=None):
+        """Lista registros de ``dte_envios`` filtrando por fecha y estado."""
+        self.ensure_column("dte_envios", "respuesta", "TEXT")
+        query = "SELECT * FROM dte_envios WHERE 1=1"
+        params = []
+        if fecha_inicio:
+            query += " AND date(fecha_hora) >= date(?)"
+            params.append(fecha_inicio)
+        if fecha_fin:
+            query += " AND date(fecha_hora) <= date(?)"
+            params.append(fecha_fin)
+        if estado:
+            query += " AND estado = ?"
+            params.append(estado)
+        query += " ORDER BY fecha_hora"
+        self.cursor.execute(query, params)
+        return [dict(row) for row in self.cursor.fetchall()]
+
     def update_venta_extra(self, venta_id, extra_dict):
         """Actualiza el campo ``extra`` de la venta, fusionando los datos."""
         self.ensure_column("ventas", "extra", "TEXT")

--- a/dte.py
+++ b/dte.py
@@ -356,11 +356,29 @@ def _load_dte_api_config():
         with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
             data = json.load(fh)
         ambiente = data.get("ambiente", "pruebas")
-        urls = data.get("recepcion_url", {})
-        url = urls.get(ambiente) if isinstance(urls, dict) else urls
+        env_conf = data.get(ambiente, {})
+        url = env_conf.get("recepcion_url")
         return {"ambiente": ambiente, "url": url}
     except Exception:
         return {}
+
+
+def _save_signed_dte(dte_data: dict, jws_token: str) -> None:
+    """Guarda el JSON original y el JWS en ``/dtes/{anio}/``."""
+    try:
+        fecha = dte_data.get("identificacion", {}).get("fecEmi") or datetime.now().strftime("%Y-%m-%d")
+        year = str(fecha)[:4]
+        base_dir = os.path.join(os.path.dirname(__file__), "dtes", year)
+        os.makedirs(base_dir, exist_ok=True)
+        nombre = dte_data.get("identificacion", {}).get("numeroControl") or uuid.uuid4().hex
+        json_path = os.path.join(base_dir, f"{nombre}.json")
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump(dte_data, fh, ensure_ascii=False)
+        jws_path = os.path.join(base_dir, f"{nombre}.jws")
+        with open(jws_path, "w", encoding="utf-8") as fh:
+            fh.write(jws_token)
+    except Exception:
+        pass
 
 
 def _post_dte(url: str, token: str, jws_token: str) -> dict:
@@ -397,6 +415,7 @@ def transmitir_dte(
     url = config.get("url") or DEFAULT_RECEPCION_URL
     cert, key, phrase = jws.get_cert_config()
     signed = jws.sign_json(dte_data, cert, phrase, key)
+    _save_signed_dte(dte_data, signed)
     token = auth.get_token()
 
     try:

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -1,6 +1,7 @@
 from db import DB
 from dte import transmitir_dte, _post_dte
 import json
+from datetime import datetime
 
 
 def create_sale(db):
@@ -44,7 +45,7 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
@@ -80,3 +81,15 @@ def test_consultar_envio_dte():
     venta = create_sale(db)
     db.registrar_envio_dte(venta, "normal", "Transmitido", "S", '{"ok": true}')
     assert db.consultar_envio_dte(venta) == {"ok": True}
+
+
+def test_listar_dtes():
+    db = DB(":memory:")
+    v1 = create_sale(db)
+    v2 = create_sale(db)
+    db.registrar_envio_dte(v1, "normal", "Transmitido", "S")
+    db.registrar_envio_dte(v2, "normal", "Rechazado", "")
+    today = datetime.now().date().isoformat()
+    rows = db.listar_dtes(today, today, "Transmitido")
+    assert len(rows) == 1
+    assert rows[0]["estado"] == "Transmitido"

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -84,11 +84,14 @@ def test_sign_and_save_pem(tmp_path, monkeypatch):
     with open(cfg_path, "w", encoding="utf-8") as fh:
         json.dump(
             {
-                "firma_electronica": {
-                    "certificado": str(cert_path),
-                    "clave_privada": str(key_path),
-                    "frase_acceso": base64.b64encode(password.encode()).decode(),
-                }
+                "ambiente": "pruebas",
+                "pruebas": {
+                    "firma_electronica": {
+                        "certificado": str(cert_path),
+                        "clave_privada": str(key_path),
+                        "frase_acceso": base64.b64encode(password.encode()).decode(),
+                    }
+                },
             },
             fh,
         )
@@ -162,13 +165,16 @@ def test_get_cert_config_embedded(tmp_path, monkeypatch):
     with open(cfg_path, "w", encoding="utf-8") as fh:
         json.dump(
             {
-                "firma_electronica": {
-                    "certificado": "",
-                    "clave_privada": "",
-                    "frase_acceso": base64.b64encode(password.encode()).decode(),
-                    "certificado_data": base64.b64encode(cert_data).decode(),
-                    "clave_privada_data": base64.b64encode(key_data).decode(),
-                }
+                "ambiente": "pruebas",
+                "pruebas": {
+                    "firma_electronica": {
+                        "certificado": "",
+                        "clave_privada": "",
+                        "frase_acceso": base64.b64encode(password.encode()).decode(),
+                        "certificado_data": base64.b64encode(cert_data).decode(),
+                        "clave_privada_data": base64.b64encode(key_data).decode(),
+                    }
+                },
             },
             fh,
         )

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -25,6 +25,13 @@ CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "
 
 def _get_ambiente() -> str:
     """Return configured DTE environment or ``"pruebas"`` by default."""
+    if os.path.exists(CONFIG_NEGOCIO_PATH):
+        try:
+            with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return data.get("ambiente", "pruebas").lower()
+        except Exception:
+            pass
     if os.path.exists(DATOS_NEGOCIO_PATH):
         try:
             with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
@@ -43,7 +50,8 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
-            fe = data.get("firma_electronica", {})
+            ambiente = data.get("ambiente", "pruebas")
+            fe = data.get(ambiente, {}).get("firma_electronica", {})
             cert = fe.get("certificado")
             key = fe.get("clave_privada")
             cert_data_b64 = fe.get("certificado_data")


### PR DESCRIPTION
## Summary
- Guarda el JSON original y su JWS en una carpeta anual tras firmar cada DTE
- Permite listar envíos DTE filtrando por fechas y estado
- Añade configuración separada para pruebas y producción con selección de ambiente

## Testing
- `pytest tests/test_dte_transmision.py tests/test_jws.py`

------
https://chatgpt.com/codex/tasks/task_e_689133f2ee948323a8a648bd2a583744