### PR TITLE
Add smoke tests for module imports

### DIFF
--- a/tests/test_add_product_indexes_smoke.py
+++ b/tests/test_add_product_indexes_smoke.py
@@ -1,0 +1,5 @@
+import add_product_indexes
+
+
+def test_add_product_indexes_imports():
+    assert hasattr(add_product_indexes, "main")

--- a/tests/test_db_smoke.py
+++ b/tests/test_db_smoke.py
@@ -1,0 +1,5 @@
+import db
+
+
+def test_db_module_imports():
+    assert hasattr(db, "DB")

--- a/tests/test_dialogs_smoke.py
+++ b/tests/test_dialogs_smoke.py
@@ -1,0 +1,5 @@
+import dialogs
+
+
+def test_dialogs_module_imports():
+    assert hasattr(dialogs, "ClienteDialog")


### PR DESCRIPTION
## Summary
- add simple smoke tests for `db`, `dialogs`, and `add_product_indexes` modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899fbcb41f48323abccba9500d424bb