### PR TITLE
Solicitar contraseña al iniciar sesión y ampliar selector de usuario

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ warnings.filterwarnings(
     message=r".*(SwigPyObject|SwigPyPacked|swigvarlink).*__module__.*",
 )
 
-from PyQt5.QtWidgets import QApplication, QMessageBox, QDialog
+from PyQt5.QtWidgets import QApplication, QMessageBox, QDialog, QInputDialog, QLineEdit
 from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow
 from user_picker_dialog import UserPickerDialog
@@ -57,7 +57,25 @@ if __name__ == "__main__":
     if not selected:
         sys.exit(0)
     user_id = selected if not isinstance(selected, list) else selected[0]
-    user = db.get_user(user_id)
+    selected_user = db.get_user(user_id)
+    if not selected_user:
+        sys.exit(0)
+
+    # Prompt for the user's password before continuing
+    while True:
+        password, ok = QInputDialog.getText(
+            None,
+            "Contraseña",
+            f"Ingrese la contraseña para {selected_user['username']}",
+            QLineEdit.Password,
+        )
+        if not ok:
+            sys.exit(0)
+        user = db.authenticate(selected_user["username"], password)
+        if user:
+            break
+        QMessageBox.critical(None, "Error", "Contraseña incorrecta")
+
     window = MainWindow(user)
     if os.path.exists(icon_path):
         window.setWindowIcon(QIcon(icon_path))

--- a/user_picker_dialog.py
+++ b/user_picker_dialog.py
@@ -20,7 +20,7 @@ BACKGROUND_COLOR = "#F7FAFC"
 TEXT_COLOR = "#1F2937"
 
 
-def _load_avatar(user: Dict, size: int = 64) -> QPixmap:
+def _load_avatar(user: Dict, size: int = 96) -> QPixmap:
     """Return a pixmap for the user avatar or a default one."""
     path = (
         user.get("avatar")
@@ -61,6 +61,8 @@ class UserPickerDialog(QDialog):
         self._buttons: Dict[Union[int, str], QPushButton] = {}
         self.setWindowTitle("Seleccionar Usuario")
         self._build_ui()
+        # Make the dialog a bit larger for easier interaction
+        self.setMinimumSize(600, 400)
 
     # ---------------------------- UI SETUP ---------------------------------
     def _build_ui(self):
@@ -75,7 +77,7 @@ class UserPickerDialog(QDialog):
                 color: {TEXT_COLOR};
                 border: 1px solid {BRAND_COLOR};
                 border-radius: 16px;
-                padding: 16px;
+                padding: 24px;
             }}
             QPushButton#CardButton:hover {{
                 background-color: #E0F2FE;
@@ -114,7 +116,7 @@ class UserPickerDialog(QDialog):
 
         grid_widget = QWidget(self)
         grid = QGridLayout(grid_widget)
-        grid.setSpacing(12)
+        grid.setSpacing(24)
         columns = max(1, min(len(self.users), 3))
 
         for index, user in enumerate(self.users):
@@ -158,7 +160,7 @@ class UserPickerDialog(QDialog):
         pix = _load_avatar(user)
         avatar.setPixmap(pix)
         avatar.setFixedSize(pix.size())
-        avatar.setStyleSheet("border-radius: 32px;")
+        avatar.setStyleSheet(f"border-radius: {pix.width() // 2}px;")
         avatar.setAlignment(Qt.AlignCenter)
 
         name = QLabel(user.get("name", ""))


### PR DESCRIPTION
## Resumen
- Solicita la contraseña del usuario elegido antes de abrir la aplicación.
- Amplía el diálogo de selección de usuario: mayor tamaño mínimo, avatares grandes y más espacio entre tarjetas.

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a2313c7908323a4339435f518a10c