### PR TITLE
Validate receiver documents and addresses

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -206,7 +206,10 @@ def _load_datos_negocio():
     return {}
 
 
-DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(15)}
+DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(1, 15)}
+
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+PHONE_RE = re.compile(r"^\+?\d{8,15}$")
 
 
 def _map_departamento(nombre: str | None) -> str:
@@ -812,20 +815,41 @@ def generar_dte_json(
         "correo": datos.get("correo"),
     }
     emisor["direccion"] = svfe_config.get_emisor_direccion()
+    if emisor.get("correo") and not EMAIL_RE.fullmatch(emisor["correo"]):
+        raise ValueError("Correo de emisor inválido")
+    if emisor.get("telefono") and not PHONE_RE.fullmatch(emisor["telefono"]):
+        raise ValueError("Teléfono de emisor inválido")
 
     rec = cliente or {}
-    def _clean_nit(nit):
-        if nit:
-            return "".join(c for c in str(nit) if c.isdigit())
-        return None
 
+    def _clean_nit(nit):
+        return "".join(c for c in str(nit) if c.isdigit()) if nit else None
+
+    tipo_doc = rec.get("tipoDocumento")
+    if tipo_doc is not None:
+        tipo_doc = int(tipo_doc)
+    num_doc = rec.get("numDocumento")
     nit = rec.get("nit")
     if fiscal:
+        tipo_doc = fiscal.get("tipoDocumento") or tipo_doc
+        num_doc = fiscal.get("numDocumento") or num_doc
         nit = fiscal.get("nit") or nit
+    if nit and not num_doc:
+        num_doc = nit
+    if nit and not tipo_doc:
+        tipo_doc = 36
+
+    if tipo_doc == 36:
+        num_doc = _clean_nit(num_doc)
+        if num_doc and not re.fullmatch(r"[0-9]{14}", num_doc):
+            raise ValueError("NIT inválido")
+    elif tipo_doc == 13:
+        if num_doc and not re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
+            raise ValueError("DUI inválido")
 
     receptor = {
-        "tipoDocumento": "36" if nit else None,
-        "numDocumento": _clean_nit(nit),
+        "tipoDocumento": str(tipo_doc) if tipo_doc is not None else None,
+        "numDocumento": num_doc,
         "nrc": (fiscal.get("nrc") if fiscal else None) or rec.get("nrc"),
         "nombre": rec.get("nombre"),
         "codActividad": None,
@@ -834,6 +858,10 @@ def generar_dte_json(
         "telefono": rec.get("telefono"),
         "correo": rec.get("correo"),
     }
+    if receptor.get("correo") and not EMAIL_RE.fullmatch(receptor["correo"]):
+        raise ValueError("Correo de receptor inválido")
+    if receptor.get("telefono") and not PHONE_RE.fullmatch(receptor["telefono"]):
+        raise ValueError("Teléfono de receptor inválido")
     if fiscal:
         if fiscal.get("no_remision"):
             receptor["noRemision"] = fiscal.get("no_remision")
@@ -984,6 +1012,7 @@ def validate_dte_json(payload: dict) -> None:
         raise ValueError("codigoGeneracion debe ser un UUID v4 válido")
     ident["codigoGeneracion"] = str(uuid_obj).upper()
     payload["identificacion"] = ident
+    tipo_dte = str(ident.get("tipoDte", ""))
 
     emisor = payload.get("emisor", {})
     emisor["nit"] = _clean_nit(emisor.get("nit") or negocio.get("nit"))
@@ -1041,14 +1070,34 @@ def validate_dte_json(payload: dict) -> None:
         raise ValueError(
             "Faltan campos obligatorios en emisor: " + ", ".join(missing)
         )
+    if emisor.get("correo") and not EMAIL_RE.fullmatch(emisor["correo"]):
+        raise ValueError("Correo de emisor inválido")
+    if emisor.get("telefono") and not PHONE_RE.fullmatch(emisor["telefono"]):
+        raise ValueError("Teléfono de emisor inválido")
     payload["emisor"] = emisor
 
     receptor = payload.get("receptor", {})
     receptor["nrc"] = _clean_nrc(receptor.get("nrc"))
-    if "nit" in receptor:
-        receptor["numDocumento"] = _clean_nit(receptor.pop("nit"))
-    else:
-        receptor["numDocumento"] = _clean_nit(receptor.get("numDocumento"))
+    if tipo_dte == "01":
+        receptor.pop("nrc", None)
+    nit_field = receptor.pop("nit", None)
+    tipo_doc = receptor.get("tipoDocumento")
+    if tipo_doc is not None:
+        tipo_doc = int(tipo_doc)
+    if nit_field is not None:
+        receptor["numDocumento"] = _clean_nit(nit_field)
+        if tipo_doc is None:
+            tipo_doc = 36
+    num_doc = receptor.get("numDocumento")
+    if tipo_doc == 36:
+        num_doc = _clean_nit(num_doc)
+        if num_doc and not re.fullmatch(r"[0-9]{14}", num_doc):
+            raise ValueError("NIT inválido en receptor")
+    elif tipo_doc == 13:
+        if num_doc and not re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
+            raise ValueError("DUI inválido en receptor")
+    receptor["tipoDocumento"] = str(tipo_doc) if tipo_doc is not None else None
+    receptor["numDocumento"] = num_doc
     receptor.pop("giro", None)
     dir_rec = receptor.get("direccion")
     if dir_rec is not None:
@@ -1063,10 +1112,13 @@ def validate_dte_json(payload: dict) -> None:
                 "Faltan campos obligatorios en receptor: direccion.complemento"
             )
         receptor["direccion"] = dir_rec
