### PR TITLE
Format fecEmi dates to YYYY-MM-DD

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -577,7 +577,14 @@ def generar_dte_json(
     codigo_generacion = str(uuid.uuid4()).upper()
     numero_control = generar_numero_control()
 
-    fecha = venta.get("fecha") or datetime.now().strftime("%Y-%m-%d")
+    raw_fecha = venta.get("fecha")
+    if raw_fecha:
+        try:
+            fecha = datetime.fromisoformat(str(raw_fecha)).strftime("%Y-%m-%d")
+        except ValueError:
+            fecha = str(raw_fecha)[:10]
+    else:
+        fecha = datetime.now().strftime("%Y-%m-%d")
     hora = datetime.now().strftime("%H:%M:%S")
 
     identificacion = {

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -67,7 +67,10 @@ def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
     if venta.get('codigo_generacion'):
         ident['codigoGeneracion'] = venta['codigo_generacion']
     if venta.get('fecha'):
-        ident['fecEmi'] = venta['fecha']
+        try:
+            ident['fecEmi'] = datetime.fromisoformat(venta['fecha']).strftime('%Y-%m-%d')
+        except ValueError:
+            ident['fecEmi'] = str(venta['fecha'])[:10]
     if venta.get('modelo_facturacion'):
         ident['modeloFacturacion'] = venta['modelo_facturacion']
     if venta.get('tipo_transmision'):


### PR DESCRIPTION
## Summary
- Normalize `ident['fecEmi']` to YYYY-MM-DD when generating documents
- Ensure generated DTE records also format `fecEmi` dates to YYYY-MM-DD

## Testing
- `pytest tests/test_doc_utils.py tests/test_generar_dte_json.py`
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689eddfed4548323b53f22ca01a187d5