### PR TITLE
Enable foreign keys and cascade deletions

### DIFF
--- a/db.py
+++ b/db.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 class DB:
     def __init__(self, db_name=os.path.join(os.path.dirname(__file__), "inventario.db")):
         self.conn = sqlite3.connect(db_name)
+        self.conn.execute("PRAGMA foreign_keys = ON")
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
         self.setup()
@@ -556,6 +557,22 @@ class DB:
 
     def delete_Distribuidor(self, id):
         try:
+            self.cursor.execute(
+                "UPDATE vendedores SET Distribuidor_id=NULL WHERE Distribuidor_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "UPDATE productos SET Distribuidor_id=NULL WHERE Distribuidor_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "UPDATE compras SET Distribuidor_id=NULL WHERE Distribuidor_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "UPDATE ventas SET Distribuidor_id=NULL WHERE Distribuidor_id=?",
+                (id,),
+            )
             self.cursor.execute("DELETE FROM Distribuidores WHERE id=?", (id,))
             self.conn.commit()
         except Exception as e:
@@ -604,6 +621,22 @@ class DB:
 
     def delete_vendedor(self, id):
         try:
+            self.cursor.execute(
+                "UPDATE productos SET vendedor_id=NULL WHERE vendedor_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "UPDATE detalles_venta SET vendedor_id=NULL WHERE vendedor_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "UPDATE compras SET vendedor_id=NULL WHERE vendedor_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "UPDATE ventas SET vendedor_id=NULL WHERE vendedor_id=?",
+                (id,),
+            )
             self.cursor.execute("DELETE FROM vendedores WHERE id=?", (id,))
             self.conn.commit()
         except Exception as e:
@@ -677,6 +710,18 @@ class DB:
         self.conn.commit()
 
     def delete_producto(self, producto_id):
+        self.cursor.execute(
+            "DELETE FROM detalles_venta WHERE producto_id=?", (producto_id,)
+        )
+        self.cursor.execute(
+            "DELETE FROM detalles_compra WHERE producto_id=?", (producto_id,)
+        )
+        self.cursor.execute(
+            "DELETE FROM compras WHERE producto_id=?", (producto_id,)
+        )
+        self.cursor.execute(
+            "DELETE FROM movimientos WHERE producto_id=?", (producto_id,)
+        )
         self.cursor.execute("DELETE FROM productos WHERE id=?", (producto_id,))
         self.conn.commit()
 
@@ -979,6 +1024,30 @@ class DB:
 
     def delete_venta(self, id):
         try:
+            self.cursor.execute(
+                "DELETE FROM detalles_venta WHERE venta_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "DELETE FROM notas WHERE venta_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "DELETE FROM ventas_credito_fiscal WHERE venta_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "DELETE FROM facturas_pdf WHERE venta_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "DELETE FROM tickets_pdf WHERE venta_id=?",
+                (id,),
+            )
+            self.cursor.execute(
+                "DELETE FROM dte_envios WHERE venta_id=?",
+                (id,),
+            )
             self.cursor.execute("DELETE FROM ventas WHERE id=?", (id,))
             self.conn.commit()
         except Exception as e:
@@ -1092,6 +1161,15 @@ class DB:
         self.conn.commit()
 
     def delete_cliente(self, id):
+        self.cursor.execute("DELETE FROM pagos WHERE cliente_id=?", (id,))
+        self.cursor.execute(
+            "UPDATE ventas SET cliente_id=NULL WHERE cliente_id=?",
+            (id,),
+        )
+        self.cursor.execute(
+            "UPDATE ventas_credito_fiscal SET cliente_id=NULL WHERE cliente_id=?",
+            (id,),
+        )
         self.cursor.execute("DELETE FROM clientes WHERE id=?", (id,))
         self.conn.commit()
 

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -246,16 +246,19 @@ class InventoryManager:
         self.db.limpiar_vendedores()
         self.db.limpiar_Distribuidores()
         try:
-            self.db.cursor.execute("DELETE FROM clientes")
-            self.db.cursor.execute("DELETE FROM ventas")
             self.db.cursor.execute("DELETE FROM detalles_venta")
