### PR TITLE
feat: support manual condicionOperacion and partial payments

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -551,18 +551,25 @@ def _build_receptor_direccion(src: dict) -> dict:
 
 # --- Helpers ---------------------------------------------------------------
 
-# Catálogo de ``condicionOperacion`` según el esquema oficial.
-# 1 = Contado, 2 = Crédito, 3 = Otro
-CONDICION_OPERACION_CATALOG = {
-    1: "Contado",
-    2: "Crédito",
-    3: "Otro",
-}
+# Catálogo de ``condicionOperacion`` según el esquema oficial.  Se obtiene de
+# ``catalogos.CONDICION_OPERACION`` cuando está disponible; de lo contrario se
+# recurre a un catálogo por defecto.
+CONDICION_OPERACION_CATALOG = (
+    catalogos.CONDICION_OPERACION
+    if getattr(catalogos, "CONDICION_OPERACION", None)
+    else {1: "Contado", 2: "Crédito", 3: "Otro"}
+)
 
 _CONDICION_OPERACION_BY_NAME = {
     v.lower(): k for k, v in CONDICION_OPERACION_CATALOG.items()
 }
-_CONDICION_OPERACION_BY_NAME["credito"] = 2
+_CONDICION_OPERACION_BY_NAME["credito"] = _CONDICION_OPERACION_BY_NAME.get(
+    "crédito", 2
+)
+if "otras" in _CONDICION_OPERACION_BY_NAME:
+    _CONDICION_OPERACION_BY_NAME.setdefault(
+        "otro", _CONDICION_OPERACION_BY_NAME["otras"]
+    )
 
 
 def _parse_condicion_operacion(value):
@@ -735,20 +742,36 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
         codigo_raw = p.get("codigo", "")
         codigo_str = str(codigo_raw).zfill(2)
         if allowed and codigo_str not in allowed:
-            continue
+            raise ValidationError(f"Código de pago inválido: {codigo_str}")
         codigo = int(codigo_raw) if code_is_int else codigo_str
+
         monto = money(p.get("montoPago", 0))
+        if monto <= 0:
+            raise ValidationError("montoPago debe ser mayor a 0")
+
         referencia = p.get("referencia") or None
+
         periodo_raw = p.get("periodo")
         if periodo_raw in ("", None):
             periodo = None
         else:
-            periodo = str(periodo_raw).zfill(2) if periodo_is_str else int(periodo_raw)
+            periodo_code = str(periodo_raw).zfill(2)
+            if periodo_code not in catalogos.PLAZO:
+                raise ValidationError("periodo inválido")
+            periodo = periodo_code if periodo_is_str else int(periodo_code)
+
         plazo_raw = p.get("plazo")
         if plazo_raw in ("", None):
             plazo = None
         else:
