### PR TITLE
Fix worker vendor import to remap distributor IDs

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -347,6 +347,12 @@ class InventoryManager:
                 tid = self.db.cursor.lastrowid
                 trabajador_id_map[t.get("id")] = tid
                 if t.get("es_vendedor"):
+                    dist_id = t.get("Distribuidor_id")
+                    new_dist_id = (
+                        Distribuidor_id_map.get(dist_id)
+                        if dist_id is not None
+                        else None
+                    )
                     self.db.cursor.execute(
                         "INSERT INTO vendedores (id, codigo, nombre, dui, descripcion, Distribuidor_id) VALUES (?, ?, ?, ?, ?, ?)",
                         (
@@ -355,7 +361,7 @@ class InventoryManager:
                             t.get("nombre"),
                             t.get("dui"),
                             t.get("descripcion", ""),
-                            t.get("Distribuidor_id"),
+                            new_dist_id,
                         ),
 
                     )


### PR DESCRIPTION
## Summary
- map worker distributor IDs during JSON inventory import

## Testing
- `pytest tests/test_import_vendor_mapping.py tests/test_detalle_venta_vendedor.py tests/test_import_detalle_venta_trabajador.py tests/test_import_trabajador_sales.py tests/test_import_products_vendor.py tests/test_fiscal_sales_cleanup.py`

------
https://chatgpt.com/codex/tasks/task_e_6893d464accc832385d612297961e68a