### PR TITLE
Refactor DTE transmission to accept pre-signed JWS

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -442,14 +442,17 @@ def transmitir_dte(
     return {"estado": estado, "sello": sello}
 
 
-def enviar_dte_a_hacienda(dte_json_firmado: dict) -> dict:
-    """Envía un DTE firmado al entorno de pruebas de Hacienda."""
+def enviar_dte_a_hacienda(jws_token: str) -> dict:
+    """Transmite un DTE ya firmado (JWS) al entorno de pruebas de Hacienda."""
     url = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
     cert, key, phrase = jws.get_cert_config()
-    jws_token = jws.sign_json(dte_json_firmado, cert, phrase, key)
     jwt_token = jws.create_auth_jwt("inventario", cert, phrase, key)
     respuesta = _post_dte(url, jwt_token, jws_token)
-    estado = respuesta.get("estado") or respuesta.get("estadoDte") or respuesta.get("descripcionEstado")
+    estado = (
+        respuesta.get("estado")
+        or respuesta.get("estadoDte")
+        or respuesta.get("descripcionEstado")
+    )
     if estado:
         respuesta["estado"] = estado
     return respuesta


### PR DESCRIPTION
## Summary
- Simplify `enviar_dte_a_hacienda` to transmit an already-signed JWS
- Update docstring and parameter to clarify expectations

## Testing
- `pytest tests/test_dte_transmision.py::test_post_dte_uses_bearer -q`
- `pytest tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c821554c8323a1075ef43eafa0d0