### PR TITLE
Validate receptor document length

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -726,11 +726,14 @@ def validate_dte_json(data: dict) -> None:
         raise ValueError("Tipo de operación inválido")
     ident["tipoOperacion"] = oper_cod
 
-    # Validación de longitud de NIT
-    for parte in ("emisor", "receptor"):
-        nit = data.get(parte, {}).get("nit")
-        if nit and len(nit.replace("-", "")) != catalogos.NIT_LENGTH:
-            raise ValueError(f"NIT inválido en {parte}")
+    # Validación de longitud de NIT / numDocumento
+    emisor_nit = data.get("emisor", {}).get("nit")
+    if emisor_nit and len(emisor_nit.replace("-", "")) != catalogos.NIT_LENGTH:
+        raise ValueError("NIT inválido en emisor")
+
+    receptor_doc = data.get("receptor", {}).get("numDocumento")
+    if receptor_doc and len(receptor_doc) not in (9, catalogos.NIT_LENGTH):
+        raise ValueError("Número de documento inválido en receptor")
 
     # --- Schema validation ---
     schema_path = catalogos.SCHEMA_MAP.get(tipo_dte)

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -21,6 +21,13 @@ def test_longitud_nit_invalida(dte_metadata_factory):
         validate_dte_json(dte)
 
 
+def test_longitud_num_documento_invalida(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["receptor"]["numDocumento"] = "123"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
 def test_estructura_invalida(dte_metadata_factory):
     from jsonschema import ValidationError
 


### PR DESCRIPTION
## Summary
- validate length of receptor `numDocumento` (must be 9 or 14 digits)
- test for invalid receptor document length

## Testing
- `pytest` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689afc09e0cc8323b94f6cb15de29710