### PR TITLE
Recalcula y corrige totales en DTE antes de firmar

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -462,6 +462,64 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     return resumen
 
 
+def recalcular_totales(data: dict) -> list[str]:
+    """Recalcula y corrige los totales del resumen en ``data``.
+
+    La función vuelve a calcular los valores de la sección ``resumen`` a partir
+    de los ítems del ``cuerpoDocumento``.  Si alguno de los totales declarados
+    difiere del valor esperado por más de un centavo, el valor se corrige en el
+    lugar.  Devuelve una lista con los nombres de los campos ajustados.
+    """
+
+    ident = data.get("identificacion", {})
+    cuerpo = data.get("cuerpoDocumento", [])
+    resumen = data.get("resumen", {})
+
+    items_total = Decimal("0")
+    for item in cuerpo:
+        cant = Decimal(str(item.get("cantidad") or 0))
+        precio = Decimal(
+            str(item.get("precioUnitario") or item.get("precioUni") or 0)
+        )
+        items_total += cant * precio
+
+    # Omitimos ``total`` para que ``calcular_resumen`` utilice el monto
+    # calculado internamente y así podamos comparar contra el declarado.
+    venta = {"total_letras": resumen.get("totalLetras", "")}
+    fiscal = {
+        "descuentos": resumen.get("totalDescu", 0),
+        "iva": resumen.get("totalIva", resumen.get("ivaPerci1", 0)),
+        "ventas_no_sujetas": resumen.get("totalNoSuj", 0),
+        "ventas_exentas": resumen.get("totalExenta", 0),
+    }
+    extra = {
+        "pagos": resumen.get("pagos"),
+        "tributos": resumen.get("tributos"),
+        "numPagoElectronico": resumen.get("numPagoElectronico"),
+    }
+
+    esperado = calcular_resumen(
+        items_total,
+        venta,
+        fiscal=fiscal,
+        extra=extra,
+        tipo_dte=ident.get("tipoDte", "01"),
+    )
+
+    modificados: list[str] = []
+    for k, v in esperado.items():
+        if not isinstance(v, (int, float, Decimal)):
+            continue
+        ref = Decimal(str(resumen.get(k, 0)))
+        nuevo = Decimal(str(v))
+        if abs(ref - nuevo) > Decimal("0.01"):
+            resumen[k] = float(nuevo) if isinstance(v, Decimal) else v
+            modificados.append(k)
+
+    data["resumen"] = resumen
+    return modificados
+
+
 def generar_numero_control(prefijo: str = "DTE-01-S001P001") -> str:
     """Crea un número de control único siguiendo el formato de Hacienda."""
     secuencia = str(uuid.uuid4().int % 10**15).zfill(15)
@@ -763,7 +821,6 @@ def validate_dte_json(payload: dict) -> None:
     payload["receptor"] = receptor
 
     cuerpo = payload.get("cuerpoDocumento", [])
-    items_total = Decimal("0")
     for item in cuerpo:
         if "precioUnitario" in item:
             item["precioUni"] = item.pop("precioUnitario")
@@ -788,7 +845,6 @@ def validate_dte_json(payload: dict) -> None:
             "ventaGravada",
             float(importe.quantize(Decimal("0.00000000"), rounding=ROUND_HALF_UP)),
         )
-        items_total += importe
     payload["cuerpoDocumento"] = cuerpo
 
     resumen = payload.get("resumen", {})
@@ -802,34 +858,11 @@ def validate_dte_json(payload: dict) -> None:
                 pass
     payload["resumen"] = resumen
 
-    total_grav = Decimal(str(resumen.get("totalGravada", 0)))
-    total_exenta = Decimal(str(resumen.get("totalExenta", 0)))
-    total_no_suj = Decimal(str(resumen.get("totalNoSuj", 0)))
-    sub_total_ventas = Decimal(
-        str(resumen.get("subTotalVentas", total_grav + total_exenta + total_no_suj))
-    )
-    total_descu = Decimal(str(resumen.get("totalDescu", 0)))
-    total_iva = Decimal(str(resumen.get("totalIva", resumen.get("ivaPerci1", 0))))
-    sub_total = Decimal(str(resumen.get("subTotal", 0)))
-    total = Decimal(str(resumen.get("totalPagar", resumen.get("montoTotalOperacion", 0))))
-
-    items_total_2 = Decimal(str(_round(items_total, 2)))
-    if abs(items_total_2 - sub_total_ventas) > Decimal("0.01"):
+    # Recalcular totales y ajustar discrepancias
+    cambios = recalcular_totales(payload)
+    if cambios:
         print(
-            f"Advertencia: la suma de los ítems {items_total_2:.2f} difiere del resumen {sub_total_ventas:.2f}"
-        )
-
-    calc_sub = sub_total_ventas - total_descu
-    calc_sub = Decimal(str(_round(calc_sub, 2)))
-    if abs(calc_sub - sub_total) > Decimal("0.01"):
-        print(
-            f"Advertencia: el subtotal calculado {calc_sub:.2f} difiere del resumen {sub_total:.2f}"
-        )
-    calc_total = calc_sub + total_iva
-    calc_total = Decimal(str(_round(calc_total, 2)))
-    if abs(calc_total - total) > Decimal("0.01"):
-        print(
-            f"Advertencia: el total a pagar {total:.2f} difiere del calculado {calc_total:.2f}"
+            "Advertencia: se corrigieron campos de resumen: " + ", ".join(cambios)
         )
 
     # --- Catálogo validations ---

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -103,3 +103,19 @@ def test_schema_reports_multiple_errors(dte_metadata_factory):
     messages = {e["message"] for e in exc.value.errors}
     assert "'descripcion' is a required property" in messages
     assert "0.0 is less than or equal to the minimum of 0" in messages
+
+
+def test_recalcula_totales(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    # Manipulamos totales para que sean incorrectos
+    dte["resumen"]["totalGravada"] = 20.0
+    dte["resumen"]["subTotalVentas"] = 20.0
+    dte["resumen"]["montoTotalOperacion"] = 20.0
+    dte["resumen"]["totalPagar"] = 20.0
+
+    validate_dte_json(dte)
+
+    assert dte["resumen"]["totalGravada"] == pytest.approx(10.0)
+    assert dte["resumen"]["subTotalVentas"] == pytest.approx(10.0)
+    assert dte["resumen"]["montoTotalOperacion"] == pytest.approx(10.0)
+    assert dte["resumen"]["totalPagar"] == pytest.approx(10.0)


### PR DESCRIPTION
## Summary
- Recalculate DTE resumen values like `totalGravada`, `totalIva` and `totalPagar` based on document items
- Integrate total recalculation into validation to adjust mismatched fields before signing
- Add regression test confirming automatic correction of altered totals

## Testing
- `pytest tests/test_dte_validation.py::test_recalcula_totales -q`
- `pytest tests/test_verificar_totales.py::test_check_document_ok -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_689e9e3ba9b48323b233b5b87165cf35