### PR TITLE
Add manual Hacienda sandbox test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ inventario.db
 
 # Tests cache
 tests/__pycache__/
+/.out/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ ejecutarlas. Puedes hacerlo ejecutando:
 pip install -r requirements.txt
 ```
 
+Para una prueba manual de extremo a extremo contra el entorno de
+Hacienda, ejecuta:
+
+```bash
+python -m tests.manual_e2e_sandbox
+```
+
 ### Generar DTE
 
 El método `generar_dte_json(venta_id)` crea un diccionario con el formato que

--- a/tests/manual_e2e_sandbox.py
+++ b/tests/manual_e2e_sandbox.py
@@ -1,0 +1,79 @@
+"""Manual end-to-end test against Hacienda sandbox.
+
+This script builds a minimal DTE, signs it and sends it to the URL
+specified in the ``HACIENDA_URL`` environment variable. The request
+payload and Hacienda response are stored under ``.out/`` for manual
+inspection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+
+import requests
+
+from db import DB
+from dte import generar_dte_json
+from utils.jws import sign_json
+
+
+def _build_sample_dte() -> dict:
+    """Return a minimal valid DTE using an in-memory database."""
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente("Cliente", "123", "0614-987654-321-0", "", "Giro", "", "", "Dir", "", "")
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return generar_dte_json(db, venta_id)
+
+
+def main() -> None:
+    url = os.getenv("HACIENDA_URL")
+    if not url:
+        print("E2E_SANDBOX_FAIL")
+        return
+
+    dte = _build_sample_dte()
+    token = sign_json(dte)
+
+    out_dir = pathlib.Path(".out")
+    out_dir.mkdir(exist_ok=True)
+
+    with (out_dir / "ultimo_dte.json").open("w", encoding="utf-8") as fh:
+        json.dump(dte, fh, ensure_ascii=False, indent=2)
+
+    payload = {"dte": token}
+    try:
+        resp = requests.post(url, json=payload, timeout=20)
+        resp_json = resp.json()
+    except Exception as exc:  # pragma: no cover - manual script
+        resp = None
+        resp_json = {"error": str(exc)}
+
+    with (out_dir / "respuesta_hacienda.json").open("w", encoding="utf-8") as fh:
+        json.dump(resp_json, fh, ensure_ascii=False, indent=2)
+
+    estado = str(
+        resp_json.get("estado")
+        or resp_json.get("estadoDte")
+        or resp_json.get("descripcionEstado")
+        or resp_json.get("status")
+        or ""
+    ).upper()
+
+    if resp and resp.status_code == 200 and (
+        "RECIB" in estado or "ACEPT" in estado or "PROCES" in estado
+    ):
+        print("E2E_SANDBOX_OK")
+    else:
+        print("E2E_SANDBOX_FAIL")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- add manual test to sign and send a sample DTE to Hacienda sandbox
- document manual end-to-end test in README
- ignore `.out` directory for generated request/response files

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic tests/test_envio_hacienda.py::test_transmision_exitosa --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_689aef493b6083239c3f296ca02d8087