### PR TITLE
Ajustar tipoDoc de notas de crédito según venta original

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -331,9 +331,18 @@ def generar_nota_credito_json(db: DB, nota_id: int) -> dict:
         raise ValueError("La nota indicada no es de crédito")
 
     venta_id = nota.get("venta_id")
+    # Determine document type of the original sale
+    venta_row = db.cursor.execute(
+        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+    ).fetchone()
+    tipo_doc = "01"
+    if venta_row:
+        venta = dict(venta_row)
+        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
+            tipo_doc = "03"
     data = generar_dte_json(db, venta_id, tipo_dte="05")
     data["documentoRelacionado"] = {
-        "tipoDoc": "01",
+        "tipoDoc": tipo_doc,
         "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
     }
 

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -8,7 +8,7 @@ def create_db():
     return DB(":memory:")
 
 
-def test_generar_nota_credito_json_basic(tmp_path):
+def test_generar_nota_credito_json_ticket(tmp_path):
     db = create_db()
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
@@ -26,8 +26,30 @@ def test_generar_nota_credito_json_basic(tmp_path):
     data = generar_nota_credito_json(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "05"
     assert data.get("documentoRelacionado")
+    assert data["documentoRelacionado"]["tipoDoc"] == "03"
     assert data["cuerpoDocumento"][0]["precioUnitario"] < 0
     assert data["resumen"]["totalPagar"] < 0
+
+
+def test_generar_nota_credito_json_factura(tmp_path):
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro", descuentos=0)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
+        (venta_id, "credito", "2024-01-02", 10, "Dev"),
+    )
+    nota_id = db.cursor.lastrowid
+    db.conn.commit()
+
+    data = generar_nota_credito_json(db, nota_id)
+    assert data["documentoRelacionado"]["tipoDoc"] == "01"
 
 
 def _sample_data():


### PR DESCRIPTION
## Resumen
- Determina el tipo de documento original al generar nota de crédito para usarlo en `documentoRelacionado`
- Cubre notas de crédito tanto para tickets como facturas con pruebas dedicadas

## Testing
- `pytest tests/test_nota_credito.py -q`
- `pytest -q` *(falla: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6892a01d790083239d7aa1ecf5b3d4d0