### PR TITLE
feat: allow explicit API credentials for token

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ configura el campo `ambiente` y las URLs en `config_negocio.json`:
   "ambiente": "pruebas",
   "pruebas": {
     "auth_url": "https://apitest.dtes.mh.gob.sv/seguridad/auth",
-    "recepcion_url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"
+    "recepcion_url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte",
+    "api_user": "MI_USUARIO_API",
+    "api_pwd": "MI_CONTRASEÑA_API"
   },
   "produccion": {
     "auth_url": "https://api.factura.gob.sv/auth",
@@ -191,6 +193,11 @@ configura el campo `ambiente` y las URLs en `config_negocio.json`:
 La aplicación buscará `auth_url` y `recepcion_url` dentro del bloque del
 ambiente seleccionado (`pruebas` o `produccion`). Al cambiar `ambiente` a
 `produccion` la aplicación utilizará los servicios productivos.
+
+Dentro del mismo bloque puede definirse `api_user` y `api_pwd` para
+especificar el usuario y la contraseña de la API. Estos datos se utilizan
+al solicitar el token de autenticación. También es posible obtener un
+token programáticamente llamando a `auth.get_token(nit="USUARIO", pwd="CLAVE")`.
 
 La contraseña puede dejarse vacía si la clave privada no está cifrada. Al
 generar facturas o tickets se creará junto al PDF un archivo `.jws` con el JSON

--- a/auth.py
+++ b/auth.py
@@ -16,6 +16,9 @@ _access_token: Optional[str] = None
 _expires_at: float = 0.0
 _obtained_at: float = 0.0
 _token_type: str = ""
+# Credenciales actualmente asociadas al token en caché
+_current_user: Optional[str] = None
+_current_pwd: Optional[str] = None
 
 
 def _read_db_credentials() -> Tuple[Optional[str], Optional[str]]:
@@ -53,16 +56,30 @@ def _read_config_credentials() -> Tuple[Optional[str], Optional[str]]:
         nit = (
             firma_conf.get("nit")
             or firma_conf.get("NIT")
+            or firma_conf.get("user")
+            or firma_conf.get("usuario")
             or env_conf.get("nit")
             or env_conf.get("NIT")
+            or env_conf.get("user")
+            or env_conf.get("usuario")
             or env_conf.get("api_nit")
+            or env_conf.get("api_user")
+            or env_conf.get("api_usuario")
             or env_conf.get("api", {}).get("nit")
+            or env_conf.get("api", {}).get("user")
             or env_conf.get("dte_api", {}).get("nit")
+            or env_conf.get("dte_api", {}).get("user")
             or data.get("nit")
             or data.get("NIT")
+            or data.get("user")
+            or data.get("usuario")
             or data.get("api_nit")
+            or data.get("api_user")
+            or data.get("api_usuario")
             or data.get("api", {}).get("nit")
+            or data.get("api", {}).get("user")
             or data.get("dte_api", {}).get("nit")
+            or data.get("dte_api", {}).get("user")
         )
         pwd = (
             firma_conf.get("pwd")
@@ -164,18 +181,29 @@ def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
         pass
 
 
-def get_token(refresh: bool = False) -> str:
-    """Devuelve un token válido reutilizándolo y renovándolo al expirar."""
-    global _access_token, _expires_at, _obtained_at, _token_type
+def get_token(
+    refresh: bool = False,
+    nit: Optional[str] = None,
+    pwd: Optional[str] = None,
+) -> str:
+    """Devuelve un token válido. Puede recibir credenciales explícitas."""
+    global _access_token, _expires_at, _obtained_at, _token_type, _current_user, _current_pwd
+
+    if nit is not None and pwd is not None:
+        if nit != _current_user or pwd != _current_pwd:
+            refresh = True
+            _access_token = None
+            _expires_at = 0.0
+            _current_user, _current_pwd = nit, pwd
+    else:
+        nit, pwd = _get_credentials()
+        if nit != _current_user or pwd != _current_pwd:
+            _current_user, _current_pwd = nit, pwd
+
     now = time.time()
-    if (
-        not refresh
-        and _access_token
-        and now < _expires_at - 60
-    ):
+    if not refresh and _access_token and now < _expires_at - 60:
         return _access_token
 
-    nit, pwd = _get_credentials()
     try:
         token, expires_in, token_type = _request_new_token(nit, pwd)
     except Exception as exc:

--- a/config_negocio.json
+++ b/config_negocio.json
@@ -1,1 +1,8 @@
-{"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://example.com"}}
+{
+  "ambiente": "pruebas",
+  "pruebas": {
+    "recepcion_url": "http://example.com",
+    "api_user": "TU_USUARIO_API",
+    "api_pwd": "TU_CONTRASEÑA_API"
+  }
+}

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -116,3 +116,31 @@ def test_env_specific_credentials(monkeypatch, tmp_path):
     nit, pwd = auth._read_config_credentials()
     assert nit == "env_nit"
     assert pwd == "env_pwd"
+
+
+def test_read_config_api_user(monkeypatch, tmp_path):
+    data = {"api_user": "user1", "api_pwd": "pass1"}
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(data))
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
+    nit, pwd = auth._read_config_credentials()
+    assert nit == "user1"
+    assert pwd == "pass1"
+
+
+def test_get_token_with_explicit_credentials(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_request(nit, pwd):
+        calls["n"] += 1
+        return "tok", 120, "Bearer"
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    t1 = auth.get_token(refresh=True, nit="u", pwd="p")
+    assert t1 == "tok"
+    t2 = auth.get_token(nit="u", pwd="p")
+    assert t2 == "tok"
+    assert calls["n"] == 1
+    auth.get_token(nit="u2", pwd="p2")
+    assert calls["n"] == 2


### PR DESCRIPTION
## Summary
- allow passing API user and password directly to `auth.get_token`
- read `api_user`/`api_pwd` from configuration files
- document credential configuration and add tests

## Testing
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b974a96c483238bcef35b2218c17a