### PR TITLE
Enable flexible filtering of trabajadores by area

### DIFF
--- a/db.py
+++ b/db.py
@@ -1634,8 +1634,8 @@ class DB:
         if solo_vendedores:
             filtros.append("es_vendedor=1")
         if area:
-            filtros.append("area=?")
-            params.append(area)
+            filtros.append("LOWER(area) LIKE LOWER(?)")
+            params.append(f"%{area}%")
         if search:
             filtros.append("(nombre LIKE ? OR codigo LIKE ?)")
             params.extend([f"%{search}%", f"%{search}%"])

--- a/tests/test_trabajadores_filter.py
+++ b/tests/test_trabajadores_filter.py
@@ -1,0 +1,27 @@
+from db import DB
+
+
+def _prepare_db(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_trabajador({"codigo": "T1", "nombre": "Carlos", "area": "Ventas"})
+    db.add_trabajador({"codigo": "T2", "nombre": "Ana", "area": "ventas"})
+    db.add_trabajador({"codigo": "T3", "nombre": "Luis", "area": "Atención al Cliente"})
+    return db
+
+
+def test_get_trabajadores_area_case_insensitive(tmp_path):
+    db = _prepare_db(tmp_path)
+    trabajadores = db.get_trabajadores(area="VENTAS")
+    codigos = {t["codigo"] for t in trabajadores}
+    assert codigos == {"T1", "T2"}
+
+
+def test_get_trabajadores_area_partial_match(tmp_path):
+    db = _prepare_db(tmp_path)
+    trabajadores = db.get_trabajadores(area="vent")
+    codigos = {t["codigo"] for t in trabajadores}
+    assert codigos == {"T1", "T2"}
+
+    trabajadores_cliente = db.get_trabajadores(area="cliente")
+    codigos_cliente = {t["codigo"] for t in trabajadores_cliente}
+    assert codigos_cliente == {"T3"}

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1370,8 +1370,10 @@ class MainWindow(QMainWindow):
 
     def _actualizar_tabla_trabajadores(self):
         solo_vendedores = self.trabajadores_filtro_vendedor.isChecked()
-        area = self.trabajadores_filtro_area.text().strip() or None
-        trabajadores = self.manager.db.get_trabajadores(solo_vendedores=solo_vendedores, area=area)
+        area = self.trabajadores_filtro_area.text()
+        trabajadores = self.manager.db.get_trabajadores(
+            solo_vendedores=solo_vendedores, area=area
+        )
         self.trabajadores_table.setRowCount(len(trabajadores))
         for row, t in enumerate(trabajadores):
             self.trabajadores_table.setItem(row, 0, QTableWidgetItem(t.get("codigo", "")))


### PR DESCRIPTION
## Summary
- Allow `get_trabajadores` to filter `area` using a case-insensitive LIKE query
- Pass raw area text from `_actualizar_tabla_trabajadores` to the database layer
- Add tests validating case-insensitive and partial area filters

## Testing
- `pytest tests/test_trabajadores_filter.py tests/test_import_trabajador_sales.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892acf194d083239f2544b75b79e56a