### PR TITLE
Expand unit tests for auth, crypto and utilities

### DIFF
--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -1,0 +1,75 @@
+import json
+import time
+import os
+import pytest
+import requests
+import auth
+
+
+def write_config(tmp_path, nit="123", pwd="pwd"):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"nit": nit, "api_pwd": pwd}))
+    return cfg
+
+
+def setup_paths(monkeypatch, tmp_path):
+    cfg = write_config(tmp_path)
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
+
+
+def test_get_credentials_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(tmp_path / "missing.json"))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "missing.db"))
+    with pytest.raises(RuntimeError):
+        auth._get_credentials()
+
+
+def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
+    setup_paths(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def fake_request(nit, pwd):
+        calls["n"] += 1
+        return f"tok{calls['n']}", 120, time.time()
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    t1 = auth.get_token(refresh=True)
+    assert t1 == "tok1"
+    t2 = auth.get_token()
+    assert t2 == "tok1"
+    assert calls["n"] == 1
+    t3 = auth.get_token(refresh=True)
+    assert t3 == "tok2"
+    assert calls["n"] == 2
+
+
+def test_get_token_expired(monkeypatch, tmp_path):
+    setup_paths(monkeypatch, tmp_path)
+
+    def fake_request(nit, pwd):
+        return "tok", 1, time.time() - 100
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    auth.get_token(refresh=True)
+    calls = {"n": 0}
+
+    def fake_request2(nit, pwd):
+        calls["n"] += 1
+        return "new", 1, time.time()
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request2)
+    token2 = auth.get_token()
+    assert token2 == "new"
+    assert calls["n"] == 1
+
+
+def test_request_error(monkeypatch, tmp_path):
+    setup_paths(monkeypatch, tmp_path)
+
+    def fake_post(url, data, headers, timeout):
+        raise requests.HTTPError("boom")
+
+    monkeypatch.setattr(auth.requests, "post", fake_post)
+    with pytest.raises(requests.HTTPError):
+        auth.get_token(refresh=True)

--- a/tests/test_db_module.py
+++ b/tests/test_db_module.py
@@ -1,0 +1,35 @@
+import threading
+from db import DB
+
+
+def test_ensure_column_creation(monkeypatch, tmp_path):
+    db = DB(str(tmp_path / 'db.sqlite'))
+    db.cursor.execute('CREATE TABLE t(id INTEGER)')
+    db.conn.commit()
+    monkeypatch.setattr('builtins.input', lambda prompt: 's')
+    assert db.ensure_column('t', 'name', 'TEXT')
+    db.cursor.execute('PRAGMA table_info(t)')
+    cols = [r[1] for r in db.cursor.fetchall()]
+    assert 'name' in cols
+
+
+def test_ensure_column_decline(monkeypatch, tmp_path):
+    db = DB(str(tmp_path / 'db.sqlite'))
+    db.cursor.execute('CREATE TABLE t(id INTEGER)')
+    db.conn.commit()
+    monkeypatch.setattr('builtins.input', lambda prompt: 'n')
+    assert not db.ensure_column('t', 'name', 'TEXT')
+
+
+def test_concurrent_access(tmp_path):
+    db_path = str(tmp_path / 'db.sqlite')
+    def worker(code):
+        d = DB(db_path)
+        d.add_cliente(f'c{code}', '', '', '', '', '', '', '', '', '')
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    d = DB(db_path)
+    assert len(d.get_clientes()) == 2

--- a/tests/test_jws_additional.py
+++ b/tests/test_jws_additional.py
@@ -1,0 +1,76 @@
+import datetime
+import pytest
+import jwt
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+import utils.jws as jws
+
+
+def create_keypair():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "t")]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "t")]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    return key_pem, cert_pem
+
+
+def test_verify_jws_invalid_signature(tmp_path):
+    key1, _ = create_keypair()
+    _, cert2 = create_keypair()
+    token = jws.sign_jwt({"a": 1}, key1)
+    cert_path = tmp_path / "cert.pem"
+    cert_path.write_bytes(cert2)
+    with pytest.raises(jwt.exceptions.InvalidSignatureError):
+        jws.verify_jws(token, str(cert_path))
+
+
+def test_expired_token(tmp_path):
+    key_pem, _ = create_keypair()
+    payload = {"sub": "s", "iat": 0, "exp": 1}
+    token = jws.sign_jwt(payload, key_pem)
+    priv = load_pem_private_key(key_pem, password=None)
+    public_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    with pytest.raises(jwt.ExpiredSignatureError):
+        jwt.decode(token, public_pem, algorithms=["RS512"])
+
+
+def test_invalid_algorithm(tmp_path):
+    key_pem, _ = create_keypair()
+    token = jws.sign_jwt({"a": 1}, key_pem)
+    priv = load_pem_private_key(key_pem, password=None)
+    public_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    with pytest.raises(jwt.InvalidAlgorithmError):
+        jwt.decode(token, public_pem, algorithms=["HS256"])
+
+
+def test_sign_json_missing_p12(tmp_path):
+    missing = tmp_path / "missing.p12"
+    with pytest.raises(FileNotFoundError):
+        jws.sign_json({}, cert_path=str(missing), password=None, key_path=None)
+
+
+def test_sign_json_missing_cert(tmp_path):
+    with pytest.raises(ValueError):
+        jws.sign_json({}, None, None, None)

