### PR TITLE
Show DTE validation errors before sending

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -951,6 +951,49 @@ def _save_signed_dte(dte_data: dict, jws_token: str) -> None:
         pass
 
 
+class DTEValidationError(Exception):
+    """Error de validación que incluye lista de errores y ruta del JSON."""
+
+    def __init__(self, errors, json_path):
+        super().__init__("; ".join(errors))
+        self.errors = errors
+        self.json_path = json_path
+
+
+def save_dte_json(dte_data: dict) -> str:
+    """Guarda ``dte_data`` en ``/dtes/{anio}/`` y devuelve la ruta."""
+    try:
+        fecha = dte_data.get("identificacion", {}).get("fecEmi") or datetime.now().strftime("%Y-%m-%d")
+        year = str(fecha)[:4]
+        base_dir = os.path.join(os.path.dirname(__file__), "dtes", year)
+        os.makedirs(base_dir, exist_ok=True)
+        nombre = dte_data.get("identificacion", {}).get("numeroControl") or uuid.uuid4().hex
+        json_path = os.path.join(base_dir, f"{nombre}.json")
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump(dte_data, fh, ensure_ascii=False)
+        return json_path
+    except Exception:
+        return ""
+
+
+def _format_validation_errors(exc: Exception) -> list:
+    """Convierte la excepción de validación en una lista de mensajes."""
+    if isinstance(exc, ValidationError) and getattr(exc, "errors", None):
+        formatted = []
+        for err in exc.errors:
+            path = ".".join(str(p) for p in err.path)
+            if path:
+                formatted.append(f"{path}: {err.message}")
+            else:
+                formatted.append(err.message)
+        return formatted
+    msg = str(exc)
+    if ":" in msg:
+        head, tail = msg.split(":", 1)
+        return [f"{head.strip()}: {part.strip()}" for part in tail.split(",")]
+    return [msg]
+
+
 def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
     if token:
@@ -983,7 +1026,12 @@ def transmitir_dte(
         data = generar_dte_json(db, venta_id)
 
     data = sanitize_dte_payload(data)
-    validate_dte_json(data)
+    try:
+        validate_dte_json(data)
+    except Exception as exc:
+        json_path = save_dte_json(data)
+        errors = _format_validation_errors(exc)
+        raise DTEValidationError(errors, json_path) from exc
     resp = _enviar_documento(db, venta_id, data, modo)
     if resp.get("sello"):
         db.update_venta_extra(venta_id, {"selloRecibido": resp["sello"]})

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -18,8 +18,8 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QCheckBox,
 )
-from PyQt5.QtCore import QDate, Qt
-from PyQt5.QtGui import QPixmap
+from PyQt5.QtCore import QDate, Qt, QUrl
+from PyQt5.QtGui import QPixmap, QDesktopServices
 import os
 import re
 
@@ -44,6 +44,7 @@ from sales_tab import DATOS_NEGOCIO_PATH
 import tempfile
 import subprocess
 import shutil
+import dte
 
 # Directory where debit notes will be stored
 NOTAS_DEBITO_DIR = os.path.join(os.path.dirname(__file__), "notas_debito")
@@ -505,6 +506,24 @@ class FacturacionTab(QWidget):
         enabled = bool(entry and entry.get("row_type") in ("venta", "ticket"))
         self.btn_enviar.setEnabled(enabled)
 
+    def _show_validation_errors(self, errors, json_path):
+        """Display validation errors and allow opening a report."""
+        msg = QMessageBox(self)
+        msg.setWindowTitle("Enviar a Hacienda")
+        msg.setIcon(QMessageBox.Warning)
+        msg.setText("El DTE contiene errores de validación:")
+        msg.setInformativeText("\n".join(f"- {e}" for e in errors))
+        open_btn = msg.addButton("Abrir reporte", QMessageBox.ActionRole)
+        msg.addButton(QMessageBox.Close)
+        msg.exec_()
+        if msg.clickedButton() == open_btn and json_path:
+            report_path = os.path.splitext(json_path)[0] + ".md"
+            with open(report_path, "w", encoding="utf-8") as fh:
+                fh.write("# Errores de validación\n\n")
+                for e in errors:
+                    fh.write(f"- {e}\n")
+            QDesktopServices.openUrl(QUrl.fromLocalFile(report_path))
+
     def send_selected_invoice(self):
         venta_id = self._selected_venta()
         entry = self._selected_entry()
@@ -534,6 +553,8 @@ class FacturacionTab(QWidget):
                     QMessageBox.information(
                         self, "Enviar a Hacienda", "Documento enviado"
                     )
+            except dte.DTEValidationError as exc:
+                self._show_validation_errors(exc.errors, exc.json_path)
             except Exception as exc:
                 QMessageBox.critical(
                     self, "Enviar a Hacienda", str(exc)

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -30,6 +30,7 @@ from utils.email_sender import EmailSender
 from utils.email_builder import build_email
 from dialogs import ManualInvoiceDialog
 from dte import transmitir_dte
+import dte
 from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
 import tempfile
 import subprocess
@@ -529,6 +530,23 @@ class SalesTab(QWidget):
     def _generate_ticket_pdf(self, venta_id):
         return generate_ticket_pdf(self.manager, venta_id)
 
+    def _show_validation_errors(self, errors, json_path):
+        msg = QMessageBox(self)
+        msg.setWindowTitle("Enviar a Hacienda")
+        msg.setIcon(QMessageBox.Warning)
+        msg.setText("El DTE contiene errores de validación:")
+        msg.setInformativeText("\n".join(f"- {e}" for e in errors))
+        open_btn = msg.addButton("Abrir reporte", QMessageBox.ActionRole)
+        msg.addButton(QMessageBox.Close)
+        msg.exec_()
+        if msg.clickedButton() == open_btn and json_path:
+            report_path = os.path.splitext(json_path)[0] + ".md"
+            with open(report_path, "w", encoding="utf-8") as fh:
+                fh.write("# Errores de validación\n\n")
+                for e in errors:
+                    fh.write(f"- {e}\n")
+            QDesktopServices.openUrl(QUrl.fromLocalFile(report_path))
+
     def save_and_send(self):
         """Generate the document for the selected sale and transmit it."""
         if self.sales_table.currentRow() < 0:
@@ -587,6 +605,12 @@ class SalesTab(QWidget):
                     "Último envío: " + datetime.now().strftime("%Y-%m-%d %H:%M")
                 )
                 envio_ok = True
+        except dte.DTEValidationError as e:
+            self.status_label.setText("Estado actual: Error")
+            self.gen_label.setText(
+                "Generado: " + datetime.now().strftime("%Y-%m-%d %H:%M")
+            )
+            self._show_validation_errors(e.errors, e.json_path)
         except Exception as e:
             self.status_label.setText("Estado actual: Error")
             self.gen_label.setText(


### PR DESCRIPTION
## Summary
- capture validation issues in DTE transmission with a new `DTEValidationError`
- block Hacienda submissions when validation fails and offer an error report
- add dialogs in factura and sales tabs listing validation errors with report option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6f071ce88323a6b1c235fb62073c