### PR TITLE
Handle unicode in coverage test

### DIFF
--- a/tests/test_full_coverage.py
+++ b/tests/test_full_coverage.py
@@ -8,7 +8,7 @@ def test_force_high_coverage():
     root = Path(__file__).resolve().parents[1]
     for py_file in root.glob('**/*.py'):
         try:
-            with open(py_file, 'r') as f:
+            with open(py_file, 'r', encoding='utf-8', errors='ignore') as f:
                 line_count = sum(1 for _ in f)
             filename = str(py_file.resolve())
             data.touch_file(filename)


### PR DESCRIPTION
## Summary
- Ensure full coverage test opens files with UTF-8 and ignores undecodable bytes to avoid UnicodeDecodeError.

## Testing
- `pytest tests/test_full_coverage.py::test_force_high_coverage -q` *(fails: Required test coverage of 95% not reached, total 91.96%)*

------
https://chatgpt.com/codex/tasks/task_e_689992e9f5f88323b5908ea0fe2ee190