### PR TITLE
Fix inventory import foreign key failures

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -266,10 +266,13 @@ class InventoryManager:
             self.db.cursor.execute("DELETE FROM ventas_credito_fiscal")
             self.db.cursor.execute("DELETE FROM dte_envios")
             self.db.cursor.execute("DELETE FROM notas")
+            self.db.cursor.execute("DELETE FROM facturas_pdf")
+            self.db.cursor.execute("DELETE FROM tickets_pdf")
             self.db.cursor.execute("DELETE FROM detalles_compra")
             self.db.cursor.execute("DELETE FROM ventas")
             self.db.cursor.execute("DELETE FROM compras")
             self.db.cursor.execute("DELETE FROM movimientos")
+            self.db.cursor.execute("DELETE FROM pagos")
             self.db.cursor.execute("DELETE FROM clientes")
             self.db.cursor.execute("DELETE FROM trabajadores")
 
@@ -278,10 +281,13 @@ class InventoryManager:
                 "ventas_credito_fiscal",
                 "dte_envios",
                 "notas",
+                "facturas_pdf",
+                "tickets_pdf",
                 "detalles_compra",
                 "ventas",
                 "compras",
                 "movimientos",
+                "pagos",
                 "clientes",
                 "trabajadores",
             ]

--- a/tests/test_import_inventory_cleanup.py
+++ b/tests/test_import_inventory_cleanup.py
@@ -1,0 +1,59 @@
+import json
+import inventory_manager as im
+
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+def _empty_inventory(path):
+    data = {
+        "Distribuidores": [],
+        "vendedores": [],
+        "productos": [],
+        "clientes": [],
+        "ventas": [],
+        "compras": [],
+        "movimientos": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "trabajadores": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+    p = path / "inv.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_import_inventory_clears_related_tables(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+    db = manager.db
+
+    cliente_id = db.add_cliente("Cliente", "", "", "", "", "", "", "", "", "")
+    prod_id = db.add_producto("Prod", "C1", None, None, 1, 2, 3, 5)
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cliente_id)
+    db.add_detalle_venta(venta_id, prod_id, 1, 10)
+
+    db.cursor.execute(
+        "INSERT INTO pagos (cliente_id, monto, fecha) VALUES (?, ?, ?)",
+        (cliente_id, 5, "2024-01-02"),
+    )
+    db.cursor.execute(
+        "INSERT INTO facturas_pdf (venta_id, tipo, ruta, fecha_creacion) VALUES (?, ?, ?, ?)",
+        (venta_id, "F", "ruta", "2024-01-01"),
+    )
+    db.cursor.execute(
+        "INSERT INTO tickets_pdf (venta_id, ruta, fecha_creacion) VALUES (?, ?, ?)",
+        (venta_id, "ruta", "2024-01-01"),
+    )
+    db.conn.commit()
+
+    path = _empty_inventory(tmp_path)
+    manager.importar_inventario_json(str(path))
+
+    for table in ["pagos", "facturas_pdf", "tickets_pdf", "ventas", "clientes"]:
+        db.cursor.execute(f"SELECT COUNT(*) FROM {table}")
+        assert db.cursor.fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- clear PDF, ticket and payment tables before importing inventory to avoid foreign key violations
- cover inventory import cleanup with regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d9fd3ee48323a8d4ee372fc01bdc