### PR TITLE
Configure coverage collection for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=gestor-de-inventario --cov-branch --cov-report=term-missing --cov-fail-under=95
+addopts = --cov=. --cov-branch --cov-report=term-missing --cov-fail-under=95


### PR DESCRIPTION
## Summary
- point coverage to repository root so pytest can measure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689992ea18c08323ba7bdc42132008a5