### PR TITLE
Enforce unique NIT for clients

### DIFF
--- a/db.py
+++ b/db.py
@@ -158,6 +158,9 @@ class DB:
                 otros TEXT
             )
         """)
+        self.cursor.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_clientes_nit ON clientes(nit)"
+        )
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS pagos (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1124,6 +1127,26 @@ class DB:
         return [row["nombre"] for row in self.cursor.fetchall()]
 
     # CRUD CLIENTES
+    def nit_exists(self, nit, exclude_id=None):
+        """Check if a NIT already exists in the clientes table.
+
+        Args:
+            nit: NIT value to check. Empty values are ignored.
+            exclude_id: Optional client ID to exclude from the check.
+
+        Returns:
+            bool: True if the NIT exists for another client.
+        """
+        if not nit:
+            return False
+        query = "SELECT 1 FROM clientes WHERE nit=?"
+        params = [nit]
+        if exclude_id is not None:
+            query += " AND id<>?"
+            params.append(exclude_id)
+        self.cursor.execute(query, params)
+        return self.cursor.fetchone() is not None
+
     def add_cliente(
         self,
         nombre,
@@ -1141,6 +1164,10 @@ class DB:
     ):
         if codigo is None:
             codigo = self.get_next_cliente_codigo()
+        nit = nit.strip() if isinstance(nit, str) else nit
+        nit = nit or None
+        if self.nit_exists(nit):
+            raise ValueError("El NIT ya existe")
         self.cursor.execute(
             """
             INSERT INTO clientes (codigo, nombre, nrc, nit, dui, giro, telefono, email, direccion, departamento, municipio)
@@ -1167,6 +1194,10 @@ class DB:
         return f"T-{(max_id + 1) if max_id else 1:03d}"
 
     def update_cliente(self, id, codigo, nombre, nrc, nit, dui, giro, telefono, email, direccion, departamento, municipio):
+        nit = nit.strip() if isinstance(nit, str) else nit
+        nit = nit or None
+        if self.nit_exists(nit, exclude_id=id):
+            raise ValueError("El NIT ya existe")
         self.cursor.execute(
             """
             UPDATE clientes SET codigo=?, nombre=?, nrc=?, nit=?, dui=?, giro=?, telefono=?, email=?, direccion=?, departamento=?, municipio=? WHERE id=?

--- a/dialogs.py
+++ b/dialogs.py
@@ -2317,6 +2317,7 @@ class DistribuidorDialog(QDialog):
         self.direccion_edit = QLineEdit()
         self.departamento_edit = QLineEdit()
         self.municipio_edit = QLineEdit()
+        self._cliente_id = cliente.get("id") if cliente else None
         self.tipo_contrato_edit = QLineEdit()
         self.comisiones_especificas_edit = QLineEdit()
         self.metodo_pago_edit = QLineEdit()
@@ -2501,6 +2502,7 @@ class ClienteDialog(QDialog):
         self.direccion_edit = QLineEdit()
         self.departamento_edit = QLineEdit()
         self.municipio_edit = QLineEdit()
+        self._cliente_id = cliente.get("id") if cliente else None
 
         form = [
             ("Código:", self.codigo_edit),
@@ -2558,15 +2560,20 @@ class ClienteDialog(QDialog):
             QMessageBox.warning(
                 self,
                 "Validación",
-                "El correo electrónico es obligatorio."
+                "El correo electrónico es obligatorio.",
             )
             return
         if not validar_email(email):
             QMessageBox.warning(
                 self,
                 "Validación",
-                "Ingrese un correo electrónico válido."
+                "Ingrese un correo electrónico válido.",
             )
+            return
+        nit = self.nit_edit.text().strip()
+        db = getattr(getattr(self.parent(), "manager", None), "db", None)
+        if db and db.nit_exists(nit, exclude_id=self._cliente_id):
+            QMessageBox.warning(self, "Validación", "El NIT ya está registrado.")
             return
         self.accept()
 

--- a/tests/test_cliente_nit_unique.py
+++ b/tests/test_cliente_nit_unique.py
@@ -1,0 +1,19 @@
+from db import DB
+import pytest
+
+def create_db():
+    return DB(":memory:")
+
+def test_add_cliente_duplicate_nit():
+    db = create_db()
+    db.add_cliente("Juan", "", "nit1", "", "", "", "", "", "", "")
+    with pytest.raises(ValueError):
+        db.add_cliente("Ana", "", "nit1", "", "", "", "", "", "", "")
+
+def test_update_cliente_duplicate_nit():
+    db = create_db()
+    db.add_cliente("Juan", "", "nit1", "", "", "", "", "", "", "")
+    db.add_cliente("Ana", "", "nit2", "", "", "", "", "", "", "")
+    cid2 = db.cursor.lastrowid
+    with pytest.raises(ValueError):
+        db.update_cliente(cid2, "C-002", "Ana", "", "nit1", "", "", "", "", "", "", "")

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1170,19 +1170,23 @@ class MainWindow(QMainWindow):
         dialog = ClienteDialog(self, codigo_sugerido=codigo)
         if dialog.exec_():
             data = dialog.get_data()
-            self.manager.add_cliente(
-                data["nombre"],
-                data["nrc"],
-                data["nit"],
-                data["dui"],
-                data["giro"],
-                data["telefono"],
-                data["email"],
-                data["direccion"],
-                data["departamento"],
-                data["municipio"],
-                data["codigo"],
-            )
+            try:
+                self.manager.add_cliente(
+                    data["nombre"],
+                    data["nrc"],
+                    data["nit"],
+                    data["dui"],
+                    data["giro"],
+                    data["telefono"],
+                    data["email"],
+                    data["direccion"],
+                    data["departamento"],
+                    data["municipio"],
+                    data["codigo"],
+                )
+            except ValueError as e:
+                QMessageBox.warning(dialog, "Cliente", str(e))
+                return
             self._actualizar_tabla_clientes()
             QMessageBox.information(self, "Cliente", "Cliente agregado correctamente.")
 
@@ -1194,20 +1198,24 @@ class MainWindow(QMainWindow):
         dialog = ClienteDialog(self, cliente=cli)
         if dialog.exec_():
             data = dialog.get_data()
-            self.manager.update_cliente(
-                cli["id"],
-                data["codigo"],
-                data["nombre"],
-                data["nrc"],
-                data["nit"],
-                data["dui"],
-                data["giro"],
-                data["telefono"],
-                data["email"],
-                data["direccion"],
-                data["departamento"],
-                data["municipio"],
-            )
+            try:
+                self.manager.update_cliente(
+                    cli["id"],
+                    data["codigo"],
+                    data["nombre"],
+                    data["nrc"],
+                    data["nit"],
+                    data["dui"],
+                    data["giro"],
+                    data["telefono"],
+                    data["email"],
+                    data["direccion"],
+                    data["departamento"],
+                    data["municipio"],
+                )
+            except ValueError as e:
+                QMessageBox.warning(dialog, "Cliente", str(e))
+                return
             self._actualizar_tabla_clientes()
             QMessageBox.information(self, "Cliente", "Cliente editado correctamente.")
 


### PR DESCRIPTION
## Summary
- ensure unique NITs for clients with an index and duplicate checks in DB insert/update
- validate NIT uniqueness in ClienteDialog and surface user-friendly errors
- handle duplicate NIT attempts gracefully from the main window and add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689298c49c388323b01dbacbcb05b5ff