### PR TITLE
Normalize DTE API endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ bloque de configuración similar al siguiente:
 ```json
 {
   "dte_api": {
-    "url": "https://api.hacienda.test/dtes",
+    "url": "https://api.hacienda.test/fesv/recepciondte",
     "ambiente": "produccion" | "pruebas",
     "token": "TOKEN_O_CREDENCIAL"
   }
 }
 ```
-La función `transmitir_dte(db, venta_id)` utilizará estos datos para enviar el
-DTE inmediatamente después de firmarlo en modo normal, o registrará un evento
+La URL debe incluir la ruta `/fesv/recepciondte`; si sólo se especifica el
+dominio, la aplicación la agregará automáticamente. La función
+`transmitir_dte(db, venta_id)` utilizará estos datos para enviar el DTE
+inmediatamente después de firmarlo en modo normal, o registrará un evento
 pendiente en modo de contingencia.
 
 ### Datos del negocio y correo

--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -1,7 +1,7 @@
 {
-  "dte_api": {
-    "url": "https://apitest.dtes.mh.gob.sv",
-    "ambiente": "pruebas",
+    "dte_api": {
+      "url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte",
+      "ambiente": "pruebas",
     "token": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIwOTA2MTcxMjc5MTAxNCIsImF1dGhvcml0aWVzIjpbIlVTRVIiLCJVU0VSX0FQSSIsIlVzdWFyaW8iXSwiY19uaXQiOiIwOTA2MTcxMjc5MTAxNCIsImNfZHVpIjoiMDAwODY4NTQ3IiwiaWF0IjoxNzU1MDQ0NDk5LCJleHAiOjE3NTUxMzA4OTl9.OoCJV79NPdsxFucXuPck2t9DA7B9c6gG-07-9IMMf6z8cmvdbOtugZT7ZhUZxtxHLjrlPwJ6HGI77HInfhDpZw",
     "prefijo_control": "DTE-01-S001P001",
     "modo_transmision": "1 - Normal",

--- a/dte.py
+++ b/dte.py
@@ -135,7 +135,13 @@ def _load_datos_negocio():
     if os.path.exists(DATOS_NEGOCIO_PATH):
         try:
             with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
-                return json.load(fh)
+                data = json.load(fh)
+            dte_api = data.get("dte_api")
+            if isinstance(dte_api, dict):
+                url = dte_api.get("url", "")
+                if url and "/fesv/recepciondte" not in url:
+                    dte_api["url"] = url.rstrip("/") + "/fesv/recepciondte"
+            return data
         except Exception:
             return {}
     return {}

--- a/tests/test_dte_api_url.py
+++ b/tests/test_dte_api_url.py
@@ -1,0 +1,10 @@
+import json
+import dte
+
+
+def test_load_datos_negocio_appends_recepcion_path(tmp_path, monkeypatch):
+    datos_path = tmp_path / "datos_negocio.json"
+    datos_path.write_text(json.dumps({"dte_api": {"url": "https://apitest.dtes.mh.gob.sv"}}))
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
+    data = dte._load_datos_negocio()
+    assert data["dte_api"]["url"].endswith("/fesv/recepciondte")


### PR DESCRIPTION
## Summary
- ensure `dte_api.url` contains `/fesv/recepciondte`
- append recepcion path when missing in business data loader
- document required endpoint and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689be041ad308323865e2834f9cbccd3