### PR TITLE
Normaliza valor de ambiente para DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1227,6 +1227,9 @@ def validate_dte_json(payload: dict) -> None:
     config = _load_dte_api_config()
     ambiente = "01" if config.get("ambiente") == "produccion" else "00"
     ident.setdefault("ambiente", ambiente)
+    amb_val = str(ident.get("ambiente", "")).lower()
+    if amb_val not in {"00", "01"}:
+        ident["ambiente"] = "01" if amb_val.startswith("produc") else "00"
     ident.setdefault("tipoMoneda", "USD")
     ident.setdefault("tipoContingencia", None)
     ident.setdefault("motivoContin", None)


### PR DESCRIPTION
## Summary
- Normaliza la clave `ambiente` al preparar `ident` en `dte.py` para aceptar valores tipo 'produccion' o desconocidos

## Testing
- `pytest` *(falla: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cfbfbb8c8323849a44dfe5552329