### PR TITLE
Preserve existing datos_negocio on import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -716,13 +716,14 @@ class InventoryManager:
 
         self.refresh_data()
 
-        datos_negocio = data.get("datos_negocio", None)
         datos_path = DATOS_NEGOCIO_PATH
-        if datos_negocio:
-            with open(datos_path, "w", encoding="utf-8") as f:
-                json.dump(datos_negocio, f, ensure_ascii=False, indent=2)
-        elif os.path.exists(datos_path):
-            os.remove(datos_path)
+        if "datos_negocio" in data:
+            datos_negocio = data.get("datos_negocio")
+            if datos_negocio is not None:
+                with open(datos_path, "w", encoding="utf-8") as f:
+                    json.dump(datos_negocio, f, ensure_ascii=False, indent=2)
+            elif os.path.exists(datos_path):
+                os.remove(datos_path)
 
         return data
 

--- a/tests/test_import_datos_negocio.py
+++ b/tests/test_import_datos_negocio.py
@@ -1,0 +1,32 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+import json
+import inventory_manager as im
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+def test_import_without_datos_negocio_keeps_existing(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    datos_path = tmp_path / "datos_negocio.json"
+    datos_path.write_text(json.dumps({"nombre": "Original"}))
+    monkeypatch.setattr(im, "DATOS_NEGOCIO_PATH", datos_path)
+    manager = im.InventoryManager()
+    data = {
+        "Distribuidores": [],
+        "vendedores": [],
+        "productos": [],
+        "clientes": [],
+        "ventas": [],
+        "compras": [],
+        "movimientos": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "trabajadores": [],
+        "ventas_credito_fiscal": [],
+    }
+    inv_path = tmp_path / "inv.json"
+    inv_path.write_text(json.dumps(data))
+    manager.importar_inventario_json(str(inv_path))
+    assert json.loads(datos_path.read_text()) == {"nombre": "Original"}


### PR DESCRIPTION
## Summary
- Only update `datos_negocio.json` when `datos_negocio` key is present in imported inventory
- Add regression test ensuring importing inventory lacking `datos_negocio` leaves existing file untouched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b89db17d08323bde9af03f74b7207