### PR TITLE
Ensure client DUI is retrieved and searchable

### DIFF
--- a/db.py
+++ b/db.py
@@ -1309,7 +1309,7 @@ class DB:
 
     def get_clientes(self, search=""):
         query = (
-            "SELECT id, codigo, nombre, nrc, nit, telefono, email, giro, direccion, departamento, municipio, otros "
+            "SELECT id, codigo, nombre, nrc, nit, dui, telefono, email, giro, direccion, departamento, municipio, otros "
             "FROM clientes"
         )
         params = []
@@ -1317,9 +1317,9 @@ class DB:
             like = f"%{search}%"
             query += (
                 " WHERE nombre LIKE ? OR codigo LIKE ? OR nit LIKE ? OR nrc LIKE ? "
-                "OR telefono LIKE ? OR email LIKE ?"
+                "OR dui LIKE ? OR telefono LIKE ? OR email LIKE ?"
             )
-            params = [like, like, like, like, like, like]
+            params = [like, like, like, like, like, like, like]
         self.cursor.execute(query, params)
         return [dict(row) for row in self.cursor.fetchall()]
 

--- a/tests/test_cliente_dui.py
+++ b/tests/test_cliente_dui.py
@@ -1,0 +1,18 @@
+from db import DB
+
+
+def test_get_clientes_returns_dui():
+    db = DB(":memory:")
+    dui = "01234567-8"
+    db.add_cliente("Juan", "", "", dui, "", "", "", "", "", "")
+    clientes = db.get_clientes()
+    assert clientes[0]["dui"] == dui
+
+
+def test_get_clientes_search_by_dui():
+    db = DB(":memory:")
+    dui = "01234567-8"
+    db.add_cliente("Juan", "", "", dui, "", "", "", "", "", "")
+    clientes = db.get_clientes(search="01234567")
+    assert len(clientes) == 1
+    assert clientes[0]["dui"] == dui


### PR DESCRIPTION
## Summary
- include `dui` column and search filter when listing clients
- test client listing to guarantee DUI persistence and search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b05c66d7083238d97df7810f498c1