### PR TITLE
Add generar_ticket_json import to sales_tab

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -32,7 +32,7 @@ from utils.jws import get_cert_config, sign_and_save, CONFIG_NEGOCIO_PATH
 
 from ticket_pdf import generar_ticket_personalizado
 from dialogs import ManualInvoiceDialog
-from dte import transmitir_dte
+from dte import transmitir_dte, generar_ticket_json
 import tempfile
 import subprocess
 import shutil


### PR DESCRIPTION
## Summary
- Import `generar_ticket_json` alongside `transmitir_dte` in `sales_tab.py`
- Ensure `_generate_ticket_pdf` uses `generar_ticket_json` to build ticket data

## Testing
- `python -m py_compile sales_tab.py`
- `pytest tests/test_generar_dte_json.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68929de32cc88323856e09526e30878a