### PR TITLE
Refactor inventory cleanup logic

### DIFF
--- a/db.py
+++ b/db.py
@@ -1426,6 +1426,32 @@ class DB:
             "saldo": saldo,
         }
 
+    def limpiar_inventario(self):
+        """Elimina ventas, compras y movimientos de forma atómica.
+
+        Se utilizan transacciones explícitas para asegurar que si ocurre un
+        error al borrar alguna tabla el estado de la base de datos se
+        restablezca mediante ``ROLLBACK``.
+        """
+        with self.lock:
+            try:
+                self.cursor.execute("BEGIN")
+                for table in (
+                    "detalles_venta",
+                    "detalles_compra",
+                    "movimientos",
+                    "ventas",
+                    "compras",
+                    "ventas_credito_fiscal",
+                    "trabajadores",
+                    "clientes",
+                ):
+                    self.cursor.execute(f"DELETE FROM {table}")
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
     def limpiar_productos(self):
         self.cursor.execute("DELETE FROM productos")
         self.conn.commit()

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -951,17 +951,14 @@ class MainWindow(QMainWindow):
         )
         if reply == QMessageBox.Yes:
             try:
-                self.manager.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
-                self.manager.db.cursor.execute("DELETE FROM trabajadores")
-                self.manager.db.cursor.execute("DELETE FROM clientes")
-                self.manager.db.cursor.execute("DELETE FROM ventas")
-                self.manager.db.cursor.execute("DELETE FROM detalles_venta")
-                self.manager.db.cursor.execute("DELETE FROM compras")
-                self.manager.db.cursor.execute("DELETE FROM detalles_compra")
-                self.manager.db.cursor.execute("DELETE FROM movimientos")
-                self.manager.db.conn.commit()
-            except Exception:
-                pass
+                self.manager.db.limpiar_inventario()
+            except Exception as exc:
+                QMessageBox.warning(
+                    self,
+                    "Nuevo inventario",
+                    f"No se pudo limpiar la base de datos: {exc}",
+                )
+                return
             self.manager.db.limpiar_productos()
             self.manager.db.limpiar_vendedores()
             self.manager.db.limpiar_Distribuidores()


### PR DESCRIPTION
## Summary
- Add `DB.limpiar_inventario` to remove sales, purchase and movement records in a single transaction
- Use new database method from `MainWindow.nuevo_inventario` and warn user on failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894411e0df88323b4c1c4139a948637