### PR TITLE
Add venta lookup helper and use it in sales tab

### DIFF
--- a/db.py
+++ b/db.py
@@ -960,6 +960,19 @@ class DB:
         self.cursor.execute("SELECT * FROM ventas")
         return [dict(row) for row in self.cursor.fetchall()]
 
+    def get_venta_by_id(self, venta_id: int):
+        """Fetch a single sale by its ID."""
+        self.cursor.execute("SELECT * FROM ventas WHERE id=?", (venta_id,))
+        row = self.cursor.fetchone()
+        if row:
+            data = dict(row)
+            try:
+                data["id"] = int(data["id"])
+            except (ValueError, TypeError):
+                pass
+            return data
+        return None
+
     def update_venta_estado(self, venta_id, estado):
         """Actualiza el estado de una venta."""
         self.cursor.execute(

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -537,9 +537,8 @@ class SalesTab(QWidget):
 
         row = self.sales_table.currentRow()
         venta_id = int(self.sales_table.item(row, 0).text())
-
-        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
-        if not venta:
+        venta = self.manager.db.get_venta_by_id(venta_id)
+        if not venta or int(venta.get("id", 0)) != venta_id:
             QMessageBox.warning(self, "Guardar y enviar", "No se encontró la venta seleccionada.")
             return
         credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
@@ -658,8 +657,8 @@ class SalesTab(QWidget):
 
         row = self.sales_table.currentRow()
         venta_id = int(self.sales_table.item(row, 0).text())
-        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
-        if not venta:
+        venta = self.manager.db.get_venta_by_id(venta_id)
+        if not venta or int(venta.get("id", 0)) != venta_id:
             QMessageBox.warning(self, "Solo enviar por correo", "No se encontró la venta seleccionada.")
             return
 

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -28,6 +28,9 @@ class FakeDB:
     def get_ventas(self):
         return self._ventas
 
+    def get_venta_by_id(self, vid):
+        return next((v for v in self._ventas if int(v["id"]) == vid), None)
+
     def get_venta_credito_fiscal(self, vid):
         return None
 

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -19,6 +19,9 @@ class FakeDB:
     def get_ventas(self):
         return self._ventas
 
+    def get_venta_by_id(self, vid):
+        return next((v for v in self._ventas if int(v["id"]) == vid), None)
+
     def get_venta_credito_fiscal(self, vid):
         return None
 


### PR DESCRIPTION
## Summary
- Add `get_venta_by_id` helper in `DB` for direct sale lookups
- Use the helper in `SalesTab.save_and_send` and `SalesTab.send_email` to avoid linear searches
- Update email-related tests with the new helper

## Testing
- `pytest --no-cov tests/test_envio_correo.py::test_transmit_success_email_fail tests/test_envio_correo.py::test_email_exitoso tests/test_envio_correo.py::test_transmit_fail_no_email tests/test_sales_tab_email.py::test_send_email_builds_message_and_marks_status tests/test_sales_tab_email.py::test_save_and_send_generates_files_and_registers`
- `pytest --no-cov tests/test_dte_validation.py::test_estructura_invalida` *(fails: DID NOT RAISE <class 'jsonschema.exceptions.ValidationError'>)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ff6726c8323a8d85a06aee8cd00