### PR TITLE
Transmit invoice before emailing

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -536,29 +536,50 @@ class FacturacionTab(QWidget):
         if dialog.exec_() != QDialog.Accepted:
             return
 
-        if dialog.email_cb.isChecked():
-            if entry.get("row_type") == "venta":
-                self._send_invoice_email(venta_id)
-            elif entry.get("row_type") == "ticket":
-                self._send_ticket_email(venta_id)
+        send_email = dialog.email_cb.isChecked()
+
         if dialog.hacienda_cb.isChecked():
             tipo = "03" if entry.get("row_type") == "ticket" else "01"
             try:
                 resp = transmitir_dte(self.manager.db, venta_id, tipo_dte=tipo)
                 if resp.get("estado") == "Error":
                     QMessageBox.critical(
-                        self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                        self,
+                        "Enviar a Hacienda",
+                        f"{resp.get('detalle', 'Error')}\nLa factura será eliminada",
                     )
-                else:
-                    QMessageBox.information(
-                        self, "Enviar a Hacienda", "Documento enviado"
-                    )
+                    self.manager.db.delete_venta(venta_id)
+                    self.delete_files()
+                    self.load_invoices()
+                    return
+                QMessageBox.information(
+                    self, "Enviar a Hacienda", "Documento enviado"
+                )
             except dte.DTEValidationError as exc:
                 self._show_validation_errors(exc.errors, exc.json_path)
+                QMessageBox.critical(
+                    self, "Enviar a Hacienda", "Error al validar. La factura será eliminada"
+                )
+                self.manager.db.delete_venta(venta_id)
+                self.delete_files()
+                self.load_invoices()
+                return
             except Exception as exc:
                 QMessageBox.critical(
-                    self, "Enviar a Hacienda", str(exc)
+                    self,
+                    "Enviar a Hacienda",
+                    f"{str(exc)}\nLa factura será eliminada",
                 )
+                self.manager.db.delete_venta(venta_id)
+                self.delete_files()
+                self.load_invoices()
+                return
+
+        if send_email:
+            if entry.get("row_type") == "venta":
+                self._send_invoice_email(venta_id)
+            elif entry.get("row_type") == "ticket":
+                self._send_ticket_email(venta_id)
 
     def _send_invoice_email(self, venta_id):
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
@@ -789,7 +810,7 @@ class FacturacionTab(QWidget):
         if row_type in ("venta", "ticket"):
             venta_id = data.get("id")
             if row_type == "venta":
-                pdf_path = self.manager.db.get_factura_pdf(venta_id)
+                pdf_path = self.manager.db.get_factura_pdf(venta_id) or data.get("pdf")
                 if pdf_path:
                     paths.append(pdf_path)
                     paths.append(os.path.splitext(pdf_path)[0] + ".json")

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -153,6 +153,69 @@ def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     assert captured_post["args"] == ("http://example.com", "TOKEN", "SIGNED")
 
 
+def test_send_selected_invoice_deletes_on_failure(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_text("pdf")
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text("{}")
+    db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
+
+    tab = _make_tab(db, cid)
+    monkeypatch.setattr(tab, "_selected_venta", lambda: venta_id)
+
+    class DummyCheck:
+        def __init__(self):
+            self._checked = False
+        def setChecked(self, v):
+            self._checked = v
+        def isChecked(self):
+            return self._checked
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+            self.email_cb.setChecked(True)
+            self.hacienda_cb.setChecked(True)
+        def exec_(self):
+            return QDialog.Accepted
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    called = {"email": False}
+    class FakeSender:
+        def __init__(self, *a, **k):
+            called["email"] = True
+            self.finished = SimpleNamespace(connect=lambda fn: setattr(self, "_fn", fn))
+        def start(self):
+            if hasattr(self, "_fn"):
+                self._fn(True, "ok")
+    monkeypatch.setattr(facturacion_tab, "EmailSender", FakeSender)
+
+    def fake_transmitir(db_, vid, tipo_dte="01"):
+        return {"estado": "Error", "detalle": "fail"}
+    monkeypatch.setattr(facturacion_tab, "transmitir_dte", fake_transmitir)
+
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(
+        facturacion_tab.QMessageBox, "question", lambda *a, **k: facturacion_tab.QMessageBox.Yes
+    )
+
+    tab.send_selected_invoice()
+
+    assert not called["email"]
+    assert not pdf_path.exists()
+    assert not json_path.exists()
+    assert (
+        db.cursor.execute("SELECT id FROM ventas WHERE id=?", (venta_id,)).fetchone()
+        is None
+    )
+    ids = [tab.table.item(r, 0).text() for r in range(tab.table.rowCount())]
+    assert str(venta_id) not in ids
+
+
 def test_delete_files_removes(qt_app, tmp_path, monkeypatch):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)


### PR DESCRIPTION
## Summary
- Send invoices to Hacienda before emailing and remove records if transmission fails
- Ensure file deletion uses stored paths when DB entries are missing
- Add regression test for failed Hacienda transmission cleanup

## Testing
- `pytest tests/test_facturacion_tab_actions.py::test_send_selected_invoice tests/test_facturacion_tab_actions.py::test_send_selected_invoice_deletes_on_failure -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689eaf47c84883238116ae5fd7396ebe