### PR TITLE
Log Hacienda responses before errors

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -168,6 +168,14 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
     url = url or _get_auth_url()
     try:
         resp = requests.post(url, data=data, headers=headers, timeout=20)
+        status_code = getattr(resp, "status_code", "N/A")
+        resp_text = getattr(resp, "text", "")
+        print(status_code)
+        print(resp_text)
+        if isinstance(status_code, int) and status_code >= 400:
+            logger.error("Respuesta de Hacienda %s: %s", status_code, resp_text)
+        else:
+            logger.debug("Respuesta de Hacienda %s: %s", status_code, resp_text)
         resp.raise_for_status()
         info = resp.json()
         body = info.get("body", {}) if isinstance(info, dict) else {}

--- a/dialogs.py
+++ b/dialogs.py
@@ -3101,6 +3101,14 @@ class DTEConfigDialog(QDialog):
                 url = "https://apitest.dtes.mh.gob.sv/seguridad/auth"
         try:
             resp = requests.post(url, data={"user": nit, "pwd": pwd}, timeout=20)
+            status_code = getattr(resp, "status_code", "N/A")
+            resp_text = getattr(resp, "text", "")
+            print(status_code)
+            print(resp_text)
+            if isinstance(status_code, int) and status_code >= 400:
+                logger.error("Respuesta de Hacienda %s: %s", status_code, resp_text)
+            else:
+                logger.debug("Respuesta de Hacienda %s: %s", status_code, resp_text)
             resp.raise_for_status()
             info = resp.json()
             if info.get("status") == "OK":

--- a/dte.py
+++ b/dte.py
@@ -1084,7 +1084,13 @@ def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None
         assert re.fullmatch(r"Bearer [^\s]+", auth_header), "Authorization header malformado"
     resp = requests.post(url, headers=headers, json=body, timeout=20)
     resp_text = getattr(resp, "text", "")
-    logger.debug("Respuesta de Hacienda: %s", resp_text)
+    status_code = getattr(resp, "status_code", "N/A")
+    print(status_code)
+    print(resp_text)
+    if isinstance(status_code, int) and status_code >= 400:
+        logger.error("Respuesta de Hacienda %s: %s", status_code, resp_text)
+    else:
+        logger.debug("Respuesta de Hacienda %s: %s", status_code, resp_text)
     resp.raise_for_status()
     try:
         return resp.json()

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -2,7 +2,9 @@ import os
 import json
 import base64
 import requests
+import logging
 
+logger = logging.getLogger(__name__)
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config_negocio.json")
 DEFAULT_SIGN_URL = "http://127.0.0.1:8080/firma/firmardocumento/"
 SIGN_TIMEOUT = 10
@@ -58,6 +60,14 @@ def sign_json(
     body = {"nit": nit, "activo": activo, "passwordPri": passwordPri, "dteJson": payload}
     try:
         response = requests.post(url, json=body, timeout=SIGN_TIMEOUT)
+        status_code = getattr(response, "status_code", "N/A")
+        resp_text = getattr(response, "text", "")
+        print(status_code)
+        print(resp_text)
+        if isinstance(status_code, int) and status_code >= 400:
+            logger.error("Respuesta del firmador %s: %s", status_code, resp_text)
+        else:
+            logger.debug("Respuesta del firmador %s: %s", status_code, resp_text)
         response.raise_for_status()
     except requests.Timeout as exc:
         raise RuntimeError("Tiempo de espera agotado al firmar") from exc


### PR DESCRIPTION
## Summary
- print and log Hacienda API responses before raising errors
- capture authentication response details for troubleshooting
- trace signer service replies and Hacienda token dialog errors

## Testing
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689e9e4a3a508323bf509d2e2683ac56