### PR TITLE
Elimina llamada duplicada a _calcular_preview_item

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1352,8 +1352,6 @@ class RegisterPurchaseDialog(QDialog):
         self.product_list.currentRowChanged.connect(self._calcular_preview_item)
         self._calcular_preview_item()
 
-        self._calcular_preview_item()
-
     # --- NUEVO MÉTODO ---
     def _actualizar_precio_unitario_por_producto(self):
         idx = self.product_list.currentRow()


### PR DESCRIPTION
## Summary
- Evita cálculo repetido de totales al remover llamada duplicada a `_calcular_preview_item` en el diálogo de registro de compras

## Testing
- `python - <<'PY'
from PyQt5.QtWidgets import QApplication
from dialogs import RegisterPurchaseDialog
app = QApplication([])
productos=[{"nombre":"Prod1","precio_compra":10.0,"vendedor_id":1}]
Distribuidores=[{"id":1,"nombre":"Distrib1"}]
Vendedores=[{"id":1,"nombre":"Vend1","Distribuidor_id":1,"comision_base":0}]
dialog=RegisterPurchaseDialog(productos,Distribuidores,Vendedores)
dialog.cantidad_spin.setValue(2)
dialog.precio_unitario_spin.setValue(10.0)
dialog._calcular_preview_item()
print(dialog.subtotal_label.text())
print(dialog.iva_label.text())
print(dialog.total_label.text())
PY`
- `QT_QPA_PLATFORM=offscreen pytest` *(failed: no output captured)*

------
https://chatgpt.com/codex/tasks/task_e_6892e349a10c8323b5d5abb1acda7558