### PR TITLE
Add secure token storage with manual deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ especificar el usuario y la contraseña de la API. Estos datos se utilizan
 al solicitar el token de autenticación. También es posible obtener un
 token programáticamente llamando a `auth.get_token(nit="USUARIO", pwd="CLAVE")`.
 
+El token obtenido se almacena en la base de datos `inventario.db` con
+permisos restringidos al usuario que ejecuta la aplicación. Si se desea
+eliminar voluntariamente el token guardado puede invocarse
+`auth.delete_token()`.
+
 La contraseña puede dejarse vacía si la clave privada no está cifrada. Al
 generar facturas o tickets se creará junto al PDF un archivo `.jws` con el JSON
 firmado.

--- a/auth.py
+++ b/auth.py
@@ -177,8 +177,30 @@ def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
                 (str(obtained_at),),
             )
             conn.commit()
+        try:
+            os.chmod(DB_PATH, 0o600)
+        except OSError:
+            pass
     except sqlite3.Error:
         pass
+
+
+def delete_token() -> None:
+    """Elimina el token almacenado y limpia la caché."""
+    global _access_token, _expires_at, _obtained_at, _token_type
+    try:
+        with sqlite3.connect(DB_PATH) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM tokens WHERE key IN ('access_token', 'expires_in', 'obtained_at')"
+            )
+            conn.commit()
+    except sqlite3.Error:
+        pass
+    _access_token = None
+    _token_type = ""
+    _expires_at = 0.0
+    _obtained_at = 0.0
 
 
 def get_token(

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import requests
 import auth
+import sqlite3
 
 
 def write_config(tmp_path, nit="123", pwd="pwd"):
@@ -143,4 +144,24 @@ def test_get_token_with_explicit_credentials(monkeypatch):
     assert t2 == "tok"
     assert calls["n"] == 1
     auth.get_token(nit="u2", pwd="p2")
+    assert calls["n"] == 2
+
+
+def test_delete_token(monkeypatch, tmp_path):
+    setup_paths(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def fake_request(nit, pwd):
+        calls["n"] += 1
+        return f"tok{calls['n']}", 120, "Bearer"
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    auth.get_token(refresh=True)
+    auth.delete_token()
+    with sqlite3.connect(auth.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM tokens WHERE key='access_token'")
+        assert cur.fetchone() is None
+    t2 = auth.get_token()
+    assert t2 == "tok2"
     assert calls["n"] == 2


### PR DESCRIPTION
## Summary
- restrict database permissions when saving token
- add `delete_token` helper for manual removal
- document token storage and deletion in README
- test token deletion path

## Testing
- `pytest tests/test_auth_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba48b090c8323ad57effc81d015bb