### PR TITLE
Stream inventory export and avoid UI blocking

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -81,24 +81,65 @@ class InventoryManager:
                     datos_negocio = json.load(f)
             except Exception:
                 logger.exception("Failed to parse %s", DATOS_NEGOCIO_PATH)
-        ventas_credito_fiscal = [dict(row) for row in self.db.cursor.execute("SELECT * FROM ventas_credito_fiscal")]
-        data = {
-            "productos": self._products,
-            "vendedores": [dict(vend) for vend in self._vendedores],
-            "Distribuidores": [dict(v) for v in self._Distribuidores],
-            "clientes": [dict(c) for c in self._clientes],
-            "ventas": [dict(v) for v in self.db.get_ventas()],
-            "compras": [dict(c) for c in self.db.get_compras()],
-            "movimientos": [dict(m) for m in self.db.get_movimientos()],
-            "detalles_venta": [dict(d) for d in self.db.cursor.execute("SELECT * FROM detalles_venta")],
-            "detalles_compra": [dict(d) for d in self.db.cursor.execute("SELECT * FROM detalles_compra")],
-            "datos_negocio": datos_negocio,
-            "trabajadores": [dict(t) for t in self.db.get_trabajadores()],
-            "ventas_credito_fiscal": ventas_credito_fiscal,
-            "tab_order": tab_order,
-        }
+
+        def write_array(key, iterator):
+            nonlocal first_section
+            if not first_section:
+                f.write(",\n")
+            f.write(f'"{key}":[')
+            first_item = True
+            for item in iterator:
+                if not first_item:
+                    f.write(",")
+                json.dump(item, f, ensure_ascii=False)
+                first_item = False
+            f.write("]")
+            first_section = False
+
         with open(filename, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+            first_section = True
+            f.write("{")
+            write_array("productos", self._products)
+            write_array("vendedores", (dict(v) for v in self._vendedores))
+            write_array("Distribuidores", (dict(v) for v in self._Distribuidores))
+            write_array("clientes", (dict(c) for c in self._clientes))
+            write_array(
+                "ventas",
+                (dict(v) for v in self.db.cursor.execute("SELECT * FROM ventas")),
+            )
+            write_array(
+                "compras",
+                (dict(c) for c in self.db.cursor.execute("SELECT * FROM compras")),
+            )
+            write_array(
+                "movimientos",
+                (dict(m) for m in self.db.cursor.execute("SELECT * FROM movimientos")),
+            )
+            write_array(
+                "detalles_venta",
+                (dict(d) for d in self.db.cursor.execute("SELECT * FROM detalles_venta")),
+            )
+            write_array(
+                "detalles_compra",
+                (dict(d) for d in self.db.cursor.execute("SELECT * FROM detalles_compra")),
+            )
+            if datos_negocio:
+                f.write(",\n\"datos_negocio\":")
+                json.dump(datos_negocio, f, ensure_ascii=False)
+            else:
+                f.write(",\n\"datos_negocio\":{}")
+            write_array(
+                "trabajadores",
+                (dict(t) for t in self.db.cursor.execute("SELECT * FROM trabajadores")),
+            )
+            write_array(
+                "ventas_credito_fiscal",
+                (dict(v) for v in self.db.cursor.execute("SELECT * FROM ventas_credito_fiscal")),
+            )
+            if tab_order is not None:
+                f.write(",\n\"tab_order\":")
+                json.dump(tab_order, f, ensure_ascii=False)
+            f.write("}")
 
     def importar_inventario_json(self, filename):
         with open(filename, "r", encoding="utf-8") as f:

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import (
     QListWidget, QInputDialog, QLabel, QComboBox, QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QDialog,
     QDateEdit, QCheckBox, QTextEdit, QAbstractItemView, QHeaderView, QSizePolicy
 )
-from PyQt5.QtCore import Qt, QDate
+from PyQt5.QtCore import Qt, QDate, QThread, pyqtSignal
 from PyQt5.QtGui import QColor
 import os
 import json
@@ -38,6 +38,26 @@ logger = logging.getLogger(__name__)
 
 def redondear(valor):
     return float(Decimal(str(valor)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+class ExportThread(QThread):
+    finished = pyqtSignal()
+    error = pyqtSignal(str)
+
+    def __init__(self, manager, filename, tab_order):
+        super().__init__()
+        self.manager = manager
+        self.filename = filename
+        self.tab_order = tab_order
+
+    def run(self):
+        try:
+            self.manager.exportar_inventario_json(
+                self.filename, tab_order=self.tab_order
+            )
+            self.finished.emit()
+        except Exception as e:
+            self.error.emit(str(e))
 
 
 class MainWindow(QMainWindow):
@@ -806,17 +826,18 @@ class MainWindow(QMainWindow):
     def guardar_como(self):
         filename, _ = QFileDialog.getSaveFileName(self, "Guardar inventario como", "", "Archivos JSON (*.json);;Todos los archivos (*)")
         if filename:
-            try:
-                self.manager.exportar_inventario_json(
-                    filename, tab_order=self.get_tab_order()
-                )
+            thread = ExportThread(self.manager, filename, self.get_tab_order())
+
+            def on_finished():
                 self.ultimo_archivo_json = filename
                 with open(LAST_INVENTORY_PATH, "w", encoding="utf-8") as f:
                     json.dump({"ultimo": filename}, f)
                 QMessageBox.information(self, "Guardar como", "Inventario guardado correctamente.")
-            except Exception as e:
-                QMessageBox.critical(self, "Error", f"No se pudo guardar el inventario:\n{e}")
-                self._actualizar_historial()
+
+            thread.finished.connect(on_finished)
+            thread.error.connect(lambda e: QMessageBox.critical(self, "Error", f"No se pudo guardar el inventario:\n{e}"))
+            thread.start()
+            self.export_thread = thread
 
     def cargar_inventario(self):
         filename, _ = QFileDialog.getOpenFileName(self, "Cargar inventario", "", "Archivos JSON (*.json);;Todos los archivos (*)")
@@ -849,13 +870,21 @@ class MainWindow(QMainWindow):
 
     def guardar_rapido(self):
         if self.ultimo_archivo_json:
-            try:
-                self.manager.exportar_inventario_json(
-                    self.ultimo_archivo_json, tab_order=self.get_tab_order()
+            thread = ExportThread(
+                self.manager, self.ultimo_archivo_json, self.get_tab_order()
+            )
+
+            def on_finished():
+                QMessageBox.information(
+                    self,
+                    "Guardar rápido",
+                    f"Inventario guardado en:\n{self.ultimo_archivo_json}",
                 )
-                QMessageBox.information(self, "Guardar rápido", f"Inventario guardado en:\n{self.ultimo_archivo_json}")
-            except Exception as e:
-                QMessageBox.critical(self, "Error", f"No se pudo guardar el inventario:\n{e}")
+
+            thread.finished.connect(on_finished)
+            thread.error.connect(lambda e: QMessageBox.critical(self, "Error", f"No se pudo guardar el inventario:\n{e}"))
+            thread.start()
+            self.export_thread = thread
         else:
             QMessageBox.warning(self, "Guardar rápido", "Primero debes guardar o cargar un inventario manualmente.")
             self._actualizar_historial()


### PR DESCRIPTION
## Summary
- Stream inventory JSON export using iterators to avoid building large lists
- Run inventory export in a background thread to keep UI responsive

## Testing
- `sudo apt-get install -y libgl1`
- `pytest` *(fails: test suite aborted around `tests/test_invoice_json_save.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68919bc2b5448323b69e0cf2e6e1dff3