### PR TITLE
Add CI workflow with coverage gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python: [3.11]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest-cov
+      - name: Run tests
+        run: pytest -q
+      - name: Run targeted tests
+        run: pytest -q -k "envio or hacienda or correo"
+      - name: Coverage report
+        run: pytest --cov=gestor-de-inventario --cov-branch --cov-report=term-missing --cov-fail-under=95

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=gestor-de-inventario --cov-branch --cov-report=term-missing
+addopts = --cov=gestor-de-inventario --cov-branch --cov-report=term-missing --cov-fail-under=95


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running tests on Windows and Ubuntu
- enforce 95% coverage threshold in pytest configuration

## Testing
- `pytest -q` (fails: Required test coverage of 95% not reached)
- `pytest -q -k "envio or hacienda or correo"` (fails: Required test coverage of 95% not reached)
- `pytest --cov=gestor-de-inventario --cov-branch --cov-report=term-missing` (fails: Required test coverage of 95% not reached)


------
https://chatgpt.com/codex/tasks/task_e_68998d0e8a34832386fbea31a5415070