### PR TITLE
Add modern user picker dialog with card UI

### DIFF
--- a/tests/test_user_picker_dialog.py
+++ b/tests/test_user_picker_dialog.py
@@ -1,0 +1,23 @@
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from user_picker_dialog import UserPickerDialog
+
+
+@pytest.fixture
+def qt_app(monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_single_selection(qt_app):
+    users = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+        {"id": 3, "name": "Carol"},
+    ]
+    dlg = UserPickerDialog(users)
+    # simulate click on first user
+    list(dlg._buttons.values())[0].click()
+    assert dlg.selected_user_ids() == 1

--- a/user_picker_dialog.py
+++ b/user_picker_dialog.py
@@ -1,0 +1,197 @@
+from typing import List, Dict, Optional, Union
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap, QIcon, QPainter, QPainterPath
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QGridLayout,
+    QPushButton,
+    QLabel,
+    QWidget,
+    QHBoxLayout,
+    QApplication,
+    QStyle,
+)
+
+BRAND_COLOR = "#0EA5E9"
+BACKGROUND_COLOR = "#F7FAFC"
+TEXT_COLOR = "#1F2937"
+
+
+def _load_avatar(user: Dict, size: int = 64) -> QPixmap:
+    """Return a pixmap for the user avatar or a default one."""
+    path = (
+        user.get("avatar")
+        or user.get("photo")
+        or user.get("image")
+        or user.get("avatar_path")
+    )
+    pix = QPixmap()
+    if path:
+        pix.load(path)
+    if pix.isNull():
+        # Fallback to a themed icon that resembles a person
+        icon = QIcon.fromTheme("user")
+        if icon.isNull():
+            icon = QApplication.style().standardIcon(QStyle.SP_FileIcon)
+        pix = icon.pixmap(size, size)
+
+    pix = pix.scaled(size, size, Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
+    # make circular
+    result = QPixmap(size, size)
+    result.fill(Qt.transparent)
+    painter = QPainter(result)
+    painter.setRenderHint(QPainter.Antialiasing, True)
+    path = QPainterPath()
+    path.addEllipse(0, 0, size, size)
+    painter.setClipPath(path)
+    painter.drawPixmap(0, 0, pix)
+    painter.end()
+    return result
+
+
+class UserPickerDialog(QDialog):
+    def __init__(self, users: List[Dict], multi_select: bool = False, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.users = users
+        self.multi_select = multi_select
+        self._buttons: Dict[Union[int, str], QPushButton] = {}
+        self.setWindowTitle("Seleccionar Usuario")
+        self._build_ui()
+
+    # ---------------------------- UI SETUP ---------------------------------
+    def _build_ui(self):
+        self.setStyleSheet(
+            f"""
+            QDialog {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+            }}
+            QPushButton#CardButton {{
+                background-color: white;
+                border: 1px solid #E2E8F0;
+                border-radius: 12px;
+                padding: 12px;
+            }}
+            QPushButton#CardButton:hover {{
+                background-color: #F1F5F9;
+            }}
+            QPushButton#CardButton:checked {{
+                border: 2px solid {BRAND_COLOR};
+                background-color: #E0F2FE;
+            }}
+            QPushButton#PrimaryButton {{
+                background-color: {BRAND_COLOR};
+                color: white;
+                border: none;
+                padding: 6px 12px;
+                border-radius: 6px;
+            }}
+            QPushButton#PrimaryButton:hover {{
+                background-color: #0284C7;
+            }}
+            QPushButton#PrimaryButton:pressed {{
+                background-color: #0369A1;
+            }}
+            QPushButton#SecondaryButton {{
+                background-color: transparent;
+                color: {TEXT_COLOR};
+                border: 1px solid #E2E8F0;
+                padding: 6px 12px;
+                border-radius: 6px;
+            }}
+            QPushButton#SecondaryButton:hover {{
+                background-color: #EDF2F7;
+            }}
+            """
+        )
+
+        main_layout = QVBoxLayout(self)
+
+        grid_widget = QWidget(self)
+        grid = QGridLayout(grid_widget)
+        grid.setSpacing(12)
+        columns = max(1, min(len(self.users), 3))
+
+        for index, user in enumerate(self.users):
+            btn = self._create_user_button(user)
+            self._buttons[user.get("id")] = btn
+            row = index // columns
+            col = index % columns
+            grid.addWidget(btn, row, col)
+
+        main_layout.addWidget(grid_widget)
+
+        # Bottom buttons
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        cancel_btn = QPushButton("Cancelar")
+        cancel_btn.setObjectName("SecondaryButton")
+        cancel_btn.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel_btn)
+        ok_btn = QPushButton("Aceptar")
+        ok_btn.setObjectName("PrimaryButton")
+        ok_btn.clicked.connect(self.accept)
+        btn_layout.addWidget(ok_btn)
+        main_layout.addLayout(btn_layout)
+
+    def _create_user_button(self, user: Dict) -> QPushButton:
+        btn = QPushButton()
+        btn.setObjectName("CardButton")
+        btn.setCheckable(True)
+        btn.setCursor(Qt.PointingHandCursor)
+        btn.setFocusPolicy(Qt.StrongFocus)
+
+        layout = QVBoxLayout(btn)
+        layout.setAlignment(Qt.AlignCenter)
+
+        avatar = QLabel()
+        pix = _load_avatar(user)
+        avatar.setPixmap(pix)
+        avatar.setFixedSize(pix.size())
+        avatar.setStyleSheet("border-radius: 32px;")
+        avatar.setAlignment(Qt.AlignCenter)
+
+        name = QLabel(user.get("name", ""))
+        name.setStyleSheet("font-weight: bold;")
+        name.setAlignment(Qt.AlignCenter)
+
+        subtitle_text = user.get("subtitle")
+        if subtitle_text:
+            subtitle = QLabel(str(subtitle_text))
+            subtitle.setAlignment(Qt.AlignCenter)
+            layout.addWidget(avatar)
+            layout.addWidget(name)
+            layout.addWidget(subtitle)
+        else:
+            layout.addWidget(avatar)
+            layout.addWidget(name)
+
+        btn.clicked.connect(lambda checked, b=btn: self._on_card_clicked(b))
+        return btn
+
+    # --------------------------- BEHAVIOR ----------------------------------
+    def _on_card_clicked(self, button: QPushButton):
+        if not self.multi_select and button.isChecked():
+            for other in self._buttons.values():
+                if other is not button:
+                    other.setChecked(False)
+
+    def selected_user_ids(self):
+        if self.multi_select:
+            return [uid for uid, btn in self._buttons.items() if btn.isChecked()]
+        for uid, btn in self._buttons.items():
+            if btn.isChecked():
+                return uid
+        return None
+
+
+# ----------------------------- Helper API ---------------------------------
+
+def pick_user(parent: QWidget, users: List[Dict], multi_select: bool = False):
+    dialog = UserPickerDialog(users, multi_select=multi_select, parent=parent)
+    result = dialog.exec_()
+    if result == QDialog.Accepted:
+        return dialog.selected_user_ids()
+    return [] if multi_select else None


### PR DESCRIPTION
## Summary
- add `UserPickerDialog` with grid of avatar cards and celeste brand styling
- expose `pick_user` helper to return selected user ids
- cover single-selection behavior with basic Qt test

## Testing
- `pytest tests/test_user_picker_dialog.py -q --cov=user_picker_dialog --cov-branch --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_689a190132048323a27903a4251da5a0