### PR TITLE
Show server response when token missing

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -117,7 +117,10 @@ def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, float]:
         info = resp.json()
         token = info.get("access_token")
         if not token:
-            raise ValueError("Respuesta de autenticación sin token")
+            response_text = resp.text
+            raise ValueError(
+                f"Respuesta de autenticación sin token: {response_text[:200]}"
+            )
         expires_in = int(info.get("expires_in", 0))
         obtained_at = time.time()
         return token, expires_in, obtained_at

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -75,6 +75,29 @@ def test_request_error(monkeypatch, tmp_path):
         auth.get_token(refresh=True)
 
 
+def test_missing_token_includes_response(monkeypatch):
+    def fake_post(url, data, headers, timeout):
+        class Resp:
+            status_code = 200
+            text = "{\"mensaje\": \"sin token\"}"
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"mensaje": "sin token"}
+
+        return Resp()
+
+    monkeypatch.setattr(auth.requests, "post", fake_post)
+    monkeypatch.setattr(auth, "_get_auth_url", lambda: "http://fake")
+    with pytest.raises(ValueError) as excinfo:
+        auth._request_new_token("nit", "pwd")
+    msg = str(excinfo.value)
+    assert "sin token" in msg
+    assert "Respuesta de autenticación sin token" in msg
+
+
 def test_env_specific_credentials(monkeypatch, tmp_path):
     data = {
         "ambiente": "pruebas",


### PR DESCRIPTION
## Summary
- include server response text when auth token is missing
- add test covering missing token response

## Testing
- `pytest` (fails: 32 errors during collection)
- `pytest tests/test_auth_module.py`

------
https://chatgpt.com/codex/tasks/task_e_689b7f65c8408323a5d331044c5af6be