### PR TITLE
Validate token length before saving and using

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -21,6 +21,7 @@ _access_token: Optional[str] = None
 _expires_at: float = 0.0
 _obtained_at: float = 0.0
 _token_type: str = ""
+_token_len: int = 0
 # Credenciales actualmente asociadas al token en caché
 _current_user: Optional[str] = None
 _current_pwd: Optional[str] = None
@@ -164,6 +165,18 @@ def _get_auth_url() -> str:
         return DEFAULT_AUTH_URL
 
 
+def _check_and_update_token_len(token: str) -> int:
+    """Verifica la longitud del token y actualiza el valor global."""
+    global _token_len
+    token_len = len(f"Bearer {token}".split()[1])
+    if not 350 <= token_len <= 800:
+        raise ValueError(f"Longitud de token inesperada: {token_len}")
+    if _token_len and token_len != _token_len:
+        raise ValueError("La longitud del token no coincide con la almacenada")
+    _token_len = token_len
+    return token_len
+
+
 def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[str, int, str]:
     """Solicita un nuevo token de acceso a la API."""
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -204,7 +217,7 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
         raise
 
 
-def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
+def _save_token(token: str, expires_in: int, obtained_at: float, token_len: int) -> None:
     """Guarda el token y metadatos en la tabla 'tokens' si es posible."""
     try:
         with sqlite3.connect(DB_PATH) as conn:
@@ -224,6 +237,10 @@ def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
                 "INSERT OR REPLACE INTO tokens(key, value) VALUES('obtained_at', ?)",
                 (str(obtained_at),),
             )
+            cur.execute(
+                "INSERT OR REPLACE INTO tokens(key, value) VALUES('token_len', ?)",
+                (str(token_len),),
+            )
             conn.commit()
         try:
             os.chmod(DB_PATH, 0o600)
@@ -235,12 +252,12 @@ def _save_token(token: str, expires_in: int, obtained_at: float) -> None:
 
 def delete_token() -> None:
     """Elimina el token almacenado y limpia la caché."""
-    global _access_token, _expires_at, _obtained_at, _token_type
+    global _access_token, _expires_at, _obtained_at, _token_type, _token_len
     try:
         with sqlite3.connect(DB_PATH) as conn:
             cur = conn.cursor()
             cur.execute(
-                "DELETE FROM tokens WHERE key IN ('access_token', 'expires_in', 'obtained_at')"
+                "DELETE FROM tokens WHERE key IN ('access_token', 'expires_in', 'obtained_at', 'token_len')"
             )
             conn.commit()
     except sqlite3.Error:
@@ -249,6 +266,7 @@ def delete_token() -> None:
     _token_type = ""
     _expires_at = 0.0
     _obtained_at = 0.0
