### PR TITLE
Validar departamento y municipio en datos del negocio

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -3022,8 +3022,18 @@ class DatosNegocioDialog(QDialog):
         self.telefono.setText(datos.get("telefono", ""))
         self.correo.setText(datos.get("correo", ""))
         dir_info = datos.get("direccion", {}) or {}
-        _set_combo_value(self.departamento, DEPARTAMENTOS, dir_info.get("departamento"))
-        _set_combo_value(self.municipio, MUNICIPIOS, dir_info.get("municipio"))
+        departamento = dir_info.get("departamento")
+        municipio = dir_info.get("municipio")
+        _set_combo_value(
+            self.departamento,
+            DEPARTAMENTOS,
+            str(departamento) if departamento else "",
+        )
+        _set_combo_value(
+            self.municipio,
+            MUNICIPIOS,
+            str(municipio) if municipio else "",
+        )
         self.municipio.setEnabled(bool(self.departamento.currentData()))
         self.complemento.setText(dir_info.get("complemento", ""))
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1450,6 +1450,10 @@ class MainWindow(QMainWindow):
             try:
                 with open(datos_path, "r", encoding="utf-8") as f:
                     datos = json.load(f)
+                    dir_info = datos.get("direccion") or {}
+                    dir_info.setdefault("departamento", "")
+                    dir_info.setdefault("municipio", "")
+                    datos["direccion"] = dir_info
             except Exception:
                 datos = {}
         from dialogs import DatosNegocioDialog
@@ -1457,6 +1461,10 @@ class MainWindow(QMainWindow):
         if dlg.exec_():
             datos_nuevos = dlg.get_data()
             datos.update(datos_nuevos)
+            dir_info = datos.get("direccion") or {}
+            dir_info.setdefault("departamento", "")
+            dir_info.setdefault("municipio", "")
+            datos["direccion"] = dir_info
             with open(datos_path, "w", encoding="utf-8") as f:
                 json.dump(datos, f, ensure_ascii=False, indent=2)
             QMessageBox.information(self, "Datos del negocio", "Datos guardados correctamente.")


### PR DESCRIPTION
## Summary
- Verifica que la dirección del negocio tenga `departamento` y `municipio` al cargar y guardar
- Ajusta `DatosNegocioDialog.set_data` para pasar valores de combo como `str`

## Testing
- `pytest` *(falla: tests/test_generar_dte_json.py y tests/test_generators.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a33aea59bc8323bab0304fd0079c7a