### PR TITLE
Decode passwordPri from Base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ configuración por ambiente. El campo `ambiente` indica qué sección utilizar
 }
 ```
 
+El campo `passwordPri` puede almacenarse codificado en Base64 y será
+decodificado automáticamente al leer la configuración.
+
 Los datos se guardan dentro del nodo del ambiente (`pruebas` o `produccion`),
 por lo que cada uno debe contar con su propio bloque `firma_electronica`.
 

--- a/auth.py
+++ b/auth.py
@@ -2,6 +2,7 @@ import os
 import json
 import sqlite3
 import time
+import base64
 from typing import Optional, Tuple
 
 import requests
@@ -96,6 +97,11 @@ def _read_config_credentials() -> Tuple[Optional[str], Optional[str]]:
             or data.get("api", {}).get("pwd")
             or data.get("dte_api", {}).get("pwd")
         )
+        if pwd:
+            try:
+                pwd = base64.b64decode(pwd).decode()
+            except Exception:
+                pass
     except (OSError, json.JSONDecodeError):
         pass
     return nit, pwd


### PR DESCRIPTION
## Summary
- decode Base64 password from config when reading credentials
- note in docs that `passwordPri` may be stored Base64-encoded

## Testing
- `pytest tests/test_auth_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc4d2571883239f0525841a0fbc4a