### PR TITLE
Align receptor data with JSON schema

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -148,8 +148,13 @@ RESUMEN_DEFAULTS = {
         "ivaRete1": 0,
         "reteRenta": 0,
         "montoTotalOperacion": 0,
+        "totalNoGravado": 0,
+        "totalPagar": 0,
         "totalLetras": "",
+        "saldoFavor": 0,
         "condicionOperacion": 1,
+        "pagos": None,
+        "numPagoElectronico": None,
     },
 }
 
@@ -363,17 +368,27 @@ def generar_dte_json(
     }
 
     rec = cliente or {}
+    def _clean_nit(nit):
+        if nit:
+            return "".join(c for c in str(nit) if c.isdigit())
+        return None
+
+    nit = rec.get("nit")
+    if fiscal:
+        nit = fiscal.get("nit") or nit
+
     receptor = {
+        "tipoDocumento": "36" if nit else None,
+        "numDocumento": _clean_nit(nit),
+        "nrc": (fiscal.get("nrc") if fiscal else None) or rec.get("nrc"),
         "nombre": rec.get("nombre"),
-        "direccion": rec.get("direccion"),
-        "nit": rec.get("nit"),
+        "codActividad": None,
+        "descActividad": None,
+        "direccion": None,
+        "telefono": rec.get("telefono"),
+        "correo": rec.get("correo"),
     }
     if fiscal:
-        receptor.update({
-            "nrc": fiscal.get("nrc") or rec.get("nrc"),
-            "giro": fiscal.get("giro") or rec.get("giro"),
-            "nit": fiscal.get("nit") or rec.get("nit"),
-        })
         if fiscal.get("no_remision"):
             receptor["noRemision"] = fiscal.get("no_remision")
         if fiscal.get("orden_no"):

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -52,7 +52,17 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente):
     monkeypatch.setattr(
         "dte.generar_dte_json",
         lambda db_obj, vid: {
-            "receptor": {"nombre": "Cliente", "nit": "0614-987654-321-0"},
+            "receptor": {
+                "nombre": "Cliente",
+                "tipoDocumento": "36",
+                "numDocumento": "06149876543210",
+                "nrc": None,
+                "codActividad": None,
+                "descActividad": None,
+                "direccion": None,
+                "telefono": None,
+                "correo": None,
+            },
             "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
             "resumen": {
                 "totalNoSuj": 0,

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -60,7 +60,17 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "dte.generar_dte_json",
         lambda db_obj, vid: {
-            "receptor": {"nombre": "Cliente", "nit": "0614-987654-321-0"},
+            "receptor": {
+                "nombre": "Cliente",
+                "tipoDocumento": "36",
+                "numDocumento": "06149876543210",
+                "nrc": None,
+                "codActividad": None,
+                "descActividad": None,
+                "direccion": None,
+                "telefono": None,
+                "correo": None,
+            },
             "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
             "resumen": {
                 "totalNoSuj": 0,
@@ -128,7 +138,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     assert captured.get("count") == 1
     payload = captured["data"]
     assert payload["receptor"]["nombre"] == "Cliente"
-    assert payload["receptor"]["nit"] == "0614-987654-321-0"
+    assert payload["receptor"]["numDocumento"] == "06149876543210"
     assert payload["cuerpoDocumento"][0]["cantidad"] == 1
 
     items_total = sum(


### PR DESCRIPTION
## Summary
- Replace `nit` in DTE receptor with schema-compliant document fields and sanitize NIT
- Add defaults like `totalPagar` for credit note summaries
- Update transmission tests to expect new receptor structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a688967a8832394125fb80c87ea35