### PR TITLE
Maneja fechas de venta nulas

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -232,13 +232,18 @@ class SalesTab(QWidget):
         rows = []
         for v in ventas:
             fecha = v.get("fecha")
-            try:
-                fdate = datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S").date()
-            except ValueError:
+            fdate = None
+            if isinstance(fecha, str):
                 try:
-                    fdate = datetime.strptime(fecha, "%Y-%m-%d").date()
-                except ValueError:
-                    fdate = None
+                    fdate = datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S").date()
+                except (ValueError, TypeError):
+                    try:
+                        fdate = datetime.strptime(fecha, "%Y-%m-%d").date()
+                    except (ValueError, TypeError):
+                        fdate = None
+            else:
+                # fecha no es una cadena o está ausente
+                fdate = None
             if fdate and (fdate < d_from or fdate > d_to):
                 continue
             cliente = ""

--- a/tests/test_date_parsing.py
+++ b/tests/test_date_parsing.py
@@ -76,3 +76,14 @@ def test_load_sales_date_formats(qt_app):
     tab.date_from.setDate(QDate(2024, 1, 2))
     tab.load_sales()
     assert tab.sales_table.rowCount() == 1
+
+
+def test_load_sales_handles_null_dates(qt_app):
+    db = setup_db()
+    db.add_venta(None, 30)
+    man = Manager(db)
+    tab = SalesTab(man)
+    tab.date_from.setDate(QDate(2024, 1, 1))
+    tab.date_to.setDate(QDate(2024, 1, 31))
+    tab.load_sales()
+    assert tab.sales_table.rowCount() == 3


### PR DESCRIPTION
## Summary
- Evita errores al cargar ventas comprobando que la fecha sea cadena antes de convertirla y manejando `TypeError` para fechas ausentes
- Añade prueba que verifica la carga correcta de ventas con fecha nula

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929de2cee8832384c6681e1a67f8a5