### PR TITLE
Sanitize configuration URLs before API calls

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -134,6 +134,8 @@ def _get_auth_url() -> str:
         ambiente = data.get("ambiente", "pruebas")
         env_conf = data.get(ambiente, {})
         url = env_conf.get("auth_url") or data.get("auth_url")
+        if url:
+            url = url.strip()
         return url or DEFAULT_AUTH_URL
     except (OSError, json.JSONDecodeError):
         return DEFAULT_AUTH_URL

--- a/dte.py
+++ b/dte.py
@@ -980,6 +980,8 @@ def _load_dte_api_config():
         ambiente = data.get("ambiente", "pruebas")
         env_conf = data.get(ambiente, {})
         url = env_conf.get("recepcion_url") or data.get("recepcion_url")
+        if url:
+            url = url.strip()
         return {"ambiente": ambiente, "url": url or DEFAULT_RECEPCION_URL}
     except Exception:
         return {"ambiente": "pruebas", "url": DEFAULT_RECEPCION_URL}

--- a/tests/test_url_sanitization.py
+++ b/tests/test_url_sanitization.py
@@ -1,0 +1,54 @@
+import json
+import auth
+import dte
+
+
+def test_auth_url_is_stripped(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({
+        "ambiente": "pruebas",
+        "pruebas": {"auth_url": " http://auth.example \n"}
+    }))
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    called = {}
+
+    def fake_post(url, data, headers, timeout):
+        called["url"] = url
+        class Resp:
+            status_code = 200
+            def json(self):
+                return {"status": "OK", "body": {"token": "t", "tokenType": "Bearer", "expiresIn": 1}}
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(auth.requests, "post", fake_post)
+    auth._request_new_token("user", "pwd")
+    assert called["url"] == "http://auth.example"
+    assert called["url"].strip() == called["url"]
+
+
+def test_recepcion_url_is_stripped(monkeypatch, tmp_path):
+    cfg = tmp_path / "config_negocio.json"
+    cfg.write_text(json.dumps({
+        "ambiente": "pruebas",
+        "pruebas": {"recepcion_url": " http://recepcion.example/path \n"}
+    }))
+    monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", str(cfg))
+    monkeypatch.setattr(dte.jws, "sign_json", lambda data: "SIGNED")
+    monkeypatch.setattr(dte.auth, "get_token", lambda: "JWT")
+    called = {}
+
+    def fake_post_dte(url, token, jws_token):
+        called["url"] = url
+        return {"estado": "Transmitido"}
+
+    monkeypatch.setattr(dte, "_post_dte", fake_post_dte)
+
+    class DummyDB:
+        def registrar_envio_dte(self, *args, **kwargs):
+            pass
+
+    dte._enviar_documento(DummyDB(), 1, {}, "normal")
+    assert called["url"] == "http://recepcion.example/path"
+    assert called["url"].strip() == called["url"]


### PR DESCRIPTION
## Summary
- Strip whitespace from DTE reception URL loaded from `config_negocio.json`
- Trim authentication URL in auth configuration
- Add tests ensuring both DTE and auth requests use cleaned hosts

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689be03b30388323b234df78cfc5ed42