### PR TITLE
Add selection state handling to user picker dialog

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -2,3 +2,9 @@
 QMainWindow {
     background-color: #f5f5f5;
 }
+
+/* User picker card styling */
+QFrame[user-card][selected="true"],
+QFrame[user-card]:hover {
+    border: 2px solid #7DD3FC;
+}

--- a/tests/test_user_picker_dialog.py
+++ b/tests/test_user_picker_dialog.py
@@ -3,13 +3,11 @@ from PyQt5.QtWidgets import QApplication
 
 from user_picker_dialog import UserPickerDialog
 
-
 @pytest.fixture
 def qt_app(monkeypatch):
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance() or QApplication([])
     return app
-
 
 def test_single_selection(qt_app):
     users = [
@@ -18,6 +16,29 @@ def test_single_selection(qt_app):
         {"id": 3, "name": "Carol"},
     ]
     dlg = UserPickerDialog(users)
-    # simulate click on first user
-    list(dlg._cards.values())[0].click()
+    assert not dlg.ok_btn.isEnabled()
+    cards = list(dlg._cards.values())
+    cards[0].click()
     assert dlg.selected_user_ids() == 1
+    assert dlg.ok_btn.isEnabled()
+    cards[1].click()
+    assert dlg.selected_user_ids() == 2
+    assert dlg.ok_btn.isEnabled()
+    cards[1].click()
+    assert dlg.selected_user_ids() is None
+    assert not dlg.ok_btn.isEnabled()
+
+
+def test_multi_selection(qt_app):
+    users = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+        {"id": 3, "name": "Carol"},
+    ]
+    dlg = UserPickerDialog(users, multi_select=True)
+    cards = list(dlg._cards.values())
+    cards[0].click()
+    cards[1].click()
+    assert set(dlg.selected_user_ids()) == {1, 2}
+    assert dlg.ok_btn.isEnabled()
+

--- a/user_picker_dialog.py
+++ b/user_picker_dialog.py
@@ -53,29 +53,29 @@ def square_avatar(path: str, size: int) -> QPixmap:
 
 
 class UserCard(QFrame):
-    clicked = pyqtSignal(bool)
+    clicked = pyqtSignal()
 
     def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(parent)
-        self._checked = False
-        self.setProperty("class", "user-card")
+        self._selected = False
+        self.setProperty("user-card", True)
+        self.setProperty("selected", "false")
         self.setCursor(Qt.PointingHandCursor)
         self.setFocusPolicy(Qt.StrongFocus)
 
     def mousePressEvent(self, event):  # type: ignore[override]
-        self.setChecked(not self._checked)
-        self.clicked.emit(self._checked)
+        self.clicked.emit()
         if event is not None:
             super().mousePressEvent(event)
 
-    def setChecked(self, checked: bool):
-        self._checked = checked
-        self.setProperty("checked", checked)
+    def setSelected(self, selected: bool):
+        self._selected = selected
+        self.setProperty("selected", "true" if selected else "false")
         self.style().unpolish(self)
         self.style().polish(self)
 
-    def isChecked(self) -> bool:
-        return self._checked
+    def isSelected(self) -> bool:
+        return self._selected
 
     def click(self):
         self.mousePressEvent(None)  # type: ignore[arg-type]
@@ -101,20 +101,17 @@ class UserPickerDialog(QDialog):
                 background-color: {BACKGROUND_COLOR};
                 color: {TEXT_COLOR};
             }}
-            QFrame.user-card {{
+            QFrame[user-card] {{
                 background-color: {BACKGROUND_COLOR};
                 color: {TEXT_COLOR};
                 border: 1px solid {BRAND_COLOR};
                 border-radius: 16px;
                 padding: 24px;
             }}
-            QFrame.user-card:hover {{
+            QFrame[user-card]:hover,
+            QFrame[user-card][selected="true"] {{
                 background-color: #E0F2FE;
                 border: 2px solid #7DD3FC;
-            }}
-            QFrame.user-card[checked="true"] {{
-                border: 2px solid {BRAND_COLOR};
-                background-color: #BAE6FD;
             }}
             QLabel.user-name {{
                 font-weight: bold;
@@ -172,10 +169,11 @@ class UserPickerDialog(QDialog):
         cancel_btn.setObjectName("SecondaryButton")
         cancel_btn.clicked.connect(self.reject)
         btn_layout.addWidget(cancel_btn)
-        ok_btn = QPushButton("Aceptar")
-        ok_btn.setObjectName("PrimaryButton")
-        ok_btn.clicked.connect(self.accept)
-        btn_layout.addWidget(ok_btn)
+        self.ok_btn = QPushButton("Aceptar")
+        self.ok_btn.setObjectName("PrimaryButton")
+        self.ok_btn.setEnabled(False)
+        self.ok_btn.clicked.connect(self.accept)
+        btn_layout.addWidget(self.ok_btn)
         main_layout.addLayout(btn_layout)
 
     def _create_user_card(self, user: Dict) -> UserCard:
@@ -209,21 +207,27 @@ class UserPickerDialog(QDialog):
             subtitle.setAlignment(Qt.AlignCenter)
             layout.addWidget(subtitle)
 
-        card.clicked.connect(lambda checked, c=card: self._on_card_clicked(c))
+        card.clicked.connect(lambda c=card: self._on_card_clicked(c))
         return card
 
     # --------------------------- BEHAVIOR ----------------------------------
     def _on_card_clicked(self, card: UserCard):
-        if not self.multi_select and card.isChecked():
+        new_state = not card.isSelected()
+        if not self.multi_select and new_state:
             for other in self._cards.values():
                 if other is not card:
-                    other.setChecked(False)
+                    other.setSelected(False)
+        card.setSelected(new_state)
+        self._update_ok_state()
+
+    def _update_ok_state(self):
+        self.ok_btn.setEnabled(bool(self.selected_user_ids()))
 
     def selected_user_ids(self):
         if self.multi_select:
-            return [uid for uid, card in self._cards.items() if card.isChecked()]
+            return [uid for uid, card in self._cards.items() if card.isSelected()]
         for uid, card in self._cards.items():
-            if card.isChecked():
+            if card.isSelected():
                 return uid
         return None
 


### PR DESCRIPTION
## Summary
- highlight and toggle user cards with a `selected` property
- keep "Aceptar" button disabled until at least one user is chosen
- test single and multi-user selection behavior

## Testing
- `pytest tests/test_user_picker_dialog.py` *(fails: Coverage failure: total of 2 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_689a3280e5bc8323a3603517c726f9b7