### PR TITLE
Integrate official municipality catalog

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -257,7 +257,7 @@ def _load_datos_negocio():
     return {}
 
 
-DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(1, 15)}
+DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(0, 15)}
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 PHONE_RE = re.compile(r"^\+?\d{8,15}$")
@@ -279,8 +279,21 @@ def _map_departamento(nombre: str | None) -> str:
 
 MUNICIPIO_RANGES = {
     # Departamento: (primer código, último código)
-    "05": ("01", "22"),  # La Libertad
-    "06": ("01", "19"),  # San Salvador
+    "00": ("00", "00"),  # Otro
+    "01": ("13", "15"),  # Ahuachapán
+    "02": ("14", "17"),  # Santa Ana
+    "03": ("17", "20"),  # Sonsonate
+    "04": ("34", "36"),  # Chalatenango
+    "05": ("23", "28"),  # La Libertad
+    "06": ("20", "24"),  # San Salvador
+    "07": ("17", "18"),  # Cuscatlán
+    "08": ("23", "25"),  # La Paz
+    "09": ("10", "11"),  # Cabañas
+    "10": ("14", "15"),  # San Vicente
+    "11": ("24", "26"),  # Usulután
+    "12": ("21", "23"),  # San Miguel
+    "13": ("27", "28"),  # Morazán
+    "14": ("19", "20"),  # La Unión
 }
 
 
