### PR TITLE
Add test for 401 token error during DTE transmission

### DIFF
--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -87,3 +87,73 @@ def test_firma_fallida_negativo(monkeypatch, tmp_path):
     ).fetchone()
     assert row["c"] == 0
     assert "called" not in called
+
+def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+
+    monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
+    monkeypatch.setattr("utils.jws.sign_json", lambda d, c, p, k: "SIGNED")
+    monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+
+    token_calls = []
+
+    def fake_get_token(refresh: bool = False):
+        token_calls.append(refresh)
+        return "JWT_VALIDO"
+
+    monkeypatch.setattr("auth.get_token", fake_get_token)
+
+    calls = {"auth": 0, "recepcion": 0}
+
+    class RespAuth:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "JWT_VALIDO"}
+
+        def raise_for_status(self):
+            pass
+
+    class Resp401:
+        status_code = 401
+        text = "TOKEN_INVALIDO"
+
+        def json(self):
+            return {"estado": "Rechazado", "descripcionMsg": self.text}
+
+        def raise_for_status(self):
+            raise requests.HTTPError(self.text)
+
+    def fake_post(url, *a, **k):
+        if "auth" in url:
+            calls["auth"] += 1
+            return RespAuth()
+        calls["recepcion"] += 1
+        return Resp401()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    monkeypatch.setattr("auth.requests.post", fake_post)
+
+    config = {
+        "ambiente": "pruebas",
+        "pruebas": {
+            "auth_url": "http://auth.example",
+            "recepcion_url": "http://recepcion.example",
+        },
+    }
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        transmitir_dte(db, venta)
+
+    assert "TOKEN_INVALIDO" in str(excinfo.value) or "401" in str(excinfo.value)
+    assert calls["recepcion"] <= 2
+    assert len(token_calls) <= 2
+
+    row = db.cursor.execute(
+        "SELECT estado, count(*) c FROM dte_envios WHERE venta_id=?", (venta,),
+    ).fetchone()
+    assert row["estado"] == "Rechazado"
+    assert row["c"] == 1


### PR DESCRIPTION
## Summary
- add test covering Hacienda reception returning 401 to ensure clear error and DB state

## Testing
- `pytest tests/test_envio_hacienda.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f8d831e08323bb697b725ad40e36