### PR TITLE
Validate trabajador fields

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -3229,6 +3229,8 @@ class TrabajadorDialog(QDialog):
         self.btn_ok.clicked.connect(self._validar_y_accept)
         self.btn_cancel.clicked.connect(self.reject)
 
+        self._trabajador_id = trabajador.get("id") if trabajador else None
+
         if trabajador:
             self.codigo.setText(trabajador.get("codigo", ""))
             self.nombre.setText(trabajador.get("nombre", ""))
@@ -3248,6 +3250,37 @@ class TrabajadorDialog(QDialog):
             self.es_vendedor.setChecked(trabajador.get("es_vendedor", 0) == 1)
 
     def _validar_y_accept(self):
+        codigo = self.codigo.text().strip()
+        nombre = self.nombre.text().strip()
+        nit = self.nit.text().strip()
+        email = self.email.text().strip()
+
+        if not codigo:
+            QMessageBox.warning(self, "Validación", "El código es obligatorio.")
+            return
+        if not nombre:
+            QMessageBox.warning(self, "Validación", "El nombre es obligatorio.")
+            return
+        if not nit:
+            QMessageBox.warning(self, "Validación", "El NIT es obligatorio.")
+            return
+        if not validar_nit(nit):
+            QMessageBox.warning(self, "Validación", "Ingrese un NIT válido.")
+            return
+        if not email:
+            QMessageBox.warning(self, "Validación", "El correo electrónico es obligatorio.")
+            return
+        if not validar_email(email):
+            QMessageBox.warning(self, "Validación", "Ingrese un correo electrónico válido.")
+            return
+
+        db = getattr(getattr(self.parent(), "manager", None), "db", None)
+        if db:
+            for t in db.get_trabajadores():
+                if t.get("codigo") == codigo and t.get("id") != self._trabajador_id:
+                    QMessageBox.warning(self, "Validación", "El código ya está registrado.")
+                    return
+
         self.accept()
 
     def get_data(self):

--- a/tests/test_trabajador_dialog_validation.py
+++ b/tests/test_trabajador_dialog_validation.py
@@ -1,0 +1,82 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication, QWidget, QMessageBox
+
+from dialogs import TrabajadorDialog
+
+
+class DummyDB:
+    def __init__(self, trabajadores=None):
+        self._trabajadores = trabajadores or []
+
+    def get_trabajadores(self, solo_vendedores=False, area=None, search=""):
+        return self._trabajadores
+
+
+class DummyParent(QWidget):
+    def __init__(self, db):
+        super().__init__()
+        self.manager = type('M', (), {'db': db})()
+
+
+def make_dialog(db, trabajador=None):
+    parent = DummyParent(db)
+    dialog = TrabajadorDialog(trabajador=trabajador, parent=parent)
+    dialog._parent_ref = parent
+    return dialog
+
+
+@pytest.fixture
+def qt_app(monkeypatch):
+    monkeypatch.setenv('QT_QPA_PLATFORM', 'offscreen')
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_missing_fields(monkeypatch, qt_app):
+    db = DummyDB()
+    dialog = make_dialog(db)
+    dialog.codigo.setText('')
+    dialog.nombre.setText('Nombre')
+    dialog.nit.setText('1234-123456-123-1')
+    dialog.email.setText('test@example.com')
+
+    accepted = {}
+    dialog.accept = lambda: accepted.setdefault('called', True)
+    monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: None)
+
+    dialog._validar_y_accept()
+    assert not accepted.get('called')
+
+
+def test_invalid_nit_email(monkeypatch, qt_app):
+    db = DummyDB()
+    dialog = make_dialog(db)
+    dialog.codigo.setText('T001')
+    dialog.nombre.setText('Nombre')
+    dialog.nit.setText('invalid')
+    dialog.email.setText('bademail')
+
+    accepted = {}
+    dialog.accept = lambda: accepted.setdefault('called', True)
+    monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: None)
+
+    dialog._validar_y_accept()
+    assert not accepted.get('called')
+
+
+def test_duplicate_codigo(monkeypatch, qt_app):
+    existing = {'id': 1, 'codigo': 'T001'}
+    db = DummyDB([existing])
+    dialog = make_dialog(db)
+    dialog.codigo.setText('T001')
+    dialog.nombre.setText('Nombre')
+    dialog.nit.setText('1234-123456-123-1')
+    dialog.email.setText('test@example.com')
+
+    accepted = {}
+    dialog.accept = lambda: accepted.setdefault('called', True)
+    monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: None)
+
+    dialog._validar_y_accept()
+    assert not accepted.get('called')


### PR DESCRIPTION
## Summary
- enforce required fields and format checks in `TrabajadorDialog`
- add unit tests for trabajador dialog validation cases

## Testing
- `pytest tests/test_trabajador_dialog_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6892acf175f0832382c7af76965b05d0