### PR TITLE
Allow 4-digit economic activity codes in JSON schemas

### DIFF
--- a/svfe-json-schemas/fe-cl-v1.json
+++ b/svfe-json-schemas/fe-cl-v1.json
@@ -107,9 +107,9 @@
         "codActividad": {
           "type": "string",
           "description": "Código de Actividad Económica (Emisor)",
-          "pattern": "^[0-9]{2,6}$",
+          "pattern": "^[0-9]{4,6}$",
           "maxLength": 6,
-          "minLength": 5
+          "minLength": 4
         },
         "descActividad": {
           "type": "string",
@@ -444,9 +444,9 @@
         "codActividad": {
           "type": "string",
           "description": "Código de Actividad Económica (Receptor)",
-          "pattern": "^[0-9]{2,6}$",
+          "pattern": "^[0-9]{4,6}$",
           "maxLength": 6,
-          "minLength": 5
+          "minLength": 4
         },
         "descActividad": {
           "type": "string",

--- a/svfe-json-schemas/fe-cr-v1.json
+++ b/svfe-json-schemas/fe-cr-v1.json
@@ -116,9 +116,9 @@
                 "codActividad": {
                     "type": "string",
                     "description": "Código de Actividad Económica (Emisor)",
-                    "pattern": "^[0-9]{5,6}$",
+                    "pattern": "^[0-9]{4,6}$",
                     "maxLength": 6,
-                    "minLength": 5
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": "string",
@@ -472,7 +472,9 @@
                 "codActividad": {
                     "type": "string",
                     "description": "Código de Actividad Económica (Receptor)",
-                    "pattern": "^[0-9]{5,6}$"
+                    "pattern": "^[0-9]{4,6}$",
+                    "maxLength": 6,
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": "string",

--- a/svfe-json-schemas/fe-dcl-v1.json
+++ b/svfe-json-schemas/fe-dcl-v1.json
@@ -104,9 +104,9 @@
                 "codActividad": {
                     "type": "string",
                     "description": "Código de Actividad Económica (Emisor)",
-                    "pattern": "^[0-9]{2,6}$",
+                    "pattern": "^[0-9]{4,6}$",
                     "maxLength": 6,
-                    "minLength": 5
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": "string",
@@ -441,9 +441,9 @@
                 "codActividad": {
                     "type": "string",
                     "description": "Código de Actividad Económica (Receptor)",
-                    "pattern": "^[0-9]{2,6}$",
+                    "pattern": "^[0-9]{4,6}$",
                     "maxLength": 6,
-                    "minLength": 5
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": "string",

--- a/svfe-json-schemas/fe-fc-v1.json
+++ b/svfe-json-schemas/fe-fc-v1.json
@@ -287,9 +287,9 @@
                 "codActividad": {
                     "type": "string",
                     "description": "Código de Actividad Económica (Emisor)",
-                    "pattern": "^[0-9]{2,6}$",
+                    "pattern": "^[0-9]{4,6}$",
                     "maxLength": 6,
-                    "minLength": 5
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": "string",
@@ -649,9 +649,9 @@
                         "null"
                     ],
                     "description": "Código de Actividad Económica (Receptor)",
-                    "pattern": "^[0-9]{2,6}$",
+                    "pattern": "^[0-9]{4,6}$",
                     "maxLength": 6,
-                    "minLength": 5
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": [

--- a/svfe-json-schemas/fe-fex-v1.json
+++ b/svfe-json-schemas/fe-fex-v1.json
@@ -188,9 +188,9 @@
                 "codActividad": {
                     "type": "string",
                     "description": "Código de Actividad Económica (Emisor)",
-                    "pattern": "^[0-9]{2,6}$",
+                    "pattern": "^[0-9]{4,6}$",
                     "maxLength": 6,
-                    "minLength": 5
+                    "minLength": 4
                 },
                 "descActividad": {
                     "type": "string",


### PR DESCRIPTION
## Summary
- permit 4–6 digit `codActividad` values for emisor and receptor in SVFE schemas

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a71dd832083238ecf3dd818e5e1e7