### PR TITLE
Validate DTE against JSON schema before sending

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -372,11 +372,9 @@ def armar_tributos(tributos_raw, tipo_dte):
     """Construye la lista de tributos o retorna ``None``."""
     if not tributos_raw:
         return None
-    schema_path = catalogos.SCHEMA_MAP.get(tipo_dte)
+    schema = catalogos.get_dte_schema(tipo_dte)
     allowed = set()
-    if schema_path and os.path.exists(schema_path):
-        with open(schema_path, "r", encoding="utf-8") as fh:
-            schema = json.load(fh)
+    if schema:
         allowed = set(
             schema.get("properties", {})
             .get("resumen", {})
@@ -899,10 +897,8 @@ def validate_dte_json(payload: dict) -> None:
         raise ValueError("Número de documento inválido en receptor")
 
     # --- Schema validation ---
-    schema_path = catalogos.SCHEMA_MAP.get(tipo_dte)
-    if schema_path and os.path.exists(schema_path):
-        with open(schema_path, "r", encoding="utf-8") as fh:
-            schema = json.load(fh)
+    schema = catalogos.get_dte_schema(tipo_dte)
+    if schema:
         _validate_schema(payload, schema)
 
 
@@ -1318,7 +1314,12 @@ def enviar_factura(db: DB, venta_id: int, modo: str = "normal") -> dict:
     """Genera y transmite una factura electrónica."""
     data = generar_dte_json(db, venta_id)
     data = sanitize_dte_payload(data)
-    validate_dte_json(data)
+    try:
+        validate_dte_json(data)
+    except Exception as exc:
+        json_path = save_dte_json(data)
+        errors = _format_validation_errors(exc)
+        raise DTEValidationError(errors, json_path) from exc
     resp = _enviar_documento(db, venta_id, data, modo)
     if resp.get("sello"):
         db.update_venta_extra(venta_id, {"selloRecibido": resp["sello"]})
@@ -1329,7 +1330,12 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     """Genera y transmite una nota de crédito."""
     data = generar_nota_credito_json(db, nota_id)
     data = sanitize_dte_payload(data)
-    validate_dte_json(data)
+    try:
+        validate_dte_json(data)
+    except Exception as exc:
+        json_path = save_dte_json(data)
+        errors = _format_validation_errors(exc)
+        raise DTEValidationError(errors, json_path) from exc
     return _enviar_documento(db, nota_id, data, modo)
 
 
@@ -1337,7 +1343,12 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     """Genera y transmite una nota de débito."""
     data = generar_nota_debito_json(db, nota_id)
     data = sanitize_dte_payload(data)
-    validate_dte_json(data)
+    try:
+        validate_dte_json(data)
+    except Exception as exc:
+        json_path = save_dte_json(data)
+        errors = _format_validation_errors(exc)
+        raise DTEValidationError(errors, json_path) from exc
     return _enviar_documento(db, nota_id, data, modo)
 
 
@@ -1345,7 +1356,12 @@ def enviar_nota_remision(db: DB, nota_id: int, modo: str = "normal") -> dict:
     """Genera y transmite una nota de remisión."""
     data = generar_nota_remision_json(db, nota_id)
     data = sanitize_dte_payload(data)
-    validate_dte_json(data)
+    try:
+        validate_dte_json(data)
+    except Exception as exc:
+        json_path = save_dte_json(data)
+        errors = _format_validation_errors(exc)
+        raise DTEValidationError(errors, json_path) from exc
     return _enviar_documento(db, nota_id, data, modo)
 
 

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pytest
 
 from pathlib import Path
 from db import DB
@@ -8,6 +9,7 @@ from dte import (
     enviar_nota_credito,
     enviar_evento_contingencia,
     enviar_evento_anulacion,
+    DTEValidationError,
 )
 from tests.conftest import make_jws
 
@@ -128,6 +130,38 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
         assert payload["codigoGeneracion"] == "ABC"
         assert "idEnvio" in payload
         assert headers["Authorization"] == "Bearer JWT"
+
+
+def test_no_envia_si_validacion_falla(monkeypatch):
+    db = DB(":memory:")
+    venta = create_sale(db)
+
+    sent = []
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        sent.append(True)
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+
+    sign_calls = {"count": 0}
+
+    def fake_sign(data):
+        sign_calls["count"] += 1
+        return "TOKEN"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
+
+    monkeypatch.setattr(
+        "dte.generar_dte_json",
+        lambda db_obj, vid: {"identificacion": {"tipoDte": "01"}},
+    )
+
+    with pytest.raises(DTEValidationError):
+        enviar_factura(db, venta)
+
+    assert sent == []
+    assert sign_calls["count"] == 0
 
 
 def test_enviar_nota_credito(monkeypatch, tmp_path):

--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 # Longitud estándar del NIT sin guiones
 NIT_LENGTH = 14
@@ -27,3 +28,17 @@ SCHEMA_MAP = {
     "05": os.path.join(SCHEMAS_DIR, "fe-nc-v3.json"),
     "06": os.path.join(SCHEMAS_DIR, "fe-nd-v3.json"),
 }
+
+
+def get_dte_schema(tipo: str) -> dict | None:
+    """Return the JSON schema dictionary for ``tipo``.
+
+    ``tipo`` debe ser un código de DTE como ``"01"`` o ``"03"``.  Si no se
+    encuentra un esquema asociado o el archivo no existe, devuelve ``None``.
+    """
+    path = SCHEMA_MAP.get(tipo)
+    if not path or not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+


### PR DESCRIPTION
## Summary
- add helper to load official JSON schema for each `tipoDte`
- validate DTE payloads against schema and raise `DTEValidationError` before signing
- add test ensuring no transmission occurs when validation fails

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689ea6f856188323855dbfb9be3d8bea