### PR TITLE
Add reusable database fixture for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+from db import DB
+
+@pytest.fixture(scope="function")
+def db_conn(tmp_path):
+    """Provide a fresh database connection for each test.
+
+    The database is created in a temporary location with foreign key
+    enforcement enabled. Schema setup and migrations run as part of ``DB``
+    initialization. The database file is removed after each test to ensure a
+    clean state.
+    """
+    db_path = tmp_path / "test.sqlite"
+    db = DB(str(db_path))
+    db.conn.execute("PRAGMA foreign_keys=ON")
+    yield db
+    db.conn.close()
+    if db_path.exists():
+        os.remove(db_path)

--- a/tests/test_get_venta_credito_fiscal.py
+++ b/tests/test_get_venta_credito_fiscal.py
@@ -1,19 +1,12 @@
 import pytest
 import json
-from db import DB
 
 
-def create_db():
-    return DB(":memory:")
+def test_get_venta_credito_fiscal_basic(db_conn):
+    db_conn.add_cliente("Juan", "123", "nit1", "", "giro", "", "", "", "", "")
+    cliente_id = db_conn.cursor.lastrowid
 
-
-
-def test_get_venta_credito_fiscal_basic():
-    db = create_db()
-    db.add_cliente("Juan", "123", "nit1", "", "giro", "", "", "", "", "")
-    cliente_id = db.cursor.lastrowid
-
-    venta_id = db.add_venta_credito_fiscal(
+    venta_id = db_conn.add_venta_credito_fiscal(
         cliente_id,
         "2024-01-01",
         100.0,
@@ -23,20 +16,19 @@ def test_get_venta_credito_fiscal_basic():
         descuentos=0,
     )
 
-    record = db.get_venta_credito_fiscal(venta_id)
+    record = db_conn.get_venta_credito_fiscal(venta_id)
     assert record is not None
     assert record["venta_id"] == venta_id
     assert record["cliente_id"] == cliente_id
     assert record["nrc"] == "123"
 
 
-def test_extra_is_json_string():
-    db = create_db()
-    db.add_cliente("Maria", "456", "nit2", "", "giro2", "", "", "", "", "")
-    cliente_id = db.cursor.lastrowid
+def test_extra_is_json_string(db_conn):
+    db_conn.add_cliente("Maria", "456", "nit2", "", "giro2", "", "", "", "", "")
+    cliente_id = db_conn.cursor.lastrowid
 
     extra = {"foo": "bar", "num": 1}
-    venta_id = db.add_venta_credito_fiscal(
+    venta_id = db_conn.add_venta_credito_fiscal(
         cliente_id,
         "2024-02-01",
         50.0,
@@ -47,11 +39,11 @@ def test_extra_is_json_string():
         extra=extra,
     )
 
-    db.cursor.execute(
+    db_conn.cursor.execute(
         "SELECT extra FROM ventas_credito_fiscal WHERE venta_id=?",
         (venta_id,),
     )
-    stored = db.cursor.fetchone()["extra"]
+    stored = db_conn.cursor.fetchone()["extra"]
     assert stored == json.dumps(extra)
 
    

--- a/tests/test_venta_extra.py
+++ b/tests/test_venta_extra.py
@@ -1,15 +1,12 @@
 import json
-from db import DB
 
 
-def create_db():
-    return DB(":memory:")
-
-
-def test_add_venta_with_extra_dict():
-    db = create_db()
-    venta_id = db.add_venta("2024-01-01", 100, extra={"note": "test", "flag": True})
-    ventas = db.get_ventas()
+def test_add_venta_with_extra_dict(db_conn):
+    """Ensure ``extra`` dicts are stored as JSON strings."""
+    venta_id = db_conn.add_venta(
+        "2024-01-01", 100, extra={"note": "test", "flag": True}
+    )
+    ventas = db_conn.get_ventas()
     assert len(ventas) == 1
     venta = ventas[0]
     assert venta["id"] == venta_id

--- a/tests/test_ventas_migration.py
+++ b/tests/test_ventas_migration.py
@@ -1,12 +1,12 @@
 import sqlite3
 import pytest
 
-from db import DB
 
-
-def test_ventas_cliente_fk_and_index(tmp_path):
-    db_path = tmp_path / "db.sqlite"
-    conn = sqlite3.connect(db_path)
+def test_ventas_cliente_fk_and_index(db_conn):
+    """Existing ``ventas`` tables are migrated to add missing constraints."""
+    conn = db_conn.conn
+    # Replace the automatically created table with one missing the cliente FK
+    conn.execute("DROP TABLE ventas")
     conn.execute(
         """
         CREATE TABLE ventas (
@@ -27,18 +27,18 @@ def test_ventas_cliente_fk_and_index(tmp_path):
         "INSERT INTO ventas (fecha, total, cliente_id) VALUES ('2024-01-01', 100, 1)"
     )
     conn.commit()
-    conn.close()
 
-    db = DB(str(db_path))
+    # Run migration on the fixture-provided DB instance
+    db_conn.migrate_ventas_cliente_fk()
 
-    db.cursor.execute("PRAGMA foreign_key_list(ventas)")
-    fks = db.cursor.fetchall()
+    db_conn.cursor.execute("PRAGMA foreign_key_list(ventas)")
+    fks = db_conn.cursor.fetchall()
     assert any(row[2] == "clientes" and row[3] == "cliente_id" for row in fks)
 
-    db.cursor.execute("PRAGMA index_list(ventas)")
-    idxs = [row[1] for row in db.cursor.fetchall()]
+    db_conn.cursor.execute("PRAGMA index_list(ventas)")
+    idxs = [row[1] for row in db_conn.cursor.fetchall()]
     assert "idx_ventas_cliente_id" in idxs
 
     with pytest.raises(sqlite3.IntegrityError):
-        db.add_venta("2024-02-01", 50, cliente_id=999)
+        db_conn.add_venta("2024-02-01", 50, cliente_id=999)
 


### PR DESCRIPTION
## Summary
- introduce `db_conn` fixture providing a clean SQLite DB with foreign keys enabled for each test
- refactor tests to use the shared fixture instead of ad-hoc connections

## Testing
- `pytest tests/test_venta_extra.py -q`
- `pytest tests/test_get_venta_credito_fiscal.py -q`
- `pytest tests/test_ventas_migration.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6898fecb7dd08323b9b1994b0f653762