### PR TITLE
Add cliente foreign key and migrate ventas table

### DIFF
--- a/db.py
+++ b/db.py
@@ -40,6 +40,59 @@ class DB:
             return False
         return True
 
+    def migrate_ventas_cliente_fk(self):
+        """Ensure ``ventas`` has a foreign key to ``clientes`` on ``cliente_id``.
+
+        Older database versions created ``ventas`` without the foreign key.
+        SQLite does not support adding foreign keys via ``ALTER TABLE``, so we
+        migrate by recreating the table when the constraint is missing.
+        """
+        self.cursor.execute("PRAGMA foreign_key_list(ventas)")
+        fk_exists = any(
+            row[2] == "clientes" and row[3] == "cliente_id"
+            for row in self.cursor.fetchall()
+        )
+        if fk_exists:
+            # Index might be missing in some installations
+            self.cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ventas_cliente_id ON ventas(cliente_id)"
+            )
+            return
+        logger.info("Migrating 'ventas' table to add cliente_id foreign key")
+        self.cursor.execute("PRAGMA foreign_keys=off")
+        try:
+            self.cursor.execute(
+                """
+                CREATE TABLE ventas_temp (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fecha TEXT,
+                    total REAL,
+                    estado TEXT DEFAULT 'Pagada',
+                    cliente_id INTEGER,
+                    Distribuidor_id INTEGER,
+                    vendedor_id INTEGER,
+                    extra TEXT,
+                    FOREIGN KEY (cliente_id) REFERENCES clientes(id),
+                    FOREIGN KEY (Distribuidor_id) REFERENCES Distribuidores(id) ON DELETE RESTRICT,
+                    FOREIGN KEY (vendedor_id) REFERENCES vendedores(id) ON DELETE RESTRICT
+                )
+                """
+            )
+            self.cursor.execute(
+                """
+                INSERT INTO ventas_temp (id, fecha, total, estado, cliente_id, Distribuidor_id, vendedor_id, extra)
+                SELECT id, fecha, total, estado, cliente_id, Distribuidor_id, vendedor_id, extra FROM ventas
+                """
+            )
+            self.cursor.execute("DROP TABLE ventas")
+            self.cursor.execute("ALTER TABLE ventas_temp RENAME TO ventas")
+            self.cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ventas_cliente_id ON ventas(cliente_id)"
+            )
+            self.conn.commit()
+        finally:
+            self.cursor.execute("PRAGMA foreign_keys=on")
+
     def setup(self):
         # Create tables if they don't exist without dropping existing data
         self.cursor.execute("""
@@ -112,10 +165,14 @@ class DB:
                 Distribuidor_id INTEGER,
                 vendedor_id INTEGER,
                 extra TEXT,
+                FOREIGN KEY (cliente_id) REFERENCES clientes(id),
                 FOREIGN KEY (Distribuidor_id) REFERENCES Distribuidores(id) ON DELETE RESTRICT,
                 FOREIGN KEY (vendedor_id) REFERENCES vendedores(id) ON DELETE RESTRICT
             )
         """)
+        self.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ventas_cliente_id ON ventas(cliente_id)"
+        )
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS detalles_venta (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -533,6 +590,7 @@ class DB:
         self.cursor.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_distribuidores_nombre ON Distribuidores(nombre)"
         )
+        self.migrate_ventas_cliente_fk()
         self.conn.commit()
 
         # Verifica que la columna estado exista en ventas

--- a/tests/test_ventas_migration.py
+++ b/tests/test_ventas_migration.py
@@ -1,0 +1,44 @@
+import sqlite3
+import pytest
+
+from db import DB
+
+
+def test_ventas_cliente_fk_and_index(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE ventas (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fecha TEXT,
+            total REAL,
+            estado TEXT DEFAULT 'Pagada',
+            cliente_id INTEGER,
+            Distribuidor_id INTEGER,
+            vendedor_id INTEGER,
+            extra TEXT,
+            FOREIGN KEY (Distribuidor_id) REFERENCES Distribuidores(id) ON DELETE RESTRICT,
+            FOREIGN KEY (vendedor_id) REFERENCES vendedores(id) ON DELETE RESTRICT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO ventas (fecha, total, cliente_id) VALUES ('2024-01-01', 100, 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    db = DB(str(db_path))
+
+    db.cursor.execute("PRAGMA foreign_key_list(ventas)")
+    fks = db.cursor.fetchall()
+    assert any(row[2] == "clientes" and row[3] == "cliente_id" for row in fks)
+
+    db.cursor.execute("PRAGMA index_list(ventas)")
+    idxs = [row[1] for row in db.cursor.fetchall()]
+    assert "idx_ventas_cliente_id" in idxs
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.add_venta("2024-02-01", 50, cliente_id=999)
+


### PR DESCRIPTION
## Summary
- Enforce cliente_id foreign key in ventas table and index it
- Migrate existing ventas table to new schema
- Add regression test for ventas migration

## Testing
- `apt-get install -y libgl1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689298d859f08323869f53af84ceb8af