### PR TITLE
Handle FC receptor fields

### DIFF
--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -108,8 +108,8 @@ def _emisor() -> Dict[str, Any]:
     }
 
 
-def _receptor() -> Dict[str, Any]:
-    return {
+def _receptor(tipo: str | None = None) -> Dict[str, Any]:
+    data = {
         "nit": "06141990011019",
         "nrc": "0000011",
         "nombre": "Consumidor Final",
@@ -124,6 +124,12 @@ def _receptor() -> Dict[str, Any]:
         "telefono": "70000001",
         "correo": "cliente@example.com",
     }
+    if tipo == "fc":
+        nit = data.pop("nit")
+        data.pop("nombreComercial", None)
+        data["tipoDocumento"] = "36"
+        data["numDocumento"] = nit
+    return data
 
 
 def _cuerpo_documento() -> List[Dict[str, Any]]:
@@ -215,7 +221,7 @@ def _generar(tipo: str) -> Dict[str, Any]:
         "identificacion": _identificacion(schema, tipo_dte),
         "documentoRelacionado": _documento_relacionado(tipo),
         "emisor": _emisor(),
-        "receptor": _receptor(),
+        "receptor": _receptor(tipo),
         "otrosDocumentos": None,
         "ventaTercero": None,
         "cuerpoDocumento": _cuerpo_documento(),

--- a/tests/test_all_dtes.py
+++ b/tests/test_all_dtes.py
@@ -25,9 +25,8 @@ def _sanitize(data, tipo):
     if tipo == "fc":
         data["receptor"].pop("nit", None)
         data["receptor"].pop("nombreComercial", None)
-        data["receptor"]["tipoDocumento"] = "03"
-        data["receptor"]["nrc"] = None
-        data["receptor"]["numDocumento"] = "12345678901234"
+        data["receptor"]["tipoDocumento"] = "36"
+        data["receptor"]["numDocumento"] = "06141990011019"
     elif tipo in {"nd", "nc"}:
         for key in ("codEstable", "codEstableMH", "codPuntoVenta", "codPuntoVentaMH"):
             data["emisor"].pop(key, None)


### PR DESCRIPTION
## Summary
- Adjust receptor generator for FC to use tipoDocumento/numDocumento and drop NIT and nombreComercial
- Pass DTE type into receptor builder
- Update FC golden test data accordingly

## Testing
- `pytest tests/test_all_dtes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2757654288323b9e8b00ecc2d2bd6