### PR TITLE
Log NIT and auth URL during reauthentication

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -3,9 +3,12 @@ import json
 import sqlite3
 import time
 import base64
+import logging
 from typing import Optional, Tuple
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_AUTH_URL = "https://apitest.dtes.mh.gob.sv/seguridad/auth"
 # URL de producción proporcionada por el MH
@@ -114,6 +117,23 @@ def _read_config_credentials() -> Tuple[Optional[str], Optional[str]]:
     return nit, pwd
 
 
+def _get_config_nit_and_url() -> Tuple[Optional[str], Optional[str]]:
+    """Obtiene ``nitUsuario`` y ``auth_url`` de ``config_negocio.json``."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        ambiente = data.get("ambiente", "pruebas")
+        env_conf = data.get(ambiente, {})
+        auth_conf = env_conf.get("auth", {})
+        nit = auth_conf.get("nitUsuario")
+        url = env_conf.get("auth_url") or data.get("auth_url")
+        if url:
+            url = url.strip()
+        return nit, url
+    except (OSError, json.JSONDecodeError):
+        return None, None
+
+
 def _get_credentials() -> Tuple[str, str]:
     """Obtiene NIT y contraseña de base de datos o de archivo de configuración."""
     nit, pwd = _read_db_credentials()
@@ -141,11 +161,11 @@ def _get_auth_url() -> str:
         return DEFAULT_AUTH_URL
 
 
-def _request_new_token(nit: str, pwd: str) -> Tuple[str, int, str]:
+def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[str, int, str]:
     """Solicita un nuevo token de acceso a la API."""
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     data = {"user": nit, "pwd": pwd}
-    url = _get_auth_url()
+    url = url or _get_auth_url()
     try:
         resp = requests.post(url, data=data, headers=headers, timeout=20)
         resp.raise_for_status()
@@ -241,8 +261,19 @@ def get_token(
     if not refresh and _access_token and now < _expires_at - 60:
         return _access_token
 
+    url = _get_auth_url()
+    conf_nit, conf_url = _get_config_nit_and_url()
+    if conf_nit and nit != conf_nit:
+        raise ValueError(
+            f"NIT utilizado {nit} difiere del configurado {conf_nit}"
+        )
+    if conf_url and url != conf_url:
+        raise ValueError(
+            f"URL de auth {url} difiere de la configurada {conf_url}"
+        )
+    logger.info("Reautenticando con NIT %s y URL %s", nit, url)
     try:
-        token, expires_in, token_type = _request_new_token(nit, pwd)
+        token, expires_in, token_type = _request_new_token(nit, pwd, url)
     except Exception as exc:
         print(f"No se pudo obtener token: {exc}")
         raise

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -1,6 +1,7 @@
 import json
 import time
 import os
+import logging
 import pytest
 import requests
 import auth
@@ -30,7 +31,7 @@ def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
     calls = {"n": 0}
 
-    def fake_request(nit, pwd):
+    def fake_request(nit, pwd, url):
         calls["n"] += 1
         return f"Bearer tok{calls['n']}", 120, "Bearer"
 
@@ -48,7 +49,7 @@ def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
 def test_get_token_expired(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
 
-    def fake_request(nit, pwd):
+    def fake_request(nit, pwd, url):
         return "Bearer tok", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
@@ -56,7 +57,7 @@ def test_get_token_expired(monkeypatch, tmp_path):
     auth._expires_at = time.time() - 1
     calls = {"n": 0}
 
-    def fake_request2(nit, pwd):
+    def fake_request2(nit, pwd, url):
         calls["n"] += 1
         return "Bearer new", 1, "Bearer"
 
@@ -133,11 +134,12 @@ def test_read_config_api_user(monkeypatch, tmp_path):
 def test_get_token_with_explicit_credentials(monkeypatch):
     calls = {"n": 0}
 
-    def fake_request(nit, pwd):
+    def fake_request(nit, pwd, url):
         calls["n"] += 1
         return "tok", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    monkeypatch.setattr(auth, "_get_config_nit_and_url", lambda: (None, None))
     t1 = auth.get_token(refresh=True, nit="u", pwd="p")
     assert t1 == "tok"
     t2 = auth.get_token(nit="u", pwd="p")
@@ -151,7 +153,7 @@ def test_delete_token(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
     calls = {"n": 0}
 
-    def fake_request(nit, pwd):
+    def fake_request(nit, pwd, url):
         calls["n"] += 1
         return f"tok{calls['n']}", 120, "Bearer"
 
@@ -165,3 +167,49 @@ def test_delete_token(monkeypatch, tmp_path):
     t2 = auth.get_token()
     assert t2 == "tok2"
     assert calls["n"] == 2
+
+
+def test_reauth_logs_nit_and_url(monkeypatch, tmp_path, caplog):
+    data = {
+        "ambiente": "pruebas",
+        "pruebas": {
+            "auth_url": "http://auth.example",
+            "auth": {"nitUsuario": "123", "pwd": "pwd"},
+        },
+    }
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(data))
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
+    caplog.set_level(logging.INFO)
+
+    def fake_request(nit, pwd, url):
+        assert nit == "123"
+        assert url == "http://auth.example"
+        return "tok", 120, "Bearer"
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    token = auth.get_token(refresh=True)
+    assert token == "tok"
+    assert "Reautenticando con NIT 123 y URL http://auth.example" in caplog.text
+
+
+def test_reauth_mismatch_nit(monkeypatch, tmp_path):
+    data = {
+        "ambiente": "pruebas",
+        "pruebas": {
+            "auth_url": "http://auth.example",
+            "auth": {"nitUsuario": "123", "pwd": "pwd"},
+        },
+    }
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(data))
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
+
+    def fake_request(nit, pwd, url):
+        return "tok", 120, "Bearer"
+
+    monkeypatch.setattr(auth, "_request_new_token", fake_request)
+    with pytest.raises(ValueError):
+        auth.get_token(refresh=True, nit="999", pwd="pwd")


### PR DESCRIPTION
## Summary
- read `nitUsuario` and `auth_url` from `config_negocio.json`
- verify reauthentication uses configured NIT and URL and log both
- expand auth module tests for logging and mismatch scenarios

## Testing
- `pytest tests/test_auth_module.py tests/test_url_sanitization.py::test_auth_url_is_stripped -q`

------
https://chatgpt.com/codex/tasks/task_e_689e260f63a4832386567158721c748d