### PR TITLE
Fix duplicate trabajador import handling

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -349,8 +349,43 @@ class InventoryManager:
                 vendedor_id_map[vend["id"]] = new_id
 
             for t in data.get("trabajadores", []):
-                self.db.add_trabajador(t, commit=False)
-                tid = self.db.cursor.lastrowid
+                codigo = t.get("codigo")
+                existing = None
+                if codigo:
+                    self.db.cursor.execute(
+                        "SELECT id FROM trabajadores WHERE codigo=?",
+                        (codigo,),
+                    )
+                    existing = self.db.cursor.fetchone()
+                if existing:
+                    tid = existing["id"]
+                    self.db.cursor.execute(
+                        """
+                        UPDATE trabajadores SET
+                            nombre=?, dui=?, nit=?, fecha_nacimiento=?, cargo=?, area=?, fecha_contratacion=?,
+                            telefono=?, email=?, direccion=?, salario_base=?, comentarios=?, es_vendedor=?
+                        WHERE id=?
+                        """,
+                        (
+                            t.get("nombre", ""),
+                            t.get("dui", ""),
+                            t.get("nit", ""),
+                            t.get("fecha_nacimiento", ""),
+                            t.get("cargo", ""),
+                            t.get("area", ""),
+                            t.get("fecha_contratacion", ""),
+                            t.get("telefono", ""),
+                            t.get("email", ""),
+                            t.get("direccion", ""),
+                            t.get("salario_base", None),
+                            t.get("comentarios", ""),
+                            1 if t.get("es_vendedor") else 0,
+                            tid,
+                        ),
+                    )
+                else:
+                    self.db.add_trabajador(t, commit=False)
+                    tid = self.db.cursor.lastrowid
                 trabajador_id_map[t.get("id")] = tid
                 if t.get("es_vendedor"):
                     dist_id = t.get("Distribuidor_id")
@@ -360,17 +395,21 @@ class InventoryManager:
                         else None
                     )
                     self.db.cursor.execute(
-                        "INSERT INTO vendedores (id, codigo, nombre, dui, descripcion, Distribuidor_id) VALUES (?, ?, ?, ?, ?, ?)",
-                        (
-                            tid,
-                            t.get("codigo"),
-                            t.get("nombre"),
-                            t.get("dui"),
-                            t.get("descripcion", ""),
-                            new_dist_id,
-                        ),
-
+                        "SELECT 1 FROM vendedores WHERE id=?",
+                        (tid,),
                     )
+                    if not self.db.cursor.fetchone():
+                        self.db.cursor.execute(
+                            "INSERT INTO vendedores (id, codigo, nombre, dui, descripcion, Distribuidor_id) VALUES (?, ?, ?, ?, ?, ?)",
+                            (
+                                tid,
+                                t.get("codigo"),
+                                t.get("nombre"),
+                                t.get("dui"),
+                                t.get("descripcion", ""),
+                                new_dist_id,
+                            ),
+                        )
                     vendedor_id_map[t.get("id")] = tid
 
             # Productos

--- a/tests/test_import_trabajador_duplicates.py
+++ b/tests/test_import_trabajador_duplicates.py
@@ -1,0 +1,49 @@
+import json
+import inventory_manager as im
+
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+def _inventory_with_duplicate(path):
+    data = {
+        "Distribuidores": [],
+        "vendedores": [
+            {"id": 1, "nombre": "Vend", "codigo": "T1", "dui": "", "descripcion": ""}
+        ],
+        "productos": [],
+        "clientes": [],
+        "ventas": [],
+        "compras": [],
+        "movimientos": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "trabajadores": [
+            {"id": 1, "nombre": "Vend", "codigo": "T1", "dui": "", "es_vendedor": True},
+            {"id": 2, "nombre": "Trab", "codigo": "T2", "dui": ""},
+        ],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+    p = path / "inv.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_import_trabajador_duplicate_codigo(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+    path = _inventory_with_duplicate(tmp_path)
+
+    manager.importar_inventario_json(str(path))
+
+    trabajadores = manager.db.get_trabajadores()
+    codigos = {t["codigo"] for t in trabajadores}
+    assert codigos == {"T1", "T2"}
+    assert len(trabajadores) == 2
+
+    vendedores = manager.db.get_vendedores()
+    assert len(vendedores) == 1
+    assert vendedores[0]["codigo"] == "T1"


### PR DESCRIPTION
## Summary
- Avoid duplicate `trabajadores` entries by updating existing records when importing inventory
- Add regression test for importing workers with duplicate codes

## Testing
- `pytest tests/test_import_trabajador_duplicates.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894dcdd182c8323b6429d4493eedf60