### PR TITLE
Increase commission percent column width in account statement PDF

### DIFF
--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -188,7 +188,7 @@ def generar_estado_cuenta_pdf(
         Spacer(1, 2),
     ]
 
-    col_widths = [70, 60, 55, 120, 50, 60, 60, 50, 55]
+    col_widths = [70, 60, 55, 120, 50, 60, 60, 60, 55]
     headers = [
         "Comprobante",
         "Valor Fact",


### PR DESCRIPTION
## Summary
- Broaden `% Comisión` column so percentage values no longer overlap the `Comisión` column in estado de cuenta PDFs

## Testing
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6892692bd28c8323bd42fb635760582d