### PR TITLE
Ensure note PDFs use invoice layout

### DIFF
--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -83,4 +83,11 @@ def test_nota_credito_pdf(tmp_path):
     assert out.exists()
     with fitz.open(out) as doc:
         text = "".join(p.get_text() for p in doc)
-    assert "NOTA DE CR\xc9DITO" in text
+    assert "DOCUMENTO TRIBUTARIO ELECTRÓNICO" in text
+    assert "NOTA DE CRÉDITO" in text
+    assert "Código Generación:" in text
+    assert "Número Control:" in text
+    assert "Sello Recepción:" in text
+    assert "Modelo Facturación:" in text
+    assert "Tipo Transmisión:" in text
+    assert "Fecha Generación:" in text

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -81,7 +81,14 @@ def test_nota_debito_pdf(tmp_path):
     assert out.exists()
     with fitz.open(out) as doc:
         text = "".join(p.get_text() for p in doc)
-    assert "NOTA DE D" in text
+    assert "DOCUMENTO TRIBUTARIO ELECTRÓNICO" in text
+    assert "NOTA DE DÉBITO" in text
+    assert "Código Generación:" in text
+    assert "Número Control:" in text
+    assert "Sello Recepción:" in text
+    assert "Modelo Facturación:" in text
+    assert "Tipo Transmisión:" in text
+    assert "Fecha Generación:" in text
 
 
 def test_nota_remision_pdf(tmp_path):


### PR DESCRIPTION
## Summary
- verify that PDF generation for credit notes outputs full invoice-like headers
- verify that PDF generation for debit notes outputs full invoice-like headers

## Testing
- `pytest -o addopts='' tests/test_nota_credito.py tests/test_nota_debito_remision.py`
- `pytest` *(fails: unrecognized arguments: --cov=. --cov-branch --cov-report=term-missing --cov-fail-under=95; follow-up: tests require additional dependencies or configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689aa1d253f083239793b007b6f5c70e