### PR TITLE
Ensure DTE emission date matches local transmission date

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -15,6 +15,7 @@ import logging
 import re
 from utils.monto import monto_a_texto_sv, d2
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
+from utils.fecha import fecha_emision_hoy_str, TZ_EL_SALVADOR
 
 logger = logging.getLogger(__name__)
 
@@ -659,15 +660,9 @@ def generar_dte_json(
     codigo_generacion = str(uuid.uuid4()).upper()
     numero_control = generar_numero_control()
 
-    raw_fecha = venta.get("fecha")
-    if raw_fecha:
-        try:
-            fecha = datetime.fromisoformat(str(raw_fecha)).strftime("%Y-%m-%d")
-        except ValueError:
-            fecha = str(raw_fecha)[:10]
-    else:
-        fecha = datetime.now().strftime("%Y-%m-%d")
-    hora = datetime.now().strftime("%H:%M:%S")
+    now = datetime.now(TZ_EL_SALVADOR)
+    fecha = fecha_emision_hoy_str(now)
+    hora = now.strftime("%H:%M:%S")
 
     identificacion = {
         "version": "1",
@@ -1133,7 +1128,7 @@ def _load_dte_api_config():
 def _save_signed_dte(dte_data: dict, jws_token: str) -> None:
     """Guarda el JSON original y el JWS en ``/dtes/{anio}/``."""
     try:
-        fecha = dte_data.get("identificacion", {}).get("fecEmi") or datetime.now().strftime("%Y-%m-%d")
+        fecha = dte_data.get("identificacion", {}).get("fecEmi") or fecha_emision_hoy_str()
         year = str(fecha)[:4]
         base_dir = os.path.join(os.path.dirname(__file__), "dtes", year)
         os.makedirs(base_dir, exist_ok=True)
@@ -1160,7 +1155,7 @@ class DTEValidationError(Exception):
 def save_dte_json(dte_data: dict) -> str:
     """Guarda ``dte_data`` en ``/dtes/{anio}/`` y devuelve la ruta."""
     try:
-        fecha = dte_data.get("identificacion", {}).get("fecEmi") or datetime.now().strftime("%Y-%m-%d")
+        fecha = dte_data.get("identificacion", {}).get("fecEmi") or fecha_emision_hoy_str()
         year = str(fecha)[:4]
         base_dir = os.path.join(os.path.dirname(__file__), "dtes", year)
         os.makedirs(base_dir, exist_ok=True)
@@ -1407,6 +1402,12 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
         "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
         "codigoGeneracion": ident.get("codigoGeneracion"),
     }
+    ident["fecEmi"] = fecha_emision_hoy_str()
+    ident["horEmi"] = datetime.now(TZ_EL_SALVADOR).strftime("%H:%M:%S")
+    if "identificacion" in data:
+        data["identificacion"] = ident
+    elif "identificador" in data:
+        data["identificador"] = ident
     token = auth.get_token()
     auth_host = auth.get_last_auth_host()
     recep_host = urlparse(url).netloc

--- a/utils/fecha.py
+++ b/utils/fecha.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+TZ_EL_SALVADOR = ZoneInfo("America/El_Salvador")
+
+def fecha_emision_hoy_str(now: Optional[datetime] = None) -> str:
+    """Return today's date in El Salvador timezone formatted as YYYY-MM-DD."""
+    if now is None:
+        now = datetime.now(TZ_EL_SALVADOR)
+    else:
+        now = now.astimezone(TZ_EL_SALVADOR)
+    return now.strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- add `fecha_emision_hoy_str` helper using America/El_Salvador timezone
- use helper across DTE generation and saving
- set `identificacion.fecEmi` and `horEmi` at send time to match transmission date

## Testing
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a2090b715883238a1f87db18f7eebe