### PR TITLE
Update authentication token handling

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -6,13 +6,16 @@ from typing import Optional, Tuple
 
 import requests
 
-DEFAULT_AUTH_URL = "https://apifacturatest.mh.gob.sv/auth"
+DEFAULT_AUTH_URL = "https://apitest.dtes.mh.gob.sv/seguridad/auth"
+# URL de producción proporcionada por el MH
+PRODUCTION_AUTH_URL = "https://api.dtes.mh.gob.sv/seguridad/auth"
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.json")
 DB_PATH = os.path.join(os.path.dirname(__file__), "inventario.db")
 
 _access_token: Optional[str] = None
 _expires_at: float = 0.0
 _obtained_at: float = 0.0
+_token_type: str = ""
 
 
 def _read_db_credentials() -> Tuple[Optional[str], Optional[str]]:
@@ -106,7 +109,7 @@ def _get_auth_url() -> str:
         return DEFAULT_AUTH_URL
 
 
-def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, float]:
+def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, str]:
     """Solicita un nuevo token de acceso a la API."""
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     data = {"user": nit, "pwd": pwd}
@@ -115,15 +118,19 @@ def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, float]:
         resp = requests.post(url, data=data, headers=headers, timeout=20)
         resp.raise_for_status()
         info = resp.json()
-        token = info.get("access_token")
+        body = info.get("body", {}) if isinstance(info, dict) else {}
+        token = body.get("token") if info.get("status") == "OK" else None
+        token_type = body.get("tokenType", "") if body else ""
+        expires_in = int(body.get("expiresIn", 0)) if body else 0
         if not token:
             response_text = resp.text
             raise ValueError(
                 f"Respuesta de autenticación sin token: {response_text[:200]}"
             )
-        expires_in = int(info.get("expires_in", 0))
-        obtained_at = time.time()
-        return token, expires_in, obtained_at
+        if token_type.lower() == "bearer":
+            token_type = "Bearer"
+            token = f"{token_type} {token}"
+        return token, expires_in, token_type
     except Exception as exc:
         report = f"Error de autenticación al solicitar token en {url}: {exc}"
         if isinstance(exc, requests.HTTPError) and exc.response is not None:
@@ -159,7 +166,7 @@ def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
 
 def get_token(refresh: bool = False) -> str:
     """Devuelve un token válido reutilizándolo y renovándolo al expirar."""
-    global _access_token, _expires_at, _obtained_at
+    global _access_token, _expires_at, _obtained_at, _token_type
     now = time.time()
     if (
         not refresh
@@ -170,11 +177,13 @@ def get_token(refresh: bool = False) -> str:
 
     nit, pwd = _get_credentials()
     try:
-        token, expires_in, obtained_at = _request_new_token(nit, pwd)
+        token, expires_in, token_type = _request_new_token(nit, pwd)
     except Exception as exc:
         print(f"No se pudo obtener token: {exc}")
         raise
+    obtained_at = time.time()
     _access_token = token
+    _token_type = token_type
     _obtained_at = obtained_at
     _expires_at = obtained_at + expires_in
     _save_token(token, expires_in, obtained_at)

--- a/dte.py
+++ b/dte.py
@@ -1049,7 +1049,9 @@ def _format_validation_errors(exc: Exception) -> list:
 def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
     if token:
-        headers["Authorization"] = f"Bearer {token}"
+        headers["Authorization"] = (
+            token if token.lower().startswith("bearer ") else f"Bearer {token}"
+        )
     payload = {"dte": jws_token}
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
     resp.raise_for_status()

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -31,16 +31,16 @@ def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
 
     def fake_request(nit, pwd):
         calls["n"] += 1
-        return f"tok{calls['n']}", 120, time.time()
+        return f"Bearer tok{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     t1 = auth.get_token(refresh=True)
-    assert t1 == "tok1"
+    assert t1 == "Bearer tok1"
     t2 = auth.get_token()
-    assert t2 == "tok1"
+    assert t2 == "Bearer tok1"
     assert calls["n"] == 1
     t3 = auth.get_token(refresh=True)
-    assert t3 == "tok2"
+    assert t3 == "Bearer tok2"
     assert calls["n"] == 2
 
 
@@ -48,19 +48,20 @@ def test_get_token_expired(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
 
     def fake_request(nit, pwd):
-        return "tok", 1, time.time() - 100
+        return "Bearer tok", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     auth.get_token(refresh=True)
+    auth._expires_at = time.time() - 1
     calls = {"n": 0}
 
     def fake_request2(nit, pwd):
         calls["n"] += 1
-        return "new", 1, time.time()
+        return "Bearer new", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request2)
     token2 = auth.get_token()
-    assert token2 == "new"
+    assert token2 == "Bearer new"
     assert calls["n"] == 1
 
 
@@ -79,13 +80,13 @@ def test_missing_token_includes_response(monkeypatch):
     def fake_post(url, data, headers, timeout):
         class Resp:
             status_code = 200
-            text = "{\"mensaje\": \"sin token\"}"
+            text = '{"status":"OK","body":{"mensaje":"sin token"}}'
 
             def raise_for_status(self):
                 return None
 
             def json(self):
-                return {"mensaje": "sin token"}
+                return {"status": "OK", "body": {"mensaje": "sin token"}}
 
         return Resp()
 

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -127,7 +127,16 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
         headers = k.get("headers", {})
         calls.append((url, headers, k.get("json")))
         if url == auth_url:
-            return Resp({"access_token": "JWT"})
+            return Resp(
+                {
+                    "status": "OK",
+                    "body": {
+                        "token": "JWT",
+                        "tokenType": "bearer",
+                        "expiresIn": 3600,
+                    },
+                }
+            )
         if url == recepcion_url:
             return Resp({"estado": "Transmitido", "sello": "ABC123"})
         raise AssertionError(f"unexpected url {url}")
@@ -258,7 +267,14 @@ def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
         status_code = 200
 
         def json(self):
-            return {"access_token": "JWT_VALIDO"}
+            return {
+                "status": "OK",
+                "body": {
+                    "token": "JWT_VALIDO",
+                    "tokenType": "bearer",
+                    "expiresIn": 3600,
+                },
+            }
 
         def raise_for_status(self):
             pass


### PR DESCRIPTION
## Summary
- update default auth URL and document production endpoint
- parse new token response format and track token type
- handle Bearer-prefixed tokens when posting DTEs

## Testing
- `pytest tests/test_auth_module.py tests/test_envio_hacienda.py tests/test_dte_transmision.py tests/test_envio_documentos.py`


------
https://chatgpt.com/codex/tasks/task_e_689b941e116c83239f61db438f0d1670