### PR TITLE
Validate operation and production signature

### DIFF
--- a/svfe/prevalidate.py
+++ b/svfe/prevalidate.py
@@ -15,6 +15,10 @@ from typing import Any, Dict
 
 from jsonschema import Draft202012Validator, FormatChecker, RefResolver
 from utils import catalogos
+from .catalogs import (
+    normalize_condicion_operacion,
+    validate_pagos_basico,
+)
 
 
 # Keys that may be present in a document returned by MH after processing but
@@ -101,7 +105,46 @@ def prevalidate_envelope(sobre: Dict[str, Any], jws: str, schema_path: str) -> N
     assert (
         sobre["codigoGeneracion"] == ident.get("codigoGeneracion")
     ), "codigoGeneracion no coincide"
-    assert ident.get("ambiente") == "00", "ambiente debe ser '00' en pruebas"
+
+    ambiente = ident.get("ambiente")
+    assert ambiente in {"00", "01"}, "ambiente debe ser '00' o '01'"
+
+    # Rules for tipoOperacion, tipoModelo and tipoContingencia
+    tipo_oper = int(ident.get("tipoOperacion", 1) or 1)
+    tipo_modelo = ident.get("tipoModelo")
+    tipo_cont = ident.get("tipoContingencia")
+    motivo = ident.get("motivoContin")
+    if isinstance(motivo, str):
+        motivo = motivo.strip() or None
+    if tipo_oper == 1:
+        assert tipo_modelo in (None, 1), "tipoModelo debe ser 1 cuando tipoOperacion=1"
+        assert not tipo_cont, "tipoContingencia debe ser nulo cuando tipoOperacion=1"
+        assert not motivo, "motivoContin debe ser nulo cuando tipoOperacion=1"
+    elif tipo_oper == 2:
+        assert tipo_modelo in (None, 2), "tipoModelo debe ser 2 cuando tipoOperacion=2"
+        assert tipo_cont is not None, "tipoContingencia requerido cuando tipoOperacion=2"
+        tipo_cont = int(tipo_cont)
+        assert tipo_cont in catalogos.CONTINGENCIA, "tipoContingencia inválido"
+        if tipo_cont == 5:
+            assert (
+                motivo and 5 <= len(motivo) <= 150
+            ), "motivoContin requerido cuando tipoContingencia=5"
+        else:
+            assert not motivo, "motivoContin sólo permitido cuando tipoContingencia=5"
+    else:
+        raise AssertionError("tipoOperacion debe ser 1 o 2")
+
+    resumen = payload.get("resumen", {})
+    condicion = normalize_condicion_operacion(resumen.get("condicionOperacion"))
+    validate_pagos_basico(resumen, condicion)
+
+    if ambiente == "01":
+        firma = payload.get("firmaElectronica")
+        assert isinstance(firma, str) and firma.strip(), "firmaElectronica requerida"
+        try:
+            base64.b64decode(firma, validate=True)
+        except Exception:
+            raise AssertionError("firmaElectronica inválida") from None
 
     validate_against_schema(strip_extras(payload), schema_path)
 

--- a/tests/test_prevalidate.py
+++ b/tests/test_prevalidate.py
@@ -1,3 +1,4 @@
+import base64
 import pytest
 
 from dte import sanitize_dte_payload
@@ -8,6 +9,9 @@ from tests.conftest import make_jws
 def _make_valid_payload(dte_metadata_factory):
     payload = dte_metadata_factory()
     payload["identificacion"]["version"] = 1
+    # Ajustar municipios a valores válidos del catálogo
+    payload["emisor"]["direccion"]["municipio"] = "01"
+    payload["receptor"]["direccion"]["municipio"] = "01"
     payload = sanitize_dte_payload(payload)
     return payload
 
@@ -45,5 +49,56 @@ def test_prevalidate_schema_error(dte_metadata_factory):
         "documento": token,
     }
     with pytest.raises(ValueError):
+        prevalidate(sobre)
+
+
+def test_prevalidate_operacion_contingencia(dte_metadata_factory):
+    payload = _make_valid_payload(dte_metadata_factory)
+    ident = payload["identificacion"]
+    ident["tipoOperacion"] = 2
+    # faltan tipoContingencia y tipoModelo adecuado
+    token = make_jws(payload)
+    sobre = {
+        "tipoDte": int(ident["tipoDte"]),
+        "codigoGeneracion": ident["codigoGeneracion"],
+        "documento": token,
+    }
+    with pytest.raises(AssertionError):
+        prevalidate(sobre)
+
+
+def test_prevalidate_credito_requiere_plazo_periodo(dte_metadata_factory):
+    payload = _make_valid_payload(dte_metadata_factory)
+    resumen = payload["resumen"]
+    resumen["condicionOperacion"] = 2
+    # pagos actuales carecen de plazo/periodo
+    token = make_jws(payload)
+    sobre = {
+        "tipoDte": int(payload["identificacion"]["tipoDte"]),
+        "codigoGeneracion": payload["identificacion"]["codigoGeneracion"],
+        "documento": token,
+    }
+    with pytest.raises(ValueError):
+        prevalidate(sobre)
+
+
+def test_prevalidate_firma_en_produccion(dte_metadata_factory):
+    payload = _make_valid_payload(dte_metadata_factory)
+    ident = payload["identificacion"]
+    ident["ambiente"] = "01"
+    payload["firmaElectronica"] = base64.b64encode(b"sig").decode()
+    token = make_jws(payload)
+    sobre = {
+        "tipoDte": int(ident["tipoDte"]),
+        "codigoGeneracion": ident["codigoGeneracion"],
+        "documento": token,
+    }
+    assert prevalidate(sobre) is True
+
+    # quitar firma -> falla
+    payload.pop("firmaElectronica")
+    token = make_jws(payload)
+    sobre["documento"] = token
+    with pytest.raises(AssertionError):
         prevalidate(sobre)
 


### PR DESCRIPTION
## Summary
- enforce tipoOperacion/tipoModelo/tipoContingencia rules during prevalidation
- require credit pagos to include plazo and periodo
- demand base64 firmaElectronica in production

## Testing
- `pytest` *(fails: libGL.so.1 missing, fastapi missing)*
- `pytest tests/test_prevalidate.py`


------
https://chatgpt.com/codex/tasks/task_e_68a58c9f02b88323ae624dfbd73a207c