### PR TITLE
Ensure DTE totals include commissions and prevent false warnings

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -978,7 +978,8 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             "ventas_exentas": ventas_exentas,
             "ventas_no_sujetas": ventas_no_sujetas,
             "subtotal": (sumas - descuentos) + iva,
-            "total": (sumas - descuentos) + iva + ventas_exentas + ventas_no_sujetas,
+            # Usar el total acumulado para reflejar comisiones u otros cargos
+            "total": total,
             "fecha": QDate.currentDate().toString("yyyy-MM-dd"),
             "Distribuidor_id": (
                 self.Distribuidor_combo.currentIndex()

--- a/dte.py
+++ b/dte.py
@@ -482,6 +482,7 @@ def generar_dte_json(
 
     cuerpo = []
     items_total = Decimal("0")
+    commission_total = Decimal("0")
     for idx, d in enumerate(detalles, 1):
         try:
             cant = Decimal(str(d.get("cantidad") or 0))
@@ -494,6 +495,10 @@ def generar_dte_json(
         cant_r = cant.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP)
         price_r = price.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP)
         items_total += cant_r * price_r
+        try:
+            commission_total += Decimal(str(d.get("comision") or 0))
+        except Exception:
+            pass
         cuerpo.append({
             "numItem": idx,
             "descripcion": d.get("descripcion"),
@@ -532,9 +537,10 @@ def generar_dte_json(
         print(
             f"Advertencia: el monto total {resumen.get('montoTotalOperacion',0):.2f} difiere del calculado {calc_total:.2f}"
         )
-    if "totalPagar" in resumen and abs(calc_total - resumen.get("totalPagar", 0)) > 0.01:
+    calc_total_commission = _round(calc_total + float(commission_total), 2)
+    if "totalPagar" in resumen and abs(calc_total_commission - resumen.get("totalPagar", 0)) > 0.01:
         print(
-            f"Advertencia: el total a pagar {resumen.get('totalPagar',0):.2f} difiere del calculado {calc_total:.2f}"
+            f"Advertencia: el total a pagar {resumen.get('totalPagar',0):.2f} difiere del calculado {calc_total_commission:.2f}"
         )
 
     result = {

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -106,3 +106,28 @@ def test_generar_ticket_json_tipo():
 
     data = generar_dte_json(db, venta_id, tipo_dte="03")
     assert data["identificacion"]["tipoDte"] == "03"
+
+
+def test_dte_comision_sin_advertencia_total(capsys):
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-01-01",
+        12,
+        "123",
+        "nit1",
+        "giro",
+        sumas=10,
+        descuentos=0,
+        iva=0,
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 10, comision=2, vendedor_id=vid)
+    generar_dte_json(db, venta_id)
+    out = capsys.readouterr().out.lower()
+    assert out.strip() == "" and "total a pagar" not in out


### PR DESCRIPTION
## Summary
- Return the accumulated sale total in `RegisterSaleDialog.get_data` so commissions and extra charges are preserved
- Account for line-item commissions when validating DTE totals to avoid false "total a pagar" warnings
- Add regression test ensuring DTE generation with commissions emits no total warnings

## Testing
- `pytest tests/test_generar_dte_json.py::test_dte_comision_sin_advertencia_total -q -p no:cov -o addopts=`
- `pytest tests/test_generar_dte_json.py::test_dte_rounding_and_validation -q -p no:cov -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_689b0768859883239261cf9cab006d9a