### PR TITLE
feat: load emitter address codes

### DIFF
--- a/config/company.json
+++ b/config/company.json
@@ -1,0 +1,7 @@
+{
+  "emisor": {
+    "departamento": "06",
+    "municipio": "15",
+    "complemento": "Calle X #123"
+  }
+}

--- a/svfe/config.py
+++ b/svfe/config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+# Path to company configuration holding the emitter address codes
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "company.json"
+
+
+def get_emisor_direccion() -> Dict[str, str]:
+    """Return the emitter address configuration.
+
+    The configuration must provide ``departamento`` and ``municipio`` as
+    two-digit strings plus a ``complemento``. If the file is missing or the
+    values do not meet these requirements, ``ValueError`` is raised.
+    """
+
+    try:
+        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError("Config de dirección del emisor inválida") from exc
+
+    emisor = data.get("emisor", {})
+    departamento = emisor.get("departamento")
+    municipio = emisor.get("municipio")
+    complemento = emisor.get("complemento")
+
+    if (
+        not isinstance(departamento, str)
+        or not isinstance(municipio, str)
+        or not isinstance(complemento, str)
+    ):
+        raise ValueError("Config de dirección del emisor inválida")
+
+    if len(departamento) != 2 or len(municipio) != 2:
+        raise ValueError("Config de dirección del emisor inválida")
+
+    return {
+        "departamento": departamento,
+        "municipio": municipio,
+        "complemento": complemento,
+    }
+
+
+__all__ = ["get_emisor_direccion", "CONFIG_PATH"]

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
+from .config import get_emisor_direccion
+
 # NOTE: jsonschema imports retained for potential future validation logic.
 from jsonschema import (
     Draft202012Validator,
@@ -184,11 +186,6 @@ def _emisor() -> Dict[str, Any]:
         "descActividad": "Venta de productos",
         "nombreComercial": "Demo Comercial",
         "tipoEstablecimiento": "01",
-        "direccion": {
-            "departamento": "05",
-            "municipio": "01",
-            "complemento": "Centro Comercial 1",
-        },
         "telefono": "22222222",
         "correo": "demo@example.com",
         "codEstableMH": "0001",
@@ -203,7 +200,7 @@ def _receptor(tipo: str | None = None) -> Dict[str, Any]:
         "nit": "06141990011019",
         "nrc": "0000011",
         "nombre": "Consumidor Final",
-        "codActividad": "62010",
+        "codActividad": "62010" if tipo == "fc" else "6201",
         "descActividad": "Servicios de software",
         "nombreComercial": "Cliente Ejemplo",
         "direccion": {
@@ -222,6 +219,15 @@ def _receptor(tipo: str | None = None) -> Dict[str, Any]:
     return data
 
 
+def _validate_direccion(d: Dict[str, Any], quien: str) -> None:
+    dep = d.get("departamento")
+    mun = d.get("municipio")
+    if not (isinstance(dep, str) and len(dep) == 2):
+        raise ValueError(f"Departamento de {quien} inválido")
+    if not (isinstance(mun, str) and len(mun) == 2):
+        raise ValueError(f"Municipio de {quien} inválido")
+
+
 def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
     cantidad = Decimal("2.5")
     precio = Decimal("9.54")
@@ -229,15 +235,12 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
     iva_item = d8(venta * Decimal("0.13"))
     numero_documento = "NA" if tipo == "fc" else None
     tipo_item = 4 if tipo == "fc" else 1
-    cod_tributo = "A8"
     uni_medida = 99 if tipo == "fc" else 59
     item = {
         "numItem": 1,
         "tipoItem": tipo_item,
         "numeroDocumento": numero_documento,
         "codigo": "SKU001",
-        # Para un ítem gravado con IVA debe indicarse el tributo aplicado.
-        "codTributo": cod_tributo,
         "descripcion": "Producto de prueba",
         "cantidad": d8(cantidad),
         "uniMedida": uni_medida,
@@ -250,10 +253,13 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
         "noGravado": d8(Decimal("0")),
     }
     if tipo == "fc":
+        # Para un ítem gravado con IVA debe indicarse el tributo aplicado.
+        item["codTributo"] = "A8"
         item["ivaItem"] = iva_item
         item["tributos"] = None
     else:
-        item["tributos"] = [cod_tributo]
+        item["codTributo"] = None
+        item["tributos"] = ["20"]
     return [item]
 
 
@@ -332,6 +338,9 @@ def _generar(tipo: str) -> Dict[str, Any]:
         "extension": None,
         "apendice": None,
     }
+    data["emisor"]["direccion"] = get_emisor_direccion()
+    _validate_direccion(data["emisor"]["direccion"], "emisor")
+    _validate_direccion(data["receptor"].get("direccion", {}), "receptor")
     return data
 
 

--- a/tests/goldens/ccf.json
+++ b/tests/goldens/ccf.json
@@ -3,7 +3,7 @@
   "cuerpoDocumento": [
     {
       "cantidad": "2.50000000",
-      "codTributo": "A8",
+      "codTributo": null,
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
       "montoDescu": "0E-8",
@@ -14,7 +14,7 @@
       "psv": "0E-8",
       "tipoItem": 1,
       "tributos": [
-        "A8"
+        "20"
       ],
       "uniMedida": 59,
       "ventaExenta": "0E-8",
@@ -32,9 +32,9 @@
     "correo": "demo@example.com",
     "descActividad": "Venta de productos",
     "direccion": {
-      "complemento": "Centro Comercial 1",
-      "departamento": "05",
-      "municipio": "01"
+      "complemento": "Calle X #123",
+      "departamento": "06",
+      "municipio": "15"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",

--- a/tests/goldens/fc.json
+++ b/tests/goldens/fc.json
@@ -31,9 +31,9 @@
     "correo": "demo@example.com",
     "descActividad": "Venta de productos",
     "direccion": {
-      "complemento": "Centro Comercial 1",
-      "departamento": "05",
-      "municipio": "01"
+      "complemento": "Calle X #123",
+      "departamento": "06",
+      "municipio": "15"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",

--- a/tests/goldens/nc.json
+++ b/tests/goldens/nc.json
@@ -3,7 +3,7 @@
   "cuerpoDocumento": [
     {
       "cantidad": "2.50000000",
-      "codTributo": "A8",
+      "codTributo": null,
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
       "montoDescu": "0E-8",
@@ -12,7 +12,7 @@
       "precioUni": "9.54000000",
       "tipoItem": 1,
       "tributos": [
-        "A8"
+        "20"
       ],
       "uniMedida": 59,
       "ventaExenta": "0E-8",
@@ -33,9 +33,9 @@
     "correo": "demo@example.com",
     "descActividad": "Venta de productos",
     "direccion": {
-      "complemento": "Centro Comercial 1",
-      "departamento": "05",
-      "municipio": "01"
+      "complemento": "Calle X #123",
+      "departamento": "06",
+      "municipio": "15"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",

--- a/tests/goldens/nd.json
+++ b/tests/goldens/nd.json
@@ -3,7 +3,7 @@
   "cuerpoDocumento": [
     {
       "cantidad": "2.50000000",
-      "codTributo": "A8",
+      "codTributo": null,
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
       "montoDescu": "0E-8",
@@ -12,7 +12,7 @@
       "precioUni": "9.54000000",
       "tipoItem": 1,
       "tributos": [
-        "A8"
+        "20"
       ],
       "uniMedida": 59,
       "ventaExenta": "0E-8",
@@ -33,9 +33,9 @@
     "correo": "demo@example.com",
     "descActividad": "Venta de productos",
     "direccion": {
-      "complemento": "Centro Comercial 1",
-      "departamento": "05",
-      "municipio": "01"
+      "complemento": "Calle X #123",
+      "departamento": "06",
+      "municipio": "15"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",

--- a/tests/goldens/nr.json
+++ b/tests/goldens/nr.json
@@ -3,7 +3,7 @@
   "cuerpoDocumento": [
     {
       "cantidad": "2.50000000",
-      "codTributo": "A8",
+      "codTributo": null,
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
       "montoDescu": "0E-8",
@@ -12,7 +12,7 @@
       "precioUni": "9.54000000",
       "tipoItem": 1,
       "tributos": [
-        "A8"
+        "20"
       ],
       "uniMedida": 59,
       "ventaExenta": "0E-8",
@@ -37,9 +37,9 @@
     "correo": "demo@example.com",
     "descActividad": "Venta de productos",
     "direccion": {
-      "complemento": "Centro Comercial 1",
-      "departamento": "05",
-      "municipio": "01"
+      "complemento": "Calle X #123",
+      "departamento": "06",
+      "municipio": "15"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",

--- a/tests/test_svfe_config.py
+++ b/tests/test_svfe_config.py
@@ -1,0 +1,28 @@
+import pytest
+
+from svfe import config
+
+
+def test_get_emisor_direccion_valid(monkeypatch, tmp_path):
+    cfg = tmp_path / "company.json"
+    cfg.write_text(
+        '{"emisor":{"departamento":"12","municipio":"34","complemento":"C"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+    assert config.get_emisor_direccion() == {
+        "departamento": "12",
+        "municipio": "34",
+        "complemento": "C",
+    }
+
+
+def test_get_emisor_direccion_invalid(monkeypatch, tmp_path):
+    cfg = tmp_path / "company.json"
+    cfg.write_text(
+        '{"emisor":{"departamento":"1","municipio":"34","complemento":"C"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+    with pytest.raises(ValueError):
+        config.get_emisor_direccion()


### PR DESCRIPTION
## Summary
- load emitter address config from `config/company.json`
- validate department and municipality codes for issuer and receiver when building DTEs
- adjust receptor data and item tributes in DTE generators

## Testing
- `pytest >/tmp/unit.log` *(fails: missing dependencies)*
- `pytest tests/test_all_dtes.py tests/test_svfe_config.py tests/test_generar_dte_json.py >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a2db64c8608323a50dc9173902b6b8