### PR TITLE
Add transmission table export/import and tests

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -238,6 +238,22 @@ class InventoryManager:
                 "detalles_compra",
                 (dict(d) for d in self.db.cursor.execute("SELECT * FROM detalles_compra")),
             )
+            write_array(
+                "dte_envios",
+                (dict(d) for d in self.db.cursor.execute("SELECT * FROM dte_envios")),
+            )
+            write_array(
+                "notas",
+                (dict(n) for n in self.db.cursor.execute("SELECT * FROM notas")),
+            )
+            write_array(
+                "facturas_pdf",
+                (dict(f) for f in self.db.cursor.execute("SELECT * FROM facturas_pdf")),
+            )
+            write_array(
+                "tickets_pdf",
+                (dict(t) for t in self.db.cursor.execute("SELECT * FROM tickets_pdf")),
+            )
             if datos_negocio:
                 f.write(",\n\"datos_negocio\":")
                 json.dump(datos_negocio, f, ensure_ascii=False)
@@ -601,6 +617,53 @@ class InventoryManager:
                         m.get("cantidad", 0),
                         m.get("motivo", ""),
                         m.get("usuario", ""),
+                    ),
+                )
+
+            for de in data.get("dte_envios", []):
+                self.db.cursor.execute(
+                    "INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        venta_id_map.get(de.get("venta_id")),
+                        de.get("modo"),
+                        de.get("estado"),
+                        de.get("sello"),
+                        de.get("fecha_hora"),
+                        de.get("respuesta"),
+                    ),
+                )
+
+            for n in data.get("notas", []):
+                self.db.cursor.execute(
+                    "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        venta_id_map.get(n.get("venta_id")),
+                        n.get("tipo"),
+                        n.get("fecha"),
+                        n.get("monto"),
+                        n.get("motivo"),
+                        n.get("detalles"),
+                    ),
+                )
+
+            for fp in data.get("facturas_pdf", []):
+                self.db.cursor.execute(
+                    "INSERT INTO facturas_pdf (venta_id, tipo, ruta, fecha_creacion) VALUES (?, ?, ?, ?)",
+                    (
+                        venta_id_map.get(fp.get("venta_id")),
+                        fp.get("tipo"),
+                        fp.get("ruta"),
+                        fp.get("fecha_creacion"),
+                    ),
+                )
+
+            for tp in data.get("tickets_pdf", []):
+                self.db.cursor.execute(
+                    "INSERT INTO tickets_pdf (venta_id, ruta, fecha_creacion) VALUES (?, ?, ?)",
+                    (
+                        venta_id_map.get(tp.get("venta_id")),
+                        tp.get("ruta"),
+                        tp.get("fecha_creacion"),
                     ),
                 )
 

