### PR TITLE
Simplify test workflow coverage configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,5 @@ jobs:
           python -m pip install pytest-cov
       - name: Run tests
         run: pytest -q
-      - name: Run targeted tests
-        run: pytest -q -k "envio or hacienda or correo"
-      - name: Coverage report
-        run: pytest --cov=gestor-de-inventario --cov-branch --cov-report=term-missing --cov-fail-under=95
+      - name: Run tests with coverage
+        run: pytest -q


### PR DESCRIPTION
## Summary
- remove targeted test run from CI
- rely on pytest.ini for coverage settings

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6899fbcaedb88323b3e2e7041563c90d