### PR TITLE
Bundle reportlab barcodes in PyInstaller build

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# Collect all barcode submodules so ReportLab barcodes such as Code93 and
+# Code128 are bundled with the executable.
+hidden_imports = collect_submodules("reportlab.graphics.barcode")
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='main',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='main',
+)


### PR DESCRIPTION
## Summary
- add main.spec that collects all `reportlab.graphics.barcode` submodules so Code93, Code128 and friends are bundled

## Testing
- `pyinstaller main.spec`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a8ea039588323b7fc24eca6de6ea1