### PR TITLE
Add stub LoginDialog to prevent legacy dialog usage

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -19,6 +19,15 @@ import os
 
 getcontext().prec = 4
 
+
+class LoginDialog(QDialog):
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("NO DEBERÍA USARSE")
+
+    def exec_(self):
+        raise RuntimeError("NO DEBERÍA USARSE")
+
+
 def get_field(obj, key, default=0):
     if isinstance(obj, dict):
         return obj.get(key, default)


### PR DESCRIPTION
## Summary
- add LoginDialog stub raising an error to detect accidental usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a30b5df888323a53aab579bc58977