### PR TITLE
Validate client data in dialogs

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -34,6 +34,17 @@ def validar_email(email):
     import re
     return bool(re.match(r"^[^@]+@[^@]+\.[^@]+$", email))
 
+def validar_nrc(nrc):
+    """Valida el formato del NRC salvadoreño (######-#)."""
+    import re
+    return bool(re.match(r"^\d{6}-\d$", nrc))
+
+def validar_telefono(telefono):
+    """Valida números de teléfono salvadoreños con o sin código de país."""
+    import re
+    digits = re.sub(r"\D", "", telefono)
+    return len(digits) == 8 or (len(digits) == 11 and digits.startswith("503"))
+
 def cargar_departamentos_municipios():
     # Lista completa de departamentos y municipios de El Salvador
     return {
@@ -2553,19 +2564,40 @@ class ClienteDialog(QDialog):
         if not self.nombre_edit.text().strip():
             QMessageBox.warning(self, "Validación", "El nombre es obligatorio.")
             return
+        nrc = self.nrc_edit.text().strip()
+        if not nrc:
+            QMessageBox.warning(self, "Validación", "El NRC es obligatorio.")
+            return
+        if not validar_nrc(nrc):
+            QMessageBox.warning(self, "Validación", "Ingrese un NRC válido.")
+            return
+        nit = self.nit_edit.text().strip()
+        if not nit:
+            QMessageBox.warning(self, "Validación", "El NIT es obligatorio.")
+            return
+        if not validar_nit(nit):
+            QMessageBox.warning(self, "Validación", "Ingrese un NIT válido.")
+            return
+        telefono = self.telefono_edit.text().strip()
+        if not telefono:
+            QMessageBox.warning(self, "Validación", "El teléfono es obligatorio.")
+            return
+        if not validar_telefono(telefono):
+            QMessageBox.warning(self, "Validación", "Ingrese un teléfono válido.")
+            return
         email = self.email_edit.text().strip()
         if not email:
             QMessageBox.warning(
                 self,
                 "Validación",
-                "El correo electrónico es obligatorio."
+                "El correo electrónico es obligatorio.",
             )
             return
         if not validar_email(email):
             QMessageBox.warning(
                 self,
                 "Validación",
-                "Ingrese un correo electrónico válido."
+                "Ingrese un correo electrónico válido.",
             )
             return
         self.accept()


### PR DESCRIPTION
## Summary
- add NRC and phone validation helpers
- validate NIT, NRC, phone and email when creating or editing clients

## Testing
- `pytest` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68929860dc788323a3c84677d8d1525a