### PR TITLE
Validate fecha type when loading purchases

### DIFF
--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -152,13 +152,15 @@ class PurchasesTab(QWidget):
         rows = []
         for c in compras:
             fecha = c.get("fecha")
-            try:
-                fdate = datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S").date()
-            except ValueError:
+            fdate = None
+            if isinstance(fecha, str):
                 try:
-                    fdate = datetime.strptime(fecha, "%Y-%m-%d").date()
-                except ValueError:
-                    fdate = None
+                    fdate = datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S").date()
+                except (ValueError, TypeError):
+                    try:
+                        fdate = datetime.strptime(fecha, "%Y-%m-%d").date()
+                    except (ValueError, TypeError):
+                        fdate = None
             if fdate and (fdate < d_from or fdate > d_to):
                 continue
             dist = Distribuidores.get(c.get("Distribuidor_id"), "")


### PR DESCRIPTION
## Summary
- ensure purchases_tab.load_purchases checks `fecha` type and catches parsing errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68928ee88e148323992c1464d4807ae2