### PR TITLE
Add token length validation

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -20,6 +20,8 @@ _access_token: Optional[str] = None
 _expires_at: float = 0.0
 _obtained_at: float = 0.0
 _token_type: str = ""
+# Longitud del token (sin el prefijo 'Bearer') medido al obtenerlo
+_token_length: int = 0
 # Credenciales actualmente asociadas al token en caché
 _current_user: Optional[str] = None
 _current_pwd: Optional[str] = None
@@ -284,6 +286,15 @@ def get_token(
     except Exception as exc:
         print(f"No se pudo obtener token: {exc}")
         raise
+    full_token = f"{token_type} {token}".strip()
+    parts = full_token.split()
+    measured_len = len(parts[1]) if len(parts) > 1 else len(parts[0])
+    global _token_length
+    _token_length = measured_len
+    if not 350 <= measured_len <= 800:
+        logger.warning(
+            "Longitud de token fuera de rango (%s)", measured_len
+        )
     obtained_at = time.time()
     _access_token = token
     _token_type = token_type
@@ -291,3 +302,8 @@ def get_token(
     _expires_at = obtained_at + expires_in
     _save_token(token, expires_in, obtained_at)
     return token
+
+
+def get_token_length() -> int:
+    """Devuelve la longitud del token medido al obtenerse."""
+    return _token_length

--- a/dte.py
+++ b/dte.py
@@ -1105,6 +1105,16 @@ def _decode_jws_payload(token: str) -> dict:
 def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None) -> dict:
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
     token = re.sub(r"^(?:Bearer\s+)+", "", token, flags=re.I)
+    used_len = len(f"Bearer {token}".split()[1]) if token else 0
+    saved_len = auth.get_token_length()
+    if saved_len and used_len != saved_len:
+        logger.warning(
+            "Longitud de token usada (%s) difiere de la guardada (%s)",
+            used_len,
+            saved_len,
+        )
+    if used_len and not 350 <= used_len <= 800:
+        logger.warning("Longitud de token fuera de rango (%s)", used_len)
     if token:
         logger.debug("Token: %s...%s", token[:5], token[-5:])
     else:


### PR DESCRIPTION
## Summary
- Measure and record token length when acquiring a new token
- Check token length again before sending DTEs and warn on mismatch or unexpected size

## Testing
- `pytest -q` *(fails: 9 failed, 209 passed)*
- `pytest tests/test_auth_module.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689eaf73243083238b17c8f58134efa7