### PR TITLE
Move fiscal sales cleanup inside transaction

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -183,7 +183,6 @@ class InventoryManager:
         self.db.limpiar_productos()
         self.db.limpiar_vendedores()
         self.db.limpiar_Distribuidores()
-        self.db.limpiar_ventas_credito_fiscal()
         try:
             self.db.cursor.execute("DELETE FROM clientes")
             self.db.cursor.execute("DELETE FROM ventas")
@@ -424,6 +423,12 @@ class InventoryManager:
                 )
 
             # Ventas crédito fiscal
+            self.db.limpiar_ventas_credito_fiscal()
+            self.db.cursor.execute(
+                "DELETE FROM sqlite_sequence WHERE name='ventas_credito_fiscal'"
+            )
+            self.db.conn.commit()
+            self.db.conn.execute("BEGIN")
             for vcf in data.get("ventas_credito_fiscal", []):
                 extra = vcf.get("extra")
                 extra_json = json.dumps(extra) if extra is not None else None


### PR DESCRIPTION
## Summary
- ensure ventas_credito_fiscal cleanup happens right before new data import
- reset sequence and commit cleanup before inserting new fiscal sales

## Testing
- `pytest` *(fails: test_fiscal_sales_cleanup, test_import_products_vendor, test_import_trabajador_sales, test_import_vendor_mapping, test_invoice_json_save, test_load_inventory_ui)*

------
https://chatgpt.com/codex/tasks/task_e_68924013e964832383eb6267becbd7f0