### PR TITLE
Manejar errores HTTP en _post_dte

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1301,13 +1301,14 @@ def _post_dte(url: str, token: str, jws_token: str, dte_data: dict | None = None
     resp = requests.post(url, headers=headers, json=body, timeout=20)
     resp_text = getattr(resp, "text", "")
     status_code = getattr(resp, "status_code", "N/A")
-    print(status_code)
-    print(resp_text)
     if isinstance(status_code, int) and status_code >= 400:
-        logger.error("Respuesta de Hacienda %s: %s", status_code, resp_text)
+        try:
+            logger.error("Hacienda %s: %s", status_code, resp_text)
+        finally:
+            resp.raise_for_status()
     else:
-        logger.debug("Respuesta de Hacienda %s: %s", status_code, resp_text)
-    resp.raise_for_status()
+        logger.debug("Hacienda %s: %s", status_code, resp_text)
+
     try:
         return resp.json()
     except Exception:


### PR DESCRIPTION
## Summary
- Registra y eleva errores HTTP del servicio de Hacienda en `_post_dte`
- Mantiene la traza de depuración para respuestas exitosas

## Testing
- `pytest` *(fails: Token JWT mal formado, El total en letras es obligatorio, Host de recepción sandbox.dtes.mh.gob.sv dif..., Faltan campos requeridos: ambiente, Errores de esquema encontrados, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a20a5d9c9883238d181206c4c42ea7