### PR TITLE
Add missing DTE required fields

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -240,6 +240,12 @@ def generar_dte_json(
         "receptor": receptor,
         "cuerpoDocumento": cuerpo,
         "resumen": resumen,
+        # Campos obligatorios que pueden no tener información
+        "documentoRelacionado": None,
+        "otrosDocumentos": None,
+        "ventaTercero": None,
+        "extension": None,
+        "apendice": None,
         "firmaElectronica": None,
         "selloRecibido": None,
     }


### PR DESCRIPTION
## Summary
- set default null values for optional DTE sections so invoice JSON passes validation

## Testing
- `pytest` (fails: 31 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_689a5b6ffff083239f9d53ba36f36cb5