### PR TITLE
Enable threaded DB usage

### DIFF
--- a/db.py
+++ b/db.py
@@ -3,16 +3,25 @@ from datetime import datetime
 import json
 import logging
 import os
+import threading
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class DB:
     def __init__(self, db_name=os.path.join(os.path.dirname(__file__), "inventario.db")):
-        self.conn = sqlite3.connect(db_name)
+        # ``check_same_thread=False`` allows the connection to be used from
+        # multiple threads.  Each thread should ideally use its own connection
+        # but this flag prevents SQLite from raising an exception if a
+        # connection crosses thread boundaries.
+        self.conn = sqlite3.connect(db_name, check_same_thread=False)
         self.conn.execute("PRAGMA foreign_keys = ON")
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
+        # Simple mutex to guard database operations when the same connection is
+        # accessed from multiple threads.  Threads may also create their own
+        # ``DB`` instances to keep connections separate.
+        self.lock = threading.Lock()
         self.setup()
 
     def ensure_column(self, table: str, column: str, definition: str) -> bool:

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -43,15 +43,21 @@ class ExportThread(QThread):
     finished = pyqtSignal()
     error = pyqtSignal(str)
 
-    def __init__(self, manager, filename, tab_order):
+    def __init__(self, filename, tab_order):
         super().__init__()
-        self.manager = manager
         self.filename = filename
         self.tab_order = tab_order
 
     def run(self):
+        """Run the export in a background thread.
+
+        A new ``InventoryManager`` instance is created so that this thread uses
+        its own database connection, avoiding any cross-thread usage of the
+        main application's connection.
+        """
         try:
-            self.manager.exportar_inventario_json(
+            manager = InventoryManager()
+            manager.exportar_inventario_json(
                 self.filename, tab_order=self.tab_order
             )
             self.finished.emit()
@@ -842,7 +848,9 @@ class MainWindow(QMainWindow):
     def guardar_como(self):
         filename, _ = QFileDialog.getSaveFileName(self, "Guardar inventario como", "", "Archivos JSON (*.json);;Todos los archivos (*)")
         if filename:
-            thread = ExportThread(self.manager, filename, self.get_tab_order())
+            # Use a background thread with its own DB connection to avoid
+            # blocking the UI or sharing the main thread's connection.
+            thread = ExportThread(filename, self.get_tab_order())
 
             def on_finished():
                 self.ultimo_archivo_json = filename
@@ -886,8 +894,10 @@ class MainWindow(QMainWindow):
 
     def guardar_rapido(self):
         if self.ultimo_archivo_json:
+            # Reuse the background export thread with its own database
+            # connection to keep the GUI responsive.
             thread = ExportThread(
-                self.manager, self.ultimo_archivo_json, self.get_tab_order()
+                self.ultimo_archivo_json, self.get_tab_order()
             )
 
             def on_finished():


### PR DESCRIPTION
## Summary
- allow SQLite connection to be shared across threads using `check_same_thread=False`
- isolate export operations by creating a dedicated `InventoryManager` per `ExportThread`

## Testing
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6893027607708323987652ead4b5d37f