### PR TITLE
Limit municipality combobox height with scroll

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -10,7 +10,7 @@ from PyQt5.QtWidgets import (
     QDoubleSpinBox, QPushButton, QListWidget, QListWidgetItem, QMessageBox, QCheckBox, QRadioButton, QComboBox,
     QDateEdit, QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QButtonGroup,
     QAbstractItemView, QTextEdit, QStackedLayout, QWidget, QHeaderView, QSizePolicy,
-    QFileDialog, QDialogButtonBox
+    QFileDialog, QDialogButtonBox, QListView
 )
 from PyQt5.QtCore import Qt, QDate, QUrl
 from PyQt5.QtGui import QColor, QDesktopServices
@@ -2940,6 +2940,12 @@ class DatosNegocioDialog(QDialog):
         self.correo = QLineEdit()
         self.departamento = QComboBox()
         self.municipio = QComboBox()
+        # Limitar el alto del listado de municipios y mostrar scroll
+        municipio_view = QListView()
+        municipio_view.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        municipio_view.setMaximumHeight(200)
+        self.municipio.setView(municipio_view)
+        self.municipio.setMaxVisibleItems(8)
         self.complemento = QLineEdit()
         _populate_combo(self.departamento, DEPARTAMENTOS)
         _populate_combo(self.municipio, MUNICIPIOS)


### PR DESCRIPTION
## Summary
- Ensure municipio dropdown in Datos del Negocio dialog uses a scrollable list with a capped height to avoid exceeding screen size

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: decimal.InvalidOperation and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d78665588323abf25183dda31929