### PR TITLE
feat: support related and additional documents in DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1134,6 +1134,10 @@ def generar_dte_json(
     motivo_contin: str | None = None,
     tipo_modelo: int | None = None,
     tipo_moneda: str = "USD",
+    documento_relacionado: list | None = None,
+    otros_documentos: list | None = None,
+    extension: dict | None = None,
+    apendice: dict | None = None,
     **kwargs,
 ) -> dict:
     """Genera un diccionario DTE básico para una venta.
@@ -1533,17 +1537,15 @@ def generar_dte_json(
         for p in resumen["pagos"]:
             p["montoPago"] = _float_money(p["montoPago"])
 
-    extension = None
-
     result = {
         "identificacion": identificacion,
         "emisor": emisor,
         "receptor": receptor,
         "cuerpoDocumento": cuerpo,
         "resumen": resumen,
-        "documentoRelacionado": None,
-        "otrosDocumentos": None,
-        "apendice": None,
+        "documentoRelacionado": documento_relacionado,
+        "otrosDocumentos": otros_documentos,
+        "apendice": apendice,
         "ventaTercero": None,
         "extension": extension,
     }
@@ -2058,6 +2060,25 @@ def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool = False) -> N
 
     payload["resumen"] = resumen
 
+    # Validación de documentoRelacionado y otrosDocumentos
+    relacionados = payload.get("documentoRelacionado") or []
+    if isinstance(relacionados, dict):
+        relacionados = [relacionados]
+        payload["documentoRelacionado"] = relacionados
+    for rel in relacionados:
+        tipo = str(rel.get("tipoDocumento"))
+        if tipo and tipo not in catalogos.TIPO_DTE:
+            raise ValueError(f"Tipo de DTE relacionado inválido: {tipo}")
+
+    otros = payload.get("otrosDocumentos") or []
+    if isinstance(otros, dict):
+        otros = [otros]
+        payload["otrosDocumentos"] = otros
+    for od in otros:
+        cod = od.get("codDocAsociado")
+        if cod is not None and cod not in catalogos.OTROS_DOCUMENTOS:
+            raise ValueError(f"Código de documento asociado inválido: {cod}")
+
     # --- Schema validation ---
     schema = catalogos.get_dte_schema(tipo_dte)
     if schema:
@@ -2103,18 +2124,24 @@ def generar_nota_credito_json(db: DB, nota_id: int) -> dict:
     venta_id = nota.get("venta_id")
     # Determine document type of the original sale
     venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+        "SELECT cliente_id, fecha FROM ventas WHERE id=?", (venta_id,)
     ).fetchone()
     tipo_doc = "01"
+    fecha_venta = None
     if venta_row:
         venta = dict(venta_row)
+        fecha_venta = venta.get("fecha")
         if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
             tipo_doc = "03"
     data = generar_dte_json(db, venta_id, tipo_dte="05")
-    data["documentoRelacionado"] = {
-        "tipoDoc": tipo_doc,
-        "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
-    }
+    data["documentoRelacionado"] = [
+        {
+            "tipoDocumento": tipo_doc,
+            "tipoGeneracion": 1,
+            "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
+            "fechaEmision": fecha_venta or data["identificacion"].get("fecEmi"),
+        }
+    ]
 
     for item in data.get("cuerpoDocumento", []):
         if isinstance(item.get("cantidad"), (int, float)):
@@ -2141,18 +2168,24 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
 
     venta_id = nota.get("venta_id")
     venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+        "SELECT cliente_id, fecha FROM ventas WHERE id=?", (venta_id,)
     ).fetchone()
     tipo_doc = "01"
+    fecha_venta = None
     if venta_row:
         venta = dict(venta_row)
+        fecha_venta = venta.get("fecha")
         if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
             tipo_doc = "03"
     data = generar_dte_json(db, venta_id, tipo_dte="06")
-    data["documentoRelacionado"] = {
-        "tipoDoc": tipo_doc,
-        "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
-    }
+    data["documentoRelacionado"] = [
+        {
+            "tipoDocumento": tipo_doc,
+            "tipoGeneracion": 1,
+            "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
+            "fechaEmision": fecha_venta or data["identificacion"].get("fecEmi"),
+        }
+    ]
     return data
 
 
@@ -2167,18 +2200,24 @@ def generar_nota_remision_json(db: DB, nota_id: int) -> dict:
 
     venta_id = nota.get("venta_id")
     venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+        "SELECT cliente_id, fecha FROM ventas WHERE id=?", (venta_id,)
     ).fetchone()
     tipo_doc = "01"
+    fecha_venta = None
     if venta_row:
         venta = dict(venta_row)
+        fecha_venta = venta.get("fecha")
         if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
             tipo_doc = "03"
     data = generar_dte_json(db, venta_id, tipo_dte="04")
-    data["documentoRelacionado"] = {
-        "tipoDoc": tipo_doc,
-        "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
-    }
+    data["documentoRelacionado"] = [
+        {
+            "tipoDocumento": tipo_doc,
+            "tipoGeneracion": 1,
+            "numeroDocumento": data["identificacion"].get("numeroControl") or venta_id,
+            "fechaEmision": fecha_venta or data["identificacion"].get("fecEmi"),
+        }
+    ]
     return data
 
 

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -2,13 +2,14 @@ import fitz
 from db import DB
 from dte import generar_nota_credito_json
 from factura_sv import generar_nota_credito_pdf
+import dte as dte_module
 
 
 def create_db():
     return DB(":memory:")
 
 
-def test_generar_nota_credito_json_ticket(tmp_path):
+def test_generar_nota_credito_json_ticket(tmp_path, monkeypatch):
     db = create_db()
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
@@ -23,23 +24,41 @@ def test_generar_nota_credito_json_ticket(tmp_path):
     nota_id = db.cursor.lastrowid
     db.conn.commit()
 
+    monkeypatch.setattr(
+        dte_module,
+        "_build_receptor_direccion",
+        lambda *_: {"departamento": "06", "municipio": "23", "complemento": "DIR"},
+    )
     data = generar_nota_credito_json(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "05"
     assert data.get("documentoRelacionado")
-    assert data["documentoRelacionado"]["tipoDoc"] == "03"
+    assert data["documentoRelacionado"][0]["tipoDocumento"] == "03"
     assert data["cuerpoDocumento"][0]["precioUni"] < 0
     assert data["resumen"]["totalPagar"] < 0
 
 
-def test_generar_nota_credito_json_factura(tmp_path):
+def test_generar_nota_credito_json_factura(tmp_path, monkeypatch):
     db = create_db()
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "",
+        "",
+        "",
+        "",
+        "",
+    )
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro", descuentos=0)
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id, "2024-01-01", 10, "123", "06141990011019", "giro", descuentos=0
+    )
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
     db.cursor.execute(
         "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
@@ -48,8 +67,13 @@ def test_generar_nota_credito_json_factura(tmp_path):
     nota_id = db.cursor.lastrowid
     db.conn.commit()
 
+    monkeypatch.setattr(
+        dte_module,
+        "_build_receptor_direccion",
+        lambda *_: {"departamento": "06", "municipio": "23", "complemento": "DIR"},
+    )
     data = generar_nota_credito_json(db, nota_id)
-    assert data["documentoRelacionado"]["tipoDoc"] == "01"
+    assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
 
 
 def _sample_data():

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -2,6 +2,7 @@ import fitz
 from db import DB
 from dte import generar_nota_debito_json, generar_nota_remision_json
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
+import dte as dte_module
 
 
 def create_db():
@@ -32,7 +33,7 @@ def _sample_data():
     return venta, detalles
 
 
-def test_generar_nota_debito_json_ticket(tmp_path):
+def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     db = create_db()
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
@@ -47,20 +48,39 @@ def test_generar_nota_debito_json_ticket(tmp_path):
     nota_id = db.cursor.lastrowid
     db.conn.commit()
 
+    monkeypatch.setattr(
+        dte_module,
+        "_build_receptor_direccion",
+        lambda *_: {"departamento": "06", "municipio": "23", "complemento": "DIR"},
+    )
     data = generar_nota_debito_json(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "06"
     assert data["resumen"]["montoTotalOperacion"] > 0
+    assert data["documentoRelacionado"][0]["tipoDocumento"] == "03"
 
 
-def test_generar_nota_remision_json_factura(tmp_path):
+def test_generar_nota_remision_json_factura(tmp_path, monkeypatch):
     db = create_db()
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "",
+        "",
+        "",
+        "",
+        "",
+    )
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro", descuentos=0)
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id, "2024-01-01", 10, "123", "06141990011019", "giro", descuentos=0
+    )
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
     db.cursor.execute(
         "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
@@ -69,9 +89,14 @@ def test_generar_nota_remision_json_factura(tmp_path):
     nota_id = db.cursor.lastrowid
     db.conn.commit()
 
+    monkeypatch.setattr(
+        dte_module,
+        "_build_receptor_direccion",
+        lambda *_: {"departamento": "06", "municipio": "23", "complemento": "DIR"},
+    )
     data = generar_nota_remision_json(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "04"
-    assert data["documentoRelacionado"]["tipoDoc"] == "01"
+    assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
 
 
 def test_nota_debito_pdf(tmp_path):

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -75,6 +75,11 @@ def _load_fc():
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _load_nc():
+    path = Path(__file__).resolve().parent / "goldens" / "nc.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def test_receptor_documentos(monkeypatch):
     monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
     data = _load_fc()
@@ -161,3 +166,31 @@ def test_complemento_opcional():
         }
     )
     assert out["complemento"] is None
+
+
+def test_validar_documento_relacionado(monkeypatch):
+    monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
+    data = _load_nc()
+    data["identificacion"]["version"] = 1
+    data["identificacion"]["tipoDte"] = "01"
+    validate_dte_json(data)
+    data["documentoRelacionado"][0]["tipoDocumento"] = "99"
+    with pytest.raises(ValueError):
+        validate_dte_json(data)
+
+
+def test_validar_otros_documentos(monkeypatch):
+    monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
+    data = _load_fc()
+    data["otrosDocumentos"] = [
+        {
+            "codDocAsociado": 1,
+            "descDocumento": "REF",
+            "detalleDocumento": "DET",
+            "medico": None,
+        }
+    ]
+    validate_dte_json(data)
+    data["otrosDocumentos"][0]["codDocAsociado"] = 99
+    with pytest.raises(ValueError):
+        validate_dte_json(data)

--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -132,6 +132,14 @@ FORMA_PAGO = {
     "04": "Tarjeta",
 }
 
+# Otros Documentos Asociados (CAT-021)
+OTROS_DOCUMENTOS = {
+    1: "Orden de compra",
+    2: "Contrato",
+    3: "Receta médica",
+    4: "Otros",
+}
+
 # Catálogos incompletos: para estos códigos el sistema solicita ingreso manual
 # del usuario en las secciones correspondientes.
 CATALOGOS_INCOMPLETOS = {
@@ -140,7 +148,6 @@ CATALOGOS_INCOMPLETOS = {
     "CAT-014": "Unidad de Medida",
     "CAT-019": "Actividad Económica",
     "CAT-020": "País",
-    "CAT-021": "Otros Documentos Asociados",
     "CAT-023": "Tipo de Documento en Contingencia",
     "CAT-024": "Tipo de Invalidación",
     "CAT-025": "Título de remisión de bienes",


### PR DESCRIPTION
## Summary
- allow passing extension, appendice, related and other documents in DTE generation
- validate referenced DTE type (CAT-002) and other docs (CAT-021)
- update notes generation and tests for new document structures

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a58ca3ee308323931b399900630e36