### PR TITLE
Sanitize DTE token and add debug log

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1048,10 +1048,14 @@ def _format_validation_errors(exc: Exception) -> list:
 
 def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
+    token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
     if token:
-        headers["Authorization"] = (
-            token if token.lower().startswith("bearer ") else f"Bearer {token}"
-        )
+        if not token.lower().startswith("bearer "):
+            token = f"Bearer {token}"
+        logger.debug("Token: %s...%s", token[:5], token[-5:])
+        headers["Authorization"] = token
+    else:
+        logger.debug("Token: <empty>")
     payload = {"dte": jws_token}
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
     resp.raise_for_status()


### PR DESCRIPTION
## Summary
- Clean and normalize DTE authorization tokens before use
- Avoid duplicate `Bearer` prefix and log token start/end for debugging

## Testing
- `python -m pytest --no-cov tests/test_dte_transmision.py::test_post_dte_uses_bearer tests/test_dte_transmision.py::test_post_dte_handles_non_json -q`

------
https://chatgpt.com/codex/tasks/task_e_689be03d990483239b9c6101d6fac9b9