### PR TITLE
Refactor settings footer into tab widget

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import (
     QDoubleSpinBox, QPushButton, QListWidget, QListWidgetItem, QMessageBox, QCheckBox, QRadioButton, QComboBox,
     QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
     QAbstractItemView, QTextEdit, QStackedLayout, QWidget, QHeaderView, QSizePolicy,
-    QFileDialog
+    QFileDialog, QTabWidget
 )
 from PyQt5.QtCore import Qt, QDate, QUrl
 from PyQt5.QtGui import QColor, QDesktopServices
@@ -2865,8 +2865,8 @@ class DatosNegocioDialog(QDialog):
         grupo3.setLayout(form3)
         h_layout.addWidget(grupo3)
 
-        # --- Grupo 4: Configuración de correo ---
-        grupo4 = QGroupBox("\ud83d\udce7 Configuraci\u00f3n de correo")
+        # --- Configuración de correo ---
+        tab_correo = QWidget()
         form4 = QFormLayout()
 
         # Proveedor de correo y configuraci\u00f3n SMTP predefinida
@@ -2890,7 +2890,7 @@ class DatosNegocioDialog(QDialog):
         form4.addRow("Puerto SMTP:", self.smtp_port)
         form4.addRow("Usuario:", self.email_usuario)
         form4.addRow("Contrase\u00f1a:", self.email_contrasena)
-        grupo4.setLayout(form4)
+        tab_correo.setLayout(form4)
 
         self.combo_email_provider.currentTextChanged.connect(
             self._update_smtp_fields
@@ -2898,8 +2898,8 @@ class DatosNegocioDialog(QDialog):
         self.email.textChanged.connect(self._update_user_field)
         self._update_smtp_fields()
 
-        # --- Grupo 5: Configuraci\u00f3n de Facturaci\u00f3n Electr\u00f3nica ---
-        grupo5 = QGroupBox("\ud83d\udcc3 Configuraci\u00f3n de Facturaci\u00f3n Electr\u00f3nica")
+        # --- Configuraci\u00f3n de Facturaci\u00f3n Electr\u00f3nica ---
+        tab_dte = QWidget()
         form5 = QFormLayout()
         self.dte_certificado = QLineEdit()
         self.btn_load_cert = QPushButton("...")
@@ -2949,17 +2949,20 @@ class DatosNegocioDialog(QDialog):
         form5.addRow(self.adjuntar_json_correo)
         form5.addRow(self.incluir_sello_pdf)
         form5.addRow(self.guardar_respuesta_bd)
-        grupo5.setLayout(form5)
+        tab_dte.setLayout(form5)
 
         self.btn_load_cert.clicked.connect(self._load_cert_file)
         self.btn_load_key.clicked.connect(self._load_key_file)
         self.btn_load_pub.clicked.connect(self._load_pub_file)
 
         main_layout.addLayout(h_layout)
-        footer_layout = QHBoxLayout()
-        footer_layout.addWidget(grupo4)
-        footer_layout.addWidget(grupo5)
-        main_layout.addLayout(footer_layout)
+        # Using a QTabWidget here instead of checkable QGroupBoxes or
+        # separate QDialog popups offers native tab switching and keeps
+        # related data in one place, simplifying state management.
+        tabs = QTabWidget()
+        tabs.addTab(tab_correo, "\ud83d\udce7 Configuraci\u00f3n de correo")
+        tabs.addTab(tab_dte, "\ud83d\udcc3 Configuraci\u00f3n de Facturaci\u00f3n Electr\u00f3nica")
+        main_layout.addWidget(tabs)
 
         # --- Botones ---
         btns = QHBoxLayout()


### PR DESCRIPTION
## Summary
- replace footer group boxes with a QTabWidget for email and DTE configuration
- note in comments that tabs were chosen over checkable group boxes or dialogs for simpler state management

## Testing
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6893d5962c088323b4816476713dc5f5