### PR TITLE
silence swig warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,17 @@
 import sys
 import os
 import json
+import warnings
+
+# Swig-generated types from external libraries (e.g. PyMuPDF) may emit
+# warnings about missing ``__module__`` attributes. Since these wrappers
+# live outside this repository, silence the warning to keep the console
+# clean until the dependencies are updated upstream.
+warnings.filterwarnings(
+    "ignore",
+    message=r".*(SwigPyObject|SwigPyPacked|swigvarlink).*__module__.*",
+)
+
 from PyQt5.QtWidgets import QApplication, QMessageBox
 from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+"""Test package configuration.
+
+This module configures warnings filtering for the test suite. Some of the
+dependencies used by the project expose SWIG-generated types (e.g. PyMuPDF)
+that currently lack the ``__module__`` attribute, which triggers warnings on
+recent Python versions. These warnings originate outside this repository, so
+they are silenced here to keep the test output focused on actionable issues.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=r".*(SwigPyObject|SwigPyPacked|swigvarlink).*__module__.*",
+)


### PR DESCRIPTION
## Summary
- silence Swig-generated wrapper warnings about missing __module__ attribute
- filter Swig warnings during tests to keep output clean

## Testing
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6894e332e600832390b94b2d8e181928