### PR TITLE
Add robust temporary DB fixture and cleanup test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,41 +11,47 @@ from db import DB
 
 @pytest.fixture(scope="function")
 def db_conn(tmp_path):
+    """Provide a temporary database connection for tests.
+
+    The database lives in ``tmp_path`` and enforces foreign key constraints.
+    After the test the database is aggressively cleaned up so the file can be
+    removed even on platforms that keep file handles open briefly (e.g.
+    Windows).
+    """
+
     db_path = tmp_path / "test.sqlite"
     db = DB(str(db_path))
     db.conn.execute("PRAGMA foreign_keys=ON")
-    yield db
-    # Cerrar cursores conocidos
-    try:
-        try:
-            db.cursor.close()
-        except Exception:
-            pass
-        # Forzar checkpoint WAL y volver a DELETE para liberar locks
-        try:
-            db.conn.execute("PRAGMA wal_checkpoint(FULL)")
-            db.conn.execute("PRAGMA journal_mode=DELETE")
-        except Exception:
-            pass
-    finally:
-        try:
-            db.conn.close()
-        except Exception:
-            pass
+    # Expose path for tests that want to assert cleanup
+    db.db_path = db_path
 
-    # Forzar GC para soltar handles colgantes
+    yield db
+
+    # Ensure cursors are closed and checkpoints run so SQLite releases locks
+    try:
+        db.cursor.close()
+    except Exception:
+        pass
+    try:
+        db.conn.execute("PRAGMA wal_checkpoint(FULL)")
+        db.conn.execute("PRAGMA journal_mode=DELETE")
+    except Exception:
+        pass
+    try:
+        db.conn.close()
+    except Exception:
+        pass
+
     gc.collect()
 
-    # Reintentar borrar el archivo en Windows
+    # Retry removing the database file a few times (helps on Windows)
     for _ in range(10):
         try:
             if db_path.exists():
                 os.remove(db_path)
             break
-        except PermissionError:
-            time.sleep(0.2)
-    else:
-        print(f"WARNING: could not delete {db_path} (locked)")
+        except OSError:
+            time.sleep(0.1)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_db_cleanup.py
+++ b/tests/test_db_cleanup.py
@@ -1,10 +1,10 @@
 import os
-from db import DB
 
-def test_db_file_removable(tmp_path):
-    db_path = tmp_path / "test.sqlite"
-    db = DB(str(db_path))
-    db.conn.execute("PRAGMA foreign_keys=ON")
-    db.close()
+
+def test_db_file_removable(db_conn):
+    """The SQLite file can be removed after closing the connection."""
+
+    db_path = db_conn.db_path
+    db_conn.close()
     os.remove(db_path)
     assert not db_path.exists()


### PR DESCRIPTION
## Summary
- add `db_conn` fixture creating SQLite DB in `tmp_path` with foreign key checks
- ensure fixture teardown checkpoints WAL, resets journal mode, closes and GC, and retries file removal
- add smoke test verifying the database file is removable

## Testing
- `pytest tests/test_db_cleanup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68997bb343308323a4e69609cc8b9b82