### PR TITLE
Ensure signer uses uploaded certificate path

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -17,7 +17,7 @@ from PyQt5.QtGui import QColor, QDesktopServices
 import os
 import shutil
 
-from utils.jws import CERT_UPLOAD_DIR
+from utils import jws
 
 getcontext().prec = 4
 
@@ -3097,7 +3097,7 @@ class DTEConfigDialog(QDialog):
         self.incluir_sello_pdf.setChecked(dte_api.get("incluir_sello_pdf", False))
         self.guardar_respuesta_bd.setChecked(dte_api.get("guardar_respuesta", False))
         nit = fe_config.get("nit", "")
-        cert = os.path.join(CERT_UPLOAD_DIR, f"{nit}.crt") if nit else ""
+        cert = os.path.join(jws.CERT_UPLOAD_DIR, f"{nit}.crt") if nit else ""
         if cert and os.path.isfile(cert):
             self.cert_path.setText(cert)
 
@@ -3157,10 +3157,11 @@ class DTEConfigDialog(QDialog):
         if not file_path:
             return
         try:
-            os.makedirs(CERT_UPLOAD_DIR, exist_ok=True)
+            dest_dir = os.path.abspath(jws.CERT_UPLOAD_DIR)
+            os.makedirs(dest_dir, exist_ok=True)
             # Remove any existing files so only the new certificate remains
-            for name in os.listdir(CERT_UPLOAD_DIR):
-                existing = os.path.join(CERT_UPLOAD_DIR, name)
+            for name in os.listdir(dest_dir):
+                existing = os.path.join(dest_dir, name)
                 try:
                     if os.path.isfile(existing) or os.path.islink(existing):
                         os.remove(existing)
@@ -3168,9 +3169,10 @@ class DTEConfigDialog(QDialog):
                         shutil.rmtree(existing)
                 except Exception as cleanup_exc:
                     logger.warning("No se pudo eliminar %s: %s", existing, cleanup_exc)
-            dest = os.path.join(CERT_UPLOAD_DIR, f"{nit}.crt")
+            dest = os.path.join(dest_dir, f"{nit}.crt")
             shutil.copy(file_path, dest)
             os.chmod(dest, 0o644)
+            jws.set_cert_upload_dir(dest_dir)
             self.cert_path.setText(dest)
             QMessageBox.information(self, "Éxito", "Certificado copiado correctamente.")
         except Exception as exc:

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -17,6 +17,17 @@ _DEFAULT_CERT_DIR = os.path.join(
 CERT_UPLOAD_DIR = os.getenv("CERT_UPLOAD_DIR", _DEFAULT_CERT_DIR).strip()
 
 
+def set_cert_upload_dir(path: str) -> None:
+    """Override global certificate directory to ``path``.
+
+    The provided path is converted to an absolute path and stripped of
+    whitespace so that subsequent signing operations read the certificate
+    from the same location where it was copied after an upload.
+    """
+    global CERT_UPLOAD_DIR
+    CERT_UPLOAD_DIR = os.path.abspath(path).strip()
+
+
 def _get_sign_url(path: str = CONFIG_NEGOCIO_PATH) -> str:
     """Return signer service URL from ``SIGN_URL`` env, config or default."""
     url = os.getenv("SIGN_URL")
@@ -58,7 +69,7 @@ def _load_config(path: str = CONFIG_NEGOCIO_PATH):
 def _ensure_cert_file(nit: str) -> None:
     """Verify that the certificate file for ``nit`` exists and is readable."""
     nit = nit.strip()
-    cert_dir = CERT_UPLOAD_DIR.strip()
+    cert_dir = os.path.abspath(CERT_UPLOAD_DIR.strip())
     cert_path = os.path.join(cert_dir, f"{nit}.crt")
     if not (os.path.isfile(cert_path) and os.access(cert_path, os.R_OK)):
         raise RuntimeError(f"Certificado no accesible: {cert_path}")


### PR DESCRIPTION
## Summary
- Allow dynamically overriding certificate directory
- Update certificate selection dialog to sync signing path with upload location

## Testing
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ad213c083239d8d2aab90bd19d2