### PR TITLE
Add product table indexes and migration script

### DIFF
--- a/add_product_indexes.py
+++ b/add_product_indexes.py
@@ -1,0 +1,27 @@
+"""Script to add missing indexes to existing ``inventario.db`` databases.
+
+This script creates the following indexes on the ``productos`` table if they do
+not already exist:
+
+* ``productos(vendedor_id)``
+* ``productos(Distribuidor_id)``
+* ``productos(codigo)``
+* ``productos(nombre)``
+
+Run the script with ``python add_product_indexes.py``. The script uses the same
+database location as the application (`inventario.db` in the repository root).
+"""
+
+from db import DB
+
+
+def main() -> None:
+    """Ensure required indexes exist on the ``productos`` table."""
+    db = DB()  # DB.__init__ already runs ``setup`` which creates the indexes.
+    db.conn.commit()
+    print("Índices de productos verificados/creados correctamente.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/db.py
+++ b/db.py
@@ -89,6 +89,18 @@ class DB:
                 FOREIGN KEY (Distribuidor_id) REFERENCES Distribuidores(id)
             )
         """)
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_productos_vendedor_id ON productos(vendedor_id)"
+        )
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_productos_distribuidor_id ON productos(Distribuidor_id)"
+        )
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_productos_codigo ON productos(codigo)"
+        )
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_productos_nombre ON productos(nombre)"
+        )
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS ventas (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- add indexes for vendedor_id, Distribuidor_id, codigo and nombre in productos table
- include script to create product indexes on existing databases

## Testing
- `python add_product_indexes.py`
- `pytest` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68919bc10e1c8323a5c60b4ec2194446