### PR TITLE
Reaplicar normalización de pagos tras recalcular totales

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1978,6 +1978,35 @@ def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool = False) -> N
     if cambios:
         print("Advertencia: se corrigieron campos de resumen: " + ", ".join(cambios))
 
+    ident = payload.get("identificacion", {})
+    resumen["pagos"] = normalizar_pagos(
+        resumen.get("pagos"),
+        resumen["totalPagar"],
+        tipo_dte=ident.get("tipoDte"),
+        condicion=resumen.get("condicionOperacion", 1),
+    )
+    cond = int(resumen.get("condicionOperacion", 1))
+    if cond == 1 and not resumen.get("pagos"):
+        resumen["pagos"] = [
+            {
+                "codigo": "01",
+                "montoPago": money(D(str(resumen["totalPagar"]))),
+            }
+        ]
+    delta = money(
+        D(str(resumen["totalPagar"]))
+        - sum(D(str(p["montoPago"])) for p in resumen.get("pagos", []))
+    )
+    if resumen.get("pagos") and D("0") < abs(delta) <= D("0.01"):
+        ultimo = resumen["pagos"][-1]
+        ult_monto = D(str(ultimo["montoPago"]))
+        ultimo["montoPago"] = money(ult_monto + delta)
+    elif abs(delta) > D("0.01"):
+        logger.warning(
+            "Pagos no cuadran con totalPagar (|delta|=%s). Se deja que el validador falle.",
+            delta,
+        )
+
     # Verificación de centavos exactos en totales clave
     for k in (
         "totalIva",


### PR DESCRIPTION
## Summary
- Reaplica `normalizar_pagos` con el `totalPagar` corregido y ajusta el último pago si existe una diferencia mínima
- Añade un pago por defecto para ventas al contado cuando no se detallan pagos
- Registra un aviso cuando la suma de pagos difiere de `totalPagar` por más de 0.01

## Testing
- `pytest tests/test_resumen_fc.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a60642356083239aaa923999f60a77