### PR TITLE
Replace legacy login dialog with user picker

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -3466,7 +3466,7 @@ class EstadoVentaDialog(QDialog):
         return self.estado_combo.currentText()
 
 
-class LoginDialog(QDialog):
+class LegacyLoginDialog(QDialog):
     def __init__(self, db, parent=None):
         super().__init__(parent)
         self.db = db
@@ -3519,6 +3519,11 @@ class LoginDialog(QDialog):
     def _update_selected(self, username: str) -> None:
         """Actualiza la etiqueta para mostrar el usuario seleccionado."""
         self.selected_label.setText(f"Ingresando como: {username}")
+
+
+class LoginDialog:
+    def __init__(self, *a, **k):
+        raise RuntimeError("LoginDialog obsoleto. Usar UserPickerDialog.")
 
 
 class UserEditDialog(QDialog):

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ warnings.filterwarnings(
 from PyQt5.QtWidgets import QApplication, QMessageBox, QDialog
 from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow
-from dialogs import LoginDialog
+from user_picker_dialog import UserPickerDialog
 from db import DB
 
 BASE_DIR = os.path.dirname(__file__)
@@ -46,10 +46,18 @@ if __name__ == "__main__":
         app.setWindowIcon(QIcon(icon_path))
 
     db = DB()
-    login = LoginDialog(db)
-    if login.exec_() != QDialog.Accepted:
+    users = [
+        {"id": u["id"], "name": u["username"], "subtitle": u.get("role", "")}
+        for u in db.get_users()
+    ]
+    dlg = UserPickerDialog(users, multi_select=False, parent=None)
+    if dlg.exec_() != QDialog.Accepted:
         sys.exit(0)
-    user = login.get_user()
+    selected = dlg.selected_user_ids()
+    if not selected:
+        sys.exit(0)
+    user_id = selected if not isinstance(selected, list) else selected[0]
+    user = db.get_user(user_id)
     window = MainWindow(user)
     if os.path.exists(icon_path):
         window.setWindowIcon(QIcon(icon_path))

--- a/tests/test_login_ui.py
+++ b/tests/test_login_ui.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+
+@pytest.fixture
+def qt_app():
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_only_new_user_picker_is_used(qt_app):
+    import dialogs
+    if hasattr(dialogs, "LoginDialog"):
+        with pytest.raises(Exception):
+            dialogs.LoginDialog()
+
+    from user_picker_dialog import UserPickerDialog
+    users = [{"id": 1, "name": "Invitado"}]
+    dlg = UserPickerDialog(users)
+    assert not dlg.selected_user_ids()

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QTableView, QLineEdit,
     QPushButton, QTabWidget, QMessageBox, QSplitter, QMenuBar, QAction, QFileDialog,
-    QListWidget, QInputDialog, QLabel, QComboBox, QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QDialog,
+    QListWidget, QLabel, QComboBox, QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QDialog,
     QDateEdit, QCheckBox, QTextEdit, QAbstractItemView, QHeaderView, QSizePolicy
 )
 from PyQt5.QtCore import Qt, QDate, QThread, pyqtSignal


### PR DESCRIPTION
## Summary
- swap old LoginDialog for new UserPickerDialog in main entry point
- block legacy LoginDialog usage and drop obsolete import
- add regression test ensuring only new user picker is used

## Testing
- `pytest` *(fails: Required test coverage of 95% not reached. Total coverage: 3.08%)*

------
https://chatgpt.com/codex/tasks/task_e_689a20647b4483238951c4778be59408