### PR TITLE
Ensure IVA totals and payment rounding for DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -435,12 +435,12 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
         )
         allowed.update(str(c).zfill(2) for c in enum_codes)
 
-    pagos = []
+    pagos: list[dict] = []
     for p in pagos_raw or []:
         codigo = str(p.get("codigo", "")).zfill(2)
         if allowed and codigo not in allowed:
             continue
-        monto = d2(p.get("montoPago", 0))
+        monto = D(str(p.get("montoPago", 0))).quantize(D("0.01"), rounding=ROUND_HALF_UP)
         periodo = p.get("periodo")
         periodo = str(periodo).zfill(2) if periodo else None
         pagos.append(
@@ -457,20 +457,20 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
         pagos = [
             {
                 "codigo": "01",
-                "montoPago": d2(total),
+                "montoPago": D(str(total)).quantize(D("0.01"), rounding=ROUND_HALF_UP),
                 "referencia": None,
                 "periodo": None,
                 "plazo": None,
             }
         ]
     else:
-        suma = sum(D(str(p["montoPago"])) for p in pagos)
-        diff = (D(str(total)) - suma).quantize(D("0.01"), rounding=ROUND_HALF_UP)
+        suma = sum(p["montoPago"] for p in pagos)
+        diff = D(str(total)).quantize(D("0.01"), rounding=ROUND_HALF_UP) - suma
         if diff:
-            nuevo = D(str(pagos[-1]["montoPago"])) + diff
+            nuevo = pagos[-1]["montoPago"] + diff
             if nuevo < 0:
                 raise ValidationError("La suma de pagos excede el total a pagar")
-            pagos[-1]["montoPago"] = d2(nuevo)
+            pagos[-1]["montoPago"] = nuevo.quantize(D("0.01"), rounding=ROUND_HALF_UP)
 
     if condicion == 2:
         first = pagos[0]
@@ -481,6 +481,10 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
                 "condicionOperacion=2 requiere pago con plazo>0 y periodo válido"
             )
         first["periodo"] = periodo
+
+    # Convertir a ``float`` para compatibilidad con JSON
+    for p in pagos:
+        p["montoPago"] = float(p["montoPago"])
 
     return pagos
 
@@ -632,7 +636,9 @@ def recalcular_totales(data: dict) -> list[str]:
         if iva_val:
             iva_total += Decimal(str(iva_val))
             iva_from_items = True
-    if not iva_from_items:
+    if iva_from_items:
+        iva_total = iva_total.quantize(D("0.01"), rounding=ROUND_HALF_UP)
+    else:
         iva_total = Decimal(
             str(resumen.get("totalIva") or resumen.get("ivaPerci1") or 0)
         )

--- a/tests/test_dte_rounding.py
+++ b/tests/test_dte_rounding.py
@@ -1,6 +1,6 @@
 import pytest
 from utils.monto import D, d8, d2, iva_item
-from dte import calcular_resumen
+from dte import calcular_resumen, normalizar_pagos
 
 
 def decimal_places(value):
@@ -28,3 +28,15 @@ def test_item_and_total_rounding():
 
     for key in ['totalGravada', 'totalIva', 'totalPagar']:
         assert decimal_places(resumen[key]) <= 2
+
+
+def test_pagos_rounding_adjusts_last_payment():
+    pagos = [
+        {"codigo": "01", "montoPago": 5.005},
+        {"codigo": "02", "montoPago": 5.005},
+    ]
+    total = D("10.01")
+    norm = normalizar_pagos(pagos, total)
+    suma = sum(D(str(p["montoPago"])) for p in norm)
+    assert suma == total
+    assert norm[-1]["montoPago"] == 5.0


### PR DESCRIPTION
## Summary
- use Decimal rounding in `normalizar_pagos` and adjust final payment to match total
- quantize IVA sum from items to two decimals when recalculating totals
- test payment rounding logic

## Testing
- `pytest tests/test_dte_rounding.py -q`
- `pytest tests/test_dte_rounding.py::test_pagos_rounding_adjusts_last_payment -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a38219d1748323b1635b5da7c17e6f