### PR TITLE
Add negative DTE schema validation tests

### DIFF
--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -259,9 +259,8 @@ def validar_contra_schema(data: Dict[str, Any], tipo: str) -> None:
     Raises
     ------
     ValueError
-        Si ``tipo`` es desconocido.
-    jsonschema.exceptions.ValidationError
-        Si ``data`` no cumple con el schema correspondiente.
+        Si ``tipo`` es desconocido o ``data`` no cumple con el schema
+        correspondiente.
     """
 
     if tipo not in SCHEMA_MAP:
@@ -298,7 +297,15 @@ def validar_contra_schema(data: Dict[str, Any], tipo: str) -> None:
     validator = DecimalValidator(
         schema, format_checker=FormatChecker(), resolver=resolver
     )
-    validator.validate(data)
+    try:
+        validator.validate(data)
+    except ValidationError as exc:
+        path_parts = list(exc.absolute_path)
+        if exc.validator == "required" and exc.message.startswith("'"):
+            missing = exc.message.split("'")[1]
+            path_parts.append(missing)
+        path = ".".join(str(part) for part in path_parts)
+        raise ValueError(f"{path}: {exc.message}") from None
 
 
 __all__ = [

--- a/tests/test_all_dtes.py
+++ b/tests/test_all_dtes.py
@@ -1,0 +1,58 @@
+import copy
+
+import pytest
+
+from svfe.generators import (
+    generar_consumidor_final,
+    generar_factura_fiscal,
+    generar_nota_credito,
+    generar_nota_debito,
+    generar_nota_remision,
+    validar_contra_schema,
+)
+
+
+GEN_MAP = {
+    "ccf": generar_factura_fiscal,
+    "fc": generar_consumidor_final,
+    "nd": generar_nota_debito,
+    "nc": generar_nota_credito,
+    "nr": generar_nota_remision,
+}
+
+
+def _sanitize(data, tipo):
+    if tipo == "fc":
+        data["receptor"].pop("nit", None)
+        data["receptor"].pop("nombreComercial", None)
+        data["receptor"]["tipoDocumento"] = "03"
+        data["receptor"]["nrc"] = None
+        data["receptor"]["numDocumento"] = "12345678901234"
+    elif tipo in {"nd", "nc"}:
+        for key in ("codEstable", "codEstableMH", "codPuntoVenta", "codPuntoVentaMH"):
+            data["emisor"].pop(key, None)
+        data["cuerpoDocumento"][0]["numeroDocumento"] = "123"
+    elif tipo == "nr":
+        data["receptor"].pop("nit", None)
+        data["receptor"]["tipoDocumento"] = "36"
+        data["receptor"]["numDocumento"] = "12345678901234"
+        data["receptor"]["bienTitulo"] = "01"
+    return data
+
+
+@pytest.mark.parametrize("tipo", ["ccf", "fc", "nd", "nc", "nr"])
+def test_dtes_invalidos(tipo):
+    gen = GEN_MAP[tipo]
+    data = _sanitize(gen(), tipo)
+
+    missing = copy.deepcopy(data)
+    missing["identificacion"].pop("version")
+    with pytest.raises(ValueError) as excinfo:
+        validar_contra_schema(missing, tipo)
+    assert "identificacion.version" in str(excinfo.value)
+
+    wrong = copy.deepcopy(data)
+    wrong["cuerpoDocumento"][0]["precioUni"] = "foo"
+    with pytest.raises(ValueError) as excinfo:
+        validar_contra_schema(wrong, tipo)
+    assert "cuerpoDocumento.0.precioUni" in str(excinfo.value)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -2,7 +2,6 @@ import copy
 from decimal import Decimal
 
 import pytest
-from jsonschema.exceptions import ValidationError
 
 from svfe.generators import (
     generar_factura_fiscal,
@@ -63,5 +62,6 @@ def test_generar_nota_remision():
 def test_validar_contra_schema_missing_required_field():
     data = generar_factura_fiscal()
     data.pop("resumen")
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError) as excinfo:
         validar_contra_schema(data, "ccf")
+    assert "resumen" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- raise `ValueError` with field path details when schema validation fails
- cover invalid DTE cases for ccf, fc, nd, nc and nr
- update generator tests for new validation behaviour

## Testing
- `pytest tests/test_all_dtes.py::test_dtes_invalidos -q`
- `pytest tests/test_generators.py::test_validar_contra_schema_missing_required_field -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2700ce0a08323b275ba106b0eb867