### PR TITLE
Validar host de autenticación y recepción

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -5,6 +5,7 @@ import time
 import base64
 import logging
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 
 import requests
 
@@ -23,6 +24,8 @@ _token_type: str = ""
 # Credenciales actualmente asociadas al token en caché
 _current_user: Optional[str] = None
 _current_pwd: Optional[str] = None
+_last_auth_url: Optional[str] = None
+_last_auth_host: Optional[str] = None
 
 
 def _read_db_credentials() -> Tuple[Optional[str], Optional[str]]:
@@ -166,6 +169,9 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     data = {"user": nit, "pwd": pwd}
     url = url or _get_auth_url()
+    global _last_auth_url, _last_auth_host
+    _last_auth_url = url
+    _last_auth_host = urlparse(url).netloc
     try:
         resp = requests.post(url, data=data, headers=headers, timeout=20)
         status_code = getattr(resp, "status_code", "N/A")
@@ -269,6 +275,9 @@ def get_token(
         return _access_token
 
     url = _get_auth_url()
+    global _last_auth_url, _last_auth_host
+    _last_auth_url = url
+    _last_auth_host = urlparse(url).netloc
     conf_nit, conf_url = _get_config_nit_and_url()
     if conf_nit and nit != conf_nit:
         raise ValueError(
@@ -291,3 +300,11 @@ def get_token(
     _expires_at = obtained_at + expires_in
     _save_token(token, expires_in, obtained_at)
     return token
+
+
+def get_last_auth_host() -> Optional[str]:
+    """Devuelve el host utilizado en la última autenticación."""
+    if _last_auth_host:
+        return _last_auth_host
+    url = _get_auth_url()
+    return urlparse(url).netloc

--- a/dte.py
+++ b/dte.py
@@ -4,6 +4,7 @@ import uuid
 import base64
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP, getcontext
+from urllib.parse import urlparse
 from db import DB
 import requests
 from utils import jws
@@ -1278,8 +1279,14 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
         "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
         "codigoGeneracion": ident.get("codigoGeneracion"),
     }
-    signed = jws.sign_json(data)
     token = auth.get_token()
+    auth_host = auth.get_last_auth_host()
+    recep_host = urlparse(url).netloc
+    if auth_host and recep_host != auth_host:
+        raise ValueError(
+            f"Host de recepción {recep_host} difiere de autenticación {auth_host}"
+        )
+    signed = jws.sign_json(data)
 
     try:
         respuesta = _post_dte(url, token, signed, meta)

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -213,3 +213,16 @@ def test_reauth_mismatch_nit(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     with pytest.raises(ValueError):
         auth.get_token(refresh=True, nit="999", pwd="pwd")
+
+
+def test_records_last_auth_host(monkeypatch, tmp_path):
+    data = {"ambiente": "pruebas", "pruebas": {"auth_url": "http://auth.example"}}
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(data))
+    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
+    monkeypatch.setattr(
+        auth, "_request_new_token", lambda nit, pwd, url: ("tok", 120, "Bearer")
+    )
+    auth.get_token(refresh=True, nit="user", pwd="pwd")
+    assert auth.get_last_auth_host() == "auth.example"

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 import pytest
+import auth
 from tests.conftest import make_jws
 
 
@@ -49,7 +50,8 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
         token_calls["count"] += 1
         return "JWT"
 
-    monkeypatch.setattr("auth.get_token", fake_get_token)
+    monkeypatch.setattr(auth, "get_token", fake_get_token)
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: f"{ambiente}.example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
     monkeypatch.setattr(
         "dte.generar_dte_json",

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -11,6 +11,7 @@ from dte import (
     enviar_evento_anulacion,
     DTEValidationError,
 )
+import auth
 from tests.conftest import make_jws
 
 
@@ -37,7 +38,8 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
     monkeypatch.setattr(
         "dte.generar_dte_json",
@@ -142,7 +144,7 @@ def test_no_envia_si_validacion_falla(monkeypatch):
         sent.append(True)
 
     monkeypatch.setattr("dte.requests.post", fake_post)
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
 
     sign_calls = {"count": 0}
 
@@ -178,7 +180,8 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
     monkeypatch.setattr(
         "dte.generar_nota_credito_json",
@@ -271,7 +274,8 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
 
     calls = []
 
@@ -341,7 +345,8 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
 
     calls = []
 

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import requests
+import auth
 
 from db import DB
 from dte import transmitir_dte
@@ -63,7 +64,8 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
         tokens["count"] += 1
         return "JWT"
 
-    monkeypatch.setattr("auth.get_token", fake_token)
+    monkeypatch.setattr(auth, "get_token", fake_token)
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "recepcion.test")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
     monkeypatch.setattr(
         "dte.generar_dte_json",
@@ -185,7 +187,8 @@ def test_http_error_negativo(monkeypatch, tmp_path, status):
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
     class Resp:
@@ -218,7 +221,8 @@ def test_firma_fallida_negativo(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
     def fail(*a, **k):
@@ -260,7 +264,8 @@ def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
         token_calls.append(refresh)
         return "JWT_VALIDO"
 
-    monkeypatch.setattr("auth.get_token", fake_get_token)
+    monkeypatch.setattr(auth, "get_token", fake_get_token)
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
 
     calls = {"auth": 0, "recepcion": 0}
 
@@ -303,8 +308,8 @@ def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
     config = {
         "ambiente": "pruebas",
         "pruebas": {
-            "auth_url": "http://auth.example",
-            "recepcion_url": "http://recepcion.example",
+            "auth_url": "http://example.com/auth",
+            "recepcion_url": "http://example.com/recepcion",
         },
     }
     with open("config_negocio.json", "w", encoding="utf-8") as fh:
@@ -329,7 +334,8 @@ def test_timeout_no_modifica_extra(monkeypatch, tmp_path):
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
-    monkeypatch.setattr("auth.get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
     def fake_post(*a, **k):
@@ -351,3 +357,17 @@ def test_timeout_no_modifica_extra(monkeypatch, tmp_path):
     assert row["sello"] == ""
     extra = db.cursor.execute("SELECT extra FROM ventas WHERE id=?", (venta,)).fetchone()["extra"]
     assert not extra
+
+
+def test_recepcion_url_host_mismatch(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
+    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "auth.example")
+    monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+    config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://other.example"}}
+    with open("config_negocio.json", "w", encoding="utf-8") as fh:
+        json.dump(config, fh)
+    with pytest.raises(ValueError):
+        transmitir_dte(db, venta)


### PR DESCRIPTION
## Summary
- Registra la última URL de autenticación utilizada y expone su host
- Verifica que el host de `recepcion_url` coincida con el host de autenticación antes de enviar DTE
- Añade pruebas para la nueva verificación de hosts y el registro de URL

## Testing
- `pytest` *(falla: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689eaf71ee248323ae82be254ad11912