### PR TITLE
Calcular IVA desde ítems y validar pagos en DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -435,6 +435,8 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
         )
         allowed.update(str(c).zfill(2) for c in enum_codes)
 
+    total_q = D(str(total)).quantize(D("0.01"), rounding=ROUND_HALF_UP)
+
     pagos: list[dict] = []
     for p in pagos_raw or []:
         codigo = str(p.get("codigo", "")).zfill(2)
@@ -457,7 +459,7 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
         pagos = [
             {
                 "codigo": "01",
-                "montoPago": D(str(total)).quantize(D("0.01"), rounding=ROUND_HALF_UP),
+                "montoPago": total_q,
                 "referencia": None,
                 "periodo": None,
                 "plazo": None,
@@ -465,12 +467,15 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
         ]
     else:
         suma = sum(p["montoPago"] for p in pagos)
-        diff = D(str(total)).quantize(D("0.01"), rounding=ROUND_HALF_UP) - suma
+        diff = total_q - suma
         if diff:
             nuevo = pagos[-1]["montoPago"] + diff
             if nuevo < 0:
                 raise ValidationError("La suma de pagos excede el total a pagar")
             pagos[-1]["montoPago"] = nuevo.quantize(D("0.01"), rounding=ROUND_HALF_UP)
+        suma = sum(p["montoPago"] for p in pagos)
+        if suma != total_q:
+            raise ValidationError("La suma de pagos no coincide con totalPagar")
 
     if condicion == 2:
         first = pagos[0]
@@ -485,6 +490,8 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
     # Convertir a ``float`` para compatibilidad con JSON
     for p in pagos:
         p["montoPago"] = float(p["montoPago"])
+
+    validate_pagos_basico({"pagos": pagos, "totalPagar": float(total_q)}, condicion)
 
     return pagos
 
@@ -535,6 +542,11 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     sumas_val = Decimal(str(fiscal.get("sumas", items_total)))
     descuentos_val = Decimal(str(fiscal.get("descuentos", 0)))
     iva_val = Decimal(str(fiscal.get("iva", 0)))
+    if not iva_val:
+        iva_items = extra.get("iva_items")
+        if iva_items:
+            iva_val = sum(Decimal(str(v)) for v in iva_items)
+    iva_val = iva_val.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     total_no_suj = Decimal(str(fiscal.get("ventas_no_sujetas", 0)))
     total_exenta = Decimal(str(fiscal.get("ventas_exentas", 0)))
 
@@ -572,8 +584,10 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
 
     if tipo_dte == "01":
         resumen["totalIva"] = iva_val
+        iva_field = "totalIva"
     else:
-        resumen["ivaPerci1"] = resumen.get("ivaPerci1", 0)
+        resumen["ivaPerci1"] = Decimal(str(resumen.get("ivaPerci1", 0)))
+        iva_field = "ivaPerci1"
 
     if "totalPagar" in resumen:
         resumen["totalPagar"] = Decimal(str(venta.get("total", monto_total)))
@@ -606,6 +620,19 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     for k, v in resumen.items():
         if isinstance(v, (int, float, Decimal)):
             resumen[k] = d2(v)
+
+    # Recalcular totales clave con Decimal para evitar discrepancias de redondeo
+    sub_total_dec = Decimal(str(resumen.get("subTotal", 0)))
+    iva_total_dec = Decimal(str(resumen.get(iva_field, 0)))
+    resumen["montoTotalOperacion"] = d2(sub_total_dec + iva_total_dec)
+    if "totalPagar" in resumen:
+        total_val = venta.get("total")
+        if total_val is None:
+            total_val = resumen["montoTotalOperacion"]
+        resumen["totalPagar"] = d2(total_val)
+        # Revalidar pagos con total definitivo
+        if resumen.get("pagos"):
+            validate_pagos_basico(resumen, resumen.get("condicionOperacion", 1))
 
     return resumen
 

--- a/tests/test_dte_resumen_multiple_items.py
+++ b/tests/test_dte_resumen_multiple_items.py
@@ -1,0 +1,43 @@
+import pytest
+from decimal import Decimal
+from utils.monto import D, d8, iva_item
+from dte import calcular_resumen, normalizar_pagos
+from jsonschema import ValidationError
+
+
+def test_calcular_resumen_con_iva_items_y_pagos():
+    cant1 = D("2.5")
+    precio1 = D("9.54")
+    venta1 = d8(cant1 * precio1)
+    iva1 = iva_item(venta1)
+
+    cant2 = D("1")
+    precio2 = D("4.20")
+    venta2 = d8(cant2 * precio2)
+    iva2 = iva_item(venta2)
+
+    items_total = venta1 + venta2
+    pagos = [
+        {"codigo": "01", "montoPago": 20},
+        {"codigo": "02", "montoPago": 11.70},
+    ]
+    extra = {"iva_items": [iva1, iva2], "pagos": pagos}
+
+    resumen = calcular_resumen(items_total, {}, fiscal={}, extra=extra)
+
+    assert resumen["totalIva"] == pytest.approx(3.65)
+    assert resumen["montoTotalOperacion"] == pytest.approx(31.70)
+    assert resumen["totalPagar"] == pytest.approx(31.70)
+    assert resumen["tributos"][0]["valor"] == pytest.approx(3.65)
+    assert sum(p["montoPago"] for p in resumen["pagos"]) == pytest.approx(
+        resumen["totalPagar"]
+    )
+
+
+def test_normalizar_pagos_excede_total():
+    pagos = [
+        {"codigo": "01", "montoPago": 5},
+        {"codigo": "02", "montoPago": 2},
+    ]
+    with pytest.raises(ValidationError):
+        normalizar_pagos(pagos, Decimal("3"))


### PR DESCRIPTION
## Summary
- Derive IVA and tributes from item-level values when not provided
- Recalculate totals using Decimal to avoid rounding drift
- Normalize payments ensuring they sum to total and are validated
- Add regression tests for summaries with multiple items and payments

## Testing
- `pytest tests/test_dte_rounding.py tests/test_resumen_condicion_operacion.py tests/test_dte_resumen_multiple_items.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38aad3a7c83238fd2c2f7b31666f9