### PR TITLE
fix: correct IVA breakdown and payment rounding

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -542,16 +542,16 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
     else:
         suma = sum((p["montoPago"] for p in pagos), D("0.00"))
         diff = money(total - suma)
-        nuevo = money(pagos[-1]["montoPago"] + diff)
-        if nuevo < 0:
-            raise ValidationError(
-                f"La suma de pagos {money(suma)} difiere del total {total} (dif {diff})"
-            )
-        if diff != 0 and (len(pagos) == 1 or abs(diff) > D("0.01")):
-            raise ValidationError(
-                f"La suma de pagos {money(suma)} difiere del total {total} (dif {diff})"
-            )
         if diff != 0:
+            if abs(diff) > D("0.01"):
+                raise ValidationError(
+                    f"La suma de pagos {money(suma)} difiere del total {total} (dif {diff})"
+                )
+            nuevo = money(pagos[-1]["montoPago"] + diff)
+            if nuevo < 0:
+                raise ValidationError(
+                    f"La suma de pagos {money(suma)} difiere del total {total} (dif {diff})"
+                )
             pagos[-1]["montoPago"] = nuevo
 
     if condicion == 2:
@@ -625,11 +625,22 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
 
     fiscal = fiscal or {}
     extra = extra or {}
+    precios_incluyen_iva = tipo_dte == "01" and extra.get("precios_incluyen_iva", True)
 
-    total_gravada = money(fiscal.get("sumas", items_total))
+    items_total = money(items_total)
     total_exenta = money(fiscal.get("ventas_exentas", 0))
     total_no_suj = money(fiscal.get("ventas_no_sujetas", 0))
     total_no_gravado = money(fiscal.get("no_gravado", 0))
+    if precios_incluyen_iva:
+        total_gravada = money(
+            fiscal.get("sumas", (items_total - total_exenta - total_no_suj) / D("1.13"))
+        )
+        total_iva = money(
+            fiscal.get("iva", items_total - total_exenta - total_no_suj - total_gravada)
+        )
+    else:
+        total_gravada = money(fiscal.get("sumas", items_total))
+        total_iva = money(fiscal.get("iva", 0)) if total_gravada > D("0") else money(0)
 
     descu_no_suj = money(fiscal.get("descu_no_suj", 0))
     descu_exenta = money(fiscal.get("descu_exenta", 0))
@@ -639,7 +650,6 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     total_descu = money(descu_no_suj + descu_exenta + descu_gravada)
     sub_total = money(sub_total_ventas - total_descu)
 
-    total_iva = money(fiscal.get("iva", 0)) if total_gravada > D("0") else money(0)
     monto_total_operacion = money(sub_total + total_no_gravado + total_iva)
     total_pagar = money(monto_total_operacion)
 
@@ -663,7 +673,7 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
             "totalNoGravado": total_no_gravado,
             "montoTotalOperacion": monto_total_operacion,
             "totalPagar": total_pagar,
-            "totalLetras": venta.get("total_letras", ""),
+            "totalLetras": numero_a_letras(total_pagar),
         }
     )
 
@@ -698,35 +708,38 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     if "numPagoElectronico" in resumen:
         resumen["numPagoElectronico"] = extra.get("numPagoElectronico")
 
-    # Normaliza posibles -0.00 manteniendo Decimal hasta la serialización final
+    excl = {"totalLetras", "condicionOperacion", "pagos", "numPagoElectronico", "tributos"}
     for key, val in list(resumen.items()):
-        if key in {
-            "totalLetras",
-            "condicionOperacion",
-            "pagos",
-            "numPagoElectronico",
-            "tributos",
-        }:
+        if key in excl:
             continue
-        if isinstance(val, Decimal) and val == D("0") and val.as_tuple().sign:
-            resumen[key] = D("0")
+        if isinstance(val, Decimal):
+            if val != money(val):
+                raise ValidationError(f"{key} debe ser múltiplo de 0.01")
+            if val == D("0") and val.as_tuple().sign:
+                resumen[key] = D("0")
 
     if resumen.get("tributos"):
         for t in resumen["tributos"]:
             val = t.get("valor")
