### PR TITLE
Make certificate directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ por lo que cada uno debe contar con su propio bloque `firma_electronica`.
 Coloca el certificado correspondiente en `svfe-api-firmador/uploads/<NIT>.crt`. La carpeta
 `uploads/` está incluida en `.gitignore`, por lo que los certificados no se versionan en el
 repositorio. Si deseas utilizar otra ubicación, define la variable de entorno
-`CERT_UPLOAD_DIR`; la aplicación eliminará espacios ocultos al leerla. Cuando se carga
-un certificado desde la interfaz de configuración, la carpeta `uploads/` se vacía antes de
-copiar el nuevo archivo, asegurando que solo el certificado vigente permanezca en ese
-directorio.
+`CERT_UPLOAD_DIR`; tanto la aplicación como el servicio de firmado la utilizan (los espacios
+ocultos se eliminan al leerla). Cuando se carga un certificado desde la interfaz de
+configuración, la carpeta `uploads/` se vacía antes de copiar el nuevo archivo, asegurando
+que solo el certificado vigente permanezca en ese directorio.
 
 El servicio de firmado debe ejecutarse con:
 

--- a/svfe-api-firmador/src/main/java/sv/mh/fe/constantes/Constantes.java
+++ b/svfe-api-firmador/src/main/java/sv/mh/fe/constantes/Constantes.java
@@ -1,8 +1,21 @@
 package sv.mh.fe.constantes;
 
+import java.io.File;
+
 public class Constantes {
 
-	
-        public static final String DIRECTORY_UPLOADS = System.getProperty("user.dir")+"/uploads/";
-	
+    public static final String DIRECTORY_UPLOADS;
+
+    static {
+        String env = System.getenv("CERT_UPLOAD_DIR");
+        if (env != null && !env.trim().isEmpty()) {
+            String dir = env.trim();
+            if (!dir.endsWith("/") && !dir.endsWith("\\")) {
+                dir = dir + File.separator;
+            }
+            DIRECTORY_UPLOADS = dir;
+        } else {
+            DIRECTORY_UPLOADS = System.getProperty("user.dir") + File.separator + "uploads" + File.separator;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow svfe-api-firmador to read certificate directory from CERT_UPLOAD_DIR
- document CERT_UPLOAD_DIR in README so both app and signer use it

## Testing
- `mvn -q -f svfe-api-firmador/pom.xml package` *(fails: Network is unreachable)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689f871655508323b28b8f16631ca0f0