### PR TITLE
Add cod_giro field for DTE generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ especificar la contraseña directamente en `email_contrasena` o definir la
 variable de entorno `INVENTARIO_EMAIL_PASSWORD` antes de ejecutar la aplicación;
 la variable de entorno tiene prioridad si se define.
 
+El campo `cod_giro` identifica el giro del negocio y se usa al generar el DTE
+como `emisor.codActividad`.
+
 Si estás ejecutando pruebas automatizadas o no planeas enviar correos, puedes
 evitar la advertencia sobre credenciales incompletas estableciendo la variable
 de entorno `INVENTARIO_SUPPRESS_SMTP_WARNING=1` o iniciando `SalesTab` con

--- a/config_negocio.json
+++ b/config_negocio.json
@@ -1,5 +1,6 @@
 {
   "ambiente": "pruebas",
+  "cod_giro": "62010",
   "pruebas": {
     "recepcion_url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte",
     "firma_electronica": {

--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -15,6 +15,7 @@
   "nrc": "2301408",
   "nombre": "INVERSIONES",
   "nombreComercial": "InverTech",
+  "cod_giro": "62010",
   "codActividad": "62010",
   "descActividad": "Desarrollo ",
   "tipoContribuyente": "Persona Natural",

--- a/dialogs.py
+++ b/dialogs.py
@@ -2821,7 +2821,7 @@ class DatosNegocioDialog(QDialog):
         self.nrc = QLineEdit()
         self.nombre = QLineEdit()
         self.nombre_comercial = QLineEdit()
-        self.cod_actividad = QLineEdit()
+        self.cod_giro = QLineEdit()
         self.desc_actividad = QLineEdit()
         self.tipo_contribuyente = QLineEdit()
         self.telefono = QLineEdit()
@@ -2833,7 +2833,7 @@ class DatosNegocioDialog(QDialog):
         form.addRow("NRC:", self.nrc)
         form.addRow("Nombre:", self.nombre)
         form.addRow("Nombre comercial:", self.nombre_comercial)
-        form.addRow("Código actividad:", self.cod_actividad)
+        form.addRow("Código giro:", self.cod_giro)
         form.addRow("Descripción actividad:", self.desc_actividad)
         form.addRow("Tipo contribuyente:", self.tipo_contribuyente)
         form.addRow("Teléfono:", self.telefono)
@@ -2861,7 +2861,8 @@ class DatosNegocioDialog(QDialog):
             "nrc": self.nrc.text(),
             "nombre": self.nombre.text(),
             "nombreComercial": self.nombre_comercial.text(),
-            "codActividad": self.cod_actividad.text(),
+            "cod_giro": self.cod_giro.text(),
+            "codActividad": self.cod_giro.text(),
             "descActividad": self.desc_actividad.text(),
             "tipoContribuyente": self.tipo_contribuyente.text(),
             "telefono": self.telefono.text(),
@@ -2878,7 +2879,7 @@ class DatosNegocioDialog(QDialog):
         self.nrc.setText(datos.get("nrc", ""))
         self.nombre.setText(datos.get("nombre", ""))
         self.nombre_comercial.setText(datos.get("nombreComercial", ""))
-        self.cod_actividad.setText(datos.get("codActividad", ""))
+        self.cod_giro.setText(datos.get("cod_giro") or datos.get("codActividad", ""))
         self.desc_actividad.setText(datos.get("descActividad", ""))
         self.tipo_contribuyente.setText(datos.get("tipoContribuyente", ""))
         self.telefono.setText(datos.get("telefono", ""))

--- a/dte.py
+++ b/dte.py
@@ -158,6 +158,22 @@ def _load_datos_negocio():
                 url = dte_api.get("url", "")
                 if url and "/fesv/recepciondte" not in url:
                     dte_api["url"] = url.rstrip("/") + "/fesv/recepciondte"
+
+            # Ensure cod_giro is available and mirrors codActividad
+            cod_giro = data.get("cod_giro")
+            if not cod_giro:
+                try:
+                    with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+                        cfg = json.load(fh)
+                    cod_giro = cfg.get("cod_giro")
+                except Exception:
+                    cod_giro = None
+            if cod_giro:
+                data.setdefault("cod_giro", cod_giro)
+                data.setdefault("codActividad", cod_giro)
+            elif "codActividad" in data:
+                data.setdefault("cod_giro", data.get("codActividad"))
+
             return data
         except Exception:
             return {}
@@ -662,7 +678,7 @@ def generar_dte_json(
         "nombreComercial": datos.get("nombreComercial"),
         "nit": datos.get("nit"),
         "nrc": datos.get("nrc"),
-        "codActividad": datos.get("codActividad"),
+        "codActividad": datos.get("cod_giro") or datos.get("codActividad"),
         "descActividad": datos.get("descActividad"),
         "tipoContribuyente": datos.get("tipoContribuyente"),
         "direccion": datos.get("direccion"),
@@ -830,7 +846,7 @@ def validate_dte_json(payload: dict) -> None:
     emisor["nrc"] = _clean_nrc(emisor.get("nrc") or negocio.get("nrc"))
     emisor.setdefault("nombre", negocio.get("nombre"))
     emisor.setdefault("nombreComercial", negocio.get("nombreComercial"))
-    emisor.setdefault("codActividad", negocio.get("codActividad"))
+    emisor.setdefault("codActividad", negocio.get("cod_giro") or negocio.get("codActividad"))
     emisor.setdefault("descActividad", negocio.get("descActividad"))
     emisor.setdefault("tipoEstablecimiento", "01")
     direccion = emisor.get("direccion")

--- a/tests/test_cod_giro.py
+++ b/tests/test_cod_giro.py
@@ -1,0 +1,23 @@
+import json
+import dte
+
+
+def test_cod_giro_used_for_emisor(tmp_path, monkeypatch):
+    datos_path = tmp_path / "datos_negocio.json"
+    config_path = tmp_path / "config_negocio.json"
+    config_path.write_text(json.dumps({"cod_giro": "99999"}))
+    datos_path.write_text("{}")
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", datos_path)
+    monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", config_path)
+    payload = {
+        "identificacion": {},
+        "emisor": {},
+        "receptor": {"nombre": "X"},
+        "cuerpoDocumento": [],
+        "resumen": {},
+    }
+    try:
+        dte.validate_dte_json(payload)
+    except Exception:
+        pass
+    assert payload["emisor"]["codActividad"] == "99999"


### PR DESCRIPTION
## Summary
- capture business giro code in config files and GUI
- wire cod_giro into DTE emission as emisor.codActividad
- document cod_giro and add regression test

## Testing
- `python -m py_compile dte.py dialogs.py tests/test_cod_giro.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a16e18d65083239eb9f643767d4a3e