### PR TITLE
Validate codigoGeneracion as UUIDv4

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -864,9 +864,12 @@ def validate_dte_json(payload: dict) -> None:
     ident["version"] = int(ident.get("version", 1))
     cg = ident.get("codigoGeneracion")
     try:
-        ident["codigoGeneracion"] = str(uuid.UUID(str(cg))).upper()
+        uuid_obj = uuid.UUID(str(cg))
     except Exception:
-        ident["codigoGeneracion"] = str(uuid.uuid4()).upper()
+        raise ValueError("codigoGeneracion debe ser un UUID v4 válido") from None
+    if uuid_obj.version != 4:
+        raise ValueError("codigoGeneracion debe ser un UUID v4 válido")
+    ident["codigoGeneracion"] = str(uuid_obj).upper()
     payload["identificacion"] = ident
 
     emisor = payload.get("emisor", {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,11 +139,11 @@ def dte_metadata_factory():
     def factory(**overrides):
         base = {
             "identificacion": {
-                "version": 2,
+                "version": 1,
                 "ambiente": "00",
                 "tipoDte": "01",
                 "numeroControl": "DTE-01-AB12CD34-000000000000001",
-                "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+                "codigoGeneracion": "13C694DE-DDA1-499A-B265-4BD5B01CF323",
                 "tipoModelo": 1,
                 "tipoOperacion": 1,
                 "fecEmi": "2024-01-01",

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -28,6 +28,16 @@ def test_longitud_num_documento_invalida(dte_metadata_factory):
         validate_dte_json(dte)
 
 
+def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["codigoGeneracion"] = "not-a-uuid"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+    dte["identificacion"]["codigoGeneracion"] = "12345678-1234-1234-1234-1234567890AB"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
 def test_estructura_invalida(dte_metadata_factory, monkeypatch):
     dte = dte_metadata_factory()
     del dte["emisor"]["nit"]


### PR DESCRIPTION
## Summary
- ensure `validate_dte_json` only accepts UUIDv4 in `codigoGeneracion`
- align test fixtures and add coverage for invalid codes

## Testing
- `pytest tests/test_dte_validation.py tests/test_prevalidate.py tests/test_generar_dte_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2686614008323812919b06bb95180