### PR TITLE
Refactor email builder and add tests

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -31,6 +31,7 @@ from utils.docs import get_document_paths, build_invoice_json
 
 from utils.jws import get_cert_config, sign_and_save, CONFIG_NEGOCIO_PATH
 from utils.email_sender import EmailSender
+from utils.email_builder import build_email
 
 from ticket_pdf import generar_ticket_personalizado
 from dialogs import ManualInvoiceDialog
@@ -847,8 +848,10 @@ class SalesTab(QWidget):
             QMessageBox.warning(self, "Solo enviar por correo", "El cliente no tiene correo registrado.")
             return
 
-        subject = self.email_subject_edit.text().strip()
-        body = self.email_body_edit.toPlainText()
+        dte_meta = {
+            "subject": self.email_subject_edit.text(),
+            "body": self.email_body_edit.toPlainText(),
+        }
 
         credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
         if credito_info or venta.get("cliente_id"):
@@ -883,9 +886,13 @@ class SalesTab(QWidget):
         user = creds["user"]
         password = creds["password"]
 
-        body += (
-            "\n\nSe adjuntan la representaci\u00f3n gr\u00e1fica en PDF y el documento firmado en formato JSON."
+        email_data = build_email(
+            cliente_email,
+            dte_meta,
+            pdf_path,
+            json_path,
         )
+
         self.status_label.setText("Estado actual: Enviando...")
         self.retry_btn.setEnabled(False)
         self.btn_enviar.setEnabled(False)
@@ -895,10 +902,10 @@ class SalesTab(QWidget):
             port,
             user,
             password,
-            cliente_email,
-            subject,
-            body,
-            [pdf_path, json_path],
+            email_data["to"],
+            email_data["subject"],
+            email_data["body"],
+            email_data["attachments"],
         )
         self.email_thread.finished.connect(self._on_email_sent)
         self.email_thread.start()

--- a/tests/test_email_builder.py
+++ b/tests/test_email_builder.py
@@ -1,0 +1,19 @@
+import os
+
+from utils.email_builder import build_email
+
+
+def test_build_email_returns_components(tmp_path):
+    pdf = tmp_path / "doc.pdf"
+    json_file = tmp_path / "doc.json"
+    pdf.write_bytes(b"%PDF")
+    json_file.write_text("{}", encoding="utf-8")
+
+    meta = {"subject": " Subj ", "body": "Cuerpo"}
+    email = build_email("to@example.com", meta, str(pdf), str(json_file))
+
+    assert email["to"] == "to@example.com"
+    assert email["subject"] == "Subj"
+    assert email["attachments"] == [str(pdf), str(json_file)]
+    assert "Cuerpo" in email["body"]
+    assert "Se adjuntan" in email["body"]

--- a/utils/email_builder.py
+++ b/utils/email_builder.py
@@ -1,0 +1,36 @@
+"""Helper to build email data for sending DTE documents."""
+
+from typing import Dict, List
+
+
+def build_email(to: str, dte_meta: Dict, pdf_path: str, json_path: str) -> Dict[str, object]:
+    """Return a simple dictionary with the email components.
+
+    Parameters
+    ----------
+    to: str
+        Recipient email address.
+    dte_meta: Dict
+        Metadata containing at least ``subject`` and ``body`` keys. Additional
+        values are ignored. The subject is stripped of surrounding whitespace.
+    pdf_path: str
+        Path to the PDF representation of the document.
+    json_path: str
+        Path to the signed JSON document.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``to``, ``subject``, ``body`` and ``attachments`` keys.
+    """
+
+    subject = (dte_meta or {}).get("subject", "").strip()
+    body = (dte_meta or {}).get("body", "")
+    body += (
+        "\n\nSe adjuntan la representación gráfica en PDF y el documento firmado en formato JSON."
+    )
+    attachments: List[str] = []
+    for path in (pdf_path, json_path):
+        if path:
+            attachments.append(path)
+    return {"to": to, "subject": subject, "body": body, "attachments": attachments}


### PR DESCRIPTION
## Summary
- extract email composition logic into new `utils.email_builder.build_email`
- adjust `SalesTab` to use the pure helper and `EmailSender`
- add unit test `test_email_builder` to validate email structure without PyQt

## Testing
- `pytest tests/test_email_builder.py tests/test_sales_tab_email.py tests/test_envio_correo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6898fec3b8a48323aa3147beb79390d2