### PR TITLE
Solicitar credenciales al obtener token de Hacienda

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -10,7 +10,7 @@ from PyQt5.QtWidgets import (
     QDoubleSpinBox, QPushButton, QListWidget, QListWidgetItem, QMessageBox, QCheckBox, QRadioButton, QComboBox,
     QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
     QAbstractItemView, QTextEdit, QStackedLayout, QWidget, QHeaderView, QSizePolicy,
-    QFileDialog
+    QFileDialog, QDialogButtonBox
 )
 from PyQt5.QtCore import Qt, QDate, QUrl
 from PyQt5.QtGui import QColor, QDesktopServices
@@ -2957,6 +2957,31 @@ class EmailConfigDialog(QDialog):
         self.email_contrasena.setText(datos.get("email_contrasena", ""))
 
 
+def prompt_auth_credentials(parent=None, user="", password=""):
+    """Abre un cuadro de diálogo para solicitar usuario y contraseña.
+
+    Retorna una tupla ``(usuario, contraseña)`` si el usuario acepta, o ``(None, None)``
+    si cancela la operación.
+    """
+    dialog = QDialog(parent)
+    dialog.setWindowTitle("Autenticación")
+    layout = QVBoxLayout(dialog)
+    form = QFormLayout()
+    layout.addLayout(form)
+    user_edit = QLineEdit(user)
+    pwd_edit = QLineEdit(password)
+    pwd_edit.setEchoMode(QLineEdit.Password)
+    form.addRow("Usuario:", user_edit)
+    form.addRow("Contraseña:", pwd_edit)
+    buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+    layout.addWidget(buttons)
+    buttons.accepted.connect(dialog.accept)
+    buttons.rejected.connect(dialog.reject)
+    if dialog.exec_() == QDialog.Accepted:
+        return user_edit.text().strip(), pwd_edit.text().strip()
+    return None, None
+
+
 class DTEConfigDialog(QDialog):
     def __init__(self, dte_api=None, fe_config=None, env_config=None, parent=None):
         super().__init__(parent)
@@ -3042,8 +3067,11 @@ class DTEConfigDialog(QDialog):
         self.guardar_respuesta_bd.setChecked(dte_api.get("guardar_respuesta", False))
 
     def _fetch_token(self):
-        nit = self.dte_nit.text().strip()
-        pwd = self.dte_pass.text().strip()
+        nit_default = self.dte_nit.text().strip()
+        pwd_default = self.dte_pass.text().strip()
+        nit, pwd = prompt_auth_credentials(self, nit_default, pwd_default)
+        if nit is None:
+            return
         if not nit or not pwd:
             QMessageBox.warning(self, "Datos faltantes", "Debe ingresar NIT y contraseña.")
             return

--- a/tests/test_token_dialog.py
+++ b/tests/test_token_dialog.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+
+@pytest.fixture
+def qt_app():
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_fetch_token_uses_credentials_dialog(qt_app, monkeypatch):
+    import dialogs
+
+    captured = {}
+
+    def fake_prompt(parent, user, password):
+        captured["parent"] = parent
+        return "nit", "pwd"
+
+    monkeypatch.setattr(dialogs, "prompt_auth_credentials", fake_prompt)
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"status": "OK", "body": {"token": "tok123"}}
+
+    def fake_post(url, data, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        return FakeResp()
+
+    monkeypatch.setattr(dialogs.requests, "post", fake_post)
+
+    dlg = dialogs.DTEConfigDialog()
+    dlg.auth_url.setText("http://example.com")
+    dlg._fetch_token()
+
+    assert captured["parent"] is dlg
+    assert captured["data"] == {"user": "nit", "pwd": "pwd"}
+    assert dlg.token_hacienda.text() == "tok123"


### PR DESCRIPTION
## Summary
- Abrir un cuadro de diálogo para ingresar usuario y contraseña antes de solicitar el token de autenticación
- Probar que `_fetch_token` usa las credenciales ingresadas para obtener el token

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba0c181688323bd8054a552841bcc