--- a/tests/test_export_import_transmission_records.py
+++ b/tests/test_export_import_transmission_records.py
@@ -1,0 +1,115 @@
+import sys
+import types
+from db import DB
+
+
+def test_export_import_transmission_records(monkeypatch, tmp_path):
+    qtcore = types.SimpleNamespace(
+        QAbstractTableModel=object,
+        Qt=types.SimpleNamespace(
+            DisplayRole=0, Horizontal=1, BackgroundRole=2
+        ),
+    )
+    qtgui = types.SimpleNamespace(QColor=object)
+    pyqt5 = types.SimpleNamespace(QtCore=qtcore, QtGui=qtgui)
+    sys.modules.setdefault("PyQt5", pyqt5)
+    sys.modules["PyQt5.QtCore"] = qtcore
+    sys.modules["PyQt5.QtGui"] = qtgui
+
+    import inventory_manager
+
+    def dummy_refresh(self):
+        self._vendedores = self.db.get_vendedores()
+        self._Distribuidores = self.db.get_Distribuidores()
+        self._vendedores_by_id = {v["id"]: v["nombre"] for v in self._vendedores}
+        self._Distribuidores_by_id = {
+            d["id"]: d["nombre"] for d in self._Distribuidores
+        }
+        self._products = self.db.get_productos(
+            vendedor_id=self._filter_vendedor_id,
+            Distribuidor_id=self._filter_Distribuidor_id,
+            search=self._filter_search,
+        )
+        self._clientes = self.db.get_clientes()
+        self._model = None
+
+    monkeypatch.setattr(
+        inventory_manager.InventoryManager, "refresh_data", dummy_refresh
+    )
+
+    monkeypatch.setattr(inventory_manager, "DB", lambda: DB(":memory:"))
+    man1 = inventory_manager.InventoryManager()
+    db = man1.db
+    db.add_Distribuidor("D1")
+    dist = db.cursor.lastrowid
+    db.add_vendedor("V1", Distribuidor_id=dist)
+    vend = db.cursor.lastrowid
+    db.add_cliente("Cliente", "", "", "", "", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vend, dist, 1, 2, 3, 5)
+    venta_id = db.add_venta(
+        "2024-01-01", 10, cliente_id=cliente_id, vendedor_id=vend, Distribuidor_id=dist
+    )
+    db.cursor.execute(
+        "INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?)",
+        (venta_id, "envio", "PROCESADO", "abc", "2024-01-01T00:00:00", "ok"),
+    )
+    db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?, ?, ?, ?, ?, ?)",
+        (venta_id, "NC", "2024-01-02", 1.23, "motivo", "det"),
+    )
+    db.cursor.execute(
+        "INSERT INTO facturas_pdf (venta_id, tipo, ruta, fecha_creacion) VALUES (?, ?, ?, ?)",
+        (venta_id, "fiscal", "/tmp/factura.pdf", "2024-01-01"),
+    )
+    db.cursor.execute(
+        "INSERT INTO tickets_pdf (venta_id, ruta, fecha_creacion) VALUES (?, ?, ?)",
+        (venta_id, "/tmp/ticket.pdf", "2024-01-01"),
+    )
+    db.conn.commit()
+    man1.refresh_data()
+    export_file = tmp_path / "export.json"
+    man1.exportar_inventario_json(str(export_file))
+
+    man2 = inventory_manager.InventoryManager()
+    man2.importar_inventario_json(str(export_file))
+
+    cur = man2.db.cursor
+    row = cur.execute(
+        "SELECT modo, estado, sello, fecha_hora, respuesta FROM dte_envios"
+    ).fetchone()
+    assert (
+        row["modo"],
+        row["estado"],
+        row["sello"],
+        row["fecha_hora"],
+        row["respuesta"],
+    ) == ("envio", "PROCESADO", "abc", "2024-01-01T00:00:00", "ok")
+
+    row = cur.execute(
+        "SELECT tipo, fecha, monto, motivo, detalles FROM notas"
+    ).fetchone()
+    assert (
+        row["tipo"],
+        row["fecha"],
+        row["monto"],
+        row["motivo"],
+        row["detalles"],
+    ) == ("NC", "2024-01-02", 1.23, "motivo", "det")
+
+    row = cur.execute(
+        "SELECT tipo, ruta, fecha_creacion FROM facturas_pdf"
+    ).fetchone()
+    assert (
+        row["tipo"],
+        row["ruta"],
+        row["fecha_creacion"],
+    ) == ("fiscal", "/tmp/factura.pdf", "2024-01-01")
+
+    row = cur.execute(
+        "SELECT ruta, fecha_creacion FROM tickets_pdf"
+    ).fetchone()
+    assert (row["ruta"], row["fecha_creacion"]) == (
+        "/tmp/ticket.pdf",
+        "2024-01-01",
+    )


### PR DESCRIPTION
## Summary
- Export dte_envios, notas, facturas_pdf, and tickets_pdf tables to JSON
- Import transmission-related tables from JSON and recreate records
- Test that export/import round-trip preserves transmission records

## Testing
- `pytest tests/test_export_import_transmission_records.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689b5ff767b88323a62c45432cf39f25