### PR TITLE
Close SQLite cursor before connection shutdown

### DIFF
--- a/db.py
+++ b/db.py
@@ -1146,6 +1146,7 @@ class DB:
         self.conn.commit()
 
     def close(self):
+        self.cursor.close()
         self.conn.close()
 
     def get_Distribuidor_info(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def db_conn(tmp_path):
     db = DB(str(db_path))
     db.conn.execute("PRAGMA foreign_keys=ON")
     yield db
-    db.conn.close()
+    db.close()
     if db_path.exists():
         os.remove(db_path)
 


### PR DESCRIPTION
## Summary
- Ensure `DB.close` closes the cursor before terminating the connection.
- Use `db.close()` in the `db_conn` fixture for proper cleanup.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899077f9664832391e7f758413fb078