+            self.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
+            self.db.cursor.execute("DELETE FROM dte_envios")
+            self.db.cursor.execute("DELETE FROM notas")
+            self.db.cursor.execute("DELETE FROM ventas")
             self.db.cursor.execute("DELETE FROM compras")
             self.db.cursor.execute("DELETE FROM detalles_compra")
             self.db.cursor.execute("DELETE FROM movimientos")
+            self.db.cursor.execute("DELETE FROM clientes")
             self.db.cursor.execute("DELETE FROM trabajadores")
             self.db.conn.commit()
         except Exception:
-            pass
+            self.db.conn.rollback()
 
         vendedor_id_map = {}
         Distribuidor_id_map = {}
@@ -300,12 +303,23 @@ class InventoryManager:
 
             for t in data.get("trabajadores", []):
                 self.db.add_trabajador(t, commit=False)
-                trabajador_id_map[t.get("id")] = self.db.cursor.lastrowid
+                tid = self.db.cursor.lastrowid
+                trabajador_id_map[t.get("id")] = tid
+                if t.get("es_vendedor"):
+                    self.db.add_vendedor(
+                        t.get("nombre"),
+                        t.get("descripcion", ""),
+                        t.get("Distribuidor_id"),
+                        t.get("codigo"),
+                        t.get("dui"),
+                        commit=False,
+                    )
+                    vendedor_id_map[t.get("id")] = self.db.cursor.lastrowid
 
             # Productos
             for p in data.get("productos", []):
                 old_vend_id = p.get("vendedor_id")
-                vend = trabajador_id_map.get(old_vend_id) or vendedor_id_map.get(old_vend_id)
+                vend = vendedor_id_map.get(old_vend_id) or trabajador_id_map.get(old_vend_id)
                 if old_vend_id and vend is None:
                     logger.warning(
                         "vendedor_id %s not found in mapping, defaulting to None",
@@ -354,7 +368,7 @@ class InventoryManager:
                 cliente_id = cliente_id_map.get(v.get("cliente_id"))
                 Distribuidor_id = Distribuidor_id_map.get(v.get("Distribuidor_id"))
                 old_vend_id = v.get("vendedor_id")
-                vendedor_id = trabajador_id_map.get(old_vend_id) or vendedor_id_map.get(old_vend_id)
+                vendedor_id = vendedor_id_map.get(old_vend_id) or trabajador_id_map.get(old_vend_id)
                 if old_vend_id and vendedor_id is None:
                     logger.warning(
                         "vendedor_id %s not found in mapping, defaulting to None",
@@ -432,7 +446,7 @@ class InventoryManager:
                 vendedor_id = None
                 old_vend_id = d.get("vendedor_id")
                 if old_vend_id is not None:
-                    vendedor_id = trabajador_id_map.get(old_vend_id) or vendedor_id_map.get(old_vend_id)
+                    vendedor_id = vendedor_id_map.get(old_vend_id) or trabajador_id_map.get(old_vend_id)
                     if vendedor_id is None:
                         logger.warning(
                             "detalle_venta vendedor_id %s not found in mapping, defaulting to None",

--- a/tests/test_delete_cascade.py
+++ b/tests/test_delete_cascade.py
@@ -1,0 +1,89 @@
+import pytest
+
+from db import DB
+
+
+def test_delete_producto_removes_dependents(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_vendedor("V1")
+    vendedor_id = db.get_vendedores()[0]["id"]
+    db.add_producto("P1", "C1", vendedor_id, None, 1, 2, 3, 10)
+    producto_id = db.get_productos()[0]["id"]
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, producto_id, 1, 10)
+    compra_id = db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "producto_id": producto_id,
+            "cantidad": 5,
+            "precio_unitario": 2,
+            "total": 10,
+        }
+    )
+    db.add_detalle_compra(compra_id, producto_id, 5, 2)
+    db.add_movimiento("2024-01-01", "entrada", producto_id, 5)
+    db.delete_producto(producto_id)
+    for table, column in [
+        ("detalles_venta", "producto_id"),
+        ("detalles_compra", "producto_id"),
+        ("compras", "producto_id"),
+        ("movimientos", "producto_id"),
+    ]:
+        db.cursor.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {column}=?", (producto_id,)
+        )
+        assert db.cursor.fetchone()[0] == 0
+    db.cursor.execute("SELECT COUNT(*) FROM productos WHERE id=?", (producto_id,))
+    assert db.cursor.fetchone()[0] == 0
+
+
+def test_delete_vendedor_clears_references(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_vendedor("V1")
+    vendedor_id = db.get_vendedores()[0]["id"]
+    db.add_producto("P1", "C1", vendedor_id, None, 1, 2, 3, 10)
+    producto_id = db.get_productos()[0]["id"]
+    venta_id = db.add_venta("2024-01-01", 10, vendedor_id=vendedor_id)
+    db.add_detalle_venta(
+        venta_id, producto_id, 1, 10, vendedor_id=vendedor_id
+    )
+    db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "producto_id": producto_id,
+            "cantidad": 5,
+            "precio_unitario": 2,
+            "total": 10,
+            "vendedor_id": vendedor_id,
+        }
+    )
+    db.delete_vendedor(vendedor_id)
+    for table, column in [
+        ("productos", "vendedor_id"),
+        ("detalles_venta", "vendedor_id"),
+        ("compras", "vendedor_id"),
+        ("ventas", "vendedor_id"),
+    ]:
+        db.cursor.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {column}=?", (vendedor_id,)
+        )
+        assert db.cursor.fetchone()[0] == 0
+    db.cursor.execute("SELECT COUNT(*) FROM vendedores WHERE id=?", (vendedor_id,))
+    assert db.cursor.fetchone()[0] == 0
+
+
+def test_delete_venta_removes_detalles(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_vendedor("V1")
+    vendedor_id = db.get_vendedores()[0]["id"]
+    db.add_producto("P1", "C1", vendedor_id, None, 1, 2, 3, 10)
+    producto_id = db.get_productos()[0]["id"]
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, producto_id, 1, 10)
+    db.delete_venta(venta_id)
+    db.cursor.execute(
+        "SELECT COUNT(*) FROM detalles_venta WHERE venta_id=?", (venta_id,)
+    )
+    assert db.cursor.fetchone()[0] == 0
+    db.cursor.execute("SELECT COUNT(*) FROM ventas WHERE id=?", (venta_id,))
+    assert db.cursor.fetchone()[0] == 0

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -97,6 +97,7 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
 
 def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     db = DB(":memory:")
