### PR TITLE
chore: block deleting workers with sales

### DIFF
--- a/db.py
+++ b/db.py
@@ -1682,6 +1682,14 @@ class DB:
         self.conn.commit()
 
     def delete_trabajador(self, id):
+        self.cursor.execute(
+            "SELECT COUNT(*) FROM ventas WHERE vendedor_id=?",
+            (id,),
+        )
+        if self.cursor.fetchone()[0] > 0:
+            raise ValueError(
+                "No se puede eliminar el trabajador: tiene ventas asociadas"
+            )
         self.cursor.execute("DELETE FROM trabajadores WHERE id=?", (id,))
         self.conn.commit()
 

--- a/tests/test_delete_trabajador_sales.py
+++ b/tests/test_delete_trabajador_sales.py
@@ -1,0 +1,17 @@
+import pytest
+from db import DB
+
+
+def test_delete_trabajador_with_sales(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_trabajador({"nombre": "Vend", "codigo": "T1", "es_vendedor": True})
+    trabajador_id = db.get_trabajadores()[0]["id"]
+    db.cursor.execute(
+        "INSERT INTO vendedores (id, codigo, nombre, descripcion, Distribuidor_id, dui) VALUES (?, ?, ?, ?, ?, ?)",
+        (trabajador_id, "V1", "Vend", "", None, None),
+    )
+    db.conn.commit()
+    db.add_venta("2024-01-01", 10, vendedor_id=trabajador_id)
+    with pytest.raises(ValueError):
+        db.delete_trabajador(trabajador_id)
+    assert db.get_trabajador(trabajador_id) is not None

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1425,11 +1425,39 @@ class MainWindow(QMainWindow):
         if not t:
             QMessageBox.warning(self, "Eliminar trabajador", "Seleccione un trabajador para eliminar.")
             return
-        confirm = QMessageBox.question(self, "Eliminar", f"¿Eliminar trabajador '{t['nombre']}'?", QMessageBox.Yes | QMessageBox.No)
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar",
+            f"¿Eliminar trabajador '{t['nombre']}'?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
         if confirm == QMessageBox.Yes:
-            self.manager.db.delete_trabajador(t["id"])
+            count = self.manager.db.cursor.execute(
+                "SELECT COUNT(*) FROM ventas WHERE vendedor_id=?",
+                (t["id"],),
+            ).fetchone()[0]
+            if count > 0:
+                QMessageBox.warning(
+                    self,
+                    "Eliminar trabajador",
+                    "El trabajador tiene ventas asociadas y no puede eliminarse.",
+                )
+                return
+            try:
+                self.manager.db.delete_trabajador(t["id"])
+            except ValueError:
+                QMessageBox.warning(
+                    self,
+                    "Eliminar trabajador",
+                    "El trabajador tiene ventas asociadas y no puede eliminarse.",
+                )
+                return
             self._actualizar_tabla_trabajadores()
-            QMessageBox.information(self, "Trabajador eliminado", f"El trabajador '{t['nombre']}' ha sido eliminado.")
+            QMessageBox.information(
+                self,
+                "Trabajador eliminado",
+                f"El trabajador '{t['nombre']}' ha sido eliminado.",
+            )
 
 
     def _toggle_estado_fechas(self, checked: bool):


### PR DESCRIPTION
## Summary
- prevent `delete_trabajador` from removing workers with associated sales
- warn in UI before deleting workers if sales exist
- add regression test ensuring worker deletion fails when sales are present

## Testing
- `pytest tests/test_delete_trabajador_sales.py -q`
- `pytest -q` *(fails: command was interrupted after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6892acf106e88323bf6138e487e95a81