### PR TITLE
Improve exception logging

### DIFF
--- a/facturacion_vacia_tab.py
+++ b/facturacion_vacia_tab.py
@@ -16,6 +16,10 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtCore import QDate, Qt
 
 from datetime import datetime
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 class FacturacionVaciaTab(QWidget):
     """Pestaña de facturación con filtros y acciones básicas."""
@@ -89,7 +93,8 @@ class FacturacionVaciaTab(QWidget):
         try:
             notas = manager.db.obtener_notas()
         except Exception:
-            pass
+            logger.exception("Error obteniendo notas")
+            notas = []
         clientes = {c["id"]: c["nombre"] for c in manager._clientes}
 
         search = self.search_bar.text().lower()
@@ -102,7 +107,8 @@ class FacturacionVaciaTab(QWidget):
             fecha = v.get("fecha", "")
             try:
                 fdate = datetime.strptime(fecha.split()[0], "%Y-%m-%d").date()
-            except Exception:
+            except (ValueError, AttributeError, IndexError):
+                logger.exception("Fecha inválida: %s", fecha)
                 fdate = None
             if fdate and (fdate < d_from or fdate > d_to):
                 continue
@@ -131,7 +137,8 @@ class FacturacionVaciaTab(QWidget):
             fecha = n.get("fecha", "")
             try:
                 fdate = datetime.strptime(fecha.split()[0], "%Y-%m-%d").date()
-            except Exception:
+            except (ValueError, AttributeError, IndexError):
+                logger.exception("Fecha inválida: %s", fecha)
                 fdate = None
             if fdate and (fdate < d_from or fdate > d_to):
                 continue

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -7,6 +7,10 @@ from PyQt5.QtGui import QColor
 from datetime import datetime, date
 
 from dialogs import CompraDetalleDialog
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class PurchasesTab(QWidget):
@@ -211,8 +215,8 @@ class PurchasesTab(QWidget):
                         fv_date = datetime.strptime(fv, "%Y-%m-%d").date()
                         if fv_date < today:
                             expired = True
-                    except Exception:
-                        pass
+                    except (ValueError, TypeError):
+                        logger.exception("Fecha de vencimiento inválida: %s", fv)
                 prod_count[d["producto_id"]] = prod_count.get(d["producto_id"], 0) + d.get("cantidad", 0)
             if compra.get("Distribuidor_id"):
                 dist_count[compra["Distribuidor_id"]] = dist_count.get(compra["Distribuidor_id"], 0) + 1

--- a/tests/test_facturacion_vacia_tab_logging.py
+++ b/tests/test_facturacion_vacia_tab_logging.py
@@ -1,0 +1,56 @@
+import os
+import logging
+import pytest
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from facturacion_vacia_tab import FacturacionVaciaTab
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+
+def test_obtener_notas_exception_logged(qt_app, caplog):
+    class DummyDB:
+        def get_ventas(self):
+            return []
+
+        def obtener_notas(self):
+            raise RuntimeError("boom")
+
+    class DummyManager:
+        def __init__(self):
+            self.db = DummyDB()
+            self._clientes = []
+
+    parent = QWidget()
+    parent.manager = DummyManager()
+
+    with caplog.at_level(logging.ERROR):
+        FacturacionVaciaTab(parent)
+
+    assert "Error obteniendo notas" in caplog.text
+
+
+def test_invalid_date_logged(qt_app, caplog):
+    class DummyDB:
+        def get_ventas(self):
+            return [{"id": 1, "fecha": "bad-date", "cliente_id": 0, "total": 0, "estado": ""}]
+
+        def obtener_notas(self):
+            return []
+
+    class DummyManager:
+        def __init__(self):
+            self.db = DummyDB()
+            self._clientes = []
+
+    parent = QWidget()
+    parent.manager = DummyManager()
+
+    with caplog.at_level(logging.ERROR):
+        FacturacionVaciaTab(parent)
+
+    assert "Fecha inválida" in caplog.text


### PR DESCRIPTION
## Summary
- add module-level loggers and use `logger.exception` in facturacion and compras tabs
- cover failure scenarios for empty billing tab

## Testing
- `pytest tests/test_facturacion_vacia_tab_logging.py -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6892e35099a08323a7b8d0617f94eca1