### PR TITLE
refactor: centralize test data factories

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import gc
+import copy
 
 import pytest
 from PyQt5.QtWidgets import QApplication
@@ -58,3 +59,184 @@ def db_conn(tmp_path):
 def qt_app():
     os.environ["QT_QPA_PLATFORM"] = "offscreen"
     return QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture
+def cliente_factory():
+    def factory(**overrides):
+        data = {
+            "id": 1,
+            "nombre": "Cliente",
+            "codigo": "C001",
+            "email": "cli@example.com",
+            "nit": "0614-123456-102-3",
+            "nrc": "",
+        }
+        data.update(overrides)
+        return data
+
+    return factory
+
+
+@pytest.fixture
+def producto_factory():
+    def factory(**overrides):
+        data = {
+            "id": 1,
+            "nombre": "Producto",
+            "codigo": "P001",
+            "vendedor_id": 1,
+            "Distribuidor_id": 1,
+            "precio_compra": 0,
+            "precio_venta_minorista": 0,
+            "precio_venta_mayorista": 0,
+            "stock": 0,
+        }
+        data.update(overrides)
+        return data
+
+    return factory
+
+
+@pytest.fixture
+def venta_factory():
+    def factory(**overrides):
+        data = {
+            "id": 1,
+            "fecha": "2024-01-01",
+            "total": 10,
+            "cliente_id": 1,
+        }
+        data.update(overrides)
+        return data
+
+    return factory
+
+
+@pytest.fixture
+def dte_metadata_factory():
+    def factory(**overrides):
+        base = {
+            "identificacion": {
+                "version": 1,
+                "ambiente": "00",
+                "tipoDte": "01",
+                "numeroControl": "DTE-01-AB12CD34-000000000000001",
+                "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+                "tipoModelo": 1,
+                "tipoOperacion": 1,
+                "fecEmi": "2024-01-01",
+                "horEmi": "12:00:00",
+                "tipoMoneda": "USD",
+                "tipoContingencia": None,
+                "motivoContin": None,
+            },
+            "emisor": {
+                "nit": "06141404100016",
+                "nrc": "1234567",
+                "nombre": "Empresa SA",
+                "codActividad": "12345",
+                "descActividad": "Venta de productos",
+                "nombreComercial": "Empresa",
+                "tipoEstablecimiento": "01",
+                "direccion": {
+                    "departamento": "01",
+                    "municipio": "01",
+                    "complemento": "Calle 1",
+                },
+                "telefono": "22223333",
+                "correo": "info@empresa.com",
+                "codEstableMH": "0001",
+                "codEstable": "0001",
+                "codPuntoVentaMH": "0001",
+                "codPuntoVenta": "0001",
+            },
+            "receptor": {
+                "tipoDocumento": "36",
+                "numDocumento": "06141404100016",
+                "nrc": "7654321",
+                "nombre": "Cliente",
+                "codActividad": "12345",
+                "descActividad": "Compra de productos",
+                "direccion": {
+                    "departamento": "01",
+                    "municipio": "01",
+                    "complemento": "Calle 2",
+                },
+                "telefono": "22223333",
+                "correo": "cliente@example.com",
+            },
+            "cuerpoDocumento": [
+                {
+                    "numItem": 1,
+                    "tipoItem": 1,
+                    "numeroDocumento": "DOC1",
+                    "codigo": "P1",
+                    "cantidad": 1,
+                    "uniMedida": 1,
+                    "descripcion": "Producto",
+                    "precioUni": 10.0,
+                    "montoDescu": 0,
+                    "ventaNoSuj": 0,
+                    "ventaExenta": 0,
+                    "ventaGravada": 10.0,
+                    "codTributo": None,
+                    "tributos": ["D5"],
+                    "psv": 0,
+                    "noGravado": 0,
+                    "ivaItem": 0,
+                }
+            ],
+            "resumen": {
+                "totalNoSuj": 0,
+                "totalExenta": 0,
+                "totalGravada": 10.0,
+                "subTotalVentas": 10.0,
+                "descuNoSuj": 0,
+                "descuExenta": 0,
+                "descuGravada": 0,
+                "porcentajeDescuento": 0,
+                "totalDescu": 0,
+                "tributos": [{"codigo": "D5", "descripcion": "IVA", "valor": 0}],
+                "subTotal": 10.0,
+                "ivaRete1": 0,
+                "reteRenta": 0,
+                "montoTotalOperacion": 10.0,
+                "totalNoGravado": 0,
+                "totalPagar": 10.0,
+                "totalLetras": "diez",
+                "totalIva": 0,
+                "saldoFavor": 0,
+                "condicionOperacion": 1,
+                "pagos": [
+                    {
+                        "codigo": "01",
+                        "montoPago": 10.0,
+                        "referencia": "efectivo",
+                        "periodo": None,
+                        "plazo": None,
+                    }
+                ],
+                "numPagoElectronico": None,
+            },
+            "documentoRelacionado": None,
+            "otrosDocumentos": None,
+            "ventaTercero": None,
+            "extension": None,
+            "apendice": None,
+        }
+        merged = copy.deepcopy(base)
+        for key, value in overrides.items():
+            merged[key] = value
+        return merged
+
+    return factory
+
+
+@pytest.fixture
+def pdf_json_files(tmp_path):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    json_path = pdf.with_suffix(".json")
+    json_path.write_text("{}", encoding="utf-8")
+    return pdf, json_path

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -2,132 +2,29 @@ import pytest
 from dte import validate_dte_json
 
 