+    if receptor.get("correo") and not EMAIL_RE.fullmatch(receptor["correo"]):
+        raise ValueError("Correo de receptor inválido")
+    if receptor.get("telefono") and not PHONE_RE.fullmatch(receptor["telefono"]):
+        raise ValueError("Teléfono de receptor inválido")
     payload["receptor"] = receptor
 
     cuerpo = payload.get("cuerpoDocumento", [])
-    tipo_dte = str(payload.get("identificacion", {}).get("tipoDte", ""))
     schema = catalogos.get_dte_schema(tipo_dte)
     if schema:
         item_props = (
@@ -1126,6 +1178,8 @@ def validate_dte_json(payload: dict) -> None:
         else:
             item.setdefault("tipoItem", 1)
             item.setdefault("uniMedida", 59)
+        item["tipoItem"] = int(item["tipoItem"])
+        item["uniMedida"] = int(item["uniMedida"])
 
         if item.get("tipoItem") not in catalogos.TIPO_ITEM:
             raise ValueError("tipoItem inválido")
@@ -1238,9 +1292,6 @@ def validate_dte_json(payload: dict) -> None:
     if emisor_nit and len(emisor_nit.replace("-", "")) != catalogos.NIT_LENGTH:
         raise ValueError("NIT inválido en emisor")
 
-    receptor_doc = payload.get("receptor", {}).get("numDocumento")
-    if receptor_doc and len(receptor_doc) not in (9, catalogos.NIT_LENGTH):
-        raise ValueError("Número de documento inválido en receptor")
 
     # --- Schema validation ---
     schema = catalogos.get_dte_schema(tipo_dte)

--- a/svfe/config.py
+++ b/svfe/config.py
@@ -4,6 +4,37 @@ import json
 from pathlib import Path
 from typing import Dict
 
+DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(1, 15)}
+MUNICIPIO_RANGES = {
+    "05": ("01", "22"),
+    "06": ("01", "19"),
+}
+
+
+def _map_departamento(nombre: str | None) -> str:
+    if nombre is None:
+        raise ValueError("Departamento requerido")
+    nombre = str(nombre)
+    if nombre.isdigit():
+        nombre = nombre.zfill(2)
+    if nombre not in DEPARTAMENTO_CODES:
+        raise ValueError("Departamento inválido")
+    return nombre
+
+
+def _map_municipio(nombre: str | None, departamento: str | None = None) -> str:
+    if nombre is None:
+        raise ValueError("Municipio requerido")
+    nombre = str(nombre)
+    if not nombre.isdigit() or len(nombre) != 2:
+        raise ValueError("Municipio inválido")
+    if departamento:
+        dep_code = _map_departamento(departamento)
+        start, end = MUNICIPIO_RANGES.get(dep_code, ("00", "99"))
+        if nombre < start or nombre > end:
+            raise ValueError("Municipio inválido para el departamento")
+    return nombre
+
 # Path to company configuration holding the emitter address codes
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "company.json"
 
@@ -30,11 +61,16 @@ def get_emisor_direccion() -> Dict[str, str]:
         not isinstance(departamento, str)
         or not isinstance(municipio, str)
         or not isinstance(complemento, str)
+        or len(departamento) != 2
+        or len(municipio) != 2
     ):
         raise ValueError("Config de dirección del emisor inválida")
 
-    if len(departamento) != 2 or len(municipio) != 2:
-        raise ValueError("Config de dirección del emisor inválida")
+    try:
+        departamento = _map_departamento(departamento)
+        municipio = _map_municipio(municipio, departamento)
+    except Exception as exc:  # pragma: no cover - invalid codes
+        raise ValueError("Config de dirección del emisor inválida") from exc
 
     return {
         "departamento": departamento,
@@ -43,4 +79,4 @@ def get_emisor_direccion() -> Dict[str, str]:
     }
 
 
-__all__ = ["get_emisor_direccion", "CONFIG_PATH"]
+__all__ = ["get_emisor_direccion", "CONFIG_PATH", "MUNICIPIO_RANGES"]

--- a/tests/goldens/fc.json
+++ b/tests/goldens/fc.json
@@ -60,7 +60,7 @@
     "version": 1
   },
   "otrosDocumentos": null,
