### PR TITLE
feat: add detailed error reporting

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -91,13 +91,22 @@ def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, float]:
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     data = {"user": nit, "pwd": pwd}
     url = _get_auth_url()
-    resp = requests.post(url, data=data, headers=headers, timeout=20)
-    resp.raise_for_status()
-    info = resp.json()
-    token = info.get("access_token")
-    expires_in = int(info.get("expires_in", 0))
-    obtained_at = time.time()
-    return token, expires_in, obtained_at
+    try:
+        resp = requests.post(url, data=data, headers=headers, timeout=20)
+        resp.raise_for_status()
+        info = resp.json()
+        token = info.get("access_token")
+        if not token:
+            raise ValueError("Respuesta de autenticación sin token")
+        expires_in = int(info.get("expires_in", 0))
+        obtained_at = time.time()
+        return token, expires_in, obtained_at
+    except Exception as exc:
+        report = f"Error de autenticación al solicitar token en {url}: {exc}"
+        if isinstance(exc, requests.HTTPError) and exc.response is not None:
+            report += f"\nRespuesta: {exc.response.text[:200]}"
+        print(report)
+        raise
 
 
 def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
@@ -137,7 +146,11 @@ def get_token(refresh: bool = False) -> str:
         return _access_token
 
     nit, pwd = _get_credentials()
-    token, expires_in, obtained_at = _request_new_token(nit, pwd)
+    try:
+        token, expires_in, obtained_at = _request_new_token(nit, pwd)
+    except Exception as exc:
+        print(f"No se pudo obtener token: {exc}")
+        raise
     _access_token = token
     _obtained_at = obtained_at
     _expires_at = obtained_at + expires_in

--- a/dte.py
+++ b/dte.py
@@ -7,7 +7,7 @@ from db import DB
 import requests
 from utils import jws
 import auth
-from jsonschema import validate as _jsonschema_validate
+from jsonschema import Draft7Validator, ValidationError
 from utils import catalogos
 import logging
 
@@ -69,6 +69,24 @@ def _round(value, digits):
         value = 0
     fmt = "0." + "0" * digits
     return float(Decimal(str(value)).quantize(Decimal(fmt), rounding=ROUND_HALF_UP))
+
+
+def _validate_schema(instance: dict, schema: dict) -> None:
+    """Validate ``instance`` against ``schema`` reporting all errors.
+
+    Prints a full report of all schema validation issues found and raises
+    ``ValidationError`` with the combined message if any problems exist.
+    """
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda e: e.path)
+    if errors:
+        lines = ["Errores de esquema encontrados:"]
+        for err in errors:
+            path = ".".join(str(p) for p in err.path) or "<root>"
+            lines.append(f"- {path}: {err.message}")
+        report = "\n".join(lines)
+        print(report)
+        raise ValidationError(report)
 
 
 def _load_datos_negocio():
@@ -574,7 +592,7 @@ def validate_dte_json(data: dict) -> None:
     if schema_path and os.path.exists(schema_path):
         with open(schema_path, "r", encoding="utf-8") as fh:
             schema = json.load(fh)
-        _jsonschema_validate(instance=data, schema=schema)
+        _validate_schema(instance=data, schema=schema)
 
 
 def generar_ticket_json(


### PR DESCRIPTION
## Summary
- print detailed report when authentication fails and include response body
- validate DTE schemas collecting all schema errors and display full report

## Testing
- `python -m pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a6bc181e88323a940c6b0df4dbd55