-def sample_dte():
-    return {
-        "identificacion": {
-            "version": 1,
-            "ambiente": "00",
-            "tipoDte": "01",
-            "numeroControl": "DTE-01-AB12CD34-000000000000001",
-            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
-            "tipoModelo": 1,
-            "tipoOperacion": 1,
-            "fecEmi": "2024-01-01",
-            "horEmi": "12:00:00",
-            "tipoMoneda": "USD",
-            "tipoContingencia": None,
-            "motivoContin": None,
-        },
-        "emisor": {
-            "nit": "06141404100016",
-            "nrc": "1234567",
-            "nombre": "Empresa SA",
-            "codActividad": "12345",
-            "descActividad": "Venta de productos",
-            "nombreComercial": "Empresa",
-            "tipoEstablecimiento": "01",
-            "direccion": {
-                "departamento": "01",
-                "municipio": "01",
-                "complemento": "Calle 1",
-            },
-            "telefono": "22223333",
-            "correo": "info@empresa.com",
-            "codEstableMH": "0001",
-            "codEstable": "0001",
-            "codPuntoVentaMH": "0001",
-            "codPuntoVenta": "0001",
-        },
-        "receptor": {
-            "tipoDocumento": "36",
-            "numDocumento": "06141404100016",
-            "nrc": "7654321",
-            "nombre": "Cliente",
-            "codActividad": "12345",
-            "descActividad": "Compra de productos",
-            "direccion": {
-                "departamento": "01",
-                "municipio": "01",
-                "complemento": "Calle 2",
-            },
-            "telefono": "22223333",
-            "correo": "cliente@example.com",
-        },
-        "cuerpoDocumento": [
-            {
-                "numItem": 1,
-                "tipoItem": 1,
-                "numeroDocumento": "DOC1",
-                "codigo": "P1",
-                "cantidad": 1,
-                "uniMedida": 1,
-                "descripcion": "Producto",
-                "precioUni": 10.0,
-                "montoDescu": 0,
-                "ventaNoSuj": 0,
-                "ventaExenta": 0,
-                "ventaGravada": 10.0,
-                "codTributo": None,
-                "tributos": ["D5"],
-                "psv": 0,
-                "noGravado": 0,
-                "ivaItem": 0,
-            }
-        ],
-        "resumen": {
-            "totalNoSuj": 0,
-            "totalExenta": 0,
-            "totalGravada": 10.0,
-            "subTotalVentas": 10.0,
-            "descuNoSuj": 0,
-            "descuExenta": 0,
-            "descuGravada": 0,
-            "porcentajeDescuento": 0,
-            "totalDescu": 0,
-            "tributos": [{"codigo": "D5", "descripcion": "IVA", "valor": 0}],
-            "subTotal": 10.0,
-            "ivaRete1": 0,
-            "reteRenta": 0,
-            "montoTotalOperacion": 10.0,
-            "totalNoGravado": 0,
-            "totalPagar": 10.0,
-            "totalLetras": "diez",
-            "totalIva": 0,
-            "saldoFavor": 0,
-            "condicionOperacion": 1,
-            "pagos": [{"codigo": "01", "montoPago": 10.0, "referencia": "efectivo", "periodo": None, "plazo": None}],
-            "numPagoElectronico": None,
-        },
-        "documentoRelacionado": None,
-        "otrosDocumentos": None,
-        "ventaTercero": None,
-        "extension": None,
-        "apendice": None,
-    }
-
-
-def test_dte_valido_pasa():
-    dte = sample_dte()
+def test_dte_valido_pasa(dte_metadata_factory):
+    dte = dte_metadata_factory()
     validate_dte_json(dte)
 
 
