### PR TITLE
Update DTE transmission for contingency mode

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -579,8 +579,14 @@ class SalesTab(QWidget):
         QMessageBox.information(self, "Guardar y enviar", f"{doc_type} guardado en {file_path}")
         envio_ok = False
         try:
-            modo = "contingencia" if str(venta.get("tipo_operacion", 1)) == "2" else "normal"
-            resp = transmitir_dte(self.manager.db, venta_id, modo=modo, tipo_dte=tipo_dte)
+            modo = (
+                "contingencia"
+                if venta.get("modo_transmision") == "contingencia"
+                else "normal"
+            )
+            resp = transmitir_dte(
+                self.manager.db, venta_id, modo=modo, tipo_dte=tipo_dte
+            )
             estado = (resp or {}).get("estado", "")
             if estado.lower() in ("rechazado", "error"):
                 self.status_label.setText("Estado actual: Error")

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -15,6 +15,7 @@ class FakeDB:
         self._ventas = []
         self.detalles = {}
         self.saved = None
+        self.envios = []
 
     def get_ventas(self):
         return self._ventas
@@ -42,6 +43,9 @@ class FakeDB:
 
     def get_factura_pdf(self, vid):
         return self.factura_path
+
+    def registrar_envio_dte(self, *args):
+        self.envios.append(args)
 
 
 class Manager:
@@ -155,3 +159,64 @@ def test_save_and_send_generates_files_and_registers(
     assert pdf.exists()
     assert pdf.with_suffix(".json").exists()
     assert db.saved == (1, "Factura", str(pdf))
+
+
+def test_save_and_send_contingencia_no_http(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    import dte
+
+    pdf, json_path = pdf_json_files
+    venta = venta_factory(modo_transmision="contingencia")
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
+
+    def fake_gen(manager, vid):
+        pdf.write_bytes(b"%PDF")
+        json_path.write_text("{}", encoding="utf-8")
+        manager.db.add_factura_pdf(vid, "Factura", str(pdf))
+        return str(pdf)
+
+    monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
+    monkeypatch.setattr(SalesTab, "send_email", lambda self: None)
+    monkeypatch.setattr("dte._load_dte_api_config", lambda: {})
+
+    post_called = {"count": 0}
+
+    def fake_post(*a, **k):
+        post_called["count"] += 1
+        return {}
+
+    monkeypatch.setattr("dte._post_dte", fake_post)
+
+    transmit_args = {}
+
+    def fake_transmitir(db_, vid, modo="normal", tipo_dte="01"):
+        transmit_args["modo"] = modo
+        return dte.transmitir_dte(db_, vid, modo=modo, tipo_dte=tipo_dte)
+
+    monkeypatch.setattr("sales_tab.transmitir_dte", fake_transmitir)
+
+    mensajes = []
+
+    def fake_info(parent, title, text):
+        mensajes.append((title, text))
+
+    monkeypatch.setattr(QMessageBox, "information", fake_info)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+    tab.sales_table.selectRow(0)
+    tab.save_and_send()
+
+    assert transmit_args["modo"] == "contingencia"
+    assert post_called["count"] == 0
+    assert any(
+        title == "Guardar y enviar" and text.startswith("Factura guardado")
+        for title, text in mensajes
+    )


### PR DESCRIPTION
## Summary
- Use `modo_transmision` to determine transmission mode in `save_and_send`
- Add regression test ensuring contingency mode avoids HTTP POST and shows confirmation

## Testing
- `pytest tests/test_sales_tab_email.py::test_save_and_send_contingencia_no_http -q`
- `pytest -q` *(fails: numerous test failures, e.g. `F` markers across suite)*

------
https://chatgpt.com/codex/tasks/task_e_68a552dfcb8483239ca83820e5b02bd9