### PR TITLE
Limit combo box dropdown size

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -142,6 +142,8 @@ def _populate_combo(combo, items):
     for item in items:
         combo.addItem(f"{item['codigo']} — {item['nombre']}", item["codigo"])
     combo.setEditable(False)
+    combo.setMaxVisibleItems(8)
+    combo.view().setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 
 
 def _set_combo_value(combo, items, value):


### PR DESCRIPTION
## Summary
- Limit combo boxes populated via `_populate_combo` to show at most eight items
- Allow scroll bars on combo box dropdowns for better navigation

## Testing
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d5ab27588323b33279164960a505