### PR TITLE
test: mock network and email interactions

### DIFF
--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -67,9 +67,16 @@ def test_get_token_expired(monkeypatch, tmp_path):
 def test_request_error(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
 
+    calls = []
+
     def fake_post(url, data, headers, timeout):
+        calls.append((url, data, headers))
         raise requests.HTTPError("boom")
 
     monkeypatch.setattr(auth.requests, "post", fake_post)
     with pytest.raises(requests.HTTPError):
         auth.get_token(refresh=True)
+
+    assert len(calls) == 1
+    assert "user" in calls[0][1]
+    assert calls[0][2]["Content-Type"] == "application/x-www-form-urlencoded"

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -2,6 +2,7 @@ from db import DB
 from dte import transmitir_dte, _post_dte
 import json
 from datetime import datetime
+import pytest
 
 
 def create_sale(db):
@@ -25,32 +26,57 @@ def test_transmitir_dte_contingencia(tmp_path):
     assert row["estado"] == "Pendiente"
 
 
-def test_transmitir_dte_normal(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "ambiente,url",
+    [
+        ("pruebas", "http://example.com"),
+        ("produccion", "http://prod.example"),
+    ],
+)
+def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente, url):
     db = DB(":memory:")
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, cert, p, key: "SIGNED")
+    sign_calls = []
+
+    def fake_sign(data, cert, p, key):
+        sign_calls.append(data)
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
 
-    def fake_post(url, json=None, headers=None, timeout=20):
+    posts = []
+
+    def fake_post(url_called, json=None, headers=None, timeout=20):
+        posts.append((url_called, json, headers))
         class R:
             status_code = 200
+
             def json(self):
                 return {"estado": "Transmitido", "sello": "ABC123"}
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": ambiente, ambiente: {"recepcion_url": url}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     res = transmitir_dte(db, venta)
     assert res["estado"] == "Transmitido"
+    assert len(posts) == 1
+    assert posts[0][0] == url
+    assert posts[0][1] == {"dte": "SIGNED"}
+    assert posts[0][2]["Authorization"] == "Bearer JWT"
+    assert len(sign_calls) == 1
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
     ).fetchone()

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -90,10 +90,10 @@ def test_transmit_success_email_fail(qt_app, tmp_path, monkeypatch):
         return {"estado": "Transmitido"}
 
     monkeypatch.setattr("sales_tab.transmitir_dte", fake_transmitir)
-    send_called = {}
+    send_called = {"count": 0}
 
     def fake_send(self):
-        send_called["called"] = True
+        send_called["count"] += 1
         raise smtplib.SMTPException("fail")
 
     def fake_start(self):
@@ -112,7 +112,7 @@ def test_transmit_success_email_fail(qt_app, tmp_path, monkeypatch):
     tab.save_and_send()
     qt_app.processEvents()
 
-    assert send_called.get("called")
+    assert send_called["count"] == 1
     assert db.envios and db.envios[0]["estado"] == "Transmitido"
     assert pdf.exists()
 
@@ -139,9 +139,10 @@ def test_email_exitoso(qt_app, tmp_path, monkeypatch):
         lambda db_obj, venta_id, modo="normal", tipo_dte="01": {"estado": "Transmitido"},
     )
 
-    captured = {}
+    captured = {"count": 0}
 
     def fake_send(self):
+        captured["count"] += 1
         captured["to"] = self.to_addr
         captured["attachments"] = list(self.attachments)
         self.finished.emit(True, "ok")
@@ -159,6 +160,7 @@ def test_email_exitoso(qt_app, tmp_path, monkeypatch):
     tab.save_and_send()
     qt_app.processEvents()
 
+    assert captured["count"] == 1
     assert captured["to"] == "cli@example.com"
     assert {os.path.basename(p) for p in captured["attachments"]} == {
         "factura.pdf",

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pytest
 
 from db import DB
 from dte import (
@@ -20,12 +21,25 @@ def create_sale(db):
     return venta_id
 
 
-def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
+@pytest.mark.parametrize(
+    "ambiente,expected_url",
+    [
+        ("pruebas", "http://pruebas.example"),
+        ("produccion", "http://prod.example"),
+    ],
+)
+def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path, ambiente, expected_url):
     db = DB(":memory:")
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = []
+
+    def fake_sign(data, c, p, k):
+        sign_calls.append(data)
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
 
@@ -33,26 +47,36 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
         {"estado": "Rechazado", "descripcionMsg": "Error", "observaciones": ["campo"]},
         {"estado": "Transmitido", "sello": "ABC"},
     ]
+    posts = []
 
     def fake_post(url, json=None, headers=None, timeout=20):
+        posts.append((url, json, headers))
         data = responses.pop(0)
         class R:
             status_code = 200
