### PR TITLE
Handle invalid commission values in purchases tab

### DIFF
--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -177,7 +177,12 @@ class PurchasesTab(QWidget):
                     if search not in nombres:
                         continue
             detalles_cache[c["id"]] = detalles_cache.get(c["id"], self.manager.db.get_detalles_compra(c["id"]))
-            comision_total = sum(float(d.get("comision_monto", 0)) for d in detalles_cache[c["id"]])
+            comision_total = 0.0
+            for d in detalles_cache[c["id"]]:
+                try:
+                    comision_total += float(d.get("comision_monto", 0))
+                except (TypeError, ValueError):
+                    continue
             rows.append((c, dist, vend, comision_total, detalles_cache[c["id"]]))
 
         self.table.setRowCount(len(rows))


### PR DESCRIPTION
## Summary
- Guard commission total calculation against non-numeric values in `PurchasesTab`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68928f298504832386941cd791c7b55a