### PR TITLE
Use base directory for inventory paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,8 +5,9 @@ from PyQt5.QtWidgets import QApplication, QMessageBox
 from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow
 
-LAST_FILE_PATH = "ultimo_inventario.json"
-DEFAULT_INVENTORY = "inventario.json"
+BASE_DIR = os.path.dirname(__file__)
+LAST_FILE_PATH = os.path.join(BASE_DIR, "ultimo_inventario.json")
+DEFAULT_INVENTORY = os.path.join(BASE_DIR, "inventario.json")
 
 def cargar_ultimo_archivo():
     """Devuelve la ruta del inventario a cargar al iniciar la aplicación."""
@@ -20,9 +21,8 @@ def cargar_ultimo_archivo():
         except Exception:
             pass
 
-    default_path = os.path.join(os.path.dirname(__file__), DEFAULT_INVENTORY)
-    if os.path.exists(default_path):
-        return default_path
+    if os.path.exists(DEFAULT_INVENTORY):
+        return DEFAULT_INVENTORY
     return ""
 
 if __name__ == "__main__":

--- a/tests/test_main_cargar.py
+++ b/tests/test_main_cargar.py
@@ -17,13 +17,11 @@ def test_cargar_ultimo_archivo_default(tmp_path, monkeypatch):
     inv = tmp_path / "inv.json"
     inv.write_text("{}")
     monkeypatch.setattr(main, "LAST_FILE_PATH", str(tmp_path / "missing.json"))
-    monkeypatch.setattr(main, "DEFAULT_INVENTORY", inv.name)
-    monkeypatch.setattr(main, "__file__", str(tmp_path / "mod.py"))
+    monkeypatch.setattr(main, "DEFAULT_INVENTORY", str(inv))
     assert main.cargar_ultimo_archivo() == str(inv)
 
 
 def test_cargar_ultimo_archivo_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "LAST_FILE_PATH", str(tmp_path / "missing.json"))
-    monkeypatch.setattr(main, "DEFAULT_INVENTORY", "missing.json")
-    monkeypatch.setattr(main, "__file__", str(tmp_path / "mod.py"))
+    monkeypatch.setattr(main, "DEFAULT_INVENTORY", str(tmp_path / "missing.json"))
     assert main.cargar_ultimo_archivo() == ""


### PR DESCRIPTION
## Summary
- define `BASE_DIR` constant and use it for inventory file paths
- simplify `cargar_ultimo_archivo` by using constants directly
- update tests for new path behavior

## Testing
- `pytest tests/test_main_cargar.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68943b70fc2c8323800a1a33fdff3bc9