### PR TITLE
Ensure SQLite test DB cleanup and close connections

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -19,19 +19,18 @@ def _read_db_credentials() -> Tuple[Optional[str], Optional[str]]:
     """Intenta obtener NIT y contraseña desde la tabla 'tokens'."""
     nit = pwd = None
     try:
-        conn = sqlite3.connect(DB_PATH)
-        cur = conn.cursor()
-        cur.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'"
-        )
-        if cur.fetchone():
-            cur.execute("SELECT value FROM tokens WHERE key='nit'")
-            row = cur.fetchone()
-            nit = row[0] if row else None
-            cur.execute("SELECT value FROM tokens WHERE key='pwd'")
-            row = cur.fetchone()
-            pwd = row[0] if row else None
-        conn.close()
+        with sqlite3.connect(DB_PATH) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'"
+            )
+            if cur.fetchone():
+                cur.execute("SELECT value FROM tokens WHERE key='nit'")
+                row = cur.fetchone()
+                nit = row[0] if row else None
+                cur.execute("SELECT value FROM tokens WHERE key='pwd'")
+                row = cur.fetchone()
+                pwd = row[0] if row else None
     except Exception:
         pass
     return nit, pwd
@@ -104,25 +103,24 @@ def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, float]:
 def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
     """Guarda el token y metadatos en la tabla 'tokens' si es posible."""
     try:
-        conn = sqlite3.connect(DB_PATH)
-        cur = conn.cursor()
-        cur.execute(
-            "CREATE TABLE IF NOT EXISTS tokens (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        cur.execute(
-            "INSERT OR REPLACE INTO tokens(key, value) VALUES('access_token', ?)",
-            (token,),
-        )
-        cur.execute(
-            "INSERT OR REPLACE INTO tokens(key, value) VALUES('expires_in', ?)",
-            (str(expires_in),),
-        )
-        cur.execute(
-            "INSERT OR REPLACE INTO tokens(key, value) VALUES('obtained_at', ?)",
-            (str(obtained_at),),
-        )
-        conn.commit()
-        conn.close()
+        with sqlite3.connect(DB_PATH) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS tokens (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            cur.execute(
+                "INSERT OR REPLACE INTO tokens(key, value) VALUES('access_token', ?)",
+                (token,),
+            )
+            cur.execute(
+                "INSERT OR REPLACE INTO tokens(key, value) VALUES('expires_in', ?)",
+                (str(expires_in),),
+            )
+            cur.execute(
+                "INSERT OR REPLACE INTO tokens(key, value) VALUES('obtained_at', ?)",
+                (str(obtained_at),),
+            )
+            conn.commit()
     except Exception:
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,51 @@
 import os
 import sys
+import time
+import gc
 
 import pytest
 from PyQt5.QtWidgets import QApplication
 
 from db import DB
 
+
 @pytest.fixture(scope="function")
 def db_conn(tmp_path):
-    """Provide a fresh database connection for each test.
-
-    The database is created in a temporary location with foreign key
-    enforcement enabled. Schema setup and migrations run as part of ``DB``
-    initialization. The database file is removed after each test to ensure a
-    clean state.
-    """
     db_path = tmp_path / "test.sqlite"
     db = DB(str(db_path))
     db.conn.execute("PRAGMA foreign_keys=ON")
     yield db
-    db.close()
-    if db_path.exists():
-        os.remove(db_path)
+    # Cerrar cursores conocidos
+    try:
+        try:
+            db.cursor.close()
+        except Exception:
+            pass
+        # Forzar checkpoint WAL y volver a DELETE para liberar locks
+        try:
+            db.conn.execute("PRAGMA wal_checkpoint(FULL)")
+            db.conn.execute("PRAGMA journal_mode=DELETE")
+        except Exception:
+            pass
+    finally:
+        try:
+            db.conn.close()
+        except Exception:
+            pass
+
+    # Forzar GC para soltar handles colgantes
+    gc.collect()
+
+    # Reintentar borrar el archivo en Windows
+    for _ in range(10):
+        try:
+            if db_path.exists():
+                os.remove(db_path)
+            break
+        except PermissionError:
+            time.sleep(0.2)
+    else:
+        print(f"WARNING: could not delete {db_path} (locked)")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_db_cleanup.py
+++ b/tests/test_db_cleanup.py
@@ -1,0 +1,10 @@
+import os
+from db import DB
+
+def test_db_file_removable(tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    db = DB(str(db_path))
+    db.conn.execute("PRAGMA foreign_keys=ON")
+    db.close()
+    os.remove(db_path)
+    assert not db_path.exists()


### PR DESCRIPTION
## Summary
- Add robust teardown for SQLite test database with WAL checkpoint and file deletion retries
- Use context-managed SQLite connections in auth helper
- Add smoke test verifying database files can be removed after closing

## Testing
- `pytest -vv -k test_ventas_cliente_fk_and_index --basetemp C:\temp\pytesttmp --maxfail=1`
- `pytest -vv tests/test_db_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_689920eb45ac8323a131b89176c954cd