### PR TITLE
feat: add envelope prevalidation helpers

### DIFF
--- a/svfe/__init__.py
+++ b/svfe/__init__.py
@@ -8,7 +8,7 @@ from .generators import (
     generar_nota_remision,
     validar_contra_schema,
 )
-from .prevalidate import prevalidate
+from .prevalidate import prevalidate, prevalidate_envelope
 
 __all__ = [
     "generar_factura_fiscal",
@@ -18,4 +18,5 @@ __all__ = [
     "generar_nota_remision",
     "validar_contra_schema",
     "prevalidate",
+    "prevalidate_envelope",
 ]

--- a/svfe/prevalidate.py
+++ b/svfe/prevalidate.py
@@ -1,104 +1,126 @@
 """Pre-validation utilities for SVFE envelopes.
 
-This module provides :func:`prevalidate` to perform a minimal validation of
-``sobre`` (envelope) structures before they are sent to the SVFE services.
-It ensures the envelope matches the signed payload and that the payload
-conforms to the official JSON schemas.
+This module offers helpers to perform lightweight validation of signed
+documents before they are sent to Hacienda.  The goal is to catch obvious
+problems early without touching the official JSON schemas shipped in the
+project.
 """
 
 from __future__ import annotations
 
 import base64
 import json
+from pathlib import Path
 from typing import Any, Dict
 
-from jsonschema import ValidationError, validate
-
+from jsonschema import Draft202012Validator, FormatChecker, RefResolver
 from utils import catalogos
 
 
-def _decode_jws_payload(token: str) -> Dict[str, Any]:
-    """Return the JSON payload embedded in ``token``.
-
-    The token must be a JWS string of the form ``header.payload.signature``.
-    Raises :class:`ValueError` if the token is malformed or cannot be decoded.
-    """
-
-    try:
-        parts = token.split(".")
-        if len(parts) != 3:
-            raise ValueError("JWS malformado")
-        payload_b64 = parts[1]
-        padding = "=" * (-len(payload_b64) % 4)
-        payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
-        return json.loads(payload_bytes.decode("utf-8"))
-    except Exception as exc:  # pragma: no cover - defensive
-        raise ValueError("documento inválido") from exc
+# Keys that may be present in a document returned by MH after processing but
+# should not be considered when validating against the schema.  These keys are
+# simply stripped out by :func:`strip_extras`.
+EXTRAS = {"responseMH", "token", "firmaElectronica", "selloRecibido"}
 
 
-def prevalidate(sobre: Dict[str, Any]) -> bool:
-    """Validate a ``sobre`` (envelope) structure.
+def strip_extras(dte: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a shallow copy of ``dte`` without non-schema keys.
 
     Parameters
     ----------
-    sobre:
-        Dictionary representing the envelope. It must contain ``documento``
-        with the JWS, ``tipoDte`` and ``codigoGeneracion`` fields.
+    dte:
+        Original DTE payload potentially containing extra fields added by MH.
 
     Returns
     -------
-    bool
-        ``True`` if the envelope passes all checks.
-
-    Raises
-    ------
-    ValueError
-        If any verification fails or the payload does not comply with the
-        JSON schema associated with its ``tipoDte``.
+    dict
+        New dictionary without the keys listed in :data:`EXTRAS`.
     """
 
-    if not isinstance(sobre, dict):
-        raise ValueError("sobre inválido")
+    return {k: v for k, v in dte.items() if k not in EXTRAS}
 
-    jws = sobre.get("documento")
-    if not isinstance(jws, str):
-        raise ValueError("documento faltante")
 
-    payload = _decode_jws_payload(jws)
-    ident = payload.get("identificacion") or {}
+def _b64url_decode(s: str) -> bytes:
+    """Decode a base64url string, adding any required padding."""
 
-    tipo_dte = ident.get("tipoDte")
-    codigo = ident.get("codigoGeneracion")
+    s += "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s.encode())
 
-    if sobre.get("tipoDte") != tipo_dte:
-        raise ValueError("tipoDte no coincide")
-    if sobre.get("codigoGeneracion") != codigo:
-        raise ValueError("codigoGeneracion no coincide")
-    if ident.get("ambiente") != "00":
-        raise ValueError("ambiente inválido")
 
-    schema = catalogos.get_dte_schema(str(tipo_dte))
-    if not schema:
-        raise ValueError(f"Esquema no disponible para tipoDte {tipo_dte}")
+def _decode_jws(jws: str) -> Dict[str, Any]:
+    """Return the JSON payload contained in a compact JWS string."""
 
-    expected_version = (
-        schema.get("properties", {})
-        .get("identificacion", {})
-        .get("properties", {})
-        .get("version", {})
-        .get("const")
-    )
-    version = ident.get("version")
-    if expected_version is not None and version != expected_version:
-        raise ValueError("versión no coincide con esquema")
+    assert jws.count(".") == 2, "JWS no compacto"
+    _header, payload_b64, _sig = jws.split(".")
+    return json.loads(_b64url_decode(payload_b64))
 
-    try:
-        validate(payload, schema)
-    except ValidationError as exc:
-        raise ValueError(str(exc)) from exc
 
+def validate_against_schema(data: Dict[str, Any], schema_path: str) -> None:
+    """Validate ``data`` against the JSON schema located at ``schema_path``.
+
+    The validator uses :class:`Draft202012Validator` with a
+    :class:`FormatChecker` and resolves local ``$ref`` references relative to
+    ``schema_path``.  All errors are collected and reported together using the
+    ``a.b.0.c`` style for paths.
+    """
+
+    base = Path(schema_path).resolve()
+    schema = json.loads(base.read_text(encoding="utf-8"))
+    resolver = RefResolver(base_uri=base.as_uri(), referrer=schema)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker(), resolver=resolver)
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+    if errors:
+        messages = []
+        for err in errors:
+            path = ".".join(str(p) for p in err.path) or "<root>"
+            messages.append(f"{path}: {err.message}")
+        raise ValueError("Errores de validación del schema:\n" + "\n".join(messages))
+
+
+def prevalidate_envelope(sobre: Dict[str, Any], jws: str, schema_path: str) -> None:
+    """Pre-validate an envelope ``sobre`` and its signed payload ``jws``.
+
+    ``sobre`` contains metadata such as ``tipoDte`` and ``codigoGeneracion``.
+    The ``jws`` string must be a JWS compact serialization containing the DTE
+    payload.  ``schema_path`` points to the JSON schema against which the
+    payload will be validated.
+    """
+
+    payload = _decode_jws(jws)
+    ident = payload.get("identificacion", {})
+
+    assert sobre["tipoDte"] == ident.get("tipoDte"), "tipoDte (sobre vs payload) no coincide"
+    assert (
+        sobre["codigoGeneracion"] == ident.get("codigoGeneracion")
+    ), "codigoGeneracion no coincide"
+    assert ident.get("ambiente") == "00", "ambiente debe ser '00' en pruebas"
+
+    validate_against_schema(strip_extras(payload), schema_path)
+
+
+# Backwards compatibility -----------------------------------------------------
+def prevalidate(sobre: Dict[str, Any]) -> bool:
+    """Compatibility wrapper around :func:`prevalidate_envelope`.
+
+    ``sobre`` must include ``documento`` containing the JWS.  The schema path
+    is looked up using the existing catalogos mapping.  The function mimics the
+    old behaviour by returning ``True`` if validation succeeds.
+    """
+
+    jws = sobre.get("documento", "")
+    tipo = str(sobre.get("tipoDte"))
+    schema_path = catalogos.SCHEMA_MAP.get(tipo)
+    if not schema_path:
+        raise ValueError(f"Esquema no disponible para tipoDte {tipo}")
+    prevalidate_envelope(sobre, jws, schema_path)
     return True
 
 
-__all__ = ["prevalidate"]
+__all__ = [
+    "strip_extras",
+    "validate_against_schema",
+    "prevalidate_envelope",
+    "prevalidate",
+]
 


### PR DESCRIPTION
## Summary
- add utilities for stripping MH extras and validating data against DTE schemas
- implement `prevalidate_envelope` to assert envelope/payload metadata and schema compliance
- expose new prevalidation helpers via package API

## Testing
- `pytest tests/test_prevalidate.py::test_prevalidate_success -q` *(fails: jsonschema.exceptions.ValidationError: Errores de esquema encontrados: cuerpoDocumento.0.codTributo: 'D5' is not of type 'null')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b913985c8323a539a991746784a3