--- a/tests/test_main_cargar.py
+++ b/tests/test_main_cargar.py
@@ -1,0 +1,29 @@
+import json
+import os
+import main
+
+
+def test_cargar_ultimo_archivo_prioriza_ultimo(tmp_path, monkeypatch):
+    last = tmp_path / "ultimo.json"
+    inv = tmp_path / "inv.json"
+    inv.write_text("{}")
+    last.write_text(json.dumps({"ultimo": str(inv)}))
+    monkeypatch.setattr(main, "LAST_FILE_PATH", str(last))
+    monkeypatch.setattr(main, "DEFAULT_INVENTORY", "def.json")
+    assert main.cargar_ultimo_archivo() == str(inv)
+
+
+def test_cargar_ultimo_archivo_default(tmp_path, monkeypatch):
+    inv = tmp_path / "inv.json"
+    inv.write_text("{}")
+    monkeypatch.setattr(main, "LAST_FILE_PATH", str(tmp_path / "missing.json"))
+    monkeypatch.setattr(main, "DEFAULT_INVENTORY", inv.name)
+    monkeypatch.setattr(main, "__file__", str(tmp_path / "mod.py"))
+    assert main.cargar_ultimo_archivo() == str(inv)
+
+
+def test_cargar_ultimo_archivo_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "LAST_FILE_PATH", str(tmp_path / "missing.json"))
+    monkeypatch.setattr(main, "DEFAULT_INVENTORY", "missing.json")
+    monkeypatch.setattr(main, "__file__", str(tmp_path / "mod.py"))
+    assert main.cargar_ultimo_archivo() == ""

--- a/tests/test_pdf_utils_draw.py
+++ b/tests/test_pdf_utils_draw.py
@@ -1,0 +1,22 @@
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+import utils.pdf_utils as pdf_utils
+
+
+def test_draw_wrapped_text_splits_long_words(tmp_path):
+    c = canvas.Canvas(str(tmp_path / "out.pdf"), pagesize=letter)
+    c.setFont("Helvetica", 12)
+    text = "PalabraLarguisimaQueDebeDividirse"
+    final_y = pdf_utils.draw_wrapped_text(c, text, 10, 750, 100, 12)
+    c.save()
+    # should move at least one line_height
+    assert final_y < 750
+
+
+def test_draw_wrapped_text_multiple_lines(tmp_path):
+    c = canvas.Canvas(str(tmp_path / "out2.pdf"), pagesize=letter)
+    c.setFont("Helvetica", 10)
+    text = "uno dos tres cuatro cinco seis siete ocho nueve diez"
+    y = pdf_utils.draw_wrapped_text(c, text, 10, 750, 60, 10)
+    c.save()
+    assert y < 750

--- a/tests/test_ticket_pdf_extra.py
+++ b/tests/test_ticket_pdf_extra.py
@@ -1,0 +1,17 @@
+import os
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+import ticket_pdf
+
+
+def test_with_falta():
+    assert ticket_pdf._with_falta("") == "falta"
+    assert ticket_pdf._with_falta("abc") == "abc"
+
+
+def test_generar_ticket_pdf_creates_file(tmp_path):
+    venta = {"fecha": "2020-01-01", "total": 10}
+    detalles = [{"descripcion": "A", "cantidad": 1, "precio_unitario": 10}]
+    out = tmp_path / "t.pdf"
+    ticket_pdf.generar_ticket_pdf(venta, detalles, archivo=str(out), datos_negocio={"nombre_comercial": "X"})
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add comprehensive tests for auth token handling
- test JWS signing error cases and certificate validation
- verify PDF text wrapping and ticket generation utilities
- cover main file selection helper and database concurrency/column management

## Testing
- `QT_QPA_PLATFORM=offscreen pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_689260fd9f348323a6ef50fc3da59dec