### PR TITLE
Ordenar facturas priorizando ventas y tickets

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -248,10 +248,11 @@ class FacturacionTab(QWidget):
 
         rows.extend(self._find_orphan_documents())
 
-        # Sort invoices by date descending, leaving entries without a date in
-        # their original relative order
+        # Sort invoices, placing sales and tickets first, orphan documents at
+        # the end, and ordering by date descending with undated entries last
         rows.sort(
             key=lambda r: (
+                r.get("row_type") == "orphan",
                 r.get("_parsed_fecha") is None,
                 -(r.get("_parsed_fecha").toordinal() if r.get("_parsed_fecha") else 0),
             )


### PR DESCRIPTION
## Summary
- Ordena filas en `load_invoices` dando prioridad a ventas y tickets, dejando documentos huérfanos al final.

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_facturacion_tab_actions.py::test_create_ticket_saves_files -q` *(los tests no finalizaron: proceso colgado)*

------
https://chatgpt.com/codex/tasks/task_e_68934c6ab29c8323b121e8193d745d38