### PR TITLE
Avoid redundant inventory reloads

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -73,7 +73,7 @@ class InventoryManager:
             precio_venta_mayorista,
             stock,
         )
-        self.load_page(self.current_page)
+        self.refresh_data()
 
     def edit_producto(
         self,
@@ -98,11 +98,11 @@ class InventoryManager:
             precio_venta_mayorista,
             stock,
         )
-        self.load_page(self.current_page)
+        self.refresh_data()
 
     def delete_producto(self, producto_id):
         self.db.delete_producto(producto_id)
-        self.load_page(self.current_page)
+        self.refresh_data()
 
     def filter_products(self, vendedor_nombre=None, Distribuidor_nombre=None, search=""):
         vendedor_id = self._vendedor_name_to_id.get(vendedor_nombre) if vendedor_nombre else None

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -538,11 +538,12 @@ class MainWindow(QMainWindow):
                 data["nombre"], data["codigo"], None, None,
                 data["precio_compra"], data["precio_venta_minorista"], data["precio_venta_mayorista"], 0
             )
-            self.manager.refresh_data()
             self._actualizar_arbol_vendedores()
             self._actualizar_arbol_Distribuidores()
             if hasattr(self, "vendedor_combo_filtro"):
+                self.vendedor_combo_filtro.blockSignals(True)
                 self.vendedor_combo_filtro.setCurrentIndex(0)
+                self.vendedor_combo_filtro.blockSignals(False)
             self.filter_products()
             QMessageBox.information(self, "Producto", "Producto agregado correctamente.")
 
@@ -573,7 +574,6 @@ class MainWindow(QMainWindow):
         confirm = QMessageBox.question(self, "Eliminar", f"¿Eliminar producto '{prod['nombre']}'?", QMessageBox.Yes | QMessageBox.No)
         if confirm == QMessageBox.Yes:
             self.manager.delete_producto(prod["id"])
-            self.manager.refresh_data()
             self._actualizar_arbol_vendedores()
             self._actualizar_arbol_Distribuidores()
             self.filter_products()


### PR DESCRIPTION
## Summary
- Ensure add, edit, and delete operations refresh inventory data rather than only reloading the current page so `_products` stays synchronized
- Remove extra UI refresh and block vendor filter signals to prevent double refreshes when adding or removing products

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689284d91bc08323864c491d578ffbd5