### PR TITLE
Usar diálogo no nativo para guardar ticket

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -550,7 +550,13 @@ class FacturacionTab(QWidget):
                 extra = json.loads(raw_extra)
             except Exception:
                 extra = {}
-        fname, _ = QFileDialog.getSaveFileName(self, "Guardar ticket", "ticket.pdf", "PDF (*.pdf)")
+        fname, _ = QFileDialog.getSaveFileName(
+            self,
+            "Guardar ticket",
+            "ticket.pdf",
+            "PDF (*.pdf)",
+            options=QFileDialog.DontUseNativeDialog,
+        )
         if not fname:
             return
         generar_ticket_personalizado(venta, detalles, fname, dte_data=extra)


### PR DESCRIPTION
## Summary
- Utiliza `QFileDialog.DontUseNativeDialog` en `create_ticket` para permitir pruebas headless

## Testing
- `pytest tests/test_facturacion_tab_actions.py::test_create_ticket_saves_files -q` *(no output; proceso se quedó sin finalizar)*

------
https://chatgpt.com/codex/tasks/task_e_68933c8116008323a03a80d83f72c1ab