-            plazo = str(plazo_raw).zfill(2) if plazo_is_str else int(plazo_raw)
+            try:
+                plazo_val = int(plazo_raw)
+            except Exception as exc:  # pragma: no cover - error path
+                raise ValidationError("plazo inválido") from exc
+            if plazo_val <= 0:
+                raise ValidationError("plazo debe ser mayor a 0")
+            plazo = str(plazo_val).zfill(2) if plazo_is_str else plazo_val
+
         pagos.append(
             {
                 "codigo": codigo,
@@ -784,15 +807,15 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
     else:
         suma = sum((p["montoPago"] for p in pagos), D("0.00"))
         diff = money(total - suma)
-        if diff != 0:
+        if diff < 0:
             if abs(diff) > D("0.01"):
                 raise ValidationError(
-                    f"La suma de pagos {money(suma)} difiere del total {total} (dif {diff})"
+                    f"La suma de pagos {money(suma)} excede el total {total} (dif {-diff})"
                 )
             nuevo = money(pagos[-1]["montoPago"] + diff)
             if nuevo < 0:
                 raise ValidationError(
-                    f"La suma de pagos {money(suma)} difiere del total {total} (dif {diff})"
+                    f"La suma de pagos {money(suma)} excede el total {total} (dif {-diff})"
                 )
             pagos[-1]["montoPago"] = nuevo
 
@@ -814,9 +837,9 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
 
     suma_final = sum((p["montoPago"] for p in pagos), D("0.00"))
     diff_final = money(total - suma_final)
-    if diff_final != 0:
+    if diff_final < 0:
         raise ValidationError(
-            f"La suma de pagos {money(suma_final)} difiere del total {total} (dif {diff_final})"
+            f"La suma de pagos {money(suma_final)} excede el total {total} (dif {-diff_final})"
         )
 
     return pagos
@@ -939,12 +962,15 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         resumen["totalIva"] = money(0)
 
     if "pagos" in resumen:
-        resumen["pagos"] = normalizar_pagos(
+        pagos_norm = normalizar_pagos(
             extra.get("pagos"),
             resumen["totalPagar"],
             tipo_dte=tipo_dte,
             condicion=resumen.get("condicionOperacion", 1),
         )
+        resumen["pagos"] = pagos_norm
+        pagos_suma = sum((p["montoPago"] for p in pagos_norm), D("0.00"))
+        resumen["saldoFavor"] = money(resumen["totalPagar"] - pagos_suma)
 
     if "numPagoElectronico" in resumen:
         resumen["numPagoElectronico"] = extra.get("numPagoElectronico")

--- a/svfe/catalogs.py
+++ b/svfe/catalogs.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 
-CAT016_CONDICION_OPERACION = {1, 2, 3}
-CAT016_ALIASES: Dict[str, int] = {
-    "1": 1,
-    "contado": 1,
-    "2": 2,
-    "credito": 2,
-    "crédito": 2,
-    "3": 3,
-    "otro": 3,
-}
+from utils import catalogos
+
+# Catalogo dinámico de ``condicionOperacion``. Si el catálogo local no está
+# disponible se utilizan los valores estándar {1, 2, 3}.
+_CAT = getattr(catalogos, "CONDICION_OPERACION", {1: "contado", 2: "crédito", 3: "otro"})
+CAT016_CONDICION_OPERACION = set(_CAT.keys()) or {1, 2, 3}
+CAT016_ALIASES: Dict[str, int] = {str(k): k for k in CAT016_CONDICION_OPERACION}
+for code, name in _CAT.items():
+    CAT016_ALIASES[name.lower()] = code
+CAT016_ALIASES.setdefault("credito", CAT016_ALIASES.get("crédito", 2))
 
 
 def normalize_condicion_operacion(value: Any) -> int:

--- a/tests/test_resumen_condicion_operacion.py
+++ b/tests/test_resumen_condicion_operacion.py
@@ -33,3 +33,9 @@ def test_validate_pagos_basico_requires_plazo_periodo():
     with pytest.raises(ValueError):
         validate_pagos_basico(resumen, 2)
 
+
+def test_validate_pagos_excede_total():
+    resumen = {"totalPagar": 10.0, "pagos": [{"codigo": "01", "montoPago": 11.0}]}
+    with pytest.raises(ValueError):
+        validate_pagos_basico(resumen, 1)
+

--- a/tests/test_resumen_fc.py
+++ b/tests/test_resumen_fc.py
@@ -81,15 +81,15 @@ def test_pagos_contado_default_int(monkeypatch):
     ]
 
 
-def test_pagos_varios_cuadre():
+def test_pagos_varios_parciales():
     pagos = [
         {'codigo': '01', 'montoPago': 5},
         {'codigo': '02', 'montoPago': 5},
     ]
     total = D('10.01')
     norm = normalizar_pagos(pagos, total)
-    assert norm[-1]['montoPago'] == D('5.01')
-    assert sum(p['montoPago'] for p in norm) == total
+    assert norm[-1]['montoPago'] == D('5.00')
+    assert sum(p['montoPago'] for p in norm) == D('10.00')
 
 
 def test_pagos_unico_ajuste():
@@ -104,6 +104,18 @@ def test_credito_requiere_plazo_periodo():
     pagos = [{'codigo': '01', 'montoPago': 5}]
     with pytest.raises(Exception):
         normalizar_pagos(pagos, D('5'), condicion=2)
+
+
+def test_calcular_resumen_saldo_parcial():
+    pagos = [{'codigo': '01', 'montoPago': 5}]
+    items_total = D('10.00')
+    resumen = calcular_resumen(
+        items_total,
+        {'total': items_total},
+        fiscal={'iva': D('0')},
+        extra={'pagos': pagos, 'precios_incluyen_iva': False},
+    )
+    assert resumen['saldoFavor'] == D('5.00')
 
 
 def test_codigo_pago_tipo_schema(monkeypatch):

--- a/utils/resumen.py
+++ b/utils/resumen.py
@@ -7,16 +7,26 @@ from decimal import Decimal
 from . import catalogos
 from .monto import d2
 
-# Catálogo permitido de condicionOperacion
-CONDICION_OPERACION_CATALOG = {1, 2, 3}
+# Catálogo permitido de ``condicionOperacion`` obtenido dinámicamente.
+# Si el catálogo local no provee los códigos se acepta cualquier valor
+# entero ingresado manualmente.
+_CATALOG = getattr(catalogos, "CONDICION_OPERACION", {})
+CONDICION_OPERACION_CATALOG = set(_CATALOG.keys())
 
-# Mapeo de nombres a códigos según catálogo oficial
-_CONDICION_OPERACION_BY_NAME = {
-    "contado": 1,
-    "credito": 2,
-    "crédito": 2,
-    "otro": 3,
-}
+# Mapeo de nombres a códigos según catálogo oficial.  Cuando el catálogo no
+# está disponible se soportan los alias más comunes.
+_CONDICION_OPERACION_BY_NAME = {str(v).lower(): k for k, v in _CATALOG.items()}
+if not _CONDICION_OPERACION_BY_NAME:
+    _CONDICION_OPERACION_BY_NAME = {
+        "contado": 1,
+        "credito": 2,
+        "crédito": 2,
+        "otro": 3,
+    }
+if "otras" in _CONDICION_OPERACION_BY_NAME:
+    _CONDICION_OPERACION_BY_NAME.setdefault(
+        "otro", _CONDICION_OPERACION_BY_NAME["otras"]
+    )
 
 
 def normalize_condicion_operacion(value: Any) -> int:
@@ -35,7 +45,8 @@ def normalize_condicion_operacion(value: Any) -> int:
             code = int(val)
         else:
             code = _CONDICION_OPERACION_BY_NAME.get(val)
-    if code not in CONDICION_OPERACION_CATALOG:
+
+    if CONDICION_OPERACION_CATALOG and code not in CONDICION_OPERACION_CATALOG:
         raise ValueError(f"condicionOperacion inválida: {value}")
     return code
 
@@ -44,7 +55,7 @@ def validate_pagos_basico(resumen: dict, condicion: int) -> None:
     """Valida estructura mínima de ``pagos`` en ``resumen``.
 
     Verifica que los códigos de pago sean válidos según ``CAT-017`` y que la
-    suma de ``montoPago`` coincida con ``totalPagar``.  Cuando la
+    suma de ``montoPago`` no exceda ``totalPagar``.  Cuando la
     ``condicionOperacion`` es 2 (crédito) se requiere que el primer pago
     contenga ``plazo`` mayor a cero y ``periodo`` perteneciente al catálogo
     ``PLAZO``.
@@ -58,8 +69,8 @@ def validate_pagos_basico(resumen: dict, condicion: int) -> None:
     total = resumen.get("totalPagar")
     if total is not None:
         suma = sum(Decimal(str(p.get("montoPago", 0))) for p in pagos)
-        if d2(suma) != d2(total):
-            raise ValueError("La suma de pagos no coincide con totalPagar")
+        if d2(suma) > d2(total):
+            raise ValueError("La suma de pagos excede totalPagar")
 
     allowed = set(catalogos.FORMA_PAGO.keys())
     for pago in pagos:
@@ -67,11 +78,30 @@ def validate_pagos_basico(resumen: dict, condicion: int) -> None:
         if allowed and codigo not in allowed:
             raise ValueError(f"Código de pago inválido: {codigo}")
 
+        monto = Decimal(str(pago.get("montoPago", 0)))
+        if monto <= 0:
+            raise ValueError("montoPago debe ser mayor a 0")
+
+        plazo_raw = pago.get("plazo")
+        if plazo_raw not in (None, ""):
+            try:
+                plazo_val = int(plazo_raw)
+            except Exception as exc:  # pragma: no cover - error path
+                raise ValueError("plazo inválido") from exc
+            if plazo_val <= 0:
+                raise ValueError("plazo debe ser mayor a 0")
+
+        periodo_raw = pago.get("periodo")
+        if periodo_raw not in (None, ""):
+            periodo_code = str(periodo_raw).zfill(2)
+            if periodo_code not in catalogos.PLAZO:
+                raise ValueError("periodo inválido")
+
     if condicion == 2:
         first = pagos[0]
-        plazo = first.get("plazo") or 0
+        plazo = int(first.get("plazo") or 0)
         periodo = str(first.get("periodo") or "").zfill(2)
         if not plazo or periodo not in catalogos.PLAZO:
             raise ValueError(
-                "Para operaciones a crédito, pagos[0] requiere plazo>0 y periodo válido"
+                "Para operaciones a crédito, pagos[0] requiere plazo>0 y periodo válido",
             )


### PR DESCRIPTION
## Summary
- derive `condicionOperacion` from catalog when available and validate aliases
- allow dynamic `pagos` array with per-entry validation and partial payments
- include remaining balance in resumen totals

## Testing
- `pytest tests/test_resumen_fc.py tests/test_resumen_condicion_operacion.py tests/test_dte_rounding.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58ca3ad58832383e7aa1220722c09