### PR TITLE
Sanitiza prefijo Bearer antes de enviar DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1059,10 +1059,9 @@ def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
     if token:
-        if not token.lower().startswith("bearer "):
-            token = f"Bearer {token}"
+        token = re.sub(r"^Bearer\s+", "", token, flags=re.I)
         logger.debug("Token: %s...%s", token[:5], token[-5:])
-        headers["Authorization"] = token
+        headers["Authorization"] = f"Bearer {token}"
     else:
         logger.debug("Token: <empty>")
     payload = {"dte": jws_token}


### PR DESCRIPTION
## Summary
- limpió el token de autorización para eliminar prefijos `Bearer` previos y rearmar el encabezado `Authorization` de forma consistente

## Testing
- `pytest -q`
- `python - <<'PY'
import dte
resp = dte._post_dte("https://httpbin.org/post", "Bearer  abc.def.ghi", "signed")
print('Authorization header from server:', resp['headers'].get('Authorization'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e4f1f03ec8323b5eac866355e9e01