### PR TITLE
Relax municipality validation against department

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -309,11 +309,8 @@ def _map_municipio(nombre: str | None, departamento: str | None = None) -> str:
     if not nombre.isdigit() or len(nombre) != 2:
         raise ValueError("Municipio inválido")
 
-    if departamento:
-        dep_code = _map_departamento(departamento)
-        start, end = MUNICIPIO_RANGES.get(dep_code, ("00", "99"))
-        if nombre < start or nombre > end:
-            raise ValueError("Municipio inválido para el departamento")
+    # No se valida que el municipio pertenezca al departamento indicado,
+    # solo se asegura que el código sea numérico de dos dígitos.
     return nombre
 
 
@@ -481,39 +478,18 @@ def _normalize_municipio(dep_code: str | None, value):
 
     if val.isdigit():
         code = val.zfill(2)
-        if dep_norm:
-            munis = _MUNICIPIOS_POR_DEPTO.get(dep_norm)
-            if munis and code not in munis:
-                raise ValidationError(
-                    "receptor.direccion: municipio inválido para el departamento seleccionado"
-                )
-            return code, dep_norm
-        matches = [(d, code) for d, ms in _MUNICIPIOS_POR_DEPTO.items() if code in ms]
-        if len(matches) == 1:
-            return matches[0][1], matches[0][0]
-        if not matches:
-            raise ValidationError("Municipio inválido")
-        raise ValidationError(
-            "receptor.direccion: municipio inválido para el departamento seleccionado"
-        )
+        return code, dep_norm
 
     norm = _normalize_text(val)
-    if dep_norm:
-        munis = _MUNICIPIOS_POR_DEPTO.get(dep_norm)
-        if not munis:
-            raise ValidationError(
-                "receptor.direccion: municipio inválido para el departamento seleccionado"
-            )
-        for code, name in munis.items():
-            if _normalize_text(name) == norm:
-                return code, dep_norm
-        raise ValidationError(
-            "receptor.direccion: municipio inválido para el departamento seleccionado"
-        )
-
     matches = _MUNI_NAME_MAP.get(norm)
     if not matches:
         raise ValidationError("Municipio inválido")
+    if dep_norm:
+        for dep, code in matches:
+            if dep == dep_norm:
+                return code, dep_norm
+        # Departamento no coincide; retornar código de municipio encontrado
+        return matches[0][1], dep_norm
     if len(matches) > 1:
         raise ValidationError(
             "receptor.direccion: municipio inválido para el departamento seleccionado"

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -420,3 +420,52 @@ def test_generar_dte_json_receptor_extra_preserva_direccion(tmp_path):
     assert direccion["departamento"] == "06"
     assert direccion["municipio"] == "01"
     assert direccion["complemento"] == "Calle"
+
+
+def test_generar_dte_json_municipio_fuera_depto(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "1234567-8",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+    }
+    datos_file = tmp_path / "datos_negocio.json"
+    datos_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(datos_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "15",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01",
+        11.3,
+        cliente_id=cliente_id,
+        extra={"precios_incluyen_iva": False},
+    )
+    db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
+
+    data = generar_dte_json(db, venta_id)
+    direccion = data["receptor"]["direccion"]
+    assert direccion["departamento"] == "06"
+    assert direccion["municipio"] == "15"

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -134,22 +134,27 @@ def test_infiere_departamento():
 
 
 def test_municipio_fuera_depto():
-    with pytest.raises(ValidationError):
-        _build_receptor_direccion(
-            {"departamento": "06", "municipio": "Santa Ana Centro"}
-        )
+    out = _build_receptor_direccion(
+        {"departamento": "06", "municipio": "Santa Ana Centro"}
+    )
+    assert out["departamento"] == "06"
+    assert out["municipio"] == "15"
 
 
 def test_receptor_direccion_municipio_nombre_fuera_depto(monkeypatch):
     monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
-    data = _load_fc()
-    data["receptor"]["direccion"] = {
+    out = _build_receptor_direccion(
+        {
+            "departamento": "06",
+            "municipio": "Santa Ana Centro",
+            "complemento": "C",
+        }
+    )
+    assert out == {
         "departamento": "06",
-        "municipio": "Santa Ana Centro",
+        "municipio": "15",
         "complemento": "C",
     }
-    with pytest.raises(ValidationError):
-        validate_dte_json(data)
 
 
 def test_complemento_opcional():


### PR DESCRIPTION
## Summary
- allow `_normalize_municipio` to accept municipalities outside the selected department and return matching codes without raising
- loosen `_map_municipio` to stop validating municipality ranges per department
- update and extend tests for relaxed municipality/department validation, including end-to-end DTE generation

## Testing
- `pytest`
- `pytest tests/test_validaciones_basicas.py::test_municipio_fuera_depto tests/test_validaciones_basicas.py::test_receptor_direccion_municipio_nombre_fuera_depto tests/test_generar_dte_json.py::test_generar_dte_json_municipio_fuera_depto -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58ab337688323a6afedcc3089f306