@@ -324,6 +337,7 @@ def _clean_nrc(nrc):
 # normalizados.
 
 _DEPARTAMENTOS = {
+    "00": "Otro (Para extranjeros)",
     "01": "Ahuachapán",
     "02": "Santa Ana",
     "03": "Sonsonate",
@@ -352,9 +366,79 @@ def _normalize_text(value: str) -> str:
 _DEPARTAMENTO_BY_NAME = {_normalize_text(v): k for k, v in _DEPARTAMENTOS.items()}
 
 _MUNICIPIOS_POR_DEPTO = {
-    "02": {"01": "Santa Ana"},
-    "05": {"01": "Santa Tecla"},
-    "06": {"01": "San Salvador"},
+    "00": {"00": "Otro (Para extranjeros)"},
+    "01": {
+        "13": "Ahuachapán Norte",
+        "14": "Ahuachapán Centro",
+        "15": "Ahuachapán Sur",
+    },
+    "02": {
+        "14": "Santa Ana Norte",
+        "15": "Santa Ana Centro",
+        "16": "Santa Ana Este",
+        "17": "Santa Ana Oeste",
+    },
+    "03": {
+        "17": "Sonsonate Norte",
+        "18": "Sonsonate Centro",
+        "19": "Sonsonate Este",
+        "20": "Sonsonate Oeste",
+    },
+    "04": {
+        "34": "Chalatenango Norte",
+        "35": "Chalatenango Centro",
+        "36": "Chalatenango Sur",
+    },
+    "05": {
+        "23": "La Libertad Norte",
+        "24": "La Libertad Centro",
+        "25": "La Libertad Oeste",
+        "26": "La Libertad Este",
+        "27": "La Libertad Costa",
+        "28": "La Libertad Sur",
+    },
+    "06": {
+        "20": "San Salvador Norte",
+        "21": "San Salvador Oeste",
+        "22": "San Salvador Este",
+        "23": "San Salvador Centro",
+        "24": "San Salvador Sur",
+    },
+    "07": {
+        "17": "Cuscatlán Norte",
+        "18": "Cuscatlán Sur",
+    },
+    "08": {
+        "23": "La Paz Oeste",
+        "24": "La Paz Centro",
+        "25": "La Paz Este",
+    },
+    "09": {
+        "10": "Cabañas Oeste",
+        "11": "Cabañas Este",
+    },
+    "10": {
+        "14": "San Vicente Norte",
+        "15": "San Vicente Sur",
+    },
+    "11": {
+        "24": "Usulután Norte",
+        "25": "Usulután Este",
+        "26": "Usulután Oeste",
+    },
+    "12": {
+        "21": "San Miguel Norte",
+        "22": "San Miguel Centro",
+        "23": "San Miguel Oeste",
+    },
+    "13": {
+        "27": "Morazán Norte",
+        "28": "Morazán Sur",
+    },
+    "14": {
+        "19": "La Unión Norte",
+        "20": "La Unión Sur",
+    },
 }
 
 _MUNI_NAME_MAP: dict[str, list[tuple[str, str]]] = {}

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -122,7 +122,7 @@ def generar_fc_ejemplo(
             "telefono": "22223333",
             "direccion": {
                 "departamento": "01",
-                "municipio": "01",
+                "municipio": "13",
                 "complemento": "Calle 1 #123",
             },
         },
@@ -132,7 +132,7 @@ def generar_fc_ejemplo(
             "nombre": "Consumidor Final",
             "direccion": {
                 "departamento": "01",
-                "municipio": "01",
+                "municipio": "13",
                 "complemento": "SN",
             },
         },
@@ -205,7 +205,7 @@ def _receptor(tipo: str | None = None) -> Dict[str, Any]:
         "nombreComercial": "Cliente Ejemplo",
         "direccion": {
             "departamento": "05",
-            "municipio": "01",
+            "municipio": "13",
             "complemento": "San Salvador",
         },
         "telefono": "70000001",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,7 +172,7 @@ def dte_metadata_factory():
                 "tipoEstablecimiento": "01",
                 "direccion": {
                     "departamento": "01",
-                    "municipio": "01",
+                    "municipio": "13",
                     "complemento": "Calle 1",
                 },
                 "telefono": "22223333",
@@ -191,7 +191,7 @@ def dte_metadata_factory():
                 "descActividad": "Compra de productos",
                 "direccion": {
                     "departamento": "01",
-                    "municipio": "01",
+                    "municipio": "13",
                     "complemento": "Calle 2",
                 },
                 "telefono": "22223333",

--- a/tests/goldens/ccf.json
+++ b/tests/goldens/ccf.json
@@ -34,7 +34,7 @@
     "direccion": {
       "complemento": "Calle X #123",
       "departamento": "06",
-      "municipio": "15"
+      "municipio": "23"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",
@@ -66,7 +66,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "05",
-      "municipio": "01"
+      "municipio": "23"
     },
     "nit": "06141990011019",
     "nombre": "Consumidor Final",

--- a/tests/goldens/fc.json
+++ b/tests/goldens/fc.json
@@ -35,7 +35,7 @@
     "direccion": {
       "complemento": "Calle X #123",
       "departamento": "06",
-      "municipio": "15"
+      "municipio": "23"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",
@@ -67,7 +67,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "05",
-      "municipio": "01"
+      "municipio": "23"
     },
     "nombre": "Consumidor Final",
     "numDocumento": "06141990011019",

--- a/tests/goldens/nc.json
+++ b/tests/goldens/nc.json
@@ -35,7 +35,7 @@
     "direccion": {
       "complemento": "Calle X #123",
       "departamento": "06",
-      "municipio": "15"
+      "municipio": "23"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",
@@ -66,7 +66,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "05",
-      "municipio": "01"
+      "municipio": "23"
     },
     "nit": "06141990011019",
     "nombre": "Consumidor Final",

--- a/tests/goldens/nd.json
+++ b/tests/goldens/nd.json
@@ -35,7 +35,7 @@
     "direccion": {
       "complemento": "Calle X #123",
       "departamento": "06",
-      "municipio": "15"
+      "municipio": "23"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",
@@ -66,7 +66,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "05",
-      "municipio": "01"
+      "municipio": "23"
     },
     "nit": "06141990011019",
     "nombre": "Consumidor Final",

--- a/tests/goldens/nr.json
+++ b/tests/goldens/nr.json
@@ -39,7 +39,7 @@
     "direccion": {
       "complemento": "Calle X #123",
       "departamento": "06",
-      "municipio": "15"
+      "municipio": "23"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",
@@ -71,7 +71,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "05",
-      "municipio": "01"
+      "municipio": "23"
     },
     "nombre": "Consumidor Final",
     "nombreComercial": "Cliente Ejemplo",

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -35,7 +35,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
             "correo": "",
             "direccion": {
                 "departamento": "06",
-                "municipio": "01",
+                "municipio": "23",
                 "complemento": "Calle 1",
             },
         },
@@ -99,14 +99,19 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
                 "montoTotalOperacion": 10,
                 "totalNoGravado": 0,
                 "totalPagar": 10,