+    _token_len = 0
 
 
 def get_token(
@@ -272,6 +290,7 @@ def get_token(
 
     now = time.time()
     if not refresh and _access_token and now < _expires_at - 60:
+        _check_and_update_token_len(_access_token)
         return _access_token
 
     url = _get_auth_url()
@@ -293,12 +312,13 @@ def get_token(
     except Exception as exc:
         print(f"No se pudo obtener token: {exc}")
         raise
+    token_len = _check_and_update_token_len(token)
     obtained_at = time.time()
     _access_token = token
     _token_type = token_type
     _obtained_at = obtained_at
     _expires_at = obtained_at + expires_in
-    _save_token(token, expires_in, obtained_at)
+    _save_token(token, expires_in, obtained_at, token_len)
     return token
 
 

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -7,6 +7,8 @@ import requests
 import auth
 import sqlite3
 
+LONG_TOKEN = "t" * 400
+
 
 def write_config(tmp_path, nit="123", pwd="pwd"):
     cfg = tmp_path / "config.json"
@@ -33,16 +35,16 @@ def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return f"tok{calls['n']}", 120, "Bearer"
+        return f"{LONG_TOKEN}{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     t1 = auth.get_token(refresh=True)
-    assert t1 == "tok1"
+    assert t1 == f"{LONG_TOKEN}1"
     t2 = auth.get_token()
-    assert t2 == "tok1"
+    assert t2 == f"{LONG_TOKEN}1"
     assert calls["n"] == 1
     t3 = auth.get_token(refresh=True)
-    assert t3 == "tok2"
+    assert t3 == f"{LONG_TOKEN}2"
     assert calls["n"] == 2
 
 
@@ -50,7 +52,7 @@ def test_get_token_expired(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
 
     def fake_request(nit, pwd, url):
-        return "tok", 1, "Bearer"
+        return f"{LONG_TOKEN}x", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     auth.get_token(refresh=True)
@@ -59,11 +61,11 @@ def test_get_token_expired(monkeypatch, tmp_path):
 
     def fake_request2(nit, pwd, url):
         calls["n"] += 1
-        return "new", 1, "Bearer"
+        return f"{LONG_TOKEN}{calls['n']}", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request2)
     token2 = auth.get_token()
-    assert token2 == "new"
+    assert token2 == f"{LONG_TOKEN}1"
     assert calls["n"] == 1
 
 
@@ -136,14 +138,14 @@ def test_get_token_with_explicit_credentials(monkeypatch):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return "tok", 120, "Bearer"
+        return f"{LONG_TOKEN}{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     monkeypatch.setattr(auth, "_get_config_nit_and_url", lambda: (None, None))
     t1 = auth.get_token(refresh=True, nit="u", pwd="p")
-    assert t1 == "tok"
+    assert t1 == f"{LONG_TOKEN}1"
     t2 = auth.get_token(nit="u", pwd="p")
-    assert t2 == "tok"
+    assert t2 == f"{LONG_TOKEN}1"
     assert calls["n"] == 1
     auth.get_token(nit="u2", pwd="p2")
     assert calls["n"] == 2
@@ -155,7 +157,7 @@ def test_delete_token(monkeypatch, tmp_path):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return f"tok{calls['n']}", 120, "Bearer"
+        return f"{LONG_TOKEN}{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     auth.get_token(refresh=True)
@@ -165,7 +167,7 @@ def test_delete_token(monkeypatch, tmp_path):
         cur.execute("SELECT value FROM tokens WHERE key='access_token'")
         assert cur.fetchone() is None
     t2 = auth.get_token()
-    assert t2 == "tok2"
+    assert t2 == f"{LONG_TOKEN}2"
     assert calls["n"] == 2
 
 
@@ -186,11 +188,11 @@ def test_reauth_logs_nit_and_url(monkeypatch, tmp_path, caplog):
     def fake_request(nit, pwd, url):
         assert nit == "123"
         assert url == "http://auth.example"
-        return "tok", 120, "Bearer"
+        return f"{LONG_TOKEN}1", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     token = auth.get_token(refresh=True)
-    assert token == "tok"
+    assert token == f"{LONG_TOKEN}1"
     assert "Reautenticando con NIT 123 y URL http://auth.example" in caplog.text
 
 
@@ -208,7 +210,7 @@ def test_reauth_mismatch_nit(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
 
     def fake_request(nit, pwd, url):
-        return "tok", 120, "Bearer"
+        return f"{LONG_TOKEN}1", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     with pytest.raises(ValueError):
@@ -222,7 +224,7 @@ def test_records_last_auth_host(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
     monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
     monkeypatch.setattr(
-        auth, "_request_new_token", lambda nit, pwd, url: ("tok", 120, "Bearer")
+        auth, "_request_new_token", lambda nit, pwd, url: (f"{LONG_TOKEN}1", 120, "Bearer")
     )
     auth.get_token(refresh=True, nit="user", pwd="pwd")
     assert auth.get_last_auth_host() == "auth.example"


### PR DESCRIPTION
## Summary
- track token length and verify it before persisting and returning
- store measured length with the token and validate consistency
- adjust auth module tests to use tokens within expected size

## Testing
- `pytest` *(fails: 11, passes: 209)*


------
https://chatgpt.com/codex/tasks/task_e_689eb55e6fe0832386a94358527652d3