+
             def json(self):
                 return data
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": ambiente, ambiente: {"recepcion_url": expected_url}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     caplog.set_level(logging.ERROR)
     res = enviar_factura(db, venta)
     assert res["estado"] == "Rechazado"
+    assert posts[0][0] == expected_url
+    assert posts[0][1] == {"dte": "SIGNED"}
+    assert posts[0][2]["Authorization"] == "Bearer JWT"
+    assert len(sign_calls) == 1
     assert "Error" in caplog.text and "campo" in caplog.text
     row = db.cursor.execute("SELECT count(*) c FROM dte_envios WHERE venta_id=?", (venta,)).fetchone()
     assert row["c"] == 1
@@ -60,8 +84,11 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     caplog.clear()
     res = enviar_factura(db, venta)
     assert res["estado"] == "Transmitido"
+    assert len(posts) == 2
+    assert posts[1][0] == expected_url
     row = db.cursor.execute("SELECT count(*) c FROM dte_envios WHERE venta_id=?", (venta,)).fetchone()
     assert row["c"] == 2
+    assert len(sign_calls) == 2
 
 
 def test_enviar_nota_credito(monkeypatch, tmp_path):
@@ -70,27 +97,44 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     nota_id = db.add_nota(venta, "credito", "2024-01-02", 10, "motivo")
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = []
+
+    def fake_sign(data, c, p, k):
+        sign_calls.append(data)
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
 
+    posts = []
+
     def fake_post(url, json=None, headers=None, timeout=20):
+        posts.append((url, json, headers))
         class R:
             status_code = 200
+
             def json(self):
                 return {"estado": "Transmitido", "sello": "XYZ"}
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     res = enviar_nota_credito(db, nota_id)
     assert res["estado"] == "Transmitido"
+    assert len(posts) == 1
+    assert posts[0][1] == {"dte": "SIGNED"}
+    assert posts[0][2]["Authorization"] == "Bearer JWT"
+    assert len(sign_calls) == 1
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (nota_id,)).fetchone()
     assert row["estado"] == "Transmitido"
 
@@ -100,31 +144,47 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     venta_id = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = []
+
+    def fake_sign(data, c, p, k):
+        sign_calls.append(data)
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
 
+    posts = []
+
     def fake_post(url, json=None, headers=None, timeout=20):
+        posts.append((url, json, headers))
         class R:
             status_code = 200
+
             def json(self):
                 return {
                     "estado": "Rechazado",
                     "descripcionMsg": "Fallo",
                     "observaciones": {"campo": "invalido"},
                 }
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     caplog.set_level(logging.ERROR)
     res = enviar_evento_contingencia(db, venta_id, {"id": venta_id})
     assert res["estado"] == "Rechazado"
+    assert posts[0][1] == {"dte": "SIGNED"}
+    assert posts[0][2]["Authorization"] == "Bearer JWT"
+    assert len(sign_calls) == 1
     assert "Fallo" in caplog.text and "campo: invalido" in caplog.text
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Rechazado"
@@ -135,26 +195,43 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     venta_id = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = []
+
+    def fake_sign(data, c, p, k):
+        sign_calls.append(data)
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
 
+    posts = []
+
     def fake_post(url, json=None, headers=None, timeout=20):
+        posts.append((url, json, headers))
         class R:
             status_code = 200
+
             def json(self):
                 return {"estado": "Transmitido", "sello": "SSS"}
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     res = enviar_evento_anulacion(db, venta_id, {"id": venta_id})
     assert res["estado"] == "Transmitido"
+    assert len(posts) == 1
+    assert posts[0][1] == {"dte": "SIGNED"}
+    assert posts[0][2]["Authorization"] == "Bearer JWT"
+    assert len(sign_calls) == 1
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Transmitido"
 

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import requests
+import json
 
 from db import DB
 from dte import transmitir_dte
@@ -17,7 +18,14 @@ def create_sale(db):
     return venta_id
 
 