-def test_codigo_invalido_rechazado():
-    dte = sample_dte()
+def test_codigo_invalido_rechazado(dte_metadata_factory):
+    dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = "99"
     with pytest.raises(ValueError):
         validate_dte_json(dte)
 
 
-def test_longitud_nit_invalida():
-    dte = sample_dte()
+def test_longitud_nit_invalida(dte_metadata_factory):
+    dte = dte_metadata_factory()
     dte["emisor"]["nit"] = "123"
     with pytest.raises(ValueError):
         validate_dte_json(dte)
 
 
-def test_estructura_invalida():
+def test_estructura_invalida(dte_metadata_factory):
     from jsonschema import ValidationError
-    dte = sample_dte()
+
+    dte = dte_metadata_factory()
     del dte["emisor"]["nit"]
     with pytest.raises(ValidationError):
         validate_dte_json(dte)

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -62,36 +62,37 @@ class Manager:
         self._Distribuidores = []
         self._clientes = []
         self._vendedores = []
+    
 
-def _setup_tab(tmp_path, monkeypatch=None):
+def _setup_tab(venta, cliente, producto, monkeypatch=None):
     db = FakeDB()
-    venta = {"id": 1, "fecha": "2024-01-01", "total": 10, "cliente_id": 1}
     db._ventas.append(venta)
-    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    db.detalles[venta["id"]] = [{**producto, "cantidad": 1, "precio_unitario": 10}]
     man = Manager(db)
-    man._clientes.append({"id": 1, "email": "cli@example.com", "nombre": "C"})
+    man._clientes.append(cliente)
     if monkeypatch:
         monkeypatch.setattr(SalesTab, "load_sales", lambda self: None)
         monkeypatch.setattr(SalesTab, "_load_email_config", lambda self: None)
         monkeypatch.setattr(SalesTab, "show_sale", lambda self, clear=False: None)
     tab = SalesTab(man, check_smtp=False)
     tab.sales_table.setRowCount(1)
-    tab.sales_table.setItem(0, 0, QTableWidgetItem("1"))
+    tab.sales_table.setItem(0, 0, QTableWidgetItem(str(venta["id"])))
     return db, tab
 
 
