### PR TITLE
Add PyInstaller spec for ReportLab barcodes

### DIFF
--- a/barcode_example.py
+++ b/barcode_example.py
@@ -1,0 +1,41 @@
+"""Example script to generate a Code128 barcode PDF using ReportLab.
+
+This script demonstrates how to include ReportLab barcode submodules when
+building with PyInstaller. It works as a regular Python script and also
+when frozen into an executable, provided the PyInstaller spec includes the
+hidden imports shown in ``barcode_example.spec``.
+"""
+
+from reportlab.graphics.barcode import code128  # Import for Code128 barcode
+from reportlab.lib.units import mm
+from reportlab.pdfgen import canvas
+
+
+def make_barcode_pdf(text: str, output: str = "barcode_example.pdf") -> None:
+    """Generate a PDF containing a Code128 barcode.
+
+    Parameters
+    ----------
+    text:
+        The text to encode inside the barcode.
+    output:
+        Name of the PDF file to generate.
+    """
+    # Create a PDF canvas to draw on
+    c = canvas.Canvas(output)
+
+    # Create the barcode object. barWidth and barHeight are optional but
+    # allow custom sizing.
+    barcode = code128.Code128(text, barWidth=0.5 * mm, barHeight=20 * mm)
+
+    # Draw the barcode onto the canvas at the specified coordinates.
+    barcode.drawOn(c, 10 * mm, 250 * mm)
+
+    # Finalize the PDF file.
+    c.save()
+    print(f"PDF generated: {output}")
+
+
+if __name__ == "__main__":
+    # Example usage: encode an invoice number
+    make_barcode_pdf("INV-0001")

--- a/barcode_example.spec
+++ b/barcode_example.spec
@@ -1,0 +1,58 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec file for barcode_example.py.
+
+The key part is the ``hiddenimports`` definition which ensures that all
+ReportLab barcode submodules (e.g., Code128, QR) are bundled into the
+executable.  Without these, running the frozen app would raise
+``ModuleNotFoundError`` for the barcode modules because ReportLab loads
+them dynamically.
+"""
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# Collect every submodule under reportlab.graphics.barcode so PyInstaller
+# includes them in the build. This covers Code128, QR, and any other
+# barcode implementations provided by ReportLab.
+hidden_imports = collect_submodules("reportlab.graphics.barcode")
+
+block_cipher = None
+
+
+a = Analysis(
+    ["barcode_example.py"],
+    pathex=["."],
+    binaries=[],
+    datas=[],
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="barcode_example",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="barcode_example",
+)


### PR DESCRIPTION
## Summary
- provide `barcode_example.py` demonstrating generating Code128 barcode PDF with ReportLab
- add `barcode_example.spec` using `collect_submodules` to bundle ReportLab barcode submodules when freezing with PyInstaller

## Testing
- `python barcode_example.py`
- `pyinstaller barcode_example.spec`
- `./dist/barcode_example/barcode_example`
- `pytest` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a85b5a7bc83238d4c126b05958c9e