### PR TITLE
Handle existing workers when importing vendors

### DIFF
--- a/db.py
+++ b/db.py
@@ -623,27 +623,39 @@ class DB:
         codigo=None,
         dui=None,
         commit: bool = True,
+        trabajador_id=None,
     ):
         """Insert a new vendor.
 
         ``commit`` can be set to ``False`` when called inside an existing
         transaction to avoid committing after each insertion.
+
+        If ``trabajador_id`` is provided, the corresponding record in
+        ``trabajadores`` will be updated (and marked as vendor) instead of
+        inserting a new one.
         """
 
         if codigo is None:
             codigo = self.get_next_vendedor_codigo()
-        self.cursor.execute(
-            """
-            INSERT INTO trabajadores (codigo, nombre, dui, es_vendedor)
-            VALUES (?, ?, ?, 1)
-            """,
-            (codigo, nombre, dui),
-        )
-        trabajador_id = self.cursor.lastrowid
+
+        if trabajador_id is None:
+            self.cursor.execute(
+                """
+                INSERT INTO trabajadores (codigo, nombre, dui, es_vendedor)
+                VALUES (?, ?, ?, 1)
+                """,
+                (codigo, nombre, dui),
+            )
+            trabajador_id = self.cursor.lastrowid
+        else:
+            self.cursor.execute(
+                "UPDATE trabajadores SET codigo=?, nombre=?, dui=?, es_vendedor=1 WHERE id=?",
+                (codigo, nombre, dui, trabajador_id),
+            )
+
         self.cursor.execute(
             "INSERT INTO vendedores (id, codigo, nombre, dui, descripcion, Distribuidor_id) VALUES (?, ?, ?, ?, ?, ?)",
             (trabajador_id, codigo, nombre, dui, descripcion, Distribuidor_id),
-
         )
         if commit:
             self.conn.commit()

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -347,8 +347,9 @@ class InventoryManager:
                         t.get("codigo"),
                         t.get("dui"),
                         commit=False,
+                        trabajador_id=tid,
                     )
-                    vendedor_id_map[t.get("id")] = self.db.cursor.lastrowid
+                    vendedor_id_map[t.get("id")] = tid
 
             # Productos
             for p in data.get("productos", []):


### PR DESCRIPTION
## Summary
- allow `DB.add_vendedor` to update an existing worker via optional `trabajador_id`
- update inventory import to reuse worker rows for vendors and map correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ae53c8508323a33ffffd5e2754c9