### PR TITLE
Validate identificacion fields

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -102,6 +102,14 @@ def d8(value: "object") -> D:
     return D(str(value)).quantize(D("0.00000000"), rounding=ROUND_HALF_UP)
 
 
+def normalize_uuid_v4_upper(value: str) -> str:
+    """Return ``value`` as a normalized uppercase UUID v4 string."""
+    u = uuid.UUID(str(value))
+    if u.version != 4:
+        raise ValueError("codigoGeneracion debe ser un UUID v4 válido")
+    return str(u).upper()
+
+
 def numero_a_letras(monto):
     """Convierte ``monto`` numérico a su representación en letras."""
     try:
@@ -971,18 +979,73 @@ def validate_dte_json(payload: dict) -> None:
     if "modeloFacturacion" in ident:
         ident["tipoModelo"] = int(str(ident.pop("modeloFacturacion")).split()[0])
     ident.setdefault("tipoModelo", 1)
+    ident["tipoModelo"] = int(ident.get("tipoModelo"))
     if "tipoTransmision" in ident:
         ident["tipoOperacion"] = int(str(ident.pop("tipoTransmision")).split()[0])
     ident.setdefault("tipoOperacion", 1)
+    ident["tipoOperacion"] = int(ident.get("tipoOperacion"))
+    if ident.get("tipoContingencia") is not None:
+        ident["tipoContingencia"] = int(ident.get("tipoContingencia"))
     ident["version"] = int(ident.get("version", 1))
-    cg = ident.get("codigoGeneracion")
     try:
-        uuid_obj = uuid.UUID(str(cg))
+        ident["codigoGeneracion"] = normalize_uuid_v4_upper(ident["codigoGeneracion"])
     except Exception:
         raise ValueError("codigoGeneracion debe ser un UUID v4 válido") from None
-    if uuid_obj.version != 4:
+    if len(ident["codigoGeneracion"]) != 36 or "-" not in ident["codigoGeneracion"]:
         raise ValueError("codigoGeneracion debe ser un UUID v4 válido")
-    ident["codigoGeneracion"] = str(uuid_obj).upper()
+    ident["tipoDte"] = str(ident.get("tipoDte")).strip().upper()
+    ident["tipoMoneda"] = "USD"
+    # Validaciones de campos de identificacion
+    if ident["version"] != 1:
+        raise ValueError("identificacion.version debe ser 1")
+    if ident.get("ambiente") not in {"00", "01"}:
+        raise ValueError("ambiente debe ser '00' o '01'")
+    if ident.get("tipoDte") != "01":
+        raise ValueError("tipoDte debe ser '01'")
+    if ident.get("tipoMoneda") != "USD":
+        raise ValueError("tipoMoneda debe ser 'USD'")
+    numero_control = ident.get("numeroControl")
+    if not (isinstance(numero_control, str) and len(numero_control) == 31 and numero_control.startswith("DTE-01-")):
+        raise ValueError("numeroControl inválido")
+    if not re.fullmatch(r"^DTE-01-[A-Z0-9]{8}-[0-9]{15}$", numero_control):
+        raise ValueError("numeroControl inválido")
+    tipo_operacion = ident.get("tipoOperacion")
+    tipo_modelo = ident.get("tipoModelo")
+    tipo_cont = ident.get("tipoContingencia")
+    motivo = ident.get("motivoContin")
+    if tipo_operacion == 1:
+        if tipo_modelo != 1 or tipo_cont is not None or motivo is not None:
+            raise ValueError("tipoOperacion=1 requiere tipoModelo=1 y sin contingencia")
+    elif tipo_operacion == 2:
+        if tipo_modelo != 2:
+            raise ValueError("tipoOperacion=2 requiere tipoModelo=2")
+        if tipo_cont is None or tipo_cont not in {1, 2, 3, 4, 5}:
+            raise ValueError("tipoContingencia debe estar entre 1 y 5")
+        if tipo_cont == 5:
+            motivo = (motivo or "").strip()
+            if not (5 <= len(motivo) <= 150):
+                raise ValueError("motivoContin requerido cuando tipoContingencia=5")
+            ident["motivoContin"] = motivo
+        else:
+            if motivo not in (None, ""):
+                raise ValueError("motivoContin debe ser null si tipoContingencia != 5")
+    else:
+        raise ValueError("tipoOperacion debe ser 1 o 2")
+    try:
+        fec = datetime.strptime(str(ident.get("fecEmi")), "%Y-%m-%d").date()
+    except Exception:
+        raise ValueError("fecEmi debe tener formato YYYY-MM-DD") from None
+    try:
+        hora_dt = datetime.strptime(str(ident.get("horEmi")), "%H:%M:%S")
+        hora = hora_dt.time()
+        if hora_dt.strftime("%H:%M:%S") != ident.get("horEmi"):
+            raise ValueError
+    except Exception:
+        raise ValueError("horEmi debe tener formato HH:MM:SS") from None
+    now = datetime.now(TZ_EL_SALVADOR)
+    emision_dt = datetime.combine(fec, hora, tzinfo=TZ_EL_SALVADOR)
+    if fec > now.date() or emision_dt > now:
+        raise ValueError("fecEmi/horEmi no pueden ser futuras")
     payload["identificacion"] = ident
 
     emisor = payload.get("emisor", {})

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 from dte import sanitize_dte_payload, validate_dte_json
 
 
@@ -34,6 +35,16 @@ def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory):
     with pytest.raises(ValueError):
         validate_dte_json(dte)
     dte["identificacion"]["codigoGeneracion"] = "12345678-1234-1234-1234-1234567890AB"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
