### PR TITLE
Ajuste de descuento con IVA desglosado

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -995,6 +995,13 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         descuento_tipo = self.descuento_tipo_combo.currentText()
         subtotal = precio_total
 
+        iva = 0
+        iva_tipo = "ninguno"
+        if hasattr(self, "iva_checkbox") and self.iva_checkbox.isChecked() and self.iva_desglosado_radio.isChecked():
+            iva_tipo = "desglosado"
+            subtotal = subtotal / 1.13  # El precio ingresado incluye IVA
+            precio = round(subtotal / cantidad, 6) if cantidad > 0 else 0
+
         if descuento_tipo == "%":
             descuento_monto = subtotal * (descuento_valor / 100)
         else:
@@ -1016,23 +1023,13 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         if comision_tipo == "Desglosada (incluida en el precio)":
             base_iva = subtotal_con_descuento - comision_monto
 
-        iva = 0
-        iva_tipo = "ninguno"
-        precio_sin_iva = precio
         if hasattr(self, "iva_checkbox") and self.iva_checkbox.isChecked():
             if self.iva_agregado_radio.isChecked():
                 iva = round(base_iva * 0.13, 2)
                 iva_tipo = "agregado"
-                total = subtotal_con_descuento + iva
             elif self.iva_desglosado_radio.isChecked():
-                iva = round(base_iva * 13 / 113, 2)
-                iva_tipo = "desglosado"
-                precio_sin_iva_total = base_iva - iva
-                precio = round(precio_sin_iva_total / cantidad, 6) if cantidad > 0 else 0
-                subtotal = precio_sin_iva_total
-                total = subtotal_con_descuento
-            else:
-                total = subtotal_con_descuento
+                iva = round(base_iva * 0.13, 2)
+            total = subtotal_con_descuento + iva
         else:
             total = subtotal_con_descuento
 

--- a/tests/test_register_sale_dialog.py
+++ b/tests/test_register_sale_dialog.py
@@ -1,0 +1,45 @@
+import pytest
+from PyQt5.QtWidgets import QApplication
+from dialogs import RegisterSaleDialog
+
+@pytest.fixture
+def qt_app(monkeypatch):
+    monkeypatch.setenv('QT_QPA_PLATFORM', 'offscreen')
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_iva_desglosado_con_descuento(qt_app):
+    productos = [{
+        "lote_id": 1,
+        "producto_id": 1,
+        "nombre": "Prod",
+        "codigo": "P1",
+        "stock": 1,
+        "Distribuidor_id": None,
+        "vendedor_id": None,
+    }]
+    dialog = RegisterSaleDialog(productos, [], [])
+    dialog.product_list.setCurrentRow(0)
+    dialog.cantidad_spin.setValue(1)
+    dialog.precio_spin.setValue(113)
+    dialog.descuento_spin.setValue(10)
+    dialog.descuento_tipo_combo.setCurrentText("%")
+    dialog.iva_checkbox.setChecked(True)
+    dialog.iva_desglosado_radio.setChecked(True)
+
+    dialog._agregar_a_venta()
+    assert len(dialog.venta_items) == 1
+    item = dialog.venta_items[0]
+    assert item["subtotal"] == pytest.approx(100.0)
+    assert item["descuento_monto"] == pytest.approx(10.0)
+    assert item["subtotal_con_descuento"] == pytest.approx(90.0)
+    assert item["iva"] == pytest.approx(11.7)
+    assert item["total"] == pytest.approx(101.7)
+
+    data = dialog.get_data()
+    assert data["sumas"] == pytest.approx(100.0)
+    assert data["descuentos"] == pytest.approx(10.0)
+    assert data["iva"] == pytest.approx(11.7)
+    assert data["total"] == pytest.approx(101.7)
+    assert data["sumas"] - data["descuentos"] + data["iva"] == pytest.approx(data["total"])


### PR DESCRIPTION
## Summary
- Recalcula el subtotal y el descuento cuando el IVA está desglosado para usar la misma base
- Ajusta el cálculo de IVA y total por ítem manteniendo la comisión en el total
- Añade prueba para ventas con IVA desglosado y descuento

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0766df888323a00b317c66f6e117