### PR TITLE
Handle missing vendor mappings for imports

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -31,6 +31,15 @@ class InventoryManager:
         self._clientes = self.db.get_clientes()
         self.load_page(self.current_page)
 
+    def load_page(self, page):
+        start = page * self.page_size
+        end = start + self.page_size
+        subset = self._products[start:end]
+        if self._model is None:
+            self._model = ProductTableModel(subset, self._vendedores, self._Distribuidores)
+        else:
+            self._model.update_data(subset)
+
     def get_vendedor_names(self):
         return [vend["nombre"] for vend in self._vendedores]
 
@@ -243,7 +252,13 @@ class InventoryManager:
 
             # Productos
             for p in data.get("productos", []):
-                vend = vendedor_id_map.get(p.get("vendedor_id"))
+                old_vend_id = p.get("vendedor_id")
+                vend = trabajador_id_map.get(old_vend_id) or vendedor_id_map.get(old_vend_id)
+                if old_vend_id and vend is None:
+                    logger.warning(
+                        "vendedor_id %s not found in mapping, defaulting to None",
+                        old_vend_id,
+                    )
                 dist = Distribuidor_id_map.get(p.get("Distribuidor_id"))
                 self.db.add_producto(
                     p.get("nombre", ""),
@@ -286,13 +301,13 @@ class InventoryManager:
             for v in data.get("ventas", []):
                 cliente_id = cliente_id_map.get(v.get("cliente_id"))
                 Distribuidor_id = Distribuidor_id_map.get(v.get("Distribuidor_id"))
-                vendedor_id = (
-                    trabajador_id_map.get(v.get("vendedor_id"))
-                    if v.get("vendedor_id") is not None
-                    else None
-                )
-                if vendedor_id is None and v.get("vendedor_id") is not None:
-                    vendedor_id = vendedor_id_map.get(v.get("vendedor_id"))
+                old_vend_id = v.get("vendedor_id")
+                vendedor_id = trabajador_id_map.get(old_vend_id) or vendedor_id_map.get(old_vend_id)
+                if old_vend_id and vendedor_id is None:
+                    logger.warning(
+                        "vendedor_id %s not found in mapping, defaulting to None",
+                        old_vend_id,
+                    )
 
                 extra = v.get("extra")
                 if isinstance(extra, str):
@@ -363,10 +378,14 @@ class InventoryManager:
                 venta_id = venta_id_map.get(d.get("venta_id"))
                 producto_id = producto_id_map.get(d.get("producto_id"))
                 vendedor_id = None
-                if d.get("vendedor_id") is not None:
-                    vendedor_id = trabajador_id_map.get(d.get("vendedor_id"))
+                old_vend_id = d.get("vendedor_id")
+                if old_vend_id is not None:
+                    vendedor_id = trabajador_id_map.get(old_vend_id) or vendedor_id_map.get(old_vend_id)
                     if vendedor_id is None:
-                        vendedor_id = vendedor_id_map.get(d.get("vendedor_id"))
+                        logger.warning(
+                            "detalle_venta vendedor_id %s not found in mapping, defaulting to None",
+                            old_vend_id,
+                        )
                 if venta_id and producto_id:
                     self.db.cursor.execute(
                         "INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/tests/test_import_detalle_venta_trabajador.py
+++ b/tests/test_import_detalle_venta_trabajador.py
@@ -1,0 +1,68 @@
+import json
+import inventory_manager as im
+
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+def test_import_maps_detalle_trabajador(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+
+    data = {
+        "Distribuidores": [],
+        "vendedores": [],
+        "productos": [
+            {
+                "id": 1,
+                "nombre": "Prod",
+                "codigo": "P1",
+                "precio_compra": 0,
+                "precio_venta_minorista": 0,
+                "precio_venta_mayorista": 0,
+                "stock": 1,
+            }
+        ],
+        "clientes": [],
+        "trabajadores": [
+            {"id": 5, "nombre": "Trab Vend", "codigo": "T1", "es_vendedor": True}
+        ],
+        "ventas": [{"id": 1, "fecha": "2024-01-01", "total": 10}],
+        "detalles_venta": [
+            {
+                "venta_id": 1,
+                "producto_id": 1,
+                "cantidad": 1,
+                "precio_unitario": 10,
+                "descuento": 0,
+                "descuento_tipo": "",
+                "iva": 0,
+                "comision": 0,
+                "iva_tipo": "",
+                "tipo_fiscal": "Gravada",
+                "extra": None,
+                "precio_con_iva": 10,
+                "vendedor_id": 5,
+            }
+        ],
+        "compras": [],
+        "movimientos": [],
+        "detalles_compra": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data))
+
+    manager.importar_inventario_json(str(path))
+
+    ventas = manager.db.get_ventas()
+    assert len(ventas) == 1
+    venta_id = ventas[0]["id"]
+    detalles = manager.db.get_detalles_venta(venta_id)
+    trab_id = manager.db.get_trabajadores()[0]["id"]
+    assert detalles[0]["vendedor_id"] == trab_id
+


### PR DESCRIPTION
## Summary
- map vendor IDs to either worker or vendor records when importing products, sales, and sale details
- warn on missing vendor mappings instead of leaving stale IDs
- test remapping of worker IDs in sale details

## Testing
- `pytest tests/test_import_products_vendor.py tests/test_import_trabajador_sales.py tests/test_import_vendor_mapping.py tests/test_detalle_venta_vendedor.py tests/test_import_detalle_venta_trabajador.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68924014a6d883239fe412be9111bc0f