### PR TITLE
Make SMTP check optional and headless-safe

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -40,6 +40,7 @@ import shutil
 import os
 import json
 import uuid
+import warnings
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
@@ -50,7 +51,7 @@ TICKETS_DIR = os.path.join(os.path.dirname(__file__), "tickets")
 class SalesTab(QWidget):
     """Simple tab to list sales and preview invoices."""
 
-    def __init__(self, manager, parent=None):
+    def __init__(self, manager, parent=None, check_smtp=True):
         super().__init__(parent)
         self.manager = manager
         self.current_credito_fiscal = None
@@ -62,7 +63,8 @@ class SalesTab(QWidget):
         self._setup_ui()
         self._load_email_config()
         self.load_sales()
-        self._check_smtp_credentials()
+        if check_smtp:
+            self._check_smtp_credentials()
 
     def _setup_ui(self):
         main_layout = QHBoxLayout(self)
@@ -357,22 +359,25 @@ class SalesTab(QWidget):
         Returns a dict with the credentials if complete, otherwise ``None``.
         """
         path = DATOS_NEGOCIO_PATH
+        headless = os.environ.get("QT_QPA_PLATFORM") in {"offscreen", "minimal"}
+        msg = (
+            "Credenciales SMTP incompletas. Configure sus datos en la opción 'Configuración de correo'."
+        )
+
+        def warn():
+            if headless:
+                warnings.warn(msg)
+            else:
+                QMessageBox.warning(self, "Configuración de correo", msg)
+
         if not os.path.exists(path):
-            QMessageBox.warning(
-                self,
-                "Configuración de correo",
-                "Credenciales SMTP incompletas. Configure sus datos en la opción 'Configuración de correo'.",
-            )
+            warn()
             return None
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except Exception:
-            QMessageBox.warning(
-                self,
-                "Configuración de correo",
-                "Credenciales SMTP incompletas. Configure sus datos en la opción 'Configuración de correo'.",
-            )
+            warn()
             return None
 
         server = data.get("smtp_server")
@@ -389,11 +394,7 @@ class SalesTab(QWidget):
                 pass
 
         if not all([server, port, user, password]):
-            QMessageBox.warning(
-                self,
-                "Configuración de correo",
-                "Credenciales SMTP incompletas. Configure sus datos en la opción 'Configuración de correo'.",
-            )
+            warn()
             return None
 
         return {

--- a/tests/test_date_parsing.py
+++ b/tests/test_date_parsing.py
@@ -67,7 +67,7 @@ def test_load_purchases_date_formats(qt_app):
 def test_load_sales_date_formats(qt_app):
     db = setup_db()
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
     tab.date_from.setDate(QDate(2024, 1, 1))
     tab.date_to.setDate(QDate(2024, 1, 31))
     tab.load_sales()
@@ -82,7 +82,7 @@ def test_load_sales_handles_null_dates(qt_app):
     db = setup_db()
     db.add_venta(None, 30)
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
     tab.date_from.setDate(QDate(2024, 1, 1))
     tab.date_to.setDate(QDate(2024, 1, 31))
     tab.load_sales()

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -47,7 +47,7 @@ def test_generate_invoice_creates_json(qt_app, tmp_path):
     db._ventas.append(venta)
     db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
 
     pdf_path = tmp_path / "fact.pdf"
     json_path = tmp_path / "fact.json"
@@ -72,12 +72,14 @@ def test_generate_invoice_creates_json(qt_app, tmp_path):
 
 
 def test_save_ticket_creates_json(qt_app, tmp_path):
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(SalesTab, "show_sale", lambda self, clear=False: None)
     db = FakeDB()
     venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
     db._ventas.append(venta)
     db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
     tab.sales_table.setRowCount(1)
     tab.sales_table.setItem(0, 0, QTableWidgetItem("1"))
     tab.sales_table.selectRow(0)
@@ -87,7 +89,6 @@ def test_save_ticket_creates_json(qt_app, tmp_path):
     def fake_paths(date, cliente, identifier, doc_type, root=None):
         pdf_path.parent.mkdir(parents=True, exist_ok=True)
         return str(pdf_path), str(json_path)
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr("sales_tab.get_document_paths", fake_paths)
     monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)

--- a/tests/test_manual_invoice.py
+++ b/tests/test_manual_invoice.py
@@ -22,9 +22,10 @@ def qt_app():
     return app
 
 def test_manual_invoice_requires_selection(qt_app, monkeypatch):
+    monkeypatch.setattr(SalesTab, "show_sale", lambda self, clear=False: None)
     db = DB(":memory:")
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
 
     opened = {}
     def fake_exec(self):
@@ -74,10 +75,11 @@ def test_manual_invoice_consumidor_final_fields(qt_app):
 
 
 def test_preview_uses_stored_pdf(qt_app, tmp_path, monkeypatch):
+    monkeypatch.setattr(SalesTab, "show_sale", lambda self, clear=False: None)
     db = DB(":memory:")
     venta_id = db.add_venta("2024-01-01", 5)
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
     tab.sales_table.setRowCount(1)
     tab.sales_table.setItem(0, 0, QTableWidgetItem(str(venta_id)))
     tab.sales_table.selectRow(0)

--- a/tests/test_preview_cleanup.py
+++ b/tests/test_preview_cleanup.py
@@ -58,7 +58,7 @@ def test_preview_keeps_pdfs(qt_app, tmp_path, monkeypatch):
 
     monkeypatch.setattr("sales_tab.get_document_paths", fake_paths)
 
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
 
     pdf1 = tab._generate_invoice_pdf(1)
     pdf2 = tab._generate_invoice_pdf(2)

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -63,7 +63,7 @@ def _setup_tab(tmp_path, monkeypatch=None):
         monkeypatch.setattr(SalesTab, "_load_email_config", lambda self: None)
         monkeypatch.setattr(SalesTab, "_check_smtp_credentials", lambda self: {})
         monkeypatch.setattr(SalesTab, "show_sale", lambda self, clear=False: None)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
     tab.sales_table.setRowCount(1)
     tab.sales_table.setItem(0, 0, QTableWidgetItem("1"))
     return db, tab

--- a/tests/test_transmission_mode.py
+++ b/tests/test_transmission_mode.py
@@ -60,7 +60,7 @@ def test_generate_invoice_registers_pending(qt_app, tmp_path, monkeypatch):
     db._ventas.append(venta)
     db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
     man = Manager(db)
-    tab = SalesTab(man)
+    tab = SalesTab(man, check_smtp=False)
     pdf = tmp_path / "fact.pdf"
     js = tmp_path / "fact.json"
     def fake_paths(date, cliente, identifier, doc_type, root=None):


### PR DESCRIPTION
## Summary
- allow skipping SMTP credential checks when creating `SalesTab`
- suppress GUI warnings for missing SMTP data during headless runs
- adjust tests to disable SMTP checks

## Testing
- `pytest tests/test_invoice_json_save.py tests/test_manual_invoice.py tests/test_sales_tab_email.py tests/test_transmission_mode.py tests/test_date_parsing.py tests/test_preview_cleanup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689336f1db7c832393495c2f98e76b18