### PR TITLE
Mock external services and validate requests

### DIFF
--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -2,6 +2,7 @@ from db import DB
 from dte import transmitir_dte, _post_dte
 import json
 from datetime import datetime
+import pytest
 
 
 def create_sale(db):
@@ -25,12 +26,19 @@ def test_transmitir_dte_contingencia(tmp_path):
     assert row["estado"] == "Pendiente"
 
 
-def test_transmitir_dte_normal(monkeypatch, tmp_path):
+@pytest.mark.parametrize("ambiente", ["pruebas", "produccion"])
+def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente):
     db = DB(":memory:")
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, cert, p, key: "SIGNED")
+    sign_calls = {"count": 0}
+
+    def fake_sign(data, cert, p, key):
+        sign_calls["count"] += 1
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
 
     token_calls = {"count": 0}
 
@@ -40,11 +48,20 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
 
     monkeypatch.setattr("auth.get_token", fake_get_token)
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
+    monkeypatch.setattr(
+        "dte.generar_dte_json",
+        lambda db_obj, vid: {
+            "receptor": {"nombre": "Cliente", "nit": "0614-987654-321-0"},
+            "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
+            "resumen": {"sumas": 10, "iva": 0, "totalPagar": 10},
+            "identificacion": {"tipoDte": "01"},
+        },
+    )
 
-    captured = {}
+    calls = []
 
     def fake_post(url, json=None, headers=None, timeout=20):
-        captured["headers"] = headers
+        calls.append((url, headers, json))
 
         class R:
             status_code = 200
@@ -59,14 +76,22 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+    config = {
+        "ambiente": ambiente,
+        ambiente: {"recepcion_url": f"http://{ambiente}.example.com"},
+    }
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
     res = transmitir_dte(db, venta)
     assert res["estado"] == "Transmitido"
     assert token_calls["count"] == 1
-    assert captured["headers"]["Authorization"] == "Bearer JWT"
+    assert sign_calls["count"] == 1
+    assert len(calls) == 1
+    url, headers, payload = calls[0]
+    assert url == f"http://{ambiente}.example.com"
+    assert headers["Authorization"] == "Bearer JWT"
+    assert payload == {"dte": "SIGNED"}
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
     ).fetchone()

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -25,28 +25,50 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = {"count": 0}
+
+    def fake_sign(data, c, p, k):
+        sign_calls["count"] += 1
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
+    monkeypatch.setattr(
+        "dte.generar_dte_json",
+        lambda db_obj, vid: {
+            "receptor": {"nombre": "Cliente"},
+            "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
+            "resumen": {"sumas": 10, "iva": 0, "totalPagar": 10},
+            "identificacion": {"tipoDte": "01"},
+        },
+    )
 
     responses = [
         {"estado": "Rechazado", "descripcionMsg": "Error", "observaciones": ["campo"]},
         {"estado": "Transmitido", "sello": "ABC"},
     ]
 
+    calls = []
+
     def fake_post(url, json=None, headers=None, timeout=20):
+        calls.append((url, headers, json))
         data = responses.pop(0)
+
         class R:
             status_code = 200
+
             def json(self):
                 return data
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
@@ -63,6 +85,13 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     row = db.cursor.execute("SELECT count(*) c FROM dte_envios WHERE venta_id=?", (venta,)).fetchone()
     assert row["c"] == 2
 
+    assert sign_calls["count"] == 2
+    assert len(calls) == 2
+    for url, headers, payload in calls:
+        assert url == "http://example.com"
+        assert payload == {"dte": "SIGNED"}
+        assert headers["Authorization"] == "Bearer JWT"
+
 
 def test_enviar_nota_credito(monkeypatch, tmp_path):
     db = DB(":memory:")
@@ -70,22 +99,44 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     nota_id = db.add_nota(venta, "credito", "2024-01-02", 10, "motivo")
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = {"count": 0}
+
+    def fake_sign(data, c, p, k):
+        sign_calls["count"] += 1
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
+    monkeypatch.setattr(
+        "dte.generar_nota_credito_json",
+        lambda db_obj, nid: {
+            "receptor": {"nombre": "Cliente"},
+            "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
+            "resumen": {"sumas": 10, "iva": 0, "totalPagar": 10},
+            "identificacion": {"tipoDte": "01"},
+        },
+    )
+
+    calls = []
 
     def fake_post(url, json=None, headers=None, timeout=20):
+        calls.append((url, headers, json))
+
         class R:
             status_code = 200
+
             def json(self):
                 return {"estado": "Transmitido", "sello": "XYZ"}
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
@@ -93,6 +144,12 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     assert res["estado"] == "Transmitido"
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (nota_id,)).fetchone()
     assert row["estado"] == "Transmitido"
+    assert sign_calls["count"] == 1
+    assert len(calls) == 1
+    url, headers, payload = calls[0]
+    assert url == "http://example.com"
+    assert payload == {"dte": "SIGNED"}
+    assert headers["Authorization"] == "Bearer JWT"
 
 
 def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