-@pytest.fixture
-def temp_invoice_files(tmp_path):
-    pdf = tmp_path / "factura.pdf"
-    pdf.write_bytes(b"%PDF")
-    json_file = pdf.with_suffix(".json")
-    json_file.write_text("{}", encoding="utf-8")
-    return pdf, json_file
-
-
-def test_transmit_success_email_fail(qt_app, tmp_path, temp_invoice_files, monkeypatch):
-    db, tab = _setup_tab(tmp_path, monkeypatch)
-    pdf, _json = temp_invoice_files
+def test_transmit_success_email_fail(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    pdf, _json = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
 
     def fake_gen(manager, vid, p=pdf):
         manager.db.add_factura_pdf(vid, "Factura", str(p))
@@ -158,9 +159,19 @@ def test_transmit_success_email_fail(qt_app, tmp_path, temp_invoice_files, monke
     assert not smtp_calls
 
 
-def test_email_exitoso(qt_app, tmp_path, temp_invoice_files, monkeypatch):
-    db, tab = _setup_tab(tmp_path, monkeypatch)
-    pdf, _json = temp_invoice_files
+def test_email_exitoso(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    pdf, _json = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
     tab.email_subject_edit.setText("Factura enviada")
 
     def fake_gen(manager, vid, p=pdf):
@@ -222,8 +233,8 @@ def test_email_exitoso(qt_app, tmp_path, temp_invoice_files, monkeypatch):
     assert captured["to"] == "cli@example.com"
     assert captured["subject"] == "Factura enviada"
     assert {os.path.basename(p) for p in captured["attachments"]} == {
-        "factura.pdf",
-        "factura.json",
+        pdf.name,
+        pdf.with_suffix(".json").name,
     }
     assert db.saved == (1, "Factura", str(pdf))
     assert len(init_calls) == 1

--- a/tests/test_import_products_vendor.py
+++ b/tests/test_import_products_vendor.py
@@ -1,30 +1,31 @@
 import json
 import inventory_manager as im
 
+
 class MemoryDB(im.DB):
     def __init__(self):
         super().__init__(db_name=":memory:")
 
-def test_import_product_vendor_mapping(tmp_path, monkeypatch):
+
+def test_import_product_vendor_mapping(tmp_path, monkeypatch, producto_factory):
     monkeypatch.setattr(im, "DB", MemoryDB)
     manager = im.InventoryManager()
 
+    producto = producto_factory(
+        id=10,
+        nombre="P1",
+        codigo="C1",
+        vendedor_id=5,
+        Distribuidor_id=1,
+        precio_compra=0,
+        precio_venta_minorista=0,
+        precio_venta_mayorista=0,
+        stock=3,
+    )
     data = {
         "Distribuidores": [{"id": 1, "nombre": "D1"}],
         "vendedores": [{"id": 5, "nombre": "V1", "Distribuidor_id": 1, "codigo": "V001"}],
-        "productos": [
-            {
-                "id": 10,
-                "nombre": "P1",
-                "codigo": "C1",
-                "vendedor_id": 5,
-                "Distribuidor_id": 1,
-                "precio_compra": 0,
-                "precio_venta_minorista": 0,
-                "precio_venta_mayorista": 0,
-                "stock": 3,
-            }
-        ],
+        "productos": [producto],
     }
     path = tmp_path / "inv.json"
     path.write_text(json.dumps(data))

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -48,13 +48,13 @@ class Manager:
         self._clientes = []
         self._vendedores = []
 
-def _setup_tab(tmp_path, monkeypatch=None):
+
+def _setup_tab(venta, cliente, producto, monkeypatch=None):
     db = FakeDB()
-    venta = {"id": 1, "fecha": "2024-01-01", "total": 10, "cliente_id": 1}
     db._ventas.append(venta)
-    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    db.detalles[venta["id"]] = [{**producto, "cantidad": 1, "precio_unitario": 10}]
     man = Manager(db)
-    man._clientes.append({"id": 1, "email": "cli@example.com", "nombre": "C"})
+    man._clientes.append(cliente)
     if monkeypatch:
         monkeypatch.setattr(SalesTab, "load_sales", lambda self: None)
         monkeypatch.setattr(SalesTab, "_load_email_config", lambda self: None)
@@ -62,15 +62,23 @@ def _setup_tab(tmp_path, monkeypatch=None):
         monkeypatch.setattr(SalesTab, "show_sale", lambda self, clear=False: None)
     tab = SalesTab(man, check_smtp=False)
     tab.sales_table.setRowCount(1)
-    tab.sales_table.setItem(0, 0, QTableWidgetItem("1"))
+    tab.sales_table.setItem(0, 0, QTableWidgetItem(str(venta["id"])))
     return db, tab
 
 
-def test_send_email_builds_message_and_marks_status(qt_app, tmp_path, monkeypatch):
-    db, tab = _setup_tab(tmp_path, monkeypatch)
-    pdf = tmp_path / "fact.pdf"
-    pdf.write_bytes(b"%PDF-1.4")
-    pdf.with_suffix(".json").write_text("{}", encoding="utf-8")
+def test_send_email_builds_message_and_marks_status(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    pdf, json_path = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
     db.factura_path = str(pdf)
 
     tab.sales_table.selectRow(0)
@@ -107,18 +115,28 @@ def test_send_email_builds_message_and_marks_status(qt_app, tmp_path, monkeypatc
     assert calls["subject"] == "Subject"
     assert calls["body"].startswith("Body")
     assert {os.path.basename(p) for p in calls["attachments"]} == {
-        "fact.pdf",
-        "fact.json",
+        pdf.name,
+        json_path.name,
     }
 
 
-def test_save_and_send_generates_files_and_registers(qt_app, tmp_path, monkeypatch):
-    db, tab = _setup_tab(tmp_path, monkeypatch)
-    pdf = tmp_path / "doc.pdf"
+def test_save_and_send_generates_files_and_registers(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    pdf, json_path = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
 
     def fake_gen(manager, vid):
         pdf.write_bytes(b"%PDF")
-        pdf.with_suffix(".json").write_text("{}", encoding="utf-8")
+        json_path.write_text("{}", encoding="utf-8")
         manager.db.add_factura_pdf(vid, "Factura", str(pdf))
         return str(pdf)
 


### PR DESCRIPTION
## Summary
- add factories for clients, products, sales, DTE metadata, and temp PDF/JSON files
- refactor tests to use factories instead of inline data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68998acbe6fc8323bde9fabf384d7182