### PR TITLE
Aggregate DTE validation errors and expand tests

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -578,9 +578,11 @@ def generar_dte_json(
 def validate_dte_json(data: dict) -> None:
     """Basic validation and normalization for DTE payload before signing."""
     required = ["identificacion", "emisor", "receptor", "cuerpoDocumento", "resumen"]
-    for key in required:
-        if key not in data:
-            raise ValueError(f"Falta el campo obligatorio: {key}")
+    missing = [key for key in required if key not in data]
+    if missing:
+        raise ValueError(
+            "Faltan campos obligatorios: " + ", ".join(missing)
+        )
 
     negocio = _load_datos_negocio()
 

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -28,13 +28,13 @@ def test_longitud_num_documento_invalida(dte_metadata_factory):
         validate_dte_json(dte)
 
 
-def test_estructura_invalida(dte_metadata_factory):
-    from jsonschema import ValidationError
-
+def test_estructura_invalida(dte_metadata_factory, monkeypatch):
     dte = dte_metadata_factory()
     del dte["emisor"]["nit"]
-    with pytest.raises(ValidationError):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {})
+    with pytest.raises(ValueError) as exc:
         validate_dte_json(dte)
+    assert "nit" in str(exc.value)
 
 
 def test_strips_additional_properties(dte_metadata_factory):
@@ -47,3 +47,50 @@ def test_strips_additional_properties(dte_metadata_factory):
     assert "selloRecibido" not in clean
     assert "firmaElectronica" not in clean["identificacion"]
     validate_dte_json(clean)
+
+
+def test_missing_top_level_fields_listed():
+    with pytest.raises(ValueError) as exc:
+        validate_dte_json({})
+    msg = str(exc.value)
+    for key in [
+        "identificacion",
+        "emisor",
+        "receptor",
+        "cuerpoDocumento",
+        "resumen",
+    ]:
+        assert key in msg
+
+
+def test_missing_emisor_fields_listed(dte_metadata_factory, monkeypatch):
+    dte = dte_metadata_factory()
+    dte["emisor"] = {}
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {})
+    with pytest.raises(ValueError) as exc:
+        validate_dte_json(dte)
+    msg = str(exc.value)
+    for key in [
+        "nit",
+        "nrc",
+        "nombre",
+        "codActividad",
+        "descActividad",
+        "direccion.complemento",
+        "telefono",
+        "correo",
+    ]:
+        assert key in msg
+
+
+def test_schema_reports_multiple_errors(dte_metadata_factory):
+    from jsonschema import ValidationError
+
+    dte = dte_metadata_factory()
+    del dte["cuerpoDocumento"][0]["descripcion"]
+    del dte["cuerpoDocumento"][0]["cantidad"]
+    with pytest.raises(ValidationError) as exc:
+        validate_dte_json(dte)
+    msg = str(exc.value)
+    assert "cuerpoDocumento.0: 'descripcion' is a required property" in msg
+    assert "cuerpoDocumento.0.cantidad" in msg


### PR DESCRIPTION
## Summary
- Aggregate missing top-level DTE fields into a single ValueError
- Exercise validation logic for missing sections and schema errors
- Cover edge cases for missing emitter details

## Testing
- `pytest tests/test_dte_validation.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5f58ac548323a702ccfd72567ae8