### PR TITLE
Remove unused comision_base from distributor editing

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2416,7 +2416,6 @@ class DistribuidorInfoDialog(QDialog):
             ("Email:", distribuidor.get("email", "")),
             ("Cargo:", distribuidor.get("cargo", "")),
             ("Sucursal/Laboratorio:", distribuidor.get("sucursal", "")),
-            ("Comisión base:", str(distribuidor.get("comision_base", ""))),
             ("Fecha de inicio:", distribuidor.get("fecha_inicio", "")),
             ("Dirección:", distribuidor.get("direccion", "")),
             ("Departamento:", distribuidor.get("departamento", "")),

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1089,7 +1089,7 @@ class MainWindow(QMainWindow):
             self.manager.db.cursor.execute("""
                 UPDATE Distribuidores SET
                     codigo=?, nombre=?, telefono=?, email=?, cargo=?, sucursal=?,
-                    comision_base=?, fecha_inicio=?, direccion=?, departamento=?, municipio=?,
+                    fecha_inicio=?, direccion=?, departamento=?, municipio=?,
                     tipo_contrato=?, comisiones_especificas=?, metodo_pago=?, nit=?, nrc=?,
                     cuenta_bancaria=?, notas=?
                 WHERE id=?
@@ -1100,7 +1100,6 @@ class MainWindow(QMainWindow):
                 data.get("email", ""),
                 data.get("cargo", ""),
                 data.get("sucursal", ""),
-                data.get("comision_base", 0),
                 data.get("fecha_inicio", ""),
                 data.get("direccion", ""),
                 data.get("departamento", ""),


### PR DESCRIPTION
## Summary
- drop comision_base from distributor update logic
- stop showing comision_base in distributor info dialog

## Testing
- `pytest` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68928a0c34a08323b339ac2a54d60245