### PR TITLE
Allow storing SMTP password in business config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ pendiente en modo de contingencia.
 ### Datos del negocio y correo
 
 La configuración general se almacena en `datos_negocio.json`. Para que el envío
-de facturas por correo funcione, completa los campos SMTP de este archivo. La
-contraseña de la cuenta utilizada para enviar correos ya **no** se guarda en el
-archivo. En su lugar, define la variable de entorno `INVENTARIO_EMAIL_PASSWORD`
-con la contraseña correspondiente antes de ejecutar la aplicación.
+de facturas por correo funcione, completa los campos SMTP de este archivo. Puedes
+especificar la contraseña directamente en `email_contrasena` o definir la
+variable de entorno `INVENTARIO_EMAIL_PASSWORD` antes de ejecutar la aplicación;
+la variable de entorno tiene prioridad si se define.
 
 Si estás ejecutando pruebas automatizadas o no planeas enviar correos, puedes
 evitar la advertencia sobre credenciales incompletas estableciendo la variable

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -569,7 +569,7 @@ class FacturacionTab(QWidget):
         server = creds.get("smtp_server")
         port = creds.get("smtp_port")
         user = creds.get("email_usuario")
-        password = os.getenv("INVENTARIO_EMAIL_PASSWORD")
+        password = os.getenv("INVENTARIO_EMAIL_PASSWORD") or creds.get("email_contrasena")
         if not all([server, port, user, password]):
             QMessageBox.warning(self, "Enviar por correo", "Credenciales SMTP incompletas.")
             return
@@ -1113,7 +1113,7 @@ class FacturacionTab(QWidget):
         server = creds.get("smtp_server")
         port = creds.get("smtp_port")
         user = creds.get("email_usuario")
-        password = os.getenv("INVENTARIO_EMAIL_PASSWORD")
+        password = os.getenv("INVENTARIO_EMAIL_PASSWORD") or creds.get("email_contrasena")
         if not all([server, port, user, password]):
             QMessageBox.warning(self, "Enviar ticket", "Credenciales SMTP incompletas.")
             return

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -443,7 +443,7 @@ class SalesTab(QWidget):
         server = data.get("smtp_server")
         port = data.get("smtp_port")
         user = data.get("email_usuario") or data.get("email")
-        password = os.getenv("INVENTARIO_EMAIL_PASSWORD")
+        password = os.getenv("INVENTARIO_EMAIL_PASSWORD") or data.get("email_contrasena")
 
         if not data.get("email_usuario") and user:
             data["email_usuario"] = user

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -92,9 +92,17 @@ def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
 
     creds_path = tmp_path / "creds.json"
-    creds_path.write_text(json.dumps({"smtp_server": "s", "smtp_port": 25, "email_usuario": "u"}))
+    creds_path.write_text(
+        json.dumps(
+            {
+                "smtp_server": "s",
+                "smtp_port": 25,
+                "email_usuario": "u",
+                "email_contrasena": "pw",
+            }
+        )
+    )
     monkeypatch.setattr(facturacion_tab, "DATOS_NEGOCIO_PATH", str(creds_path))
-    monkeypatch.setenv("INVENTARIO_EMAIL_PASSWORD", "pw")
 
     tab = _make_tab(db, cid)
     monkeypatch.setattr(tab, "_selected_venta", lambda: venta_id)


### PR DESCRIPTION
## Summary
- Read SMTP password from `email_contrasena` in datos_negocio.json with env var override
- Use same logic when sending invoices or tickets in FacturacionTab
- Document new configuration option and update tests

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a672e2f048323b39d6540894933a8