### PR TITLE
feat: allow uploading certificate

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -15,6 +15,9 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtCore import Qt, QDate, QUrl
 from PyQt5.QtGui import QColor, QDesktopServices
 import os
+import shutil
+
+from utils.jws import CERT_UPLOAD_DIR
 
 getcontext().prec = 4
 
@@ -2991,6 +2994,9 @@ class DTEConfigDialog(QDialog):
         self.dte_nit = QLineEdit()
         self.dte_pass = QLineEdit()
         self.dte_pass.setEchoMode(QLineEdit.Password)
+        self.cert_path = QLineEdit()
+        self.cert_path.setReadOnly(True)
+        self.cert_btn = QPushButton("Seleccionar")
         self.api_user = QLineEdit()
         self.api_pwd = QLineEdit()
         self.api_pwd.setEchoMode(QLineEdit.Password)
@@ -3014,6 +3020,12 @@ class DTEConfigDialog(QDialog):
         self.guardar_respuesta_bd = QCheckBox("Guardar respuesta de Hacienda en base de datos")
         form.addRow("NIT certificación:", self.dte_nit)
         form.addRow("Contraseña firma:", self.dte_pass)
+        cert_widget = QWidget()
+        cert_layout = QHBoxLayout(cert_widget)
+        cert_layout.setContentsMargins(0, 0, 0, 0)
+        cert_layout.addWidget(self.cert_path)
+        cert_layout.addWidget(self.cert_btn)
+        form.addRow("Archivo certificado (.crt):", cert_widget)
         form.addRow("NIT usuario API:", self.api_user)
         form.addRow("Contraseña API:", self.api_pwd)
         form.addRow(self.dte_activo)
@@ -3045,6 +3057,7 @@ class DTEConfigDialog(QDialog):
         guardar.clicked.connect(self.accept)
         cancelar.clicked.connect(self.reject)
         self.token_btn.clicked.connect(self._fetch_token)
+        self.cert_btn.clicked.connect(self._select_cert)
         if dte_api or fe_config or env_config:
             self.set_data(dte_api or {}, fe_config or {}, env_config or {})
 
@@ -3083,6 +3096,10 @@ class DTEConfigDialog(QDialog):
         self.adjuntar_json_correo.setChecked(dte_api.get("adjuntar_json_correo", False))
         self.incluir_sello_pdf.setChecked(dte_api.get("incluir_sello_pdf", False))
         self.guardar_respuesta_bd.setChecked(dte_api.get("guardar_respuesta", False))
+        nit = fe_config.get("nit", "")
+        cert = os.path.join(CERT_UPLOAD_DIR, f"{nit}.crt") if nit else ""
+        if cert and os.path.isfile(cert):
+            self.cert_path.setText(cert)
 
     def _fetch_token(self):
         nit_default = self.api_user.text().strip()
@@ -3128,6 +3145,26 @@ class DTEConfigDialog(QDialog):
                 QMessageBox.warning(self, "Error", msg)
         except Exception as exc:
             QMessageBox.critical(self, "Error", f"No se pudo obtener token: {exc}")
+
+    def _select_cert(self):
+        nit = self.dte_nit.text().strip()
+        if not nit:
+            QMessageBox.warning(self, "NIT requerido", "Ingrese el NIT antes de seleccionar el certificado.")
+            return
+        file_path, _ = QFileDialog.getOpenFileName(
+            self, "Seleccionar certificado", "", "Certificados (*.crt)"
+        )
+        if not file_path:
+            return
+        try:
+            os.makedirs(CERT_UPLOAD_DIR, exist_ok=True)
+            dest = os.path.join(CERT_UPLOAD_DIR, f"{nit}.crt")
+            shutil.copy(file_path, dest)
+            os.chmod(dest, 0o644)
+            self.cert_path.setText(dest)
+            QMessageBox.information(self, "Éxito", "Certificado copiado correctamente.")
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo copiar el certificado: {exc}")
 
     def get_data(self):
         dte_api = {

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -9,6 +9,11 @@ CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "
 DEFAULT_SIGN_URL = "http://127.0.0.1:8080/firma/firmardocumento/"
 SIGN_TIMEOUT = 10
 
+# Directory where the signing service expects certificate files (.crt)
+CERT_UPLOAD_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "svfe-api-firmador", "uploads"
+)
+
 
 def _get_sign_url(path: str = CONFIG_NEGOCIO_PATH) -> str:
     """Return signer service URL from ``SIGN_URL`` env, config or default."""
@@ -46,6 +51,13 @@ def _load_config(path: str = CONFIG_NEGOCIO_PATH):
     return nit, password, activo
 
 
+def _ensure_cert_file(nit: str) -> None:
+    """Verify that the certificate file for ``nit`` exists and is readable."""
+    cert_path = os.path.join(CERT_UPLOAD_DIR, f"{nit}.crt")
+    if not os.path.isfile(cert_path) or not os.access(cert_path, os.R_OK):
+        raise RuntimeError(f"Certificado no accesible: {cert_path}")
+
+
 def sign_json(
     payload: dict,
     nit: str | None = None,
@@ -56,6 +68,9 @@ def sign_json(
     """Sign ``payload`` using the external ``svfe-api-firmador`` service."""
     if nit is None or passwordPri is None:
         nit, passwordPri, activo = _load_config()
+    if not nit:
+        raise RuntimeError("NIT del certificado no configurado")
+    _ensure_cert_file(nit)
     url = url or _get_sign_url()
     ident = payload.get("identificacion", {})
     version = ident.get("version")


### PR DESCRIPTION
## Summary
- allow selecting and uploading `.crt` certificate from configuration dialog
- verify certificate file exists before invoking signing service

## Testing
- `pytest` *(fails: El total en letras es obligatorio, Token JWT mal formado)*

------
https://chatgpt.com/codex/tasks/task_e_689f78247d8c83239fe5f2e786d4c3ad