### PR TITLE
Add default certificate lookup

### DIFF
--- a/tests/test_jws_additional.py
+++ b/tests/test_jws_additional.py
@@ -74,3 +74,21 @@ def test_sign_json_missing_p12(tmp_path):
 def test_sign_json_missing_cert(tmp_path):
     with pytest.raises(ValueError):
         jws.sign_json({}, None, None, None)
+
+
+def test_get_cert_config_defaults(tmp_path, monkeypatch):
+    key, cert = create_keypair()
+    key_file = tmp_path / "default.key"
+    cert_file = tmp_path / "default.crt"
+    key_file.write_bytes(key)
+    cert_file.write_bytes(cert)
+
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(jws, "CONFIG_NEGOCIO_PATH", str(cfg_path))
+    monkeypatch.setattr(jws, "DATOS_NEGOCIO_PATH", str(tmp_path / "missing.json"))
+
+    cert_path, key_path, phrase = jws.get_cert_config(str(cfg_path))
+    assert cert_path == str(cert_file)
+    assert key_path == str(key_file)
+    assert phrase is None

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -3,6 +3,7 @@ import json
 import base64
 import time
 import subprocess
+import glob
 from cryptography.hazmat.primitives.serialization import (
     pkcs12,
     Encoding,
@@ -46,6 +47,7 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
     """Return certificate (.crt), key (.key) and password from config."""
     ambiente = _get_ambiente()
     verificar = ambiente == "produccion"
+    password = None
     if os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as fh:
@@ -101,6 +103,23 @@ def get_cert_config(path: str = CONFIG_NEGOCIO_PATH):
                 return cert_path, None, password
         except Exception:
             return None, None, None
+
+    # Fallback: search for certificate and key files in repository root
+    root_dir = os.path.dirname(path)
+    cert_candidates = sorted(glob.glob(os.path.join(root_dir, "*.crt")))
+    key_candidates = sorted(glob.glob(os.path.join(root_dir, "*.key")))
+    if cert_candidates and key_candidates:
+        cert_path = cert_candidates[0]
+        key_path = key_candidates[0]
+        if verificar:
+            with open(cert_path, "rb") as fh:
+                x509.load_pem_x509_certificate(fh.read())
+            with open(key_path, "rb") as fh:
+                key_bytes = fh.read()
+            if b"-----BEGIN" not in key_bytes:
+                raise ValueError("La clave privada no parece ser PEM")
+            load_pem_private_key(key_bytes, password.encode() if password else None)
+        return cert_path, key_path, password
 
     return None, None, None
 


### PR DESCRIPTION
## Summary
- load certificate and key automatically from project root if config is missing
- cover default lookup with tests

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a8ca304d083239de2ca1792334ea8