### PR TITLE
Fix distributor dialog initialization

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2326,7 +2326,6 @@ class DistribuidorDialog(QDialog):
         self.direccion_edit = QLineEdit()
         self.departamento_edit = QLineEdit()
         self.municipio_edit = QLineEdit()
-        self._cliente_id = cliente.get("id") if cliente else None
         self.tipo_contrato_edit = QLineEdit()
         self.comisiones_especificas_edit = QLineEdit()
         self.metodo_pago_edit = QLineEdit()


### PR DESCRIPTION
## Summary
- remove obsolete `_cliente_id` assignment from `DistribuidorDialog`

## Testing
- `python dialogs: DistribuidorDialog` (offscreen)
- `pytest tests/test_cliente_dialog.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689449dc83f083238c005e6949f2cb16