### PR TITLE
docs: add optional https env sample

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Variables opcionales para habilitar el perfil SSL del firmador
+# SVFE_ARCHIVO=
+# SVFE_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ vendor/jdk/bin/java -jar target/svfe-api-firmador-0.1.1.jar --server.port=8080
 Luego se firmará cada DTE enviándolo a
 `http://127.0.0.1:8080/firma/firmardocumento` de forma automática.
 
+El firmador utiliza HTTP por defecto. Si deseas habilitar HTTPS, define las
+variables `SVFE_ARCHIVO` y `SVFE_PASSWORD` en un archivo `.env` (consulta
+`.env.example`). Esta configuración es opcional y el perfil principal seguirá
+siendo el modo normal basado en HTTP.
+
 Para diferenciar entre los ambientes de pruebas y producción de Hacienda,
 configura el campo `ambiente` y las URLs en `config_negocio.json`:
 


### PR DESCRIPTION
## Summary
- add `.env.example` with commented SSL variables
- document optional HTTPS configuration in README

## Testing
- `pip install -r requirements.txt`
- `pytest` (fails: ImportError libGL.so.1 missing)

------
https://chatgpt.com/codex/tasks/task_e_689ae9c9b3d083238548e1b1fc7a350f