### PR TITLE
Permitir DUI o NIT sin guiones en validación

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -34,8 +34,21 @@ def get_field(obj, key, default=0):
     return default
 
 def validar_nit(nit):
+    """Valida NIT salvadoreño con o sin guiones o un DUI."""
     import re
-    return bool(re.match(r"^\d{4}-\d{6}-\d{3}-\d$", nit))
+    if not nit:
+        return False
+    # NIT con guiones: ####-######-###-#
+    nit_pattern = r"^\d{4}-\d{6}-\d{3}-\d$"
+    # NIT sin guiones: 14 dígitos
+    nit_plain_pattern = r"^\d{14}$"
+    # DUI: ########-# o #########
+    dui_pattern = r"^\d{8}-?\d$"
+    return bool(
+        re.match(nit_pattern, nit)
+        or re.match(nit_plain_pattern, nit)
+        or re.match(dui_pattern, nit)
+    )
 
 def validar_email(email):
     import re

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -9,10 +9,12 @@ from dialogs import (
 
 
 @pytest.mark.parametrize("nit, expected", [
-    ("1234-123456-123-1", True),
-    ("0000-000000-000-0", True),
-    ("1234-123456-123-12", False),
-    ("1234-123456-123", False),
+    ("1234-123456-123-1", True),  # NIT con guiones
+    ("12341234561231", True),     # NIT sin guiones
+    ("12345678-9", True),         # DUI con guion
+    ("123456789", True),          # DUI sin guion
+    ("1234-123456-123", False),  # NIT incompleto
+    ("abcd", False),             # caracteres inválidos
 ])
 def test_validar_nit(nit, expected):
     assert validar_nit(nit) is expected


### PR DESCRIPTION
## Summary
- allow NIT validation to accept DUI numbers or NITs without hyphens
- add tests for new NIT/DUI formats

## Testing
- `QT_QPA_PLATFORM=offscreen pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b061a4fb08323a886de3a83edd69b