### PR TITLE
Validate condicionOperacion and payments before signing

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -14,6 +14,7 @@ from utils import catalogos
 import logging
 import re
 from utils.monto import monto_a_texto_sv
+from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 
 logger = logging.getLogger(__name__)
 
@@ -1374,6 +1375,18 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
         raise ValueError(
             f"Host de recepción {recep_host} difiere de autenticación {auth_host}"
         )
+    try:
+        resumen = data.get("resumen", {})
+        condicion = normalize_condicion_operacion(
+            resumen.get("condicionOperacion")
+        )
+        resumen["condicionOperacion"] = condicion
+        validate_pagos_basico(resumen, condicion)
+        data["resumen"] = resumen
+    except ValueError as exc:
+        logger.error("ERROR: DTE inválido: %s", exc)
+        raise ValueError(f"DTE inválido: {exc}") from exc
+
     signed = jws.sign_json(data)
 
     # Verify that metadata matches the signed payload and update it

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+import logging
 
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado
@@ -8,7 +9,10 @@ from dte import generar_ticket_json
 from utils.monto import monto_a_texto_sv
 from utils.docs import get_document_paths, build_invoice_json
 from utils.jws import sign_and_save
+from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 
+
+logger = logging.getLogger(__name__)
 
 def generate_invoice_pdf(manager, venta_id):
     """Generate and store the invoice PDF for the given sale."""
@@ -136,6 +140,17 @@ def generate_invoice_pdf(manager, venta_id):
     if not os.path.exists(json_path):
         raise IOError(f"No se pudo guardar JSON en {json_path}")
     try:
+        resumen = json_data.get("resumen", {})
+        condicion = normalize_condicion_operacion(
+            resumen.get("condicionOperacion")
+        )
+        resumen["condicionOperacion"] = condicion
+        validate_pagos_basico(resumen, condicion)
+        json_data["resumen"] = resumen
+    except ValueError as exc:
+        logger.error("ERROR: DTE inválido: %s", exc)
+        raise ValueError(f"DTE inválido: {exc}") from exc
+    try:
         sign_and_save(json_data, json_path)
     except Exception:
         pass
@@ -181,6 +196,17 @@ def generate_ticket_pdf(manager, venta_id):
         json.dump(ticket_json, fh, ensure_ascii=False, indent=2)
     if not os.path.exists(json_path):
         raise IOError(f"No se pudo guardar JSON en {json_path}")
+    try:
+        resumen = ticket_json.get("resumen", {})
+        condicion = normalize_condicion_operacion(
+            resumen.get("condicionOperacion")
+        )
+        resumen["condicionOperacion"] = condicion
+        validate_pagos_basico(resumen, condicion)
+        ticket_json["resumen"] = resumen
+    except ValueError as exc:
+        logger.error("ERROR: DTE inválido: %s", exc)
+        raise ValueError(f"DTE inválido: {exc}") from exc
     try:
         sign_and_save(ticket_json, json_path)
     except Exception:

--- a/utils/resumen.py
+++ b/utils/resumen.py
@@ -1,0 +1,53 @@
+"""Validaciones básicas para campos del resumen de DTE."""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+# Catálogo permitido de condicionOperacion
+CONDICION_OPERACION_CATALOG = {1, 2, 3}
+
+# Mapeo de nombres a códigos según catálogo oficial
+_CONDICION_OPERACION_BY_NAME = {
+    "contado": 1,
+    "credito": 2,
+    "crédito": 2,
+    "otro": 3,
+}
+
+
+def normalize_condicion_operacion(value: Any) -> int:
+    """Normaliza ``condicionOperacion`` a su código numérico.
+
+    Acepta códigos numéricos o descripciones textuales y devuelve un entero
+    dentro del catálogo. Lanza ``ValueError`` si el valor es inválido.
+    """
+    if value in (None, ""):
+        code = 1
+    elif isinstance(value, (int, float)):
+        code = int(value)
+    else:
+        val = str(value).strip().lower().replace("...", "")
+        if val.isdigit():
+            code = int(val)
+        else:
+            code = _CONDICION_OPERACION_BY_NAME.get(val)
+    if code not in CONDICION_OPERACION_CATALOG:
+        raise ValueError(f"condicionOperacion inválida: {value}")
+    return code
+
+
+def validate_pagos_basico(resumen: dict, condicion: int) -> None:
+    """Valida estructura básica de ``pagos`` según ``condicionOperacion``.
+
+    Cuando ``condicion`` es 2 (crédito) se requiere ``plazo`` y ``periodo`` en
+    cada elemento de ``pagos``. Lanza ``ValueError`` si faltan.
+    """
+    pagos: Iterable[dict] | None = resumen.get("pagos")
+    if not pagos:
+        return
+    if condicion == 2:
+        for pago in pagos:
+            if not pago.get("plazo") or not pago.get("periodo"):
+                raise ValueError(
+                    "Para operaciones a crédito, cada pago requiere 'plazo' y 'periodo'"
+                )


### PR DESCRIPTION
## Summary
- add `normalize_condicion_operacion` and `validate_pagos_basico` helpers
- validate and normalize `resumen.condicionOperacion` before signing DTEs
- log and raise clear errors when DTE payload is invalid

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689f727f960c8323adea70e07fb738a7