### PR TITLE
Refactor user picker to use avatar cards

### DIFF
--- a/tests/test_user_picker_dialog.py
+++ b/tests/test_user_picker_dialog.py
@@ -19,5 +19,5 @@ def test_single_selection(qt_app):
     ]
     dlg = UserPickerDialog(users)
     # simulate click on first user
-    list(dlg._buttons.values())[0].click()
+    list(dlg._cards.values())[0].click()
     assert dlg.selected_user_ids() == 1

--- a/user_picker_dialog.py
+++ b/user_picker_dialog.py
@@ -1,18 +1,19 @@
 from typing import List, Dict, Optional, Union
 import os
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QPixmap, QColor, QPainter
 from PyQt5.QtWidgets import (
     QDialog,
     QVBoxLayout,
     QGridLayout,
-    QPushButton,
     QLabel,
     QWidget,
     QHBoxLayout,
     QApplication,
     QGraphicsDropShadowEffect,
+    QFrame,
+    QPushButton,
 )
 
 BRAND_COLOR = "#0EA5E9"
@@ -22,21 +23,14 @@ TEXT_COLOR = "#1F2937"
 DEFAULT_AVATAR = os.path.join(os.path.dirname(__file__), "avatar.jpg")
 
 
-def _load_avatar(user: Dict, size: int = 96) -> QPixmap:
-    """Return a squared pixmap for the user avatar or a placeholder image."""
-    path = (
-        user.get("avatar")
-        or user.get("photo")
-        or user.get("image")
-        or user.get("avatar_path")
-        or DEFAULT_AVATAR
-    )
+def square_avatar(path: str, size: int) -> QPixmap:
+    """Load an image, crop it to a square and scale to ``size`` pixels."""
+
     pix = QPixmap()
     if path and os.path.exists(path):
         pix.load(path)
 
     if pix.isNull():
-        # Draw a placeholder gray square with a question mark
         pix = QPixmap(size, size)
         pix.fill(QColor("#E5E7EB"))
         painter = QPainter(pix)
@@ -49,16 +43,42 @@ def _load_avatar(user: Dict, size: int = 96) -> QPixmap:
         painter.end()
         return pix
 
-    # Crop a centered square from the original image
     if pix.width() != pix.height():
         side = min(pix.width(), pix.height())
         x = (pix.width() - side) // 2
         y = (pix.height() - side) // 2
         pix = pix.copy(x, y, side, side)
 
-    # Scale to the desired size smoothly without distortion
-    pix = pix.scaled(size, size, Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
-    return pix
+    return pix.scaled(size, size, Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
+
+
+class UserCard(QFrame):
+    clicked = pyqtSignal(bool)
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._checked = False
+        self.setProperty("class", "user-card")
+        self.setCursor(Qt.PointingHandCursor)
+        self.setFocusPolicy(Qt.StrongFocus)
+
+    def mousePressEvent(self, event):  # type: ignore[override]
+        self.setChecked(not self._checked)
+        self.clicked.emit(self._checked)
+        if event is not None:
+            super().mousePressEvent(event)
+
+    def setChecked(self, checked: bool):
+        self._checked = checked
+        self.setProperty("checked", checked)
+        self.style().unpolish(self)
+        self.style().polish(self)
+
+    def isChecked(self) -> bool:
+        return self._checked
+
+    def click(self):
+        self.mousePressEvent(None)  # type: ignore[arg-type]
 
 
 class UserPickerDialog(QDialog):
@@ -67,7 +87,7 @@ class UserPickerDialog(QDialog):
         super().__init__(parent)
         self.users = users
         self.multi_select = multi_select
-        self._buttons: Dict[Union[int, str], QPushButton] = {}
+        self._cards: Dict[Union[int, str], UserCard] = {}
         self.setWindowTitle("Seleccionar Usuario")
         self._build_ui()
         # Make the dialog a bit larger for easier interaction
@@ -81,20 +101,23 @@ class UserPickerDialog(QDialog):
                 background-color: {BACKGROUND_COLOR};
                 color: {TEXT_COLOR};
             }}
-            QPushButton#CardButton {{
+            QFrame.user-card {{
                 background-color: {BACKGROUND_COLOR};
                 color: {TEXT_COLOR};
                 border: 1px solid {BRAND_COLOR};
                 border-radius: 16px;
                 padding: 24px;
             }}
-            QPushButton#CardButton:hover {{
+            QFrame.user-card:hover {{
                 background-color: #E0F2FE;
                 border: 2px solid #7DD3FC;
             }}