-            if isinstance(val, Decimal) and val == D("0") and val.as_tuple().sign:
-                t["valor"] = D("0")
+            if isinstance(val, Decimal):
+                if val != money(val):
+                    raise ValidationError("valor de tributo debe ser múltiplo de 0.01")
+                if val == D("0") and val.as_tuple().sign:
+                    t["valor"] = D("0")
 
     if resumen.get("pagos"):
         for p in resumen["pagos"]:
             mp = p.get("montoPago")
-            if isinstance(mp, Decimal) and mp == D("0") and mp.as_tuple().sign:
-                p["montoPago"] = D("0")
+            if isinstance(mp, Decimal):
+                if mp != money(mp):
+                    raise ValidationError("montoPago debe ser múltiplo de 0.01")
+                if mp == D("0") and mp.as_tuple().sign:
+                    p["montoPago"] = D("0")
 
     return resumen
 
 
-def recalcular_totales(data: dict) -> list[str]:
+def recalcular_totales(data: dict, *, precios_incluyen_iva: bool = False) -> list[str]:
     """Recalcula y corrige los totales del resumen en ``data``.
 
     La función vuelve a calcular los valores de la sección ``resumen`` a partir
@@ -746,7 +759,12 @@ def recalcular_totales(data: dict) -> list[str]:
     for item in cuerpo:
         cant = Decimal(str(item.get("cantidad") or 0))
         precio = Decimal(str(item.get("precioUni") or 0))
-        items_total += cant * precio
+        if precios_incluyen_iva:
+            venta_linea = Decimal(str(item.get("ventaGravada") or 0))
+            iva_linea = Decimal(str(item.get("ivaItem") or 0))
+            items_total += venta_linea + iva_linea
+        else:
+            items_total += cant * precio
         venta_gravada_sum += Decimal(str(item.get("ventaGravada") or 0))
         iva_val = item.get("ivaItem") or item.get("montoIva") or item.get("iva")
         if iva_val:
@@ -772,6 +790,7 @@ def recalcular_totales(data: dict) -> list[str]:
         "tributos": resumen.get("tributos"),
         "numPagoElectronico": resumen.get("numPagoElectronico"),
         "condicion_operacion": resumen.get("condicionOperacion"),
+        "precios_incluyen_iva": precios_incluyen_iva,
     }
 
     esperado = calcular_resumen(
@@ -1051,15 +1070,16 @@ def generar_dte_json(
     total_exenta_sum = D("0")
     total_no_suj_sum = D("0")
     total_no_gravado_sum = D("0")
+    precios_incluyen_iva = tipo_dte == "01" and extra.get("precios_incluyen_iva", True)
     for idx, d in enumerate(detalles, 1):
         try:
             cant = d8(D(str(d.get("cantidad") or 0)))
         except Exception:
             cant = d8(D(0))
         try:
-            precio = d8(D(str(d.get("precio_unitario") or 0)))
+            precio_raw = d8(D(str(d.get("precio_unitario") or 0)))
         except Exception:
-            precio = d8(D(0))
+            precio_raw = d8(D(0))
         try:
             tipo_item = int(d.get("tipoItem", 1))
         except Exception:
@@ -1071,12 +1091,24 @@ def generar_dte_json(
         monto_descu = d8(D(str(d.get("descuento") or 0)))
         if monto_descu < 0:
             monto_descu = D("0")
-        base = d8(cant * precio - monto_descu)
-        if base < 0:
-            base = D("0")
-        venta_gravada = d2(base)
-        items_total += base
-        iva_val = d8(venta_gravada * D("0.13")) if venta_gravada > 0 else D("0")
+        if precios_incluyen_iva:
+            total_final = d8(cant * precio_raw - monto_descu)
+            if total_final < 0:
+                total_final = D("0")
+            base_total = money(total_final / D("1.13"))
+            iva_val = money(total_final - base_total)
+            precio = money(precio_raw / D("1.13"))
+            venta_gravada = base_total
+            line_total = base_total + iva_val
+        else:
+            precio = precio_raw
+            base = d8(cant * precio - monto_descu)
+            if base < 0:
+                base = D("0")
+            venta_gravada = d2(base)
+            iva_val = d8(venta_gravada * D("0.13")) if venta_gravada > 0 else D("0")
+            line_total = venta_gravada + iva_val
+        items_total += line_total
         iva_total += iva_val
         try:
             commission_total += D(str(d.get("comision") or 0))
@@ -1088,16 +1120,16 @@ def generar_dte_json(
             "numeroDocumento": "NA",
             "codigo": d.get("codigo") or "SKU-NA",
             "descripcion": d.get("descripcion"),
-            "cantidad": float(cant),
+            "cantidad": cant,
             "uniMedida": uni_medida,
-            "precioUni": float(precio),
-            "montoDescu": float(d2(monto_descu)),
-            "ventaNoSuj": 0.0,
-            "ventaExenta": 0.0,
-            "ventaGravada": float(venta_gravada),
-            "psv": 0.0,
-            "noGravado": 0.0,
-            "ivaItem": float(iva_val),
+            "precioUni": precio,
+            "montoDescu": d2(monto_descu),
+            "ventaNoSuj": D("0"),
+            "ventaExenta": D("0"),
+            "ventaGravada": venta_gravada,
+            "psv": D("0"),
+            "noGravado": D("0"),
+            "ivaItem": iva_val,
             "tributos": ["19"] if venta_gravada > 0 else [],
 
         }
@@ -1182,7 +1214,7 @@ def generar_dte_json(
             raise ValidationError("totalIva debe ser 0 sin venta gravada")
 
     # Validaciones básicas de consistencia
-    items_total_2 = d2(items_total)
+    items_total_2 = d2(total_gravada_sum + total_exenta_sum + total_no_suj_sum)
     if abs(items_total_2 - D(str(resumen.get("subTotalVentas", 0)))) > D("0.01"):
         print(
             f"Advertencia: la suma de los ítems {items_total_2:.2f} difiere del resumen {resumen.get('subTotalVentas',0):.2f}"
@@ -1266,12 +1298,12 @@ def generar_dte_json(
         "extension": extension,
     }
 
-    validate_dte_json(result)
+    validate_dte_json(result, precios_incluyen_iva=precios_incluyen_iva)
     return result
 
 
-def validate_dte_json(payload: dict) -> None:
-    """Basic validation and normalization for DTE payload before signing."""
+def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool = False) -> None:
+    """Basic validation and normalization for DTE payload antes de firmar."""
     # Normalización omitida para preservar códigos con ceros a la izquierda
     # ("01", etc.) que ``_normalize_payload`` convertiría a enteros.
     required = ["identificacion", "emisor", "receptor", "cuerpoDocumento", "resumen"]
@@ -1372,6 +1404,7 @@ def validate_dte_json(payload: dict) -> None:
         raise ValueError("fecEmi/horEmi no pueden ser futuras")
     payload["identificacion"] = ident
     tipo_dte = str(ident.get("tipoDte", ""))
+    precios_flag = precios_incluyen_iva if tipo_dte == "01" else False
 
     emisor = payload.get("emisor", {})
     emisor["nit"] = _clean_nit(emisor.get("nit") or negocio.get("nit"))
@@ -1630,7 +1663,10 @@ def validate_dte_json(payload: dict) -> None:
                     f"Código(s) de tributo inválido(s): {', '.join(invalid)}"
                 )
             if iva_key:
-                item[iva_key] = d8(venta_gravada_val * D("0.13"))
+                if precios_flag and item.get(iva_key) not in (None, 0, D("0")):
+                    item[iva_key] = d8(D(str(item.get(iva_key))))
+                else:
+                    item[iva_key] = d8(venta_gravada_val * D("0.13"))
         else:
             item["tributos"] = []
             item.pop("codTributo", None)
@@ -1664,11 +1700,48 @@ def validate_dte_json(payload: dict) -> None:
     payload["resumen"] = resumen
 
     # Recalcular totales y ajustar discrepancias
-    cambios = recalcular_totales(payload)
+    cambios = recalcular_totales(payload, precios_incluyen_iva=precios_flag)
     if cambios:
         print(
             "Advertencia: se corrigieron campos de resumen: " + ", ".join(cambios)
         )
+
+    # Verificación de centavos exactos en totales clave
+    for k in (
+        "totalIva",
+        "montoTotalOperacion",
+        "totalPagar",
+        "totalGravada",
+        "totalExenta",
+        "totalNoSuj",
+        "totalNoGravado",
+    ):
+        if k in resumen:
+            val = D(str(resumen[k]))
+            if val != money(val):
+                raise ValidationError(f"{k} debe ser múltiplo de 0.01 (recibido={resumen[k]})")
+            if val == D("0") and val.as_tuple().sign:
+                resumen[k] = D("0")
+
+    if resumen.get("tributos"):
+        for t in resumen["tributos"]:
+            val = D(str(t.get("valor") or 0))
+            if val != money(val):
+                raise ValidationError("valor de tributo debe ser múltiplo de 0.01")
+            if val == D("0") and val.as_tuple().sign:
+                t["valor"] = D("0")
+
+    if resumen.get("pagos"):
+        for p in resumen["pagos"]:
+            val = D(str(p.get("montoPago") or 0))
+            if val != money(val):
+                raise ValidationError("montoPago debe ser múltiplo de 0.01")
+            if val == D("0") and val.as_tuple().sign:
+                p["montoPago"] = D("0")
+
+    def _float_money(value: D) -> float:
+        val = float(money(value))
+        return 0.0 if val == -0.0 else val
 
     # --- Catálogo validations ---
     ident = payload.get("identificacion", {})
@@ -1712,16 +1785,19 @@ def validate_dte_json(payload: dict) -> None:
             item[k] = 0.0 if val == 0 else float(val)
 
     resumen = payload.get("resumen", {})
-    for k, v in resumen.items():
+    for k, v in list(resumen.items()):
+        if k in {"totalLetras", "condicionOperacion", "pagos", "numPagoElectronico", "tributos"}:
+            continue
         if isinstance(v, Decimal):
-            val = d2(v)
-            resumen[k] = 0.0 if val == 0 else float(val)
-    tribs = resumen.get("tributos")
-    if isinstance(tribs, list):
-        for t in tribs:
-            if isinstance(t.get("valor"), Decimal):
-                val = d2(t["valor"])
-                t["valor"] = 0.0 if val == 0 else float(val)
+            resumen[k] = _float_money(v)
+
+    if resumen.get("tributos"):
+        for t in resumen["tributos"]:
+            t["valor"] = _float_money(t["valor"])
+
+    if resumen.get("pagos"):
+        for p in resumen["pagos"]:
+            p["montoPago"] = _float_money(p["montoPago"])
 
     payload["resumen"] = resumen
 

--- a/tests/test_dte_rounding.py
+++ b/tests/test_dte_rounding.py
@@ -20,7 +20,7 @@ def test_item_and_total_rounding():
     assert str(iva) == '3.10050000'
     assert decimal_places(iva) <= 8
 
-    resumen = calcular_resumen(venta, {'total': venta + iva}, fiscal={'iva': iva})
+    resumen = calcular_resumen(venta, {'total': venta + iva}, fiscal={'iva': iva}, extra={"precios_incluyen_iva": False})
 
     assert f"{d2(resumen['totalGravada']):.2f}" == '23.85'
     assert f"{d2(resumen['totalIva']):.2f}" == '3.10'

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -36,7 +36,7 @@ def test_generar_dte_json_basic(tmp_path):
     prod_id = db.cursor.lastrowid
     db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "70000001", "", "", "", "")
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta("2024-01-01", 11.3, cliente_id=cliente_id)
+    venta_id = db.add_venta("2024-01-01", 11.3, cliente_id=cliente_id, extra={"precios_incluyen_iva": False})
     db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
 
     data = generar_dte_json(db, venta_id)
@@ -69,6 +69,42 @@ def test_generar_dte_json_basic(tmp_path):
     assert set(data.keys()) == expected
 
 
+def test_generar_dte_json_precios_incluyen_iva_default(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "1234567-8",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 13)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 13)
+    db.add_detalle_venta(venta_id, pid, 1, 13, vendedor_id=vid)
+    data = generar_dte_json(db, venta_id)
+    item = data["cuerpoDocumento"][0]
+    res = data["resumen"]
+    D = Decimal
+    assert D(str(item["ventaGravada"])) == D("11.50")
+    assert D(str(item["ivaItem"])) == D("1.50")
+    assert D(str(res["totalGravada"])) == D("11.50")
+    assert D(str(res["totalIva"])) == D("1.50")
+    assert D(str(res["totalPagar"])) == D("13.00")
+    assert res["totalLetras"].startswith("TRECE")
+
+
 @pytest.mark.parametrize("cfg, expected", [("pruebas", "00"), ("produccion", "01")])
 def test_generar_dte_json_normaliza_ambiente_config(tmp_path, cfg, expected, monkeypatch):
     import dte as dte_module
@@ -98,12 +134,12 @@ def test_generar_dte_json_normaliza_ambiente_config(tmp_path, cfg, expected, mon
     prod_id = db.cursor.lastrowid
     db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "70000001", "", "", "", "")
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cliente_id)
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cliente_id, extra={"precios_incluyen_iva": False})
     db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
 
     orig_validate = dte_module.validate_dte_json
     orig_norm = dte_module._normalize_payload
-    monkeypatch.setattr(dte_module, "validate_dte_json", lambda payload: None)
+    monkeypatch.setattr(dte_module, "validate_dte_json", lambda payload, **kwargs: None)
     monkeypatch.setattr(dte_module, "_normalize_payload", lambda x: x)
     data = dte_module.generar_dte_json(db, venta_id, ambiente="00")
     monkeypatch.setattr(dte_module, "validate_dte_json", orig_validate)
@@ -119,7 +155,7 @@ def test_dte_rounding_and_validation(capsys):
     vend_id = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
     precio = 1.123456789
     venta_id = db.add_venta_credito_fiscal(
@@ -127,11 +163,12 @@ def test_dte_rounding_and_validation(capsys):
         "2024-01-01",
         precio * 2,
         "123",
-        "nit1",
+        "06141990011019",
         "giro",
         sumas=precio * 2,
         descuentos=0,
         iva=0,
+        extra={"precios_incluyen_iva": False},
     )
     db.add_detalle_venta(venta_id, prod_id, 2, precio, vendedor_id=vend_id)
 
@@ -150,18 +187,19 @@ def test_dte_sum_mismatch_warning(capsys):
     vend_id = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cliente_id,
         "2024-01-01",
         10,
         "123",
-        "nit1",
+        "06141990011019",
         "giro",
         sumas=10,
         descuentos=0,
         iva=0,
+        extra={"precios_incluyen_iva": False},
     )
     db.add_detalle_venta(venta_id, prod_id, 1, 5, vendedor_id=vend_id)
 
@@ -176,7 +214,7 @@ def test_generar_ticket_json_tipo():
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    venta_id = db.add_venta("2024-01-01", 5)
+    venta_id = db.add_venta("2024-01-01", 5, extra={"precios_incluyen_iva": False})
     db.add_detalle_venta(venta_id, pid, 1, 5, vendedor_id=vid)
 
     data = generar_dte_json(db, venta_id, tipo_dte="03")
@@ -192,10 +230,10 @@ def test_generar_dte_json_normaliza_ambiente_param(ambiente, expected, monkeypat
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    venta_id = db.add_venta("2024-01-01", 5)
+    venta_id = db.add_venta("2024-01-01", 5, extra={"precios_incluyen_iva": False})
     db.add_detalle_venta(venta_id, pid, 1, 5, vendedor_id=vid)
 
-    monkeypatch.setattr(dte_module, "validate_dte_json", lambda payload: None)
+    monkeypatch.setattr(dte_module, "validate_dte_json", lambda payload, **kwargs: None)
     data = dte_module.generar_dte_json(db, venta_id, ambiente=ambiente)
     assert data["identificacion"]["ambiente"] == expected
 
@@ -206,18 +244,19 @@ def test_dte_comision_sin_advertencia_total(capsys):
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cliente_id,
         "2024-01-01",
         12,
         "123",
-        "nit1",
+        "06141990011019",
         "giro",
         sumas=10,
         descuentos=0,
         iva=0,
+        extra={"precios_incluyen_iva": False},
     )
     db.add_detalle_venta(venta_id, pid, 1, 10, comision=2, vendedor_id=vid)
     generar_dte_json(db, venta_id)
@@ -231,16 +270,17 @@ def test_generar_dte_json_condicion_operacion_invalida():
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(
         cliente_id,
         "2024-01-01",
         10,
         "123",
-        "nit1",
+        "06141990011019",
         "giro",
         condicion_pago="Invalida",
+        extra={"precios_incluyen_iva": False},
     )
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
 

--- a/tests/test_resumen_fc.py
+++ b/tests/test_resumen_fc.py
@@ -19,7 +19,7 @@ def test_resumen_formulas_fc():
         'descu_gravada': D('0.33333333'),
         'iva': D('3.10444444'),
     }
-    resumen = calcular_resumen(items_total, {}, fiscal=fiscal, extra={})
+    resumen = calcular_resumen(items_total, {}, fiscal=fiscal, extra={"precios_incluyen_iva": False})
     assert D(str(resumen['totalNoSuj'])) == D('2.33')
     assert D(str(resumen['totalExenta'])) == D('1.22')
     assert D(str(resumen['totalGravada'])) == D('23.85')
@@ -35,7 +35,7 @@ def test_resumen_formulas_fc():
 def test_resumen_sin_gravada_sin_tributos():
     items_total = D('0')
     fiscal = {'sumas': D('0'), 'ventas_exentas': D('5'), 'iva': D('0')}
-    resumen = calcular_resumen(items_total, {}, fiscal=fiscal, extra={})
+    resumen = calcular_resumen(items_total, {}, fiscal=fiscal, extra={"precios_incluyen_iva": False})
     assert D(str(resumen['totalGravada'])) == D('0.00')
     assert D(str(resumen['totalIva'])) == D('0.00')
     assert resumen['tributos'] is None
@@ -89,6 +89,14 @@ def test_pagos_varios_cuadre():
     total = D('10.01')
     norm = normalizar_pagos(pagos, total)
     assert norm[-1]['montoPago'] == D('5.01')
+    assert sum(p['montoPago'] for p in norm) == total
+
+
+def test_pagos_unico_ajuste():
+    pagos = [{'codigo': '01', 'montoPago': 10.01}]
+    total = D('10.00')
+    norm = normalizar_pagos(pagos, total)
+    assert norm[0]['montoPago'] == D('10.00')
     assert sum(p['montoPago'] for p in norm) == total
 
 


### PR DESCRIPTION
## Summary
- decompose IVA-included prices into base and tax for FC items
- enforce cent-precision and clean negative zeros when serializing
- adjust the last payment by up to a cent to match the total

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_precios_incluyen_iva_default -q`
- `pytest tests/test_resumen_fc.py -q`
- `pytest tests/test_dte_rounding.py::test_pagos_rounding_adjusts_last_payment -q`


------
https://chatgpt.com/codex/tasks/task_e_68a54350a98c8323a17c0e81af6ac55a