@@ -100,25 +157,38 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     venta_id = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = {"count": 0}
+
+    def fake_sign(data, c, p, k):
+        sign_calls["count"] += 1
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
 
+    calls = []
+
     def fake_post(url, json=None, headers=None, timeout=20):
+        calls.append((url, headers, json))
+
         class R:
             status_code = 200
+
             def json(self):
                 return {
                     "estado": "Rechazado",
                     "descripcionMsg": "Fallo",
                     "observaciones": {"campo": "invalido"},
                 }
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
@@ -128,6 +198,12 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     assert "Fallo" in caplog.text and "campo: invalido" in caplog.text
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Rechazado"
+    assert sign_calls["count"] == 1
+    assert len(calls) == 1
+    url, headers, payload = calls[0]
+    assert url == "http://example.com"
+    assert payload == {"dte": "SIGNED"}
+    assert headers["Authorization"] == "Bearer JWT"
 
 
 def test_enviar_evento_anulacion(monkeypatch, tmp_path):
@@ -135,21 +211,34 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     venta_id = create_sale(db)
 
     monkeypatch.setattr("utils.jws.get_cert_config", lambda: (None, None, None))
-    monkeypatch.setattr("utils.jws.sign_json", lambda data, c, p, k: "SIGNED")
+    sign_calls = {"count": 0}
+
+    def fake_sign(data, c, p, k):
+        sign_calls["count"] += 1
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
 
+    calls = []
+
     def fake_post(url, json=None, headers=None, timeout=20):
+        calls.append((url, headers, json))
+
         class R:
             status_code = 200
+
             def json(self):
                 return {"estado": "Transmitido", "sello": "SSS"}
+
             def raise_for_status(self):
                 pass
+
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
 
-    config = {"ambiente": "pruebas", "recepcion_url": {"pruebas": "http://example.com"}}
+    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
@@ -157,4 +246,10 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     assert res["estado"] == "Transmitido"
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Transmitido"
+    assert sign_calls["count"] == 1
+    assert len(calls) == 1
+    url, headers, payload = calls[0]
+    assert url == "http://example.com"
+    assert payload == {"dte": "SIGNED"}
+    assert headers["Authorization"] == "Bearer JWT"
 

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -48,7 +48,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
         return "JWS_SIGNED"
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-
+    
     tokens = {"count": 0}
 
     def fake_token():
@@ -57,6 +57,15 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
 
     monkeypatch.setattr("auth.get_token", fake_token)
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+    monkeypatch.setattr(
+        "dte.generar_dte_json",
+        lambda db_obj, vid: {
+            "receptor": {"nombre": "Cliente", "nit": "0614-987654-321-0"},
+            "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
+            "resumen": {"sumas": 10, "iva": 0, "totalPagar": 10},
+            "identificacion": {"tipoDte": "01"},
+        },
+    )
 
     auth_url = "http://auth.test"
     recepcion_url = "http://recepcion.test"
@@ -92,6 +101,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
 
     transmitir_dte(db, venta)
 
+    assert len(calls) == 1
     assert captured.get("count") == 1
     payload = captured["data"]
     assert payload["receptor"]["nombre"] == "Cliente"

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -80,10 +80,18 @@ def test_send_email_builds_message_and_marks_status(qt_app, tmp_path, monkeypatc
 
     monkeypatch.setattr(SalesTab, "_check_smtp_credentials", lambda self: {"server": "s", "port": 25, "user": "u", "password": "p"})
 
-    calls = {}
+    calls = {"count": 0}
 
     def fake_send(self):
-        calls.update({"to": self.to_addr, "subject": self.subject, "body": self.body, "attachments": self.attachments})
+        calls.update(
+            {
+                "to": self.to_addr,
+                "subject": self.subject,
+                "body": self.body,
+                "attachments": self.attachments,
+            }
+        )
+        calls["count"] += 1
         self.finished.emit(True, "ok")
 
     monkeypatch.setattr("utils.email_sender.EmailSender.send", fake_send, raising=False)
@@ -95,6 +103,7 @@ def test_send_email_builds_message_and_marks_status(qt_app, tmp_path, monkeypatc
     tab.send_email()
     qt_app.processEvents()
 
+    assert calls["count"] == 1
     assert calls["subject"] == "Subject"
     assert calls["body"].startswith("Body")
     assert {os.path.basename(p) for p in calls["attachments"]} == {


### PR DESCRIPTION
## Summary
- mock DTE submission tests using monkeypatch for signing and HTTP posts
- check payloads, headers and call counts for document and event transmissions
- parameterize transmission URL per environment and validate email sending

## Testing
- `pytest tests/test_envio_documentos.py tests/test_dte_transmision.py::test_transmitir_dte_normal tests/test_sales_tab_email.py::test_send_email_builds_message_and_marks_status tests/test_sales_tab_email.py::test_save_and_send_generates_files_and_registers tests/test_envio_hacienda.py::test_transmision_exitosa -q`

------
https://chatgpt.com/codex/tasks/task_e_68997dab070883239824c8e8e326ac25