### PR TITLE
Use IDs for vendor and distributor filters

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -52,6 +52,12 @@ class InventoryManager:
     def get_Distribuidor_names(self):
         return [dist["nombre"] for dist in self._Distribuidores]
 
+    def get_vendedores(self):
+        return self._vendedores
+
+    def get_Distribuidores(self):
+        return self._Distribuidores
+
     def add_producto(
         self,
         nombre,
@@ -104,9 +110,7 @@ class InventoryManager:
         self.db.delete_producto(producto_id)
         self.refresh_data()
 
-    def filter_products(self, vendedor_nombre=None, Distribuidor_nombre=None, search=""):
-        vendedor_id = self._vendedor_name_to_id.get(vendedor_nombre) if vendedor_nombre else None
-        Distribuidor_id = self._Distribuidor_name_to_id.get(Distribuidor_nombre) if Distribuidor_nombre else None
+    def filter_products(self, vendedor_id=None, Distribuidor_id=None, search=""):
         changed = False
         if vendedor_id != self._filter_vendedor_id:
             self._filter_vendedor_id = vendedor_id

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -155,15 +155,17 @@ class MainWindow(QMainWindow):
         # --- Filtros en una sola fila ---
         filtros_layout = QHBoxLayout()
         self.vendedor_combo_filtro = QComboBox()
-        self.vendedor_combo_filtro.addItem("Todos")
-        self.vendedor_combo_filtro.addItems(self.manager.get_vendedor_names())
+        self.vendedor_combo_filtro.addItem("Todos", None)
+        for vend in self.manager.get_vendedores():
+            self.vendedor_combo_filtro.addItem(vend["nombre"], vend["id"])
         self.vendedor_combo_filtro.currentIndexChanged.connect(self.filter_products)
         filtros_layout.addWidget(QLabel("Vendedor:"))
         filtros_layout.addWidget(self.vendedor_combo_filtro)
 
         self.distribuidor_combo_filtro = QComboBox()
-        self.distribuidor_combo_filtro.addItem("Todos")
-        self.distribuidor_combo_filtro.addItems(self.manager.get_Distribuidor_names())
+        self.distribuidor_combo_filtro.addItem("Todos", None)
+        for dist in self.manager.get_Distribuidores():
+            self.distribuidor_combo_filtro.addItem(dist["nombre"], dist["id"])
         self.distribuidor_combo_filtro.currentIndexChanged.connect(self.filter_products)
         filtros_layout.addWidget(QLabel("Distribuidor:"))
         filtros_layout.addWidget(self.distribuidor_combo_filtro)
@@ -516,16 +518,16 @@ class MainWindow(QMainWindow):
 
     def filter_products(self):
         search = self.search_bar.text()
-        vendedor_nombre = None
+        vendedor_id = None
         vendedor_combo_index = self.vendedor_combo_filtro.currentIndex()
         if vendedor_combo_index > 0:  # Si no es "Todos"
-            vendedor_nombre = self.vendedor_combo_filtro.itemText(vendedor_combo_index)
+            vendedor_id = self.vendedor_combo_filtro.itemData(vendedor_combo_index)
 
-        Distribuidor_nombre = None
+        Distribuidor_id = None
         if hasattr(self, "distribuidor_combo_filtro"):
             distribuidor_index = self.distribuidor_combo_filtro.currentIndex()
             if distribuidor_index > 0:  # Si no es "Todos"
-                Distribuidor_nombre = self.distribuidor_combo_filtro.itemText(distribuidor_index)
+                Distribuidor_id = self.distribuidor_combo_filtro.itemData(distribuidor_index)
 
         # Orden por stock
         stock_sort = None
@@ -533,8 +535,8 @@ class MainWindow(QMainWindow):
             stock_sort = self.stock_sort_combo.currentIndex()
 
         self.manager.filter_products(
-            vendedor_nombre=vendedor_nombre,
-            Distribuidor_nombre=Distribuidor_nombre,
+            vendedor_id=vendedor_id,
+            Distribuidor_id=Distribuidor_id,
             search=search,
         )
         productos = self.manager._products


### PR DESCRIPTION
## Summary
- Populate vendor and distributor filter combos with IDs and forward them in product filtering
- Update InventoryManager filtering to accept IDs directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68928a0c8db4832396aceb218b948d52