### PR TITLE
feat: add OAuth email example

### DIFF
--- a/docs/m365_oauth_email.md
+++ b/docs/m365_oauth_email.md
@@ -1,0 +1,73 @@
+# Envío de correo con Microsoft 365 y OAuth 2.0
+
+Guía rápida para reemplazar la autenticación SMTP básica por OAuth 2.0 usando
+Microsoft Graph.
+
+## 1. Registrar la aplicación en Azure Active Directory
+
+1. Ingresa al [portal de Azure](https://portal.azure.com/).
+2. Dirígete a **Azure Active Directory → App registrations** y selecciona
+   **New registration**.
+3. Asigna un nombre a la aplicación y registra el redirect URI si usarás el
+   flujo **Authorization Code** (por ejemplo `http://localhost:8000/callback`).
+4. Tras crearla copia los valores de **Application (client) ID** y
+   **Directory (tenant) ID**.
+
+### Generar un `client_secret`
+
+1. Dentro del registro de la aplicación ve a **Certificates & secrets**.
+2. Crea un nuevo **Client secret** y guarda su valor; se mostrará solo una vez.
+
+### Otorgar permisos
+
+1. En **API permissions** elige **Add a permission → Microsoft Graph**.
+2. Selecciona **Application permissions** y marca `Mail.Send`.
+3. Haz clic en **Grant admin consent** para aplicar el permiso a todo el tenant.
+
+## 2. Obtener un token de acceso
+
+### Flujo *Client Credentials*
+
+El script [`send_mail.py`](../send_mail.py) usa este flujo. Define las
+variables de entorno requeridas y ejecuta:
+
+```bash
+export AZURE_TENANT_ID=<tu_tenant>
+export AZURE_CLIENT_ID=<tu_app_id>
+export AZURE_CLIENT_SECRET=<tu_client_secret>
+export AZURE_SENDER_EMAIL=<buzon@dominio.com>
+export AZURE_TEST_RECIPIENT=<destinatario@dominio.com>
+python send_mail.py
+```
+
+MSAL almacena en caché el token y lo renueva automáticamente cuando expira
+(`acquire_token_silent`); no se maneja un *refresh token* explícito en este
+flujo.
+
+### Flujo *Authorization Code* (opcional)
+
+Para enviar correos en nombre de un usuario interactivo, registra el redirect
+URI y usa `Msal.PublicClientApplication` o una biblioteca compatible para
+obtener el `authorization_code`. Tras el primer inicio de sesión MSAL guardará
+un *refresh token* y `acquire_token_silent` permitirá renovar el `access_token`
+sin intervención del usuario.
+
+## 3. Manejo de errores comunes
+
+- **401/invalid_grant**: verifica `client_id`, `client_secret` y `tenant_id`.
+- **403/Insufficient privileges**: la aplicación no tiene el permiso `Mail.Send`
+  o no se otorgó **admin consent**.
+- **429/503**: reintenta luego de unos segundos respetando los encabezados
+  `Retry-After` devueltos por el servicio.
+
+## 4. Verificar el envío
+
+1. Ejecuta `send_mail.py`.
+2. El script imprimirá `Correo enviado correctamente.` si Microsoft Graph
+   devuelve un código `202 Accepted`.
+3. Revisa el buzón del destinatario para confirmar la recepción.
+
+Esta guía se basa en el uso de Microsoft Graph; también es posible autenticar
+contra el servidor SMTP de Microsoft 365 usando OAuth 2.0, pero se recomienda
+preferir Graph para nuevas integraciones.
+

--- a/send_mail.py
+++ b/send_mail.py
@@ -1,41 +1,99 @@
+"""Ejemplo de envío de correo mediante Microsoft 365 usando OAuth 2.0.
+
+Este script reemplaza la autenticación básica (usuario/contraseña) por un flujo
+de *client credentials* y el endpoint ``sendMail`` de Microsoft Graph. Para
+utilizarlo define las siguientes variables de entorno:
+
+* ``AZURE_CLIENT_ID`` – ID de la aplicación registrada en Azure AD.
+* ``AZURE_CLIENT_SECRET`` – secreto de cliente generado en Azure AD.
+* ``AZURE_TENANT_ID`` – identificador del tenant donde se registró la app.
+* ``AZURE_SENDER_EMAIL`` – dirección del buzón que enviará el correo.
+* ``AZURE_TEST_RECIPIENT`` – destinatario de prueba.
+
+El permiso ``Mail.Send`` (Application) debe concederse a la aplicación y
+contar con *admin consent*.
+"""
+
 import os
 import requests
-from msal import ConfidentialClientApplication
+from msal import ConfidentialClientApplication, MsalServiceError
 
 CLIENT_ID = os.environ["AZURE_CLIENT_ID"]
 CLIENT_SECRET = os.environ["AZURE_CLIENT_SECRET"]
 TENANT_ID = os.environ["AZURE_TENANT_ID"]
-SENDER = os.environ.get("AZURE_SENDER_EMAIL")
+SENDER = os.environ["AZURE_SENDER_EMAIL"]
+RECIPIENT = os.environ["AZURE_TEST_RECIPIENT"]
 
+SCOPE = ["https://graph.microsoft.com/.default"]
+
+# Inicializa el cliente confidencial de MSAL. Internamente manejará el caché
+# de tokens y renovará el access token cuando caduque.
 app = ConfidentialClientApplication(
     client_id=CLIENT_ID,
     client_credential=CLIENT_SECRET,
-    authority=f"https://login.microsoftonline.com/{TENANT_ID}"
+    authority=f"https://login.microsoftonline.com/{TENANT_ID}",
 )
 
-token_result = app.acquire_token_for_client(scopes=["https://graph.microsoft.com/.default"])
-access_token = token_result.get("access_token")
-if not access_token:
-    raise RuntimeError(f"No se pudo obtener token: {token_result.get('error_description')}")
 
-message = {
-    "message": {
-        "subject": "Hola desde OAuth",
-        "body": {
-            "contentType": "Text",
-            "content": "¡Mensaje enviado con autenticación moderna!"
-        },
-        "toRecipients": [
-            {"emailAddress": {"address": os.environ.get("AZURE_TEST_RECIPIENT")}}
-        ]
+def get_access_token() -> str:
+    """Obtiene un token de acceso válido.
+
+    Primero intenta recuperar un token en caché (``acquire_token_silent``). Si no
+    existe o ya expiró, solicita uno nuevo. Para el flujo de *client
+    credentials* no se utilizan tokens de actualización; simplemente se genera
+    un nuevo access token cuando sea necesario.
+    """
+
+    result = app.acquire_token_silent(SCOPE, account=None)
+    if not result:
+        try:
+            result = app.acquire_token_for_client(scopes=SCOPE)
+        except MsalServiceError as exc:
+            raise RuntimeError(f"Error al solicitar token a Azure AD: {exc}") from exc
+
+    token = result.get("access_token")
+    if not token:
+        raise RuntimeError(f"No se pudo obtener token: {result.get('error_description')}")
+    return token
+
+
+def send_mail(subject: str, content: str, recipient: str) -> None:
+    """Envía un correo utilizando Microsoft Graph.
+
+    Args:
+        subject: Asunto del correo.
+        content: Cuerpo del mensaje en texto plano.
+        recipient: Dirección del destinatario.
+
+    Lanza ``RuntimeError`` si la API devuelve un código distinto de 202.
+    """
+
+    access_token = get_access_token()
+    message = {
+        "message": {
+            "subject": subject,
+            "body": {"contentType": "Text", "content": content},
+            "toRecipients": [{"emailAddress": {"address": recipient}}],
+        }
     }
-}
 
-send_url = f"https://graph.microsoft.com/v1.0/users/{SENDER}/sendMail"
-headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
-response = requests.post(send_url, headers=headers, json=message)
+    send_url = f"https://graph.microsoft.com/v1.0/users/{SENDER}/sendMail"
+    headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+    response = requests.post(send_url, headers=headers, json=message)
+    if response.status_code != 202:
+        raise RuntimeError(f"Error al enviar correo: {response.status_code} {response.text}")
 
-if response.status_code == 202:
-    print("Correo enviado correctamente.")
-else:
-    print("Error al enviar correo:", response.status_code, response.text)
+
+if __name__ == "__main__":
+    try:
+        send_mail(
+            subject="Hola desde OAuth",
+            content="¡Mensaje enviado con autenticación moderna!",
+            recipient=RECIPIENT,
+        )
+        print("Correo enviado correctamente.")
+    except Exception as err:  # pragma: no cover - manejo simple para este ejemplo
+        # Si la respuesta es 403 verifica que la aplicación tenga el permiso
+        # Mail.Send y que se haya otorgado el consentimiento de administrador.
+        print(f"Error al enviar correo: {err}")
+


### PR DESCRIPTION
## Summary
- add script using MSAL to send email via Microsoft Graph with OAuth 2.0
- document Azure AD setup and usage steps

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a725e28488323923e38578f8bc537