-                "totalLetras": "",
+                "totalLetras": "diez",
                 "totalIva": 0,
                 "saldoFavor": 0,
                 "condicionOperacion": 1,
                 "pagos": None,
                 "numPagoElectronico": None,
             },
-            "identificacion": {"tipoDte": "01"},
+                "identificacion": {
+                    "tipoDte": "01",
+                    "codigoGeneracion": "00000000-0000-4000-8000-000000000001",
+                    "version": 1,
+                    "ambiente": "00",
+                },
         },
     )
 

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -100,7 +100,7 @@ def test_receptor_direccion(monkeypatch):
     data = _load_fc()
     data["receptor"]["direccion"] = {
         "departamento": "05",
-        "municipio": "01",
+        "municipio": "23",
         "complemento": "C",
     }
     validate_dte_json(data)
@@ -116,32 +116,48 @@ def test_receptor_direccion(monkeypatch):
 
 def test_direccion_normaliza_por_nombre():
     out = _build_receptor_direccion(
-        {"departamento": "San Salvador", "municipio": "San Salvador"}
+        {"departamento": "San Salvador", "municipio": "San Salvador Centro"}
     )
-    assert out == {"departamento": "06", "municipio": "01", "complemento": None}
+    assert out == {"departamento": "06", "municipio": "23", "complemento": None}
 
 
 def test_direccion_normaliza_por_codigo():
-    out = _build_receptor_direccion({"departamento": 6, "municipio": 1})
+    out = _build_receptor_direccion({"departamento": 6, "municipio": 23})
     assert out["departamento"] == "06"
-    assert out["municipio"] == "01"
+    assert out["municipio"] == "23"
 
 
 def test_infiere_departamento():
-    out = _build_receptor_direccion({"municipio": "Santa Tecla"})
-    assert out["departamento"] == "05"
-    assert out["municipio"] == "01"
+    out = _build_receptor_direccion({"municipio": "San Salvador Centro"})
+    assert out["departamento"] == "06"
+    assert out["municipio"] == "23"
 
 
 def test_municipio_fuera_depto():
     with pytest.raises(ValidationError):
         _build_receptor_direccion(
-            {"departamento": "06", "municipio": "Santa Ana"}
+            {"departamento": "06", "municipio": "Santa Ana Centro"}
         )
+
+
+def test_receptor_direccion_municipio_nombre_fuera_depto(monkeypatch):
+    monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
+    data = _load_fc()
+    data["receptor"]["direccion"] = {
+        "departamento": "06",
+        "municipio": "Santa Ana Centro",
+        "complemento": "C",
+    }
+    with pytest.raises(ValidationError):
+        validate_dte_json(data)
 
 
 def test_complemento_opcional():
     out = _build_receptor_direccion(
-        {"departamento": "06", "municipio": "San Salvador", "complemento": ""}
+        {
+            "departamento": "06",
+            "municipio": "San Salvador Centro",
+            "complemento": "",
+        }
     )
     assert out["complemento"] is None

--- a/tests/test_validar_todo_integration.py
+++ b/tests/test_validar_todo_integration.py
@@ -33,11 +33,11 @@ def datos_negocio_completo(tmp_path):
         "descActividad": "Comercio",
         "telefono": "12345678",
         "correo": "test@example.com",
-        "direccion": {
-            "departamento": "06",
-            "municipio": "01",
-            "complemento": "Calle Falsa 123",
-        },
+            "direccion": {
+                "departamento": "06",
+                "municipio": "23",
+                "complemento": "Calle Falsa 123",
+            },
     }
     path = tmp_path / "datos_negocio.json"
     path.write_text(json.dumps(data), encoding="utf-8")


### PR DESCRIPTION
## Summary
- replace reduced municipality/department catalog with official lists
- restore strict municipality validation
- align tests and example DTEs with official codes

## Testing
- `pytest tests/test_validaciones_basicas.py::test_receptor_direccion tests/test_validaciones_basicas.py::test_municipio_fuera_depto tests/test_validaciones_basicas.py::test_receptor_direccion_municipio_nombre_fuera_depto tests/test_validar_todo_integration.py::test_reporta_errores_schema tests/test_envio_hacienda.py::test_transmision_exitosa -q --override-ini addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68a5820d4aa4832399c8b63afcec584f