### PR TITLE
Optimize client lookup and delegate search to database

### DIFF
--- a/db.py
+++ b/db.py
@@ -158,6 +158,15 @@ class DB:
                 otros TEXT
             )
         """)
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_clientes_nombre ON clientes(nombre)"
+        )
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_clientes_nit ON clientes(nit)"
+        )
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_clientes_nrc ON clientes(nrc)"
+        )
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS pagos (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1202,11 +1211,18 @@ class DB:
         self.conn.commit()
 
     def get_clientes(self, search=""):
-        query = "SELECT * FROM clientes"
+        query = (
+            "SELECT id, codigo, nombre, nrc, nit, telefono, email, giro, direccion, departamento, municipio, otros "
+            "FROM clientes"
+        )
         params = []
         if search:
-            query += " WHERE nombre LIKE ? OR codigo LIKE ? OR nit LIKE ?"
-            params = [f"%{search}%"] * 3
+            like = f"%{search}%"
+            query += (
+                " WHERE nombre LIKE ? OR codigo LIKE ? OR nit LIKE ? OR nrc LIKE ? "
+                "OR telefono LIKE ? OR email LIKE ?"
+            )
+            params = [like, like, like, like, like, like]
         self.cursor.execute(query, params)
         return [dict(row) for row in self.cursor.fetchall()]
 

--- a/dialogs.py
+++ b/dialogs.py
@@ -118,17 +118,17 @@ def cargar_departamentos_municipios():
     }
 
 class ClienteSelectorDialog(QDialog):
-    def __init__(self, clientes, parent=None):
+    def __init__(self, db, parent=None):
         super().__init__(parent)
+        self.db = db
         self.setWindowTitle("Seleccionar Cliente")
         layout = QVBoxLayout()
         self.search_bar = QLineEdit()
         self.search_bar.setPlaceholderText("Buscar cliente por nombre, NIT, NRC, etc.")
         layout.addWidget(self.search_bar)
         self.lista_clientes = QListWidget()
-        self.clientes = sorted(clientes, key=lambda c: get_field(c, "codigo", "") or get_field(c, "nombre", ""))
-        self.clientes_mostrados = self.clientes[:]  # <-- NUEVO: lista de los clientes actualmente mostrados
-        self._mostrar_clientes(self.clientes)
+        self.clientes_mostrados = []
+        self._mostrar_clientes(self.db.get_clientes())
         layout.addWidget(self.lista_clientes)
         self.btn_ok = QPushButton("Seleccionar")
         self.btn_ok.clicked.connect(self.accept)
@@ -149,14 +149,7 @@ class ClienteSelectorDialog(QDialog):
             self.lista_clientes.addItem(texto)
 
     def _filtrar_clientes(self, texto):
-        texto = texto.lower()
-        filtrados = [
-            cli for cli in self.clientes
-            if texto in (get_field(cli, "codigo", "") or "").lower()
-            or texto in (get_field(cli, "nombre", "") or "").lower()
-            or texto in (get_field(cli, "nit", "") or "").lower()
-            or texto in (get_field(cli, "nrc", "") or "").lower()
-        ]
+        filtrados = self.db.get_clientes(texto)
         self._mostrar_clientes(filtrados)
 
     def _seleccionar_cliente(self, item):
@@ -502,7 +495,7 @@ class ProductDialogBase:
                     break
 
     def _abrir_selector_cliente(self):
-        selector = ClienteSelectorDialog(self.clientes, self)
+        selector = ClienteSelectorDialog(self.db, self)
         if selector.exec_():
             cli = selector.get_selected_cliente()
             if cli:
@@ -522,15 +515,15 @@ class ProductDialogBase:
 
 
 class RegisterSaleDialog(QDialog, ProductDialogBase):
-    def __init__(self, productos, clientes, Distribuidores, vendedores_trabajadores, parent=None):
+    def __init__(self, productos, Distribuidores, vendedores_trabajadores, parent=None, db=None):
         super().__init__(parent)
+        self.db = db or (parent.manager.db if parent and hasattr(parent, "manager") else None)
         self.setWindowTitle("Registrar Venta")
 
 
         main_layout = QHBoxLayout()
 
         self.productos = productos
-        self.clientes = clientes
         self.vendedores_trabajadores = vendedores_trabajadores
         self.venta_items = []
 
@@ -1690,8 +1683,9 @@ class RegisterPurchaseDialog(QDialog):
         }
     
 class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
-    def __init__(self, productos, clientes, Distribuidores, vendedores_trabajadores, parent=None):
+    def __init__(self, productos, Distribuidores, vendedores_trabajadores, parent=None, db=None):
         super().__init__(parent)
+        self.db = db or (parent.manager.db if parent and hasattr(parent, "manager") else None)
         self.setWindowTitle("Registrar Venta a Crédito Fiscal")
         main_layout = QHBoxLayout()
 
@@ -1699,8 +1693,8 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         left_layout = QVBoxLayout()
         self.productos = productos
         self.venta_items = []
-        self.clientes = clientes
         self.Distribuidores = Distribuidores
+        self.vendedores_trabajadores = vendedores_trabajadores
 
         # Distribuidor
         left_layout.addWidget(QLabel("Distribuidor:"))

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -11,7 +11,6 @@ import json
 from inventory_manager import InventoryManager
 from dialogs import (
     RegisterSaleDialog,
-    ClienteSelectorDialog,
     ProductDialog,
     RegisterPurchaseDialog,
     DistribuidorDialog,
@@ -624,10 +623,9 @@ class MainWindow(QMainWindow):
                         "precio_venta_minorista": prod.get("precio_venta_minorista", 0),
                         "precio_venta_mayorista": prod.get("precio_venta_mayorista", 0),
                     })
-        clientes = [dict(c) for c in self.manager._clientes]
         Distribuidores = [v["nombre"] for v in self.manager._Distribuidores]
         vendedores_trabajadores = self.manager.db.get_trabajadores(solo_vendedores=True)
-        dialog = RegisterSaleDialog(productos_lote, clientes, Distribuidores, vendedores_trabajadores, self)
+        dialog = RegisterSaleDialog(productos_lote, Distribuidores, vendedores_trabajadores, self)
         try:
             if dialog.exec_():
                 data = dialog.get_data()
@@ -751,7 +749,7 @@ class MainWindow(QMainWindow):
             from dialogs import RegisterCreditoFiscalDialog
             Distribuidores = [dict(v) for v in self.manager._Distribuidores]
             vendedores_trabajadores = self.manager.db.get_trabajadores(solo_vendedores=True)
-            dialog = RegisterCreditoFiscalDialog(productos_lote, clientes, Distribuidores, vendedores_trabajadores, self)
+            dialog = RegisterCreditoFiscalDialog(productos_lote, Distribuidores, vendedores_trabajadores, self)
             dialog.set_productos_data(productos_lote)
             if dialog.exec_():
                 


### PR DESCRIPTION
## Summary
- index `clientes` table on `nombre`, `nit` and `nrc`
- expand `get_clientes` and delegate selector dialog filtering to database
- align UI dialogs with new client search mechanism

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689298cb2c348323be865a2e6e340641