### PR TITLE
Strip Bearer prefix from auth token

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -166,9 +166,9 @@ def _get_auth_url() -> str:
 
 
 def _check_and_update_token_len(token: str) -> int:
-    """Verifica la longitud del token y actualiza el valor global."""
+    """Verifica la longitud del JWT y actualiza el valor global."""
     global _token_len
-    token_len = len(f"Bearer {token}".split()[1])
+    token_len = len(token)
     if not 350 <= token_len <= 800:
         raise ValueError(f"Longitud de token inesperada: {token_len}")
     if _token_len and token_len != _token_len:
@@ -199,6 +199,8 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
         info = resp.json()
         body = info.get("body", {}) if isinstance(info, dict) else {}
         token = body.get("token") if info.get("status") == "OK" else None
+        if token and isinstance(token, str) and token.startswith("Bearer "):
+            token = token[7:]
         token_type = body.get("tokenType", "") if body else ""
         expires_in = int(body.get("expiresIn", 0)) if body else 0
         if not token:

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -103,6 +103,36 @@ def test_missing_token_includes_response(monkeypatch):
     assert "Respuesta de autenticación sin token" in msg
 
 
+def test_request_new_token_strips_bearer(monkeypatch):
+    """Se obtiene solo el JWT cuando la respuesta incluye el prefijo Bearer."""
+
+    def fake_post(url, data, headers, timeout):
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "status": "OK",
+                    "body": {
+                        "token": "Bearer ABC.DEF.GHI",
+                        "tokenType": "Bearer",
+                        "expiresIn": 60,
+                    },
+                }
+
+        return Resp()
+
+    monkeypatch.setattr(auth.requests, "post", fake_post)
+    monkeypatch.setattr(auth, "_get_auth_url", lambda: "http://fake")
+    token, expires_in, token_type = auth._request_new_token("nit", "pwd")
+    assert token == "ABC.DEF.GHI"
+    assert token_type == "Bearer"
+    assert expires_in == 60
+
+
 def test_env_specific_credentials(monkeypatch, tmp_path):
     data = {
         "ambiente": "pruebas",


### PR DESCRIPTION
## Summary
- ensure `_request_new_token` returns JWT without `Bearer` prefix
- simplify `_check_and_update_token_len` to work on raw JWT
- add regression test for token prefix stripping

## Testing
- `pytest` *(fails: 35 errors during collection)*
- `pytest tests/test_auth_module.py`

------
https://chatgpt.com/codex/tasks/task_e_689ec4d590d88323882aedb7ea1ec1c1