-  "receptor": {
+    "receptor": {
     "codActividad": "62010",
     "correo": "cliente@example.com",
     "descActividad": "Servicios de software",
@@ -70,7 +70,6 @@
       "municipio": "01"
     },
     "nombre": "Consumidor Final",
-    "nrc": "0000011",
     "numDocumento": "06141990011019",
     "telefono": "70000001",
     "tipoDocumento": "36"

--- a/tests/test_svfe_config.py
+++ b/tests/test_svfe_config.py
@@ -26,3 +26,19 @@ def test_get_emisor_direccion_invalid(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "CONFIG_PATH", cfg)
     with pytest.raises(ValueError):
         config.get_emisor_direccion()
+
+
+def test_get_emisor_direccion_invalid_municipio(monkeypatch, tmp_path):
+    cfg = tmp_path / "company.json"
+    cfg.write_text(
+        '{"emisor":{"departamento":"05","municipio":"99","complemento":"C"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+    with pytest.raises(ValueError):
+        config.get_emisor_direccion()
+
+
+def test_catalogo_muni_por_depto():
+    assert config.MUNICIPIO_RANGES["05"] == ("01", "22")
+    assert config.MUNICIPIO_RANGES["06"] == ("01", "19")

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -1,21 +1,37 @@
 import pytest
 
-from dialogs import (
-    validar_nit,
-    validar_nrc,
-    validar_email,
-    validar_telefono,
-)
+import json
+from pathlib import Path
+
+import json
+from pathlib import Path
+
+try:
+    from dialogs import (
+        validar_nit,
+        validar_nrc,
+        validar_email,
+        validar_telefono,
+    )
+except Exception:  # pragma: no cover - missing UI deps
+    validar_nit = validar_nrc = validar_email = validar_telefono = None
+    _dialog_import_error = True
+else:  # pragma: no cover
+    _dialog_import_error = False
+
+from dte import validate_dte_json
+from utils import catalogos
 
 
 @pytest.mark.parametrize("nit, expected", [
-    ("1234-123456-123-1", True),  # NIT con guiones
-    ("12341234561231", True),     # NIT sin guiones
-    ("12345678-9", True),         # DUI con guion
-    ("123456789", True),          # DUI sin guion
-    ("1234-123456-123", False),  # NIT incompleto
-    ("abcd", False),             # caracteres inválidos
+    ("1234-123456-123-1", True),
+    ("12341234561231", True),
+    ("12345678-9", True),
+    ("123456789", True),
+    ("1234-123456-123", False),
+    ("abcd", False),
 ])
+@pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_nit(nit, expected):
     assert validar_nit(nit) is expected
 
@@ -26,6 +42,7 @@ def test_validar_nit(nit, expected):
     ("12345-7", False),
     ("123456-78", False),
 ])
+@pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_nrc(nrc, expected):
     assert validar_nrc(nrc) is expected
 
@@ -36,6 +53,7 @@ def test_validar_nrc(nrc, expected):
     ("invalid@domain", False),
     ("userexample.com", False),
 ])
+@pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_email(email, expected):
     assert validar_email(email) is expected
 
@@ -46,5 +64,49 @@ def test_validar_email(email, expected):
     ("1234567", False),
     ("5031234567", False),
 ])
+@pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_telefono(telefono, expected):
     assert validar_telefono(telefono) is expected
+
+
+def _load_fc():
+    path = Path(__file__).resolve().parent / "goldens" / "fc.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_receptor_documentos(monkeypatch):
+    monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
+    data = _load_fc()
+    data["receptor"]["tipoDocumento"] = 36
+    data["receptor"]["numDocumento"] = "06141990011019"
+    validate_dte_json(data)
+
+    data["receptor"]["numDocumento"] = "123"
+    with pytest.raises(ValueError):
+        validate_dte_json(data)
+
+    data = _load_fc()
+    data["receptor"]["tipoDocumento"] = 13
+    data["receptor"]["numDocumento"] = "12345678-9"
+    validate_dte_json(data)
+    data["receptor"]["numDocumento"] = "123456789"
+    with pytest.raises(ValueError):
+        validate_dte_json(data)
+
+
+def test_receptor_direccion(monkeypatch):
+    monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
+    data = _load_fc()
+    data["receptor"]["direccion"] = {
+        "departamento": "05",
+        "municipio": "01",
+        "complemento": "C",
+    }
+    validate_dte_json(data)
+
+    data["receptor"]["direccion"]["municipio"] = "99"
+    with pytest.raises(ValueError):
+        validate_dte_json(data)
+
+    data["receptor"]["direccion"] = None
+    validate_dte_json(data)


### PR DESCRIPTION
## Summary
- enforce regex-based email and phone validation in DTE generation and validation
- validate receiver document numbers and addresses against catalog codes, omitting NRC for consumer final
- add unit tests for municipality catalogs and receiver document/address checks

## Testing
- `pytest tests/test_svfe_config.py::test_catalogo_muni_por_depto -q`
- `pytest tests/test_validaciones_basicas.py::test_receptor_documentos -q`
- `pytest tests/test_validaciones_basicas.py::test_receptor_direccion -q`
- `pytest` *(fails: missing UI dependencies, e.g., PyQt5/libGL)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c3b97e0c8323b694cda560b633ce