### PR TITLE
Fix inventory reset foreign key violation

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -950,11 +950,8 @@ class MainWindow(QMainWindow):
             QMessageBox.Yes | QMessageBox.No
         )
         if reply == QMessageBox.Yes:
-            self.manager.db.limpiar_productos()
-            self.manager.db.limpiar_vendedores()
-            self.manager.db.limpiar_Distribuidores()
-            self.manager.db.limpiar_ventas_credito_fiscal()
             try:
+                self.manager.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
                 self.manager.db.cursor.execute("DELETE FROM trabajadores")
                 self.manager.db.cursor.execute("DELETE FROM clientes")
                 self.manager.db.cursor.execute("DELETE FROM ventas")
@@ -965,6 +962,9 @@ class MainWindow(QMainWindow):
                 self.manager.db.conn.commit()
             except Exception:
                 pass
+            self.manager.db.limpiar_productos()
+            self.manager.db.limpiar_vendedores()
+            self.manager.db.limpiar_Distribuidores()
             # Reset last loaded inventory so old data is not reimported
             self.ultimo_archivo_json = None
             try:


### PR DESCRIPTION
## Summary
- Delete related sales and purchase records before clearing product tables to respect foreign key constraints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68943d73c35c8323901177652044e539