### PR TITLE
Normalize ambiente parameter for DTE generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -863,6 +863,10 @@ def generar_dte_json(
         raise ValueError("Venta no encontrada")
     venta = dict(row)
 
+    if ambiente not in ("00", "01"):
+        ambiente_cfg = str(ambiente).lower()
+        ambiente = "01" if ambiente_cfg.startswith("produc") else "00"
+
     if not venta.get("total_letras"):
         total = venta.get("total")
         if total is not None:
@@ -1671,6 +1675,9 @@ def generar_ticket_json(
     **kwargs,
 ) -> dict:
     """Genera la estructura JSON para un Ticket Electrónico."""
+    if ambiente not in ("00", "01"):
+        ambiente_cfg = str(ambiente).lower()
+        ambiente = "01" if ambiente_cfg.startswith("produc") else "00"
     return generar_dte_json(
         db,
         venta_id,

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -183,6 +183,23 @@ def test_generar_ticket_json_tipo():
     assert data["identificacion"]["tipoDte"] == "03"
 
 
+@pytest.mark.parametrize("ambiente, expected", [("pruebas", "00"), ("produccion", "01")])
+def test_generar_dte_json_normaliza_ambiente_param(ambiente, expected, monkeypatch):
+    import dte as dte_module
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 5)
+    db.add_detalle_venta(venta_id, pid, 1, 5, vendedor_id=vid)
+
+    monkeypatch.setattr(dte_module, "validate_dte_json", lambda payload: None)
+    data = dte_module.generar_dte_json(db, venta_id, ambiente=ambiente)
+    assert data["identificacion"]["ambiente"] == expected
+
+
 def test_dte_comision_sin_advertencia_total(capsys):
     db = create_db()
     db.add_vendedor("V1")


### PR DESCRIPTION
## Summary
- Normalize non-numeric ambiente values to SAT codes in DTE generation
- Apply same normalization when generating ticket JSON
- Test ambiente normalization for 'pruebas' and 'produccion'

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_normaliza_ambiente_param -q --no-cov`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c852fa8083239d78875e7cfb6eed