### PR TITLE
Use persistent datos_negocio location

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -24,10 +24,10 @@ from utils.fecha import fecha_emision_hoy_str, TZ_EL_SALVADOR
 from svfe import config as svfe_config
 from pathlib import Path
 import jsonpatch
+from paths import DATOS_NEGOCIO_PATH
 
 logger = logging.getLogger(__name__)
 
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.json")
 DEFAULT_RECEPCION_URL = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"
 PATCHES_DIR = Path(__file__).resolve().parent / "schema_patches"

--- a/estado_cuenta_pdf.py
+++ b/estado_cuenta_pdf.py
@@ -13,8 +13,7 @@ from reportlab.lib.enums import TA_CENTER, TA_LEFT
 from datetime import datetime
 import json
 import os
-
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+from paths import DATOS_NEGOCIO_PATH
 
 
 def generar_reporte_vendedor_pdf(

--- a/estado_ventas_pdf.py
+++ b/estado_ventas_pdf.py
@@ -5,8 +5,7 @@ from reportlab.lib import colors
 from datetime import datetime
 import json
 import os
-
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+from paths import DATOS_NEGOCIO_PATH
 
 
 def _draw_header(c, width, height, vendedor, fecha_inicio, fecha_fin, datos_negocio):

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -12,8 +12,7 @@ from dte import generar_cabecera_dte_data
 from urllib.parse import urlencode
 import json
 import os
-
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+from paths import DATOS_NEGOCIO_PATH
 
 
 def build_qr_value(

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -40,7 +40,7 @@ from utils.monto import monto_a_texto_sv
 from utils.docs import get_document_paths, build_invoice_json
 import uuid
 from utils.email_sender import EmailSender
-from sales_tab import DATOS_NEGOCIO_PATH
+from paths import DATOS_NEGOCIO_PATH
 import tempfile
 import subprocess
 import shutil

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import os
 import logging
 import sqlite3
+from paths import DATOS_NEGOCIO_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,6 @@ class InventoryManagerError(Exception):
     """Errores de dominio del administrador de inventario."""
 
 
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 
 
 class InventoryManager:

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from ui_mainwindow import MainWindow
 from user_picker_dialog import UserPickerDialog
 from db import DB
 from utils import resource_path
+from paths import migrate_datos_negocio
 
 LAST_FILE_PATH = resource_path("ultimo_inventario.json")
 DEFAULT_INVENTORY = resource_path("inventario.json")
@@ -46,6 +47,7 @@ def cargar_ultimo_archivo():
     return ""
 
 if __name__ == "__main__":
+    migrate_datos_negocio()
     app = QApplication(sys.argv)
     style_path = resource_path("style.qss")
     if style_path.exists():

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,23 @@
+import os
+import shutil
+from appdirs import user_data_dir
+
+APP_NAME = "gestor-de-inventario"
+
+
+def _get_user_data_dir():
+    path = user_data_dir(APP_NAME)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+DATOS_NEGOCIO_PATH = os.path.join(_get_user_data_dir(), "datos_negocio.json")
+
+
+def migrate_datos_negocio():
+    """Copy existing datos_negocio.json to user data dir if needed."""
+    old_path = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+    if os.path.exists(old_path) and not os.path.exists(DATOS_NEGOCIO_PATH):
+        try:
+            shutil.copyfile(old_path, DATOS_NEGOCIO_PATH)
+        except OSError:
+            pass

--- a/prueba de estado de ventas.py
+++ b/prueba de estado de ventas.py
@@ -10,8 +10,7 @@ from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfbase import pdfmetrics
 import json
 import os
-
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+from paths import DATOS_NEGOCIO_PATH
 
 # Puedes registrar Arial si tienes el archivo, si no, Helvetica es suficiente
 # pdfmetrics.registerFont(TTFont('Arial', 'arial.ttf'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ msal
 
 jsonschema
 jsonpatch
+appdirs

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -38,8 +38,7 @@ import shutil
 import os
 import json
 import warnings
-
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+from paths import DATOS_NEGOCIO_PATH
 
 CF_DIR = os.path.join(os.path.dirname(__file__), "facturas_consumidor_final")
 CREDITO_DIR = os.path.join(os.path.dirname(__file__), "facturas_credito_fiscal")

--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -4,8 +4,7 @@ from reportlab.lib.units import mm
 from datetime import datetime
 import json
 import os
-
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
+from paths import DATOS_NEGOCIO_PATH
 
 
 def _with_falta(value):

--- a/tools/validar_todo.py
+++ b/tools/validar_todo.py
@@ -13,8 +13,9 @@ from jsonschema import Draft7Validator, ValidationError
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+from paths import DATOS_NEGOCIO_PATH as _DATOS_NEGOCIO_PATH
 BASE_DIR = Path(__file__).resolve().parents[1]
-DATOS_NEGOCIO_PATH = BASE_DIR / "datos_negocio.json"
+DATOS_NEGOCIO_PATH = Path(_DATOS_NEGOCIO_PATH)
 SCHEMAS_DIR = BASE_DIR / "svfe-json-schemas"
 
 TIPOS_DTE = [

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -11,6 +11,7 @@ import os
 import json
 import sys
 from inventory_manager import InventoryManager
+from paths import DATOS_NEGOCIO_PATH
 from dialogs import (
     RegisterSaleDialog,
     ProductDialog,
@@ -22,7 +23,6 @@ from dialogs import (
     UserConfigDialog,
 )
 
-DATOS_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "datos_negocio.json")
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.json")
 LAST_INVENTORY_PATH = os.path.join(os.path.dirname(__file__), "ultimo_inventario.json")
 from sales_tab import SalesTab


### PR DESCRIPTION
## Summary
- centralize `datos_negocio.json` in a user-specific directory using `appdirs`
- replace `DATOS_NEGOCIO_PATH` imports across the app
- copy existing `datos_negocio.json` to the new location on startup

## Testing
- `pytest` *(fails: ERROR tests/test_preview_cleanup.py ... Interrupted: 64 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c8cc84988323aadc42dcdac4ce33