### PR TITLE
fix: sanitize bearer token handling

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1056,18 +1056,20 @@ def _format_validation_errors(exc: Exception) -> list:
 
 
 def _post_dte(url: str, token: str, jws_token: str) -> dict:
-    headers = {"Content-Type": "application/json"}
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
+    token = re.sub(r"^(?:Bearer\s+)+", "", token, flags=re.I)
     if token:
-        token = re.sub(r"^Bearer\s+", "", token, flags=re.I)
         logger.debug("Token: %s...%s", token[:5], token[-5:])
-        headers["Authorization"] = f"Bearer {token}"
     else:
         logger.debug("Token: <empty>")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
     payload = {"dte": jws_token}
     auth_header = headers.get("Authorization")
     print(repr(auth_header))
-    if auth_header:
+    if token:
         assert re.fullmatch(r"Bearer [^\s]+", auth_header), "Authorization header malformado"
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
     resp.raise_for_status()


### PR DESCRIPTION
## Summary
- ensure `_post_dte` strips repeated `Bearer` prefixes from tokens
- always build authorization header with a single `Bearer` prefix

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689e51b663a483238084c2d346544ffb