### PR TITLE
refactor: use SIGN_URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Para firmar electrónicamente los DTE define en `config_negocio.json` el bloque
 
 ```json
 {
-  "firmador_url": "http://127.0.0.1:8080/firma/firmardocumento/",
+  "sign_url": "http://127.0.0.1:8080/firma/firmardocumento/",
   "firma_electronica": {
     "nit": "09061712791014",
     "passwordPri": "PASSWORD_EN_BASE64",
@@ -131,14 +131,14 @@ server:
 ```
 
 Si el firmador escucha en otro puerto o en otro equipo, especifica la URL
-mediante la variable de entorno `FIRMADOR_URL`:
+mediante la variable de entorno `SIGN_URL`:
 
 ```bash
-export FIRMADOR_URL="http://127.0.0.1:8080/firma/firmardocumento/"
+export SIGN_URL="http://127.0.0.1:8080/firma/firmardocumento/"
 ```
 
 Alternativamente, puede definirse en `config_negocio.json` bajo la clave
-`firmador_url`.
+`sign_url`.
 
 Luego se firmará cada DTE enviándolo a
 `http://127.0.0.1:8080/firma/firmardocumento/` de forma automática si no se

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -9,13 +9,13 @@ SIGN_TIMEOUT = 10
 
 
 def _get_sign_url(path: str = CONFIG_NEGOCIO_PATH) -> str:
-    """Return signer service URL using env var, config or default."""
-    url = os.getenv("FIRMADOR_URL")
+    """Return signer service URL from ``SIGN_URL`` env, config or default."""
+    url = os.getenv("SIGN_URL")
     if not url and os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
-            url = data.get("firmador_url")
+            url = data.get("sign_url")
         except Exception:
             pass
     return url or DEFAULT_SIGN_URL


### PR DESCRIPTION
## Summary
- read SIGN_URL environment variable or sign_url config to locate sign service
- document SIGN_URL and sign_url usage in README

## Testing
- `pytest` *(fails: Interrupted: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689aeda0c7e08323b6be4de99b9f0eda