### PR TITLE
Return raw JWT and add Bearer prefix when sending

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -181,7 +181,6 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
             )
         if token_type.lower() == "bearer":
             token_type = "Bearer"
-            token = f"{token_type} {token}"
         return token, expires_in, token_type
     except Exception as exc:
         report = f"Error de autenticación al solicitar token en {url}: {exc}"

--- a/dte.py
+++ b/dte.py
@@ -1059,7 +1059,6 @@ def _post_dte(url: str, token: str, jws_token: str) -> dict:
     headers = {"Content-Type": "application/json"}
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
     if token:
-        token = re.sub(r"^Bearer\s+", "", token, flags=re.I)
         logger.debug("Token: %s...%s", token[:5], token[-5:])
         headers["Authorization"] = f"Bearer {token}"
     else:

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -33,16 +33,16 @@ def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return f"Bearer tok{calls['n']}", 120, "Bearer"
+        return f"tok{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     t1 = auth.get_token(refresh=True)
-    assert t1 == "Bearer tok1"
+    assert t1 == "tok1"
     t2 = auth.get_token()
-    assert t2 == "Bearer tok1"
+    assert t2 == "tok1"
     assert calls["n"] == 1
     t3 = auth.get_token(refresh=True)
-    assert t3 == "Bearer tok2"
+    assert t3 == "tok2"
     assert calls["n"] == 2
 
 
@@ -50,7 +50,7 @@ def test_get_token_expired(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
 
     def fake_request(nit, pwd, url):
-        return "Bearer tok", 1, "Bearer"
+        return "tok", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     auth.get_token(refresh=True)
@@ -59,11 +59,11 @@ def test_get_token_expired(monkeypatch, tmp_path):
 
     def fake_request2(nit, pwd, url):
         calls["n"] += 1
-        return "Bearer new", 1, "Bearer"
+        return "new", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request2)
     token2 = auth.get_token()
-    assert token2 == "Bearer new"
+    assert token2 == "new"
     assert calls["n"] == 1
 
 


### PR DESCRIPTION
## Summary
- Return raw JWT token from `_request_new_token` and keep type separately
- Prefix access token with `Bearer` only when sending DTEs
- Update auth tests to expect raw tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e51b703ec8323854ac2dc9dba5212