### PR TITLE
Imprime y valida encabezado Authorization

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -10,6 +10,7 @@ import auth
 from jsonschema import Draft7Validator, ValidationError
 from utils import catalogos
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -1065,6 +1066,10 @@ def _post_dte(url: str, token: str, jws_token: str) -> dict:
     else:
         logger.debug("Token: <empty>")
     payload = {"dte": jws_token}
+    auth_header = headers.get("Authorization")
+    print(repr(auth_header))
+    if auth_header:
+        assert re.fullmatch(r"Bearer [^\s]+", auth_header), "Authorization header malformado"
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
     resp.raise_for_status()
     try:

--- a/send_mail.py
+++ b/send_mail.py
@@ -15,6 +15,7 @@ contar con *admin consent*.
 """
 
 import os
+import re
 import requests
 from msal import ConfidentialClientApplication, MsalServiceError
 
@@ -79,6 +80,8 @@ def send_mail(subject: str, content: str, recipient: str) -> None:
 
     send_url = f"https://graph.microsoft.com/v1.0/users/{SENDER}/sendMail"
     headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+    print(repr(headers["Authorization"]))
+    assert re.fullmatch(r"Bearer [^\s]+", headers["Authorization"]), "Authorization header malformado"
     response = requests.post(send_url, headers=headers, json=message)
     if response.status_code != 202:
         raise RuntimeError(f"Error al enviar correo: {response.status_code} {response.text}")


### PR DESCRIPTION
## Summary
- Imprime y valida el encabezado Authorization antes de enviar DTEs
- Verifica el formato del token Authorization al enviar correos

## Testing
- `pytest --no-cov tests/test_dte_transmision.py::test_post_dte_uses_bearer`
- `pytest` *(falla: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689e26105adc8323b7bd7fb4b64fe416