### PR TITLE
Add sample signing env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Variables opcionales para habilitar el perfil SSL del firmador
 # SVFE_ARCHIVO=
 # SVFE_PASSWORD=
+SIGN_URL=http://127.0.0.1:8080/firma/firmardocumento/
+SVFE_ARCHIVO=PATH_AL_KEYSTORE_O_CERT_SI_APLICA
+SVFE_PASSWORD=COLOCAR_AQUI_PASSWORD
+NIT_FIRMADOR=09061712791014
+HACIENDA_URL=https://sandbox.ejemplo.hacienda.sv/...


### PR DESCRIPTION
## Summary
- add placeholder URLs and credentials for signing and Hacienda services in `.env.example`

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689aeda705588323a66ca4210a5e810b