+    venta_id = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
     monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
@@ -122,15 +123,16 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
         json.dump(config, fh)
 
     caplog.set_level(logging.ERROR)
-    res = enviar_evento_contingencia(db, 1, {"id": 1})
+    res = enviar_evento_contingencia(db, venta_id, {"id": venta_id})
     assert res["estado"] == "Rechazado"
     assert "Fallo" in caplog.text and "campo: invalido" in caplog.text
-    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (1,)).fetchone()
+    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Rechazado"
 
 
 def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     db = DB(":memory:")
+    venta_id = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
     monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
@@ -151,8 +153,8 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
-    res = enviar_evento_anulacion(db, 2, {"id": 2})
+    res = enviar_evento_anulacion(db, venta_id, {"id": venta_id})
     assert res["estado"] == "Transmitido"
-    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (2,)).fetchone()
+    row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Transmitido"
 

--- a/tests/test_import_detalle_venta_trabajador.py
+++ b/tests/test_import_detalle_venta_trabajador.py
@@ -63,6 +63,6 @@ def test_import_maps_detalle_trabajador(tmp_path, monkeypatch):
     assert len(ventas) == 1
     venta_id = ventas[0]["id"]
     detalles = manager.db.get_detalles_venta(venta_id)
-    trab_id = manager.db.get_trabajadores()[0]["id"]
-    assert detalles[0]["vendedor_id"] == trab_id
+    vend_id = manager.db.get_vendedores()[0]["id"]
+    assert detalles[0]["vendedor_id"] == vend_id
 


### PR DESCRIPTION
## Summary
- enforce SQLite foreign keys on connection startup
- cascade or null-out related rows when deleting distributors, vendors, products, sales or clients
- clean and remap inventory imports to satisfy FK constraints
- add tests guarding against orphaned records on deletes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689284e0fc708323a7a355f501fdc6f5