### PR TITLE
feat: add basic user management

### DIFF
--- a/db.py
+++ b/db.py
@@ -69,6 +69,24 @@ class DB:
             logger.exception("Failed to add column %s to table %s", column, table)
             return False
 
+    def _ensure_default_users(self) -> None:
+        """Create default user, admin and guest accounts if missing."""
+        users = [
+            ("invitado", "invitado", "guest"),
+            ("usuario", "usuario", "user"),
+            ("admin", "admin", "admin"),
+        ]
+        for username, password, role in users:
+            self.cursor.execute(
+                "SELECT id FROM usuarios WHERE username=?", (username,)
+            )
+            if not self.cursor.fetchone():
+                self.cursor.execute(
+                    "INSERT INTO usuarios (username, password, role) VALUES (?, ?, ?)",
+                    (username, password, role),
+                )
+        self.conn.commit()
+
     def migrate_ventas_cliente_fk(self):
         """Ensure ``ventas`` has proper foreign keys for cliente and vendedor.
 
@@ -472,10 +490,23 @@ class DB:
 
                 FOREIGN KEY (venta_id) REFERENCES ventas(id)
             )
-        """
+            """
         )
         self.conn.commit()
 
+        # Tabla de usuarios y cuentas por defecto
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS usuarios (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE,
+                password TEXT NOT NULL,
+                role TEXT CHECK(role IN ('admin','user','guest')) NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+        self._ensure_default_users()
 
         # Si no hay registro, crea uno por defecto
         self.cursor.execute("SELECT COUNT(*) FROM Distribuidor_info")
@@ -1878,3 +1909,43 @@ class DB:
             (json.dumps(current, ensure_ascii=False), venta_id),
         )
         self.conn.commit()
+
+    # ---- Gestión de usuarios ----
+
+    def get_users(self):
+        self.cursor.execute("SELECT id, username, role FROM usuarios")
+        return [dict(row) for row in self.cursor.fetchall()]
+
+    def get_user(self, user_id):
+        self.cursor.execute(
+            "SELECT id, username, password, role FROM usuarios WHERE id=?",
+            (user_id,),
+        )
+        row = self.cursor.fetchone()
+        return dict(row) if row else None
+
+    def add_user(self, username, password, role):
+        self.cursor.execute(
+            "INSERT INTO usuarios (username, password, role) VALUES (?, ?, ?)",
+            (username, password, role),
+        )
+        self.conn.commit()
+
+    def update_user(self, user_id, username, password, role):
+        self.cursor.execute(
+            "UPDATE usuarios SET username=?, password=?, role=? WHERE id=?",
+            (username, password, role, user_id),
+        )
+        self.conn.commit()
+
+    def delete_user(self, user_id):
+        self.cursor.execute("DELETE FROM usuarios WHERE id=?", (user_id,))
+        self.conn.commit()
+
+    def authenticate(self, username, password):
+        self.cursor.execute(
+            "SELECT id, username, role FROM usuarios WHERE username=? AND password=?",
+            (username, password),
+        )
+        row = self.cursor.fetchone()
+        return dict(row) if row else None

--- a/dialogs.py
+++ b/dialogs.py
@@ -3466,3 +3466,170 @@ class EstadoVentaDialog(QDialog):
         return self.estado_combo.currentText()
 
 
+class LoginDialog(QDialog):
+    def __init__(self, db, parent=None):
+        super().__init__(parent)
+        self.db = db
+        self.user = None
+        self.setWindowTitle("Iniciar sesión")
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        self.username_edit = QLineEdit()
+        self.password_edit = QLineEdit()
+        self.password_edit.setEchoMode(QLineEdit.Password)
+        form.addRow("Usuario:", self.username_edit)
+        form.addRow("Contraseña:", self.password_edit)
+        layout.addLayout(form)
+        btns = QHBoxLayout()
+        ok_btn = QPushButton("Aceptar")
+        cancel_btn = QPushButton("Cancelar")
+        ok_btn.clicked.connect(self._attempt_login)
+        cancel_btn.clicked.connect(self.reject)
+        btns.addWidget(ok_btn)
+        btns.addWidget(cancel_btn)
+        layout.addLayout(btns)
+
+    def _attempt_login(self):
+        user = self.db.authenticate(
+            self.username_edit.text().strip(),
+            self.password_edit.text().strip(),
+        )
+        if user:
+            self.user = user
+            self.accept()
+        else:
+            QMessageBox.warning(self, "Error", "Usuario o contraseña incorrectos")
+
+    def get_user(self):
+        return self.user
+
+
+class UserEditDialog(QDialog):
+    def __init__(self, username="", password="", role="user", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Usuario")
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        self.username_edit = QLineEdit(username)
+        self.password_edit = QLineEdit(password)
+        self.password_edit.setEchoMode(QLineEdit.Password)
+        self.role_combo = QComboBox()
+        self.role_combo.addItems(["guest", "user", "admin"])
+        idx = self.role_combo.findText(role)
+        if idx >= 0:
+            self.role_combo.setCurrentIndex(idx)
+        form.addRow("Usuario:", self.username_edit)
+        form.addRow("Contraseña:", self.password_edit)
+        form.addRow("Rol:", self.role_combo)
+        layout.addLayout(form)
+        btns = QHBoxLayout()
+        ok_btn = QPushButton("Aceptar")
+        cancel_btn = QPushButton("Cancelar")
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        btns.addWidget(ok_btn)
+        btns.addWidget(cancel_btn)
+        layout.addLayout(btns)
+
+    def get_data(self):
+        return (
+            self.username_edit.text().strip(),
+            self.password_edit.text().strip(),
+            self.role_combo.currentText(),
+        )
+
+
+class UserConfigDialog(QDialog):
+    def __init__(self, db, parent=None):
+        super().__init__(parent)
+        self.db = db
+        self.setWindowTitle("Configuración de usuarios")
+        layout = QVBoxLayout(self)
+        self.table = QTableWidget()
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["ID", "Usuario", "Rol"])
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        layout.addWidget(self.table)
+        btns = QHBoxLayout()
+        add_btn = QPushButton("Agregar")
+        edit_btn = QPushButton("Editar")
+        del_btn = QPushButton("Eliminar")
+        btns.addWidget(add_btn)
+        btns.addWidget(edit_btn)
+        btns.addWidget(del_btn)
+        layout.addLayout(btns)
+        add_btn.clicked.connect(self._add_user)
+        edit_btn.clicked.connect(self._edit_user)
+        del_btn.clicked.connect(self._delete_user)
+        self.refresh()
+
+    def refresh(self):
+        users = self.db.get_users()
+        self.table.setRowCount(len(users))
+        for row, u in enumerate(users):
+            self.table.setItem(row, 0, QTableWidgetItem(str(u["id"])))
+            self.table.setItem(row, 1, QTableWidgetItem(u["username"]))
+            self.table.setItem(row, 2, QTableWidgetItem(u["role"]))
+
+    def _add_user(self):
+        dlg = UserEditDialog(parent=self)
+        if dlg.exec_() == QDialog.Accepted:
+            username, password, role = dlg.get_data()
+            if not username or not password:
+                QMessageBox.warning(self, "Error", "Usuario y contraseña requeridos")
+                return
+            if not self._check_limit(role):
+                return
+            try:
+                self.db.add_user(username, password, role)
+            except Exception:
+                QMessageBox.warning(self, "Error", "No se pudo crear el usuario")
+            self.refresh()
+
+    def _edit_user(self):
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        user_id = int(self.table.item(row, 0).text())
+        current = self.db.get_user(user_id)
+        dlg = UserEditDialog(
+            current["username"], current["password"], current["role"], self
+        )
+        if dlg.exec_() == QDialog.Accepted:
+            username, password, role = dlg.get_data()
+            if not username or not password:
+                QMessageBox.warning(self, "Error", "Usuario y contraseña requeridos")
+                return
+            if role != current["role"] and not self._check_limit(role):
+                return
+            try:
+                self.db.update_user(user_id, username, password, role)
+            except Exception:
+                QMessageBox.warning(self, "Error", "No se pudo actualizar el usuario")
+            self.refresh()
+
+    def _delete_user(self):
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        user_id = int(self.table.item(row, 0).text())
+        if (
+            QMessageBox.question(self, "Eliminar", "¿Desea eliminar el usuario?")
+            == QMessageBox.Yes
+        ):
+            self.db.delete_user(user_id)
+            self.refresh()
+
+    def _check_limit(self, role):
+        users = self.db.get_users()
+        limits = {"guest": 1, "user": 6, "admin": 3}
+        count = sum(1 for u in users if u["role"] == role)
+        if count >= limits[role]:
+            QMessageBox.warning(
+                self, "Error", "Se alcanzó el límite para el rol seleccionado"
+            )
+            return False
+        return True
+
+

--- a/main.py
+++ b/main.py
@@ -13,9 +13,11 @@ warnings.filterwarnings(
     message=r".*(SwigPyObject|SwigPyPacked|swigvarlink).*__module__.*",
 )
 
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt5.QtWidgets import QApplication, QMessageBox, QDialog
 from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow
+from dialogs import LoginDialog
+from db import DB
 
 BASE_DIR = os.path.dirname(__file__)
 LAST_FILE_PATH = os.path.join(BASE_DIR, "ultimo_inventario.json")
@@ -43,7 +45,12 @@ if __name__ == "__main__":
     if os.path.exists(icon_path):
         app.setWindowIcon(QIcon(icon_path))
 
-    window = MainWindow()
+    db = DB()
+    login = LoginDialog(db)
+    if login.exec_() != QDialog.Accepted:
+        sys.exit(0)
+    user = login.get_user()
+    window = MainWindow(user)
     if os.path.exists(icon_path):
         window.setWindowIcon(QIcon(icon_path))
     window.show()

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -17,6 +17,7 @@ from dialogs import (
     DistribuidorInfoDialog,
     ClienteDialog,
     EstadoCuentaDialog,
+    UserConfigDialog,
 )
 
 DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
@@ -66,8 +67,9 @@ class ExportThread(QThread):
 
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self, user=None):
         super().__init__()
+        self.user = user or {"username": "admin", "role": "admin"}
         self.setWindowTitle("Inventario Farmacia")
         self.resize(1200, 700)
         self.manager = InventoryManager()
@@ -107,6 +109,12 @@ class MainWindow(QMainWindow):
         dte_action = QAction("Facturación electrónica", self)
         dte_action.triggered.connect(self._abrir_config_facturacion)
         config_menu.addAction(dte_action)
+        if self.user["role"] == "admin":
+            user_action = QAction("Configuración de usuarios", self)
+            user_action.triggered.connect(self._abrir_config_usuarios)
+            config_menu.addAction(user_action)
+        else:
+            config_menu.menuAction().setVisible(False)
 
         # --- BOTONES LATERALES ---
         self.btn_add_product = QPushButton("Agregar Producto")
@@ -130,6 +138,19 @@ class MainWindow(QMainWindow):
             btn.setMinimumWidth(140)
             btn.setMaximumWidth(200)
             btn.setStyleSheet("font-size:11px; padding:4px 0;")
+
+        if self.user["role"] == "guest":
+            for btn in [
+                self.btn_add_product,
+                self.btn_edit_product,
+                self.btn_register_sale,
+                self.btn_register_credito_fiscal,
+                self.btn_register_purchase,
+                self.btn_delete_product,
+                self.btn_guardar_rapido,
+                self.btn_cargar_inventario,
+            ]:
+                btn.setEnabled(False)
 
         # Botones verdes más pequeños y debajo de los celestes pero encima del rojo
         self.btn_guardar_rapido.setStyleSheet(
@@ -1421,6 +1442,10 @@ class MainWindow(QMainWindow):
             with open(config_path, "w", encoding="utf-8") as f:
                 json.dump(config, f, ensure_ascii=False, indent=2)
             QMessageBox.information(self, "Facturación electrónica", "Datos guardados correctamente.")
+
+    def _abrir_config_usuarios(self):
+        dlg = UserConfigDialog(self.manager.db, self)
+        dlg.exec_()
 
     def _actualizar_tabla_trabajadores(self):
         solo_vendedores = self.trabajadores_filtro_vendedor.isChecked()


### PR DESCRIPTION
## Summary
- add usuarios table with default admin, user, and guest accounts
- implement login and user configuration dialogs
- restrict UI actions based on user roles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a10d2164883239ca63f9a343fcc74