### PR TITLE
Ensure tributo codes validated and auto-added for taxable items

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -436,10 +436,13 @@ def armar_tributos(tributos_raw, tipo_dte):
     """Construye la lista de tributos o retorna ``None``."""
     if not tributos_raw:
         return None
+    # Los códigos válidos se obtienen tanto del catálogo local como del
+    # esquema oficial del tipo de documento.  Esto permite extender el catálogo
+    # sin depender de que el esquema se encuentre actualizado.
+    allowed = set(catalogos.TRIBUTOS.keys())
     schema = catalogos.get_dte_schema(tipo_dte)
-    allowed = set()
     if schema:
-        allowed = set(
+        allowed.update(
             schema.get("properties", {})
             .get("resumen", {})
             .get("properties", {})
@@ -453,11 +456,13 @@ def armar_tributos(tributos_raw, tipo_dte):
     for t in tributos_raw or []:
         codigo = str(t.get("codigo", "")).upper()
         if allowed and codigo not in allowed:
-            continue
+            raise ValueError(f"Código de tributo inválido: {codigo}")
         result.append(
             {
                 "codigo": codigo,
-                "descripcion": t.get("descripcion"),
+                # Si no se proporciona descripción, intentar obtenerla del catálogo
+                "descripcion": t.get("descripcion")
+                or catalogos.TRIBUTOS.get(codigo),
                 "valor": d2(t.get("valor", 0)),
             }
         )
@@ -948,6 +953,34 @@ def validate_dte_json(payload: dict) -> None:
         item["precioUni"] = float(precio_q)
         importe = cantidad_q * precio_q
         item.setdefault("ventaGravada", float(d8(importe)))
+
+        # --- Manejo y validación de tributos ---
+        venta_gravada = D(str(item.get("ventaGravada") or 0))
+        tributos = item.get("tributos")
+        if venta_gravada > 0:
+            # Si la venta es gravada y no se especifican tributos, se asigna un
+            # código por defecto (IVA "20").
+            if not tributos:
+                tributos = ["20"]
+            elif isinstance(tributos, str):
+                tributos = [tributos]
+            item["tributos"] = [str(t).upper() for t in tributos]
+
+            # ``codTributo`` toma el primer código de la lista si no fue
+            # proporcionado explícitamente.
+            cod = item.get("codTributo") or item["tributos"][0]
+            item["codTributo"] = str(cod).upper()
+
+            allowed = set(catalogos.TRIBUTOS.keys())
+            if item["codTributo"] not in allowed:
+                raise ValueError(f"codTributo inválido: {item['codTributo']}")
+            invalid = [t for t in item["tributos"] if t not in allowed]
+            if invalid:
+                raise ValueError(f"Código(s) de tributo inválido(s): {', '.join(invalid)}")
+        else:
+            # Si no hay venta gravada, no deben declararse tributos
+            item["tributos"] = None
+            item["codTributo"] = None
     payload["cuerpoDocumento"] = cuerpo
 
     resumen = payload.get("resumen", {})

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -119,3 +119,27 @@ def test_recalcula_totales(dte_metadata_factory):
     assert dte["resumen"]["subTotalVentas"] == pytest.approx(10.0)
     assert dte["resumen"]["montoTotalOperacion"] == pytest.approx(10.0)
     assert dte["resumen"]["totalPagar"] == pytest.approx(10.0)
+
+
+def test_autocompleta_tributos(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    item = dte["cuerpoDocumento"][0]
+    # Eliminamos tributos para forzar el valor por defecto
+    item.pop("tributos", None)
+    item.pop("codTributo", None)
+    validate_dte_json(dte)
+    item = dte["cuerpoDocumento"][0]
+    assert item["tributos"] == ["20"]
+    assert item["codTributo"] == "20"
+
+
+def test_tributos_invalidos_rechazados(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["cuerpoDocumento"][0]["tributos"] = ["ZZ"]
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["cuerpoDocumento"][0]["codTributo"] = "ZZ"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)

--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -18,6 +18,25 @@ MODELOS_FACTURACION = {
     2: "Facturación posterior",
 }
 
+# Catálogo simplificado de tributos aplicables a los ítems del DTE
+#
+# Las claves corresponden a los códigos oficiales de tributo definidos por
+# el Ministerio de Hacienda.  Los valores son meramente descriptivos y no se
+# utilizan actualmente en la lógica; se mantienen para referencia humana.
+#
+# Este catálogo se utiliza para validar los campos ``codTributo`` y
+# ``tributos`` dentro del ``cuerpoDocumento``.
+TRIBUTOS = {
+    "20": "IVA 13%",
+    "A8": "Percepción a sujetos excluidos",
+    "57": "Renta",
+    "90": "IVA retenido",
+    "D4": "IEPES",
+    "D5": "IVA",
+    "25": "Fovial",
+    "A6": "CESC",
+}
+
 # Mapa de esquemas oficiales por tipo de documento
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 SCHEMAS_DIR = os.path.join(ROOT_DIR, "svfe-json-schemas")


### PR DESCRIPTION
## Summary
- Add catalog of tributo codes
- Auto-populate tributos and codTributo when ventaGravada > 0
- Validate tributo codes against catalog
- Add tests covering tributo auto-fill and validation

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a21fc306c48323936f246abecfec05