### PR TITLE
Manejar errores al agregar vendedor

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -5,10 +5,17 @@ import json
 from datetime import datetime, timedelta
 import os
 import logging
+import sqlite3
 
 logger = logging.getLogger(__name__)
 
+
+class InventoryManagerError(Exception):
+    """Errores de dominio del administrador de inventario."""
+
+
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+
 
 class InventoryManager:
     def __init__(self, page_size=50):
@@ -606,7 +613,24 @@ class InventoryManager:
         self.refresh_data()
 
     def add_vendedor(self, nombre, Distribuidor_id=None, codigo=None, dui=None):
-        self.db.add_vendedor(nombre, descripcion="", Distribuidor_id=Distribuidor_id, codigo=codigo, dui=dui)
+        try:
+            self.db.add_vendedor(
+                nombre,
+                descripcion="",
+                Distribuidor_id=Distribuidor_id,
+                codigo=codigo,
+                dui=dui,
+            )
+        except sqlite3.IntegrityError as exc:
+            logger.exception("Error de integridad al agregar vendedor %s", nombre)
+            raise InventoryManagerError(
+                "No se pudo agregar el vendedor; el registro ya existe o los datos son inválidos."
+            ) from exc
+        except sqlite3.DatabaseError as exc:
+            logger.exception("Error de base de datos al agregar vendedor %s", nombre)
+            raise InventoryManagerError(
+                "Ocurrió un error de base de datos al agregar el vendedor."
+            ) from exc
 
         self.refresh_data()
 


### PR DESCRIPTION
## Summary
- Add domain-specific `InventoryManagerError` and SQLite import.
- Wrap vendor insertion in `add_vendedor` with defensive error handling and logging.

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6893ae7cc9c083239d992502efe04001