### PR TITLE
Validate JWS metadata before DTE submission

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+import base64
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP, getcontext
 from db import DB
@@ -1055,6 +1056,23 @@ def _format_validation_errors(exc: Exception) -> list:
     return [msg]
 
 
+def _decode_jws_payload(token: str) -> dict:
+    """Return the JSON payload embedded in ``token``.
+
+    Raises ``ValueError`` if the token is not a valid JWS string.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError("JWS malformado")
+        payload = parts[1]
+        padding = "=" * (-len(payload) % 4)
+        payload_bytes = base64.urlsafe_b64decode(payload + padding)
+        return json.loads(payload_bytes.decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError("documento inválido") from exc
+
+
 def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None) -> dict:
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
     token = re.sub(r"^(?:Bearer\s+)+", "", token, flags=re.I)
@@ -1068,15 +1086,29 @@ def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None
     }
     ident = {}
     if isinstance(dte_data, dict):
-        ident = dte_data.get("identificacion") or dte_data.get("identificador") or {}
+        ident = dte_data.get("identificacion") or dte_data.get("identificador") or dte_data
+    ambiente = ident.get("ambiente")
+    tipo_dte = ident.get("tipoDte") or ident.get("tipoDocumento")
+    version = ident.get("version")
+    codigo = ident.get("codigoGeneracion")
+
+    # Ensure the JWS payload matches the provided metadata
+    payload = _decode_jws_payload(jws_token)
+    pident = payload.get("identificacion") or payload.get("identificador") or {}
+    if codigo and pident.get("codigoGeneracion") != codigo:
+        raise ValueError("documento no coincide con codigoGeneracion")
+    if tipo_dte and (pident.get("tipoDte") or pident.get("tipoDocumento")) != tipo_dte:
+        raise ValueError("documento no coincide con tipoDte")
+    if ambiente and pident.get("ambiente") != ambiente:
+        raise ValueError("documento no coincide con ambiente")
+
     body = {
-        "ambiente": ident.get("ambiente"),
+        "ambiente": ambiente,
         "idEnvio": uuid.uuid4().hex,
-        "version": ident.get("version"),
-        "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
+        "version": version or pident.get("version"),
+        "tipoDte": tipo_dte,
         "documento": jws_token,
     }
-    codigo = ident.get("codigoGeneracion")
     if codigo:
         body["codigoGeneracion"] = codigo
     auth_header = headers.get("Authorization")
@@ -1127,8 +1159,16 @@ def transmitir_dte(
 def enviar_dte_a_hacienda(jws_token: str) -> dict:
     """Transmite un DTE ya firmado (JWS) al entorno de pruebas de Hacienda."""
     url = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+    payload = _decode_jws_payload(jws_token)
+    ident = payload.get("identificacion") or payload.get("identificador") or {}
+    meta = {
+        "ambiente": ident.get("ambiente"),
+        "version": ident.get("version"),
+        "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
+        "codigoGeneracion": ident.get("codigoGeneracion"),
+    }
     token = auth.get_token()
-    respuesta = _post_dte(url, token, jws_token, {})
+    respuesta = _post_dte(url, token, jws_token, meta)
     estado = (
         respuesta.get("estado")
         or respuesta.get("estadoDte")
@@ -1167,11 +1207,18 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
         return {"estado": "Pendiente"}
 
     url = config.get("url") or DEFAULT_RECEPCION_URL
+    ident = data.get("identificacion") or data.get("identificador") or {}
+    meta = {
+        "ambiente": ident.get("ambiente"),
+        "version": ident.get("version"),
+        "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
+        "codigoGeneracion": ident.get("codigoGeneracion"),
+    }
     signed = jws.sign_json(data)
     token = auth.get_token()
 
     try:
-        respuesta = _post_dte(url, token, signed, data)
+        respuesta = _post_dte(url, token, signed, meta)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = (
             respuesta.get("estado")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import time
 import gc
 import copy
 import sqlite3
+import json
+import base64
 
 
 import pytest
@@ -20,6 +22,13 @@ except ImportError:  # pragma: no cover - PyQt5 may be missing in CI
             return None
 
 from db import DB
+
+
+def make_jws(payload: dict) -> str:
+    """Return a simple unsigned JWS token for ``payload``."""
+    header = base64.urlsafe_b64encode(b"{}" ).decode().rstrip("=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{header}.{body}.sig"
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 import pytest
+from tests.conftest import make_jws
 
 
 def create_sale(db):
@@ -32,11 +33,13 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    sign_calls = {"count": 0}
+    sign_calls = {"count": 0, "tokens": []}
 
     def fake_sign(data):
         sign_calls["count"] += 1
-        return "SIGNED"
+        token = make_jws(data)
+        sign_calls["tokens"].append(token)
+        return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
 
@@ -130,7 +133,7 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path, ambiente):
     url, headers, payload = calls[0]
     assert url == f"http://{ambiente}.example.com"
     assert headers["Authorization"] == "Bearer JWT"
-    assert payload["documento"] == "SIGNED"
+    assert payload["documento"] in sign_calls["tokens"]
     assert payload["tipoDte"] == "01"
     assert payload["version"] == 1
     assert payload["ambiente"] == ("01" if ambiente == "produccion" else "00")
@@ -158,12 +161,9 @@ def test_post_dte_uses_bearer(monkeypatch):
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
-    _post_dte(
-        "http://example.com",
-        "TOKEN",
-        "SIGNED",
-        {"identificacion": {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}},
-    )
+    meta = {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    _post_dte("http://example.com", "TOKEN", token, meta)
     assert captured["headers"]["Authorization"] == "Bearer TOKEN"
 
 
@@ -182,13 +182,31 @@ def test_post_dte_handles_non_json(monkeypatch):
         return R()
 
     monkeypatch.setattr("dte.requests.post", fake_post)
-    res = _post_dte(
-        "http://example.com",
-        "",
-        "SIGNED",
-        {"identificacion": {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}},
-    )
+    meta = {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    res = _post_dte("http://example.com", "", token, meta)
     assert res == {"estado": "Error", "detalle": "error"}
+
+
+def test_post_dte_rejects_mismatch(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {}
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    meta = {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    with pytest.raises(ValueError):
+        _post_dte("http://example.com", "TOKEN", token, {**meta, "codigoGeneracion": "XYZ"})
 
 
 def test_consultar_envio_dte():

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -9,6 +9,7 @@ from dte import (
     enviar_evento_contingencia,
     enviar_evento_anulacion,
 )
+from tests.conftest import make_jws
 
 
 def create_sale(db):
@@ -25,11 +26,13 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    sign_calls = {"count": 0}
+    sign_calls = {"count": 0, "tokens": []}
 
     def fake_sign(data):
         sign_calls["count"] += 1
-        return "SIGNED"
+        token = make_jws(data)
+        sign_calls["tokens"].append(token)
+        return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
@@ -118,7 +121,7 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     assert len(calls) == 2
     for url, headers, payload in calls:
         assert url == "http://example.com"
-        assert payload["documento"] == "SIGNED"
+        assert payload["documento"] in sign_calls["tokens"]
         assert payload["tipoDte"] == "01"
         assert payload["version"] == 1
         assert payload["ambiente"] == "00"
@@ -132,11 +135,13 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     venta = create_sale(db)
     nota_id = db.add_nota(venta, "credito", "2024-01-02", 10, "motivo")
 
-    sign_calls = {"count": 0}
+    sign_calls = {"count": 0, "tokens": []}
 
     def fake_sign(data):
         sign_calls["count"] += 1
-        return "SIGNED"
+        token = make_jws(data)
+        sign_calls["tokens"].append(token)
+        return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
@@ -210,7 +215,7 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     assert len(calls) == 1
     url, headers, payload = calls[0]
     assert url == "http://example.com"
-    assert payload["documento"] == "SIGNED"
+    assert payload["documento"] in sign_calls["tokens"]
     assert payload["tipoDte"] == "01"
     assert payload["version"] == 1
     assert payload["ambiente"] == "00"
@@ -223,11 +228,13 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     db = DB(":memory:")
     venta_id = create_sale(db)
 
-    sign_calls = {"count": 0}
+    sign_calls = {"count": 0, "token": ""}
 
     def fake_sign(data):
         sign_calls["count"] += 1
-        return "SIGNED"
+        token = make_jws(data)
+        sign_calls["token"] = token
+        return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
@@ -278,7 +285,7 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     assert len(calls) == 1
     url, headers, payload = calls[0]
     assert url == "http://example.com"
-    assert payload["documento"] == "SIGNED"
+    assert payload["documento"] == sign_calls["token"]
     assert payload["tipoDte"] == "CON"
     assert payload["version"] == 1
     assert payload["ambiente"] == "00"
@@ -291,11 +298,13 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta_id = create_sale(db)
 
-    sign_calls = {"count": 0}
+    sign_calls = {"count": 0, "token": ""}
 
     def fake_sign(data):
         sign_calls["count"] += 1
-        return "SIGNED"
+        token = make_jws(data)
+        sign_calls["token"] = token
+        return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
@@ -340,7 +349,7 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     assert len(calls) == 1
     url, headers, payload = calls[0]
     assert url == "http://example.com"
-    assert payload["documento"] == "SIGNED"
+    assert payload["documento"] == sign_calls["token"]
     assert payload["tipoDte"] == "ANU"
     assert payload["version"] == 1
     assert payload["ambiente"] == "00"

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -4,6 +4,7 @@ import requests
 
 from db import DB
 from dte import transmitir_dte
+from tests.conftest import make_jws
 
 
 def create_sale(db):
@@ -52,7 +53,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     def fake_sign(data):
         captured["data"] = data
         captured["count"] = captured.get("count", 0) + 1
-        return "JWS_SIGNED"
+        return make_jws(data)
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
     
@@ -183,7 +184,7 @@ def test_http_error_negativo(monkeypatch, tmp_path, status):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    monkeypatch.setattr("utils.jws.sign_json", lambda d: "SIGNED")
+    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
@@ -250,7 +251,7 @@ def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    monkeypatch.setattr("utils.jws.sign_json", lambda d: "SIGNED")
+    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
     token_calls = []
@@ -327,7 +328,7 @@ def test_timeout_no_modifica_extra(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    monkeypatch.setattr("utils.jws.sign_json", lambda d: "SIGNED")
+    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     monkeypatch.setattr("auth.get_token", lambda: "JWT")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 


### PR DESCRIPTION
## Summary
- ensure recepcion body reuses ambiente, tipoDte and codigoGeneracion extracted before signing
- check that the provided JWS payload matches those identification values
- add tests covering JWS verification and metadata handling

## Testing
- `pytest tests/test_dte_transmision.py`  
- `pytest tests/test_envio_documentos.py`  
- `pytest tests/test_envio_hacienda.py`  
- `pytest tests/test_url_sanitization.py`  
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689e9e479fe4832387e1771ff949e3b2