-def test_transmision_exitosa(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "ambiente,recepcion_url",
+    [
+        ("pruebas", "http://recepcion.test"),
+        ("produccion", "http://recepcion.prod"),
+    ],
+)
+def test_transmision_exitosa(monkeypatch, tmp_path, ambiente, recepcion_url):
     db = DB(":memory:")
     monkeypatch.setattr(
         "dte._load_datos_negocio",
@@ -40,11 +48,10 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
 
-    captured = {}
+    sign_calls = []
 
     def fake_sign(data, c, p, k):
-        captured["data"] = data
-        captured["count"] = captured.get("count", 0) + 1
+        sign_calls.append(data)
         return "JWS_SIGNED"
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
@@ -58,8 +65,6 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     monkeypatch.setattr("auth.get_token", fake_token)
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
-    auth_url = "http://auth.test"
-    recepcion_url = "http://recepcion.test"
     calls = []
 
     class Resp:
@@ -77,23 +82,21 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     def fake_post(url, *a, **k):
         headers = k.get("headers", {})
         calls.append((url, headers, k.get("json")))
-        if url == auth_url:
-            return Resp({"access_token": "JWT"})
         if url == recepcion_url:
             return Resp({"estado": "Transmitido", "sello": "ABC123"})
         raise AssertionError(f"unexpected url {url}")
 
     monkeypatch.setattr("requests.post", fake_post)
 
-    cfg = {"ambiente": "pruebas", "pruebas": {"recepcion_url": recepcion_url}}
+    cfg = {"ambiente": ambiente, ambiente: {"recepcion_url": recepcion_url}}
     config_path = tmp_path / "cfg.json"
     config_path.write_text(json.dumps(cfg), encoding="utf-8")
     monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(config_path))
 
     transmitir_dte(db, venta)
 
-    assert captured.get("count") == 1
-    payload = captured["data"]
+    assert len(sign_calls) == 1
+    payload = sign_calls[0]
     assert payload["receptor"]["nombre"] == "Cliente"
     assert payload["receptor"]["nit"] == "0614-987654-321-0"
     assert payload["cuerpoDocumento"][0]["cantidad"] == 1
@@ -108,8 +111,10 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     assert payload["identificacion"]["tipoDte"] == "01"
 
     assert tokens["count"] == 1
-    recep = [c for c in calls if c[0] == recepcion_url]
-    assert recep[0][1]["Authorization"] == "Bearer JWT"
+    assert len(calls) == 1
+    assert calls[0][0] == recepcion_url
+    assert calls[0][1]["Authorization"] == "Bearer JWT"
+    assert calls[0][2] == {"dte": "JWS_SIGNED"}
 
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
@@ -141,9 +146,10 @@ def test_http_error_negativo(monkeypatch, tmp_path, status):
 
     monkeypatch.setattr("dte.requests.post", lambda *a, **k: Resp())
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     with pytest.raises(requests.HTTPError) as excinfo:
         transmitir_dte(db, venta)
@@ -176,9 +182,10 @@ def test_firma_fallida_negativo(monkeypatch, tmp_path):
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
-    with open("config_negocio.json", "w", encoding="utf-8") as fh:
-        json.dump(config, fh)
+    cfg = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr("dte.CONFIG_NEGOCIO_PATH", str(cfg_path))
 
     with pytest.raises(RuntimeError):
         transmitir_dte(db, venta)

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -80,9 +80,10 @@ def test_send_email_builds_message_and_marks_status(qt_app, tmp_path, monkeypatc
 
     monkeypatch.setattr(SalesTab, "_check_smtp_credentials", lambda self: {"server": "s", "port": 25, "user": "u", "password": "p"})
 
-    calls = {}
+    calls = {"count": 0}
 
     def fake_send(self):
+        calls["count"] += 1
         calls.update({"to": self.to_addr, "subject": self.subject, "body": self.body, "attachments": self.attachments})
         self.finished.emit(True, "ok")
 
@@ -95,6 +96,7 @@ def test_send_email_builds_message_and_marks_status(qt_app, tmp_path, monkeypatc
     tab.send_email()
     qt_app.processEvents()
 
+    assert calls["count"] == 1
     assert calls["subject"] == "Subject"
     assert calls["body"].startswith("Body")
     assert {os.path.basename(p) for p in calls["attachments"]} == {


### PR DESCRIPTION
## Summary
- use monkeypatch to intercept `requests.post`, `jws.sign_json` and email senders in tests
- verify URLs, payloads and headers per environment
- ensure mocked email flows track send attempts and attachments

## Testing
- `pytest tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio tests/test_envio_documentos.py::test_enviar_nota_credito tests/test_envio_documentos.py::test_enviar_evento_contingencia tests/test_envio_documentos.py::test_enviar_evento_anulacion tests/test_dte_transmision.py::test_transmitir_dte_normal tests/test_envio_hacienda.py::test_transmision_exitosa tests/test_envio_hacienda.py::test_http_error_negativo tests/test_envio_hacienda.py::test_firma_fallida_negativo tests/test_envio_hacienda.py::test_transmision_token_401_en_recepcion tests/test_sales_tab_email.py::test_send_email_builds_message_and_marks_status tests/test_envio_correo.py::test_transmit_success_email_fail tests/test_envio_correo.py::test_email_exitoso tests/test_auth_module.py::test_request_error -q` *(failed: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68997bb438ec83239c00a7a386521be8