### PR TITLE
Include DTE metadata in Hacienda requests

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1055,7 +1055,7 @@ def _format_validation_errors(exc: Exception) -> list:
     return [msg]
 
 
-def _post_dte(url: str, token: str, jws_token: str) -> dict:
+def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None) -> dict:
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
     token = re.sub(r"^(?:Bearer\s+)+", "", token, flags=re.I)
     if token:
@@ -1066,9 +1066,20 @@ def _post_dte(url: str, token: str, jws_token: str) -> dict:
         "Content-Type": "application/json",
         "Authorization": f"Bearer {token}",
     }
-    payload = {"dte": jws_token}
+    ident = {}
+    if isinstance(dte_data, dict):
+        ident = dte_data.get("identificacion") or dte_data.get("identificador") or {}
+    payload = {
+        "ambiente": ident.get("ambiente"),
+        "idEnvio": uuid.uuid4().hex,
+        "version": ident.get("version"),
+        "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
+        "documento": jws_token,
+    }
+    codigo = ident.get("codigoGeneracion")
+    if codigo:
+        payload["codigoGeneracion"] = codigo
     auth_header = headers.get("Authorization")
-    print(repr(auth_header))
     if token:
         assert re.fullmatch(r"Bearer [^\s]+", auth_header), "Authorization header malformado"
     resp = requests.post(url, json=payload, headers=headers, timeout=20)
@@ -1115,7 +1126,7 @@ def enviar_dte_a_hacienda(jws_token: str) -> dict:
     """Transmite un DTE ya firmado (JWS) al entorno de pruebas de Hacienda."""
     url = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
     token = auth.get_token()
-    respuesta = _post_dte(url, token, jws_token)
+    respuesta = _post_dte(url, token, jws_token, {})
     estado = (
         respuesta.get("estado")
         or respuesta.get("estadoDte")
@@ -1158,7 +1169,7 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
     token = auth.get_token()
 
     try:
-        respuesta = _post_dte(url, token, signed)
+        respuesta = _post_dte(url, token, signed, data)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = (
             respuesta.get("estado")
@@ -1229,7 +1240,7 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     token = auth.get_token()
 
     try:
-        respuesta = _post_dte(url, token, signed)
+        respuesta = _post_dte(url, token, signed, data)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = (
             respuesta.get("estado")

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -87,7 +87,12 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente):
                 "pagos": None,
                 "numPagoElectronico": None,
             },
-            "identificacion": {"tipoDte": "01"},
+            "identificacion": {
+                "tipoDte": "01",
+                "version": 1,
+                "ambiente": "01" if ambiente == "produccion" else "00",
+                "codigoGeneracion": "ABC",
+            },
         },
     )
 
@@ -125,7 +130,12 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente):
     url, headers, payload = calls[0]
     assert url == f"http://{ambiente}.example.com"
     assert headers["Authorization"] == "Bearer JWT"
-    assert payload == {"dte": "SIGNED"}
+    assert payload["documento"] == "SIGNED"
+    assert payload["tipoDte"] == "01"
+    assert payload["version"] == 1
+    assert payload["ambiente"] == ("01" if ambiente == "produccion" else "00")
+    assert payload["codigoGeneracion"] == "ABC"
+    assert "idEnvio" in payload
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
     ).fetchone()
@@ -147,7 +157,12 @@ def test_post_dte_uses_bearer(monkeypatch):
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
-    _post_dte("http://example.com", "TOKEN", "SIGNED")
+    _post_dte(
+        "http://example.com",
+        "TOKEN",
+        "SIGNED",
+        {"identificacion": {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}},
+    )
     assert captured["headers"]["Authorization"] == "Bearer TOKEN"
 
 
@@ -166,7 +181,12 @@ def test_post_dte_handles_non_json(monkeypatch):
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
-    res = _post_dte("http://example.com", "", "SIGNED")
+    res = _post_dte(
+        "http://example.com",
+        "",
+        "SIGNED",
+        {"identificacion": {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}},
+    )
     assert res == {"estado": "Error", "detalle": "error"}
 
 

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -63,7 +63,12 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
                 "pagos": None,
                 "numPagoElectronico": None,
             },
-            "identificacion": {"tipoDte": "01"},
+            "identificacion": {
+                "tipoDte": "01",
+                "version": 1,
+                "ambiente": "00",
+                "codigoGeneracion": "ABC",
+            },
         },
     )
 
@@ -113,7 +118,12 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     assert len(calls) == 2
     for url, headers, payload in calls:
         assert url == "http://example.com"
-        assert payload == {"dte": "SIGNED"}
+        assert payload["documento"] == "SIGNED"
+        assert payload["tipoDte"] == "01"
+        assert payload["version"] == 1
+        assert payload["ambiente"] == "00"
+        assert payload["codigoGeneracion"] == "ABC"
+        assert "idEnvio" in payload
         assert headers["Authorization"] == "Bearer JWT"
 
 
@@ -160,7 +170,12 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
                 "pagos": None,
                 "numPagoElectronico": None,
             },
