### PR TITLE
Validate DTE metadata and payload

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1261,24 +1261,29 @@ def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None
             "Faltan campos requeridos: " + ", ".join(missing)
         )
 
-    ambiente = str(ambiente)
-    tipo_dte = str(tipo_dte)
-    version = int(version)
+    ambiente = "00"
+    version = 2
     id_envio = int(uuid.uuid4()) & 0x7FFFFFFF or 1
     documento = str(jws_token)
+    assert documento.count(".") == 2, "documento JWS malformado"
     codigo = str(codigo)
 
-    body = {
+    tipo_dte = str(tipo_dte)
+    assert re.fullmatch(r"\d{2}", tipo_dte), "tipoDte debe ser dos dígitos"
+    assert tipo_dte in catalogos.TIPOS_DTE, "tipoDte inválido"
+
+    payload = {
         "ambiente": ambiente,
-        "idEnvio": id_envio,
         "version": version,
+        "idEnvio": int(id_envio),
         "tipoDte": tipo_dte,
         "documento": documento,
     }
     if codigo:
-        body["codigoGeneracion"] = codigo
+        payload["codigoGeneracion"] = codigo
+    assert payload.get("codigoGeneracion") == codigo, "codigoGeneracion no coincide"
 
-    print({k: type(v).__name__ for k, v in body.items()})
+    print({k: type(v).__name__ for k, v in payload.items()})
 
     required = {
         "ambiente": str,
@@ -1287,18 +1292,18 @@ def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None
         "idEnvio": int,
         "documento": str,
     }
-    if "codigoGeneracion" in body:
+    if "codigoGeneracion" in payload:
         required["codigoGeneracion"] = str
 
     for field, expected in required.items():
-        assert field in body, f"{field} requerido"
-        assert isinstance(body[field], expected), f"{field} debe ser {expected.__name__}"
+        assert field in payload, f"{field} requerido"
+        assert isinstance(payload[field], expected), f"{field} debe ser {expected.__name__}"
 
-    assert body["idEnvio"] > 0
+    assert payload["idEnvio"] > 0
     auth_header = headers.get("Authorization")
     if token:
         assert re.fullmatch(r"Bearer [^\s]+", auth_header), "Authorization header malformado"
-    resp = requests.post(url, headers=headers, json=body, timeout=20)
+    resp = requests.post(url, headers=headers, json=payload, timeout=20)
     resp_text = getattr(resp, "text", "")
     status_code = getattr(resp, "status_code", "N/A")
     print(status_code)

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -68,29 +68,29 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
                 "correo": None,
             },
             "cuerpoDocumento": [{"cantidad": 1, "precioUnitario": 10}],
-            "resumen": {
-                "totalNoSuj": 0,
-                "totalExenta": 0,
-                "totalGravada": 10,
-                "subTotalVentas": 10,
-                "descuNoSuj": 0,
-                "descuExenta": 0,
-                "descuGravada": 0,
-                "porcentajeDescuento": 0,
-                "totalDescu": 0,
-                "tributos": None,
-                "subTotal": 10,
-                "ivaRete1": 0,
-                "reteRenta": 0,
-                "montoTotalOperacion": 10,
-                "totalNoGravado": 0,
-                "totalPagar": 10,
-                "totalLetras": "",
-                "totalIva": 0,
-                "saldoFavor": 0,
-                "condicionOperacion": 1,
-                "pagos": None,
-                "numPagoElectronico": None,
+                "resumen": {
+                    "totalNoSuj": 0,
+                    "totalExenta": 0,
+                    "totalGravada": 10,
+                    "subTotalVentas": 10,
+                    "descuNoSuj": 0,
+                    "descuExenta": 0,
+                    "descuGravada": 0,
+                    "porcentajeDescuento": 0,
+                    "totalDescu": 0,
+                    "tributos": None,
+                    "subTotal": 10,
+                    "ivaRete1": 0,
+                    "reteRenta": 0,
+                    "montoTotalOperacion": 10,
+                    "totalNoGravado": 0,
+                    "totalPagar": 10,
+                    "totalLetras": "DIEZ",
+                    "totalIva": 0,
+                    "saldoFavor": 0,
+                    "condicionOperacion": 1,
+                    "pagos": None,
+                    "numPagoElectronico": None,
             },
             "identificacion": {
                 "tipoDte": "01",
@@ -230,6 +230,27 @@ def test_post_dte_missing_fields(monkeypatch):
     with pytest.raises(AssertionError):
         _post_dte("http://example.com", "TOKEN", token, {})
     assert calls["count"] == 0
+
+
+def test_post_dte_invalid_tipo(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=20):
+        class R:
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {}
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    meta = {"ambiente": "00", "version": 2, "tipoDte": "99", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    with pytest.raises(AssertionError):
+        _post_dte("http://example.com", "TOKEN", token, meta)
 
 
 def test_consultar_envio_dte():


### PR DESCRIPTION
## Summary
- Ensure `_post_dte` builds a sanitized payload with fixed ambiente, version, numeric idEnvio, and matching codigoGeneracion
- Validate JWS structure and restrict `tipoDte` to allowed two-digit codes
- Add regression test for invalid `tipoDte` handling

## Testing
- `pytest tests/test_dte_transmision.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a209d672a4832383c30e51af14c9dd