### PR TITLE
feat: automatically manage missing columns

### DIFF
--- a/db.py
+++ b/db.py
@@ -18,26 +18,25 @@ class DB:
     def ensure_column(self, table: str, column: str, definition: str) -> bool:
         """Ensure that a specific column exists in ``table``.
 
-        If the column is missing the user is asked whether it should be created.
-        Returns ``True`` if the column exists or was created successfully.
+        Missing columns are created automatically. If the creation fails a
+        warning is logged. Returns ``True`` if the column exists or was created
+        successfully, ``False`` otherwise.
         """
         self.cursor.execute(f"PRAGMA table_info({table})")
         cols = [row[1] for row in self.cursor.fetchall()]
         if column not in cols:
-            resp = input(
-                f"La tabla '{table}' no tiene la columna '{column}'. ¿Crear columna? (s/n): "
-            )
-            if resp.strip().lower().startswith("s"):
+            try:
                 self.cursor.execute(
                     f"ALTER TABLE {table} ADD COLUMN {column} {definition}"
                 )
                 self.conn.commit()
-                print(f"Columna '{column}' creada en '{table}'.")
+                logger.info("Column '%s' added to '%s'.", column, table)
                 return True
-            print(
-                f"No se agregó la columna '{column}'. Algunas funciones podrían fallar."
-            )
-            return False
+            except Exception as exc:  # sqlite3.OperationalError, etc.
+                logger.warning(
+                    "No se agregó la columna '%s' en '%s': %s", column, table, exc
+                )
+                return False
         return True
 
     def migrate_ventas_cliente_fk(self):

--- a/tests/test_db_module.py
+++ b/tests/test_db_module.py
@@ -2,23 +2,21 @@ import threading
 from db import DB
 
 
-def test_ensure_column_creation(monkeypatch, tmp_path):
+def test_ensure_column_creation(tmp_path):
     db = DB(str(tmp_path / 'db.sqlite'))
     db.cursor.execute('CREATE TABLE t(id INTEGER)')
     db.conn.commit()
-    monkeypatch.setattr('builtins.input', lambda prompt: 's')
     assert db.ensure_column('t', 'name', 'TEXT')
     db.cursor.execute('PRAGMA table_info(t)')
     cols = [r[1] for r in db.cursor.fetchall()]
     assert 'name' in cols
 
 
-def test_ensure_column_decline(monkeypatch, tmp_path):
+def test_ensure_column_warning(tmp_path, caplog):
     db = DB(str(tmp_path / 'db.sqlite'))
-    db.cursor.execute('CREATE TABLE t(id INTEGER)')
-    db.conn.commit()
-    monkeypatch.setattr('builtins.input', lambda prompt: 'n')
-    assert not db.ensure_column('t', 'name', 'TEXT')
+    with caplog.at_level('WARNING'):
+        assert not db.ensure_column('missing_table', 'name', 'TEXT')
+    assert "No se agregó la columna" in caplog.text
 
 
 def test_concurrent_access(tmp_path):


### PR DESCRIPTION
## Summary
- auto-create missing columns in DB.ensure_column and log warnings on failure
- update tests for DB.ensure_column to remove interactive prompts and cover warning cases

## Testing
- `pytest tests/test_db_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6892df1d9c888323a6316e192839dca5