### PR TITLE
Handle DTE post errors

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -401,7 +401,7 @@ def _post_dte(url: str, token: str, jws_token: str) -> dict:
     try:
         return resp.json()
     except Exception:
-        return {"estado": "Transmitido", "sello": ""}
+        return {"estado": "Error", "detalle": resp.text}
 
 
 def transmitir_dte(
@@ -432,6 +432,7 @@ def transmitir_dte(
         respuesta = _post_dte(url, token, signed)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = respuesta.get("estado") or "Transmitido"
+        detalle = respuesta.get("detalle")
     except Exception:
         db.registrar_envio_dte(venta_id, modo, "Rechazado", "")
         raise
@@ -439,7 +440,10 @@ def transmitir_dte(
     db.registrar_envio_dte(venta_id, modo, estado, sello, json.dumps(respuesta, ensure_ascii=False))
     if sello:
         db.update_venta_extra(venta_id, {"selloRecibido": sello})
-    return {"estado": estado, "sello": sello}
+    res = {"estado": estado, "sello": sello}
+    if detalle:
+        res["detalle"] = detalle
+    return res
 
 
 def enviar_dte_a_hacienda(dte_json_firmado: dict) -> dict:
@@ -496,6 +500,7 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
             or respuesta.get("descripcionEstado")
             or "Transmitido"
         )
+        detalle = respuesta.get("detalle")
     except Exception:
         db.registrar_envio_dte(doc_id, modo, "Rechazado", "")
         raise
@@ -509,7 +514,10 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)
-    return {"estado": estado, "sello": sello}
+    res = {"estado": estado, "sello": sello}
+    if detalle:
+        res["detalle"] = detalle
+    return res
 
 
 def enviar_factura(db: DB, venta_id: int, modo: str = "normal") -> dict:
@@ -546,6 +554,7 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
             or respuesta.get("descripcionEstado")
             or "Transmitido"
         )
+        detalle = respuesta.get("detalle")
     except Exception:
         db.registrar_envio_dte(evento_id, "evento", "Rechazado", "")
         raise
@@ -559,7 +568,10 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)
-    return {"estado": estado, "sello": sello}
+    res = {"estado": estado, "sello": sello}
+    if detalle:
+        res["detalle"] = detalle
+    return res
 
 
 def enviar_evento_contingencia(db: DB, evento_id: int, data: dict) -> dict:

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -459,10 +459,15 @@ class FacturacionTab(QWidget):
         if dialog.hacienda_cb.isChecked():
             tipo = "03" if entry.get("row_type") == "ticket" else "01"
             try:
-                transmitir_dte(self.manager.db, venta_id, tipo_dte=tipo)
-                QMessageBox.information(
-                    self, "Enviar a Hacienda", "Documento enviado"
-                )
+                resp = transmitir_dte(self.manager.db, venta_id, tipo_dte=tipo)
+                if resp.get("estado") == "Error":
+                    QMessageBox.critical(
+                        self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                    )
+                else:
+                    QMessageBox.information(
+                        self, "Enviar a Hacienda", "Documento enviado"
+                    )
             except Exception as exc:
                 QMessageBox.critical(
                     self, "Enviar a Hacienda", str(exc)

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -686,15 +686,19 @@ class SalesTab(QWidget):
             modo = "contingencia" if venta.get("tipo_transmision", "").startswith("2") else "normal"
             resp = transmitir_dte(self.manager.db, venta_id, modo=modo, tipo_dte=tipo_dte)
             estado = (resp or {}).get("estado", "")
-            if estado.lower() != "rechazado":
-                self.status_label.setText("Estado actual: Enviado")
-                self.sent_label.setText(
-                    "Último envío: " + datetime.now().strftime("%Y-%m-%d %H:%M")
-                )
-            else:
+            if estado.lower() in ("rechazado", "error"):
                 self.status_label.setText("Estado actual: Error")
                 self.gen_label.setText(
                     "Generado: " + datetime.now().strftime("%Y-%m-%d %H:%M")
+                )
+                if estado.lower() == "error":
+                    QMessageBox.warning(
+                        self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                    )
+            else:
+                self.status_label.setText("Estado actual: Enviado")
+                self.sent_label.setText(
+                    "Último envío: " + datetime.now().strftime("%Y-%m-%d %H:%M")
                 )
         except Exception as e:
             self.status_label.setText("Estado actual: Error")

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -76,6 +76,25 @@ def test_post_dte_uses_bearer(monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer TOKEN"
 
 
+def test_post_dte_handles_non_json(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            text = "error"
+
+            def json(self):
+                raise ValueError("no json")
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    res = _post_dte("http://example.com", "", "SIGNED")
+    assert res == {"estado": "Error", "detalle": "error"}
+
+
 def test_consultar_envio_dte():
     db = DB(":memory:")
     venta = create_sale(db)


### PR DESCRIPTION
## Summary
- handle non-JSON responses from Hacienda by returning explicit `estado: Error` and detail
- surface error details in `transmitir_dte` callers
- test `_post_dte` error branch

## Testing
- `pytest tests/test_dte_transmision.py -q`
- `pytest tests/test_facturacion_tab_actions.py -q`
- `pytest tests/test_sales_tab_email.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c81fb5548323938c783963279b73