### PR TITLE
Use resource_path helper for bundled resources

### DIFF
--- a/db.py
+++ b/db.py
@@ -2,14 +2,15 @@ import sqlite3
 from datetime import datetime
 import json
 import logging
-import os
 import threading
+
+from utils import resource_path
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class DB:
-    def __init__(self, db_name=os.path.join(os.path.dirname(__file__), "inventario.db")):
+    def __init__(self, db_name=resource_path("inventario.db")):
         # ``check_same_thread=False`` allows the connection to be used from
         # multiple threads.  Each thread should ideally use its own connection
         # but this flag prevents SQLite from raising an exception if a

--- a/main.py
+++ b/main.py
@@ -24,10 +24,10 @@ from PyQt5.QtGui import QIcon
 from ui_mainwindow import MainWindow
 from user_picker_dialog import UserPickerDialog
 from db import DB
+from utils import resource_path
 
-BASE_DIR = os.path.dirname(__file__)
-LAST_FILE_PATH = os.path.join(BASE_DIR, "ultimo_inventario.json")
-DEFAULT_INVENTORY = os.path.join(BASE_DIR, "inventario.json")
+LAST_FILE_PATH = resource_path("ultimo_inventario.json")
+DEFAULT_INVENTORY = resource_path("inventario.json")
 
 def cargar_ultimo_archivo():
     """Devuelve la ruta del inventario a cargar al iniciar la aplicación."""
@@ -42,18 +42,18 @@ def cargar_ultimo_archivo():
             pass
 
     if os.path.exists(DEFAULT_INVENTORY):
-        return DEFAULT_INVENTORY
+        return str(DEFAULT_INVENTORY)
     return ""
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    style_path = os.path.join(os.path.dirname(__file__), "style.qss")
-    if os.path.exists(style_path):
+    style_path = resource_path("style.qss")
+    if style_path.exists():
         with open(style_path, "r", encoding="utf-8") as f:
             app.setStyleSheet(f.read())
-    icon_path = os.path.join(os.path.dirname(__file__), "logoinventario.jpg")
-    if os.path.exists(icon_path):
-        app.setWindowIcon(QIcon(icon_path))
+    icon_path = resource_path("logoinventario.jpg")
+    if icon_path.exists():
+        app.setWindowIcon(QIcon(str(icon_path)))
 
     db = DB()
     users = [
@@ -86,8 +86,8 @@ if __name__ == "__main__":
             QMessageBox.warning(None, "Error", "Contraseña incorrecta")
 
     window = MainWindow(user)
-    if os.path.exists(icon_path):
-        window.setWindowIcon(QIcon(icon_path))
+    if icon_path.exists():
+        window.setWindowIcon(QIcon(str(icon_path)))
     window.show()
 
     # Cargar automáticamente el último inventario usado

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import sys
+
+
+def resource_path(relative: str) -> Path:
+    """Return absolute path to resource bundled via PyInstaller.
+
+    In frozen mode (e.g., when packaged with PyInstaller) resources live
+    inside ``sys._MEIPASS``. During development, resources are resolved
+    relative to the project root directory.
+    """
+    base = Path(sys._MEIPASS) if getattr(sys, "frozen", False) else Path(__file__).resolve().parent.parent
+    return base / relative


### PR DESCRIPTION
## Summary
- Add `resource_path` utility to resolve paths for PyInstaller bundles
- Use `resource_path` for loading resources in `main` and `db`

## Testing
- `pytest -q`
- `python - <<'PY'
from utils import resource_path
print('dev:', resource_path('style.qss'))
import sys
sys.frozen = True
sys._MEIPASS = '/tmp'
print('frozen:', resource_path('style.qss'))
PY`
- `QT_QPA_PLATFORM=offscreen python main.py >/tmp/main.log 2>&1 & pid=$!; sleep 2; kill $pid; tail -n 20 /tmp/main.log`


------
https://chatgpt.com/codex/tasks/task_e_689a7f342c808323b917f5418f5f8036