+def test_codigo_generacion_rechaza_uuids_no_v4(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["codigoGeneracion"] = str(uuid.uuid1()).upper()
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+    dte["identificacion"]["codigoGeneracion"] = str(uuid.uuid3(uuid.NAMESPACE_DNS, "test")).upper()
     with pytest.raises(ValueError):
         validate_dte_json(dte)
 
@@ -156,5 +167,106 @@ def test_tributos_invalidos_rechazados(dte_metadata_factory):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = "03"
     dte["cuerpoDocumento"][0]["codTributo"] = "ZZ"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
+def test_numero_control_regex(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["numeroControl"] = "INVALID"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
+@pytest.mark.parametrize(
+    "numero",
+    [
+        "DTE-01-ABCDEFGH-123456789012345",
+        "DTE-01-12345678-000000000000000",
+    ],
+)
+def test_numero_control_validos(dte_metadata_factory, numero):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["numeroControl"] = numero
+    validate_dte_json(dte)
+
+
+@pytest.mark.parametrize(
+    "numero",
+    [
+        "DTE-02-ABCDEFGH-123456789012345",
+        "DTE-01-ABC-123456789012345",
+        "DTE-01-ABCDEFGH-12345",
+        "dte-01-ABCDEFGH-123456789012345",
+    ],
+)
+def test_numero_control_invalidos(dte_metadata_factory, numero):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["numeroControl"] = numero
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
+def test_tipo_operacion_rules(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoModelo"] = 2
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoContingencia"] = 1
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["motivoContin"] = "Razón"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoOperacion"] = 2
+    dte["identificacion"]["tipoModelo"] = 1
+    dte["identificacion"]["tipoContingencia"] = 1
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoOperacion"] = 2
+    dte["identificacion"]["tipoModelo"] = 2
+    dte["identificacion"]["tipoContingencia"] = 6
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoOperacion"] = 2
+    dte["identificacion"]["tipoModelo"] = 2
+    dte["identificacion"]["tipoContingencia"] = 5
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoOperacion"] = 2
+    dte["identificacion"]["tipoModelo"] = 2
+    dte["identificacion"]["tipoContingencia"] = 5
+    dte["identificacion"]["motivoContin"] = "bad"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
+def test_no_motivo_contin_si_operacion_1(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["motivoContin"] = " Justificacion "
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+
+def test_fecha_hora_format(dte_metadata_factory):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["fecEmi"] = "01-01-2024"
+    with pytest.raises(ValueError):
+        validate_dte_json(dte)
+
+    dte = dte_metadata_factory()
+    dte["identificacion"]["horEmi"] = "25:00:00"
     with pytest.raises(ValueError):
         validate_dte_json(dte)


### PR DESCRIPTION
## Summary
- enforce real UUID v4 normalization, numeroControl length/prefix, strict contingency and timestamp checks
- add tests for UUID versions, numeroControl examples, and forbidden motiveContin in normal operations

## Testing
- `pytest tests/test_dte_validation.py::test_codigo_generacion_debe_ser_uuid_v4 tests/test_dte_validation.py::test_codigo_generacion_rechaza_uuids_no_v4 tests/test_dte_validation.py::test_numero_control_regex tests/test_dte_validation.py::test_numero_control_validos tests/test_dte_validation.py::test_numero_control_invalidos tests/test_dte_validation.py::test_tipo_operacion_rules tests/test_dte_validation.py::test_no_motivo_contin_si_operacion_1 tests/test_dte_validation.py::test_fecha_hora_format -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3c3af1d888323aefc97eec68089f0