### PR TITLE
Validate receptor details and address mapping

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -814,26 +814,60 @@ def generar_dte_json(
     emisor["direccion"] = svfe_config.get_emisor_direccion()
 
     rec = cliente or {}
-    def _clean_nit(nit):
-        if nit:
-            return "".join(c for c in str(nit) if c.isdigit())
-        return None
+    fiscal = fiscal or {}
 
-    nit = rec.get("nit")
-    if fiscal:
-        nit = fiscal.get("nit") or nit
+    nit = fiscal.get("nit") or rec.get("nit")
+    nrc = fiscal.get("nrc") or rec.get("nrc")
+    nombre = fiscal.get("nombre") or rec.get("nombre")
+    telefono = fiscal.get("telefono") or rec.get("telefono")
+    correo = fiscal.get("correo") or rec.get("email") or rec.get("correo")
+
+    dir_src = {
+        "departamento": fiscal.get("departamento"),
+        "municipio": fiscal.get("municipio"),
+        "complemento": fiscal.get("direccion"),
+    }
+    fiscal_extra = fiscal.get("extra")
+    if isinstance(fiscal_extra, dict):
+        dir_src["departamento"] = fiscal_extra.get("departamento") or dir_src["departamento"]
+        dir_src["municipio"] = fiscal_extra.get("municipio") or dir_src["municipio"]
+        dir_src["complemento"] = (
+            fiscal_extra.get("direccion")
+            or fiscal_extra.get("complemento")
+            or dir_src["complemento"]
+        )
+
+    if not dir_src["departamento"]:
+        dir_src["departamento"] = rec.get("departamento")
+    if not dir_src["municipio"]:
+        dir_src["municipio"] = rec.get("municipio")
+    if not dir_src["complemento"]:
+        dir_src["complemento"] = rec.get("direccion")
+
+    depto = _map_departamento(dir_src.get("departamento"))
+    municipio = _map_municipio(dir_src.get("municipio"), depto)
+    complemento = dir_src.get("complemento")
+    if not complemento:
+        raise ValueError("Complemento de dirección requerido")
 
     receptor = {
         "tipoDocumento": "36" if nit else None,
         "numDocumento": _clean_nit(nit),
-        "nrc": (fiscal.get("nrc") if fiscal else None) or rec.get("nrc"),
-        "nombre": rec.get("nombre"),
+        "nrc": _clean_nrc(nrc),
+        "nombre": nombre,
         "codActividad": None,
         "descActividad": None,
-        "direccion": None,
-        "telefono": rec.get("telefono"),
-        "correo": rec.get("correo"),
+        "direccion": {
+            "departamento": depto,
+            "municipio": municipio,
+            "complemento": complemento,
+        },
+        "telefono": telefono,
+        "correo": correo,
     }
+    for campo in ["tipoDocumento", "numDocumento", "nrc", "nombre", "telefono", "correo"]:
+        if not receptor.get(campo):
+            raise ValueError(f"Campo receptor {campo} requerido")
     if fiscal:
         if fiscal.get("no_remision"):
             receptor["noRemision"] = fiscal.get("no_remision")

--- a/tests/test_dte_schema_alignment.py
+++ b/tests/test_dte_schema_alignment.py
@@ -18,7 +18,18 @@ def _create_basic_sale(descuento=0, tributos=None, pagos=None):
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "0614-000000-102-5", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "0614-000000-102-5",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
     cid = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cid,
@@ -54,7 +65,7 @@ def test_resumen_matches_schema_keys():
 
 
 def test_resumen_with_descuentos_tributos_pagos():
-    tributos = [{"codigo": "59", "descripcion": "FOVIAL", "valor": 1.0}]
+    tributos = [{"codigo": "25", "descripcion": "FOVIAL", "valor": 1.0}]
     pagos = [{"codigo": "02", "montoPago": 9.0, "referencia": "ref", "periodo": None, "plazo": None}]
     db, venta_id = _create_basic_sale(descuento=1.0, tributos=tributos, pagos=pagos)
     data = generar_dte_json(db, venta_id, tipo_dte="03")
@@ -63,7 +74,7 @@ def test_resumen_with_descuentos_tributos_pagos():
     js_validate(resumen, schema)
     assert resumen["totalDescu"] == 1.0
     assert resumen["porcentajeDescuento"] == 10.0
-    assert resumen["tributos"][0]["codigo"] == "59"
+    assert resumen["tributos"][0]["codigo"] == "25"
     assert resumen["pagos"][0]["codigo"] == "02"
     # ensure mapping of iva
     assert "iva" not in resumen

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -19,7 +19,18 @@ def test_generar_dte_json_basic():
     vend_id = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "nit1",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
@@ -56,7 +67,18 @@ def test_dte_rounding_and_validation(capsys):
     vend_id = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "nit1",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
     cliente_id = db.cursor.lastrowid
     precio = 1.123456789
     venta_id = db.add_venta_credito_fiscal(
@@ -87,7 +109,18 @@ def test_dte_sum_mismatch_warning(capsys):
     vend_id = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "nit1",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cliente_id,
@@ -113,7 +146,20 @@ def test_generar_ticket_json_tipo():
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    venta_id = db.add_venta("2024-01-01", 5)
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "nit1",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 5, cliente_id=cid)
     db.add_detalle_venta(venta_id, pid, 1, 5, vendedor_id=vid)
 
     data = generar_dte_json(db, venta_id, tipo_dte="03")
@@ -126,7 +172,18 @@ def test_dte_comision_sin_advertencia_total(capsys):
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "nit1",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cliente_id,
@@ -151,7 +208,18 @@ def test_generar_dte_json_condicion_operacion_invalida():
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "nit1",
+        "",
+        "giro",
+        "7000-0000",
+        "c@x.com",
+        "Dir",
+        "06",
+        "01",
+    )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cliente_id,


### PR DESCRIPTION
## Summary
- Validate and populate DTE `receptor` using client or credit fiscal data
- Build and verify receiver address codes while cleaning NIT/NRC
- Update tests for complete receptor data and adjusted tributo codes

## Testing
- `pytest tests/test_generar_dte_json.py tests/test_dte_schema_alignment.py`
- `pytest` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a38aac8d788323b9a50481e73b1ecc