### PR TITLE
Evitar envío de correo si transmisión falla

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -568,6 +568,7 @@ class SalesTab(QWidget):
             QMessageBox.warning(self, "Guardar y enviar", "No se pudo generar el documento.")
             return
         QMessageBox.information(self, "Guardar y enviar", f"{doc_type} guardado en {file_path}")
+        envio_ok = False
         try:
             modo = "contingencia" if venta.get("tipo_transmision", "").startswith("2") else "normal"
             resp = transmitir_dte(self.manager.db, venta_id, modo=modo, tipo_dte=tipo_dte)
@@ -586,6 +587,7 @@ class SalesTab(QWidget):
                 self.sent_label.setText(
                     "Último envío: " + datetime.now().strftime("%Y-%m-%d %H:%M")
                 )
+                envio_ok = True
         except Exception as e:
             self.status_label.setText("Estado actual: Error")
             self.gen_label.setText(
@@ -593,8 +595,9 @@ class SalesTab(QWidget):
             )
             QMessageBox.warning(self, "Enviar a Hacienda", str(e))
 
-        # Después de guardar y transmitir, también enviar por correo
-        self.send_email()
+        # Después de guardar y transmitir, también enviar por correo si la transmisión fue exitosa
+        if envio_ok:
+            self.send_email()
 
     def save_ticket(self):
         """Generate a simple ticket PDF for the selected sale."""

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -240,3 +240,41 @@ def test_email_exitoso(
     assert len(init_calls) == 1
     assert not smtp_calls
 
+
+def test_transmit_fail_no_email(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    pdf, _json = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
+
+    def fake_gen(manager, vid, p=pdf):
+        manager.db.add_factura_pdf(vid, "Factura", str(p))
+        return str(p)
+
+    monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
+    monkeypatch.setattr(
+        "sales_tab.transmitir_dte", lambda *a, **k: {"estado": "error"}
+    )
+
+    called = {}
+
+    def fake_send(self):
+        called["called"] = True
+
+    monkeypatch.setattr(SalesTab, "send_email", fake_send)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+    tab.sales_table.selectRow(0)
+    tab.save_and_send()
+
+    assert "called" not in called
+


### PR DESCRIPTION
## Summary
- Solo se envía el correo si la transmisión a Hacienda termina correctamente.
- Se prueba que al fallar la transmisión no se intente enviar por correo.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a9072433883238e9b31a4f4e7b959