-            QPushButton#CardButton:checked {{
+            QFrame.user-card[checked="true"] {{
                 border: 2px solid {BRAND_COLOR};
                 background-color: #BAE6FD;
+            }}
+            QLabel.user-name {{
+                font-weight: bold;
             }}
             QPushButton#PrimaryButton {{
                 background-color: {BRAND_COLOR};
@@ -124,24 +147,23 @@ class UserPickerDialog(QDialog):
 
         main_layout = QVBoxLayout(self)
 
-        grid_widget = QWidget(self)
-        grid = QGridLayout(grid_widget)
+        grid = QGridLayout()
         grid.setSpacing(24)
         columns = max(1, min(len(self.users), 3))
 
         for index, user in enumerate(self.users):
-            btn = self._create_user_button(user)
-            shadow = QGraphicsDropShadowEffect(btn)
+            card = self._create_user_card(user)
+            shadow = QGraphicsDropShadowEffect(card)
             shadow.setBlurRadius(15)
             shadow.setOffset(0, 3)
             shadow.setColor(QColor(0, 0, 0, 80))
-            btn.setGraphicsEffect(shadow)
-            self._buttons[user.get("id")] = btn
+            card.setGraphicsEffect(shadow)
+            self._cards[user.get("id")] = card
             row = index // columns
             col = index % columns
-            grid.addWidget(btn, row, col)
+            grid.addWidget(card, row, col)
 
-        main_layout.addWidget(grid_widget)
+        main_layout.addLayout(grid)
 
         # Bottom buttons
         btn_layout = QHBoxLayout()
@@ -156,52 +178,52 @@ class UserPickerDialog(QDialog):
         btn_layout.addWidget(ok_btn)
         main_layout.addLayout(btn_layout)
 
-    def _create_user_button(self, user: Dict) -> QPushButton:
-        btn = QPushButton()
-        btn.setObjectName("CardButton")
-        btn.setCheckable(True)
-        btn.setCursor(Qt.PointingHandCursor)
-        btn.setFocusPolicy(Qt.StrongFocus)
+    def _create_user_card(self, user: Dict) -> UserCard:
+        card = UserCard()
 
-        layout = QVBoxLayout(btn)
+        layout = QVBoxLayout(card)
         layout.setAlignment(Qt.AlignCenter)
 
+        path = (
+            user.get("avatar")
+            or user.get("photo")
+            or user.get("image")
+            or user.get("avatar_path")
+            or DEFAULT_AVATAR
+        )
         avatar = QLabel()
-        pix = _load_avatar(user)
+        pix = square_avatar(path, 96)
         avatar.setPixmap(pix)
         avatar.setFixedSize(pix.size())
         avatar.setAlignment(Qt.AlignCenter)
 
         name = QLabel(user.get("name", ""))
-        name.setStyleSheet("font-weight: bold;")
+        name.setProperty("class", "user-name")
         name.setAlignment(Qt.AlignCenter)
 
         subtitle_text = user.get("subtitle")
+        layout.addWidget(avatar)
+        layout.addWidget(name)
         if subtitle_text:
             subtitle = QLabel(str(subtitle_text))
             subtitle.setAlignment(Qt.AlignCenter)
-            layout.addWidget(avatar)
-            layout.addWidget(name)
             layout.addWidget(subtitle)
-        else:
-            layout.addWidget(avatar)
-            layout.addWidget(name)
 
-        btn.clicked.connect(lambda checked, b=btn: self._on_card_clicked(b))
-        return btn
+        card.clicked.connect(lambda checked, c=card: self._on_card_clicked(c))
+        return card
 
     # --------------------------- BEHAVIOR ----------------------------------
-    def _on_card_clicked(self, button: QPushButton):
-        if not self.multi_select and button.isChecked():
-            for other in self._buttons.values():
-                if other is not button:
+    def _on_card_clicked(self, card: UserCard):
+        if not self.multi_select and card.isChecked():
+            for other in self._cards.values():
+                if other is not card:
                     other.setChecked(False)
 
     def selected_user_ids(self):
         if self.multi_select:
-            return [uid for uid, btn in self._buttons.items() if btn.isChecked()]
-        for uid, btn in self._buttons.items():
-            if btn.isChecked():
+            return [uid for uid, card in self._cards.items() if card.isChecked()]
+        for uid, card in self._cards.items():
+            if card.isChecked():
                 return uid
         return None
 


### PR DESCRIPTION
## Summary
- add `square_avatar` helper for cropping and scaling avatars
- replace user picker buttons with `QFrame` cards and grid layout
- adapt tests for new `UserCard` interface

## Testing
- `pytest tests/test_user_picker_dialog.py tests/test_login_ui.py --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_689a30b4ecc4832390193cead733c067