### PR TITLE
Log Hacienda response before raising

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1072,11 +1072,13 @@ def _post_dte(url: str, token: str, jws_token: str) -> dict:
     if token:
         assert re.fullmatch(r"Bearer [^\s]+", auth_header), "Authorization header malformado"
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
+    resp_text = resp.text
+    logger.debug("Respuesta de Hacienda: %s", resp_text)
     resp.raise_for_status()
     try:
         return resp.json()
     except Exception:
-        return {"estado": "Error", "detalle": resp.text}
+        return {"estado": "Error", "detalle": resp_text}
 
 
 def transmitir_dte(

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -140,6 +140,7 @@ def test_post_dte_uses_bearer(monkeypatch):
         captured["headers"] = headers
         class R:
             status_code = 200
+            text = ""
             def json(self):
                 return {}
             def raise_for_status(self):


### PR DESCRIPTION
## Summary
- capture Hacienda response text before raising HTTP errors
- log response body for easier debugging
- adjust tests to include a text attribute in fake responses

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689e8a7f006c83239cec2ddf911e2c26