### PR TITLE
Soportar credenciales por ambiente en auth

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -42,15 +42,35 @@ def _read_config_credentials() -> Tuple[Optional[str], Optional[str]]:
     try:
         with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
             data = json.load(fh)
+
+        ambiente = data.get("ambiente", "pruebas")
+        env_conf = data.get(ambiente, {})
+        firma_conf = env_conf.get("firma_electronica", {})
+
         nit = (
-            data.get("nit")
+            firma_conf.get("nit")
+            or firma_conf.get("NIT")
+            or env_conf.get("nit")
+            or env_conf.get("NIT")
+            or env_conf.get("api_nit")
+            or env_conf.get("api", {}).get("nit")
+            or env_conf.get("dte_api", {}).get("nit")
+            or data.get("nit")
             or data.get("NIT")
             or data.get("api_nit")
             or data.get("api", {}).get("nit")
             or data.get("dte_api", {}).get("nit")
         )
         pwd = (
-            data.get("api_pwd")
+            firma_conf.get("pwd")
+            or firma_conf.get("password")
+            or firma_conf.get("passwordPri")
+            or env_conf.get("api_pwd")
+            or env_conf.get("api_password")
+            or env_conf.get("clave")
+            or env_conf.get("api", {}).get("pwd")
+            or env_conf.get("dte_api", {}).get("pwd")
+            or data.get("api_pwd")
             or data.get("api_password")
             or data.get("clave")
             or data.get("api", {}).get("pwd")

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -73,3 +73,22 @@ def test_request_error(monkeypatch, tmp_path):
     monkeypatch.setattr(auth.requests, "post", fake_post)
     with pytest.raises(requests.HTTPError):
         auth.get_token(refresh=True)
+
+
+def test_env_specific_credentials(monkeypatch, tmp_path):
+    data = {
+        "ambiente": "pruebas",
+        "pruebas": {
+            "firma_electronica": {
+                "nit": "env_nit",
+                "passwordPri": "env_pwd",
+            }
+        },
+    }
+    cfg = tmp_path / "config_env.json"
+    cfg.write_text(json.dumps(data))
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
+    nit, pwd = auth._read_config_credentials()
+    assert nit == "env_nit"
+    assert pwd == "env_pwd"


### PR DESCRIPTION
## Summary
- ampliar lectura de credenciales en `auth` considerando bloques específicos del ambiente activo
- probar que las credenciales dentro de `pruebas.firma_electronica` se reconocen

## Testing
- `pytest tests/test_auth_module.py -q --no-cov`
- `pytest -q` *(falla: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689b081563f48323b274dfcef37db9e9