### PR TITLE
feat: allow suppressing smtp warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ contraseña de la cuenta utilizada para enviar correos ya **no** se guarda en el
 archivo. En su lugar, define la variable de entorno `INVENTARIO_EMAIL_PASSWORD`
 con la contraseña correspondiente antes de ejecutar la aplicación.
 
+Si estás ejecutando pruebas automatizadas o no planeas enviar correos, puedes
+evitar la advertencia sobre credenciales incompletas estableciendo la variable
+de entorno `INVENTARIO_SUPPRESS_SMTP_WARNING=1` o iniciando `SalesTab` con
+`check_smtp=False`.
+
 Para firmar electrónicamente los DTE define los archivos de firma en
 `config_negocio.json` dentro del bloque `firma_electronica`:
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -423,6 +423,8 @@ class SalesTab(QWidget):
             "Credenciales SMTP incompletas. Configure sus datos en la opción 'Configuración de correo'."
         )
 
+        suppress = os.environ.get("INVENTARIO_SUPPRESS_SMTP_WARNING")
+
         def warn():
             if headless:
                 warnings.warn(msg)
@@ -430,13 +432,15 @@ class SalesTab(QWidget):
                 QMessageBox.warning(self, "Configuración de correo", msg)
 
         if not os.path.exists(path):
-            warn()
+            if not suppress:
+                warn()
             return None
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except Exception:
-            warn()
+            if not suppress:
+                warn()
             return None
 
         server = data.get("smtp_server")
@@ -453,7 +457,8 @@ class SalesTab(QWidget):
                 pass
 
         if not all([server, port, user, password]):
-            warn()
+            if not suppress:
+                warn()
             return None
 
         return {

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -1,8 +1,13 @@
 import os
+import warnings
 import pytest
 from PyQt5.QtWidgets import QApplication, QTableWidgetItem, QMessageBox
 
 from sales_tab import SalesTab
+
+warnings.filterwarnings(
+    "ignore", message="Credenciales SMTP incompletas.*"
+)
 
 
 class FakeDB:


### PR DESCRIPTION
## Summary
- add optional suppression of SMTP warning when running tests
- document how to configure SMTP credentials and disable warning
- silence SMTP warning in email tests

## Testing
- `pytest tests/test_sales_tab_email.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e33291108323a5cdaa0cabde922e