-            "identificacion": {"tipoDte": "01"},
+            "identificacion": {
+                "tipoDte": "01",
+                "version": 1,
+                "ambiente": "00",
+                "codigoGeneracion": "NC1",
+            },
         },
     )
 
@@ -195,7 +210,12 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     assert len(calls) == 1
     url, headers, payload = calls[0]
     assert url == "http://example.com"
-    assert payload == {"dte": "SIGNED"}
+    assert payload["documento"] == "SIGNED"
+    assert payload["tipoDte"] == "01"
+    assert payload["version"] == 1
+    assert payload["ambiente"] == "00"
+    assert payload["codigoGeneracion"] == "NC1"
+    assert "idEnvio" in payload
     assert headers["Authorization"] == "Bearer JWT"
 
 
@@ -240,7 +260,16 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
         json.dump(config, fh)
 
     caplog.set_level(logging.ERROR)
-    res = enviar_evento_contingencia(db, venta_id, {"id": venta_id})
+    data = {
+        "identificacion": {
+            "version": 1,
+            "ambiente": "00",
+            "tipoDte": "CON",
+            "codigoGeneracion": "EV1",
+        },
+        "id": venta_id,
+    }
+    res = enviar_evento_contingencia(db, venta_id, data)
     assert res["estado"] == "Rechazado"
     assert "Fallo" in caplog.text and "campo: invalido" in caplog.text
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
@@ -249,7 +278,12 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     assert len(calls) == 1
     url, headers, payload = calls[0]
     assert url == "http://example.com"
-    assert payload == {"dte": "SIGNED"}
+    assert payload["documento"] == "SIGNED"
+    assert payload["tipoDte"] == "CON"
+    assert payload["version"] == 1
+    assert payload["ambiente"] == "00"
+    assert payload["codigoGeneracion"] == "EV1"
+    assert "idEnvio" in payload
     assert headers["Authorization"] == "Bearer JWT"
 
 
@@ -289,7 +323,16 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     with open(cfg_path, "w", encoding="utf-8") as fh:
         json.dump(config, fh)
 
-    res = enviar_evento_anulacion(db, venta_id, {"id": venta_id})
+    data = {
+        "identificacion": {
+            "version": 1,
+            "ambiente": "00",
+            "tipoDte": "ANU",
+            "codigoGeneracion": "EV2",
+        },
+        "id": venta_id,
+    }
+    res = enviar_evento_anulacion(db, venta_id, data)
     assert res["estado"] == "Transmitido"
     row = db.cursor.execute("SELECT estado FROM dte_envios WHERE venta_id=?", (venta_id,)).fetchone()
     assert row["estado"] == "Transmitido"
@@ -297,6 +340,11 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     assert len(calls) == 1
     url, headers, payload = calls[0]
     assert url == "http://example.com"
-    assert payload == {"dte": "SIGNED"}
+    assert payload["documento"] == "SIGNED"
+    assert payload["tipoDte"] == "ANU"
+    assert payload["version"] == 1
+    assert payload["ambiente"] == "00"
+    assert payload["codigoGeneracion"] == "EV2"
+    assert "idEnvio" in payload
     assert headers["Authorization"] == "Bearer JWT"
 

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -134,12 +134,12 @@ def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     monkeypatch.setattr(facturacion_tab, "EmailSender", FakeSender)
 
     captured_post = {}
-    def fake_post(url, token, jws):
+    def fake_post(url, token, jws, data):
         captured_post["args"] = (url, token, jws)
         return {"estado": "Transmitido"}
     monkeypatch.setattr("dte._post_dte", fake_post)
     def fake_transmitir(db_, vid, modo="normal", tipo_dte="01"):
-        fake_post("http://example.com", "TOKEN", "SIGNED")
+        fake_post("http://example.com", "TOKEN", "SIGNED", {})
         return {"estado": "Transmitido"}
     monkeypatch.setattr(facturacion_tab, "transmitir_dte", fake_transmitir)
 

--- a/tests/test_url_sanitization.py
+++ b/tests/test_url_sanitization.py
@@ -39,7 +39,7 @@ def test_recepcion_url_is_stripped(monkeypatch, tmp_path):
     monkeypatch.setattr(dte.auth, "get_token", lambda: "JWT")
     called = {}
 
-    def fake_post_dte(url, token, jws_token):
+    def fake_post_dte(url, token, jws_token, dte_data):
         called["url"] = url
         return {"estado": "Transmitido"}
 


### PR DESCRIPTION
## Summary
- Send `ambiente`, `idEnvio`, `version`, `tipoDte`, `documento` and `codigoGeneracion` when posting DTEs
- Adjust document and event senders and tests for new payload structure

## Testing
- `pytest tests/test_dte_transmision.py::test_transmitir_dte_normal -q`
- `pytest tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio tests/test_envio_documentos.py::test_enviar_nota_credito tests/test_envio_documentos.py::test_enviar_evento_contingencia tests/test_envio_documentos.py::test_enviar_evento_anulacion -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8a7bdc888323bb208de6aef2399c