### PR TITLE
fix: avoid double netting for consumer final items

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1028,8 +1028,7 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         iva_tipo = "ninguno"
         if hasattr(self, "iva_checkbox") and self.iva_checkbox.isChecked() and self.iva_desglosado_radio.isChecked():
             iva_tipo = "desglosado"
-            subtotal = subtotal / 1.13  # El precio ingresado incluye IVA
-            precio = round(subtotal / cantidad, 6) if cantidad > 0 else 0
+            # Mantener precio unitario y subtotal brutos; el DTE calculará base e IVA
 
         if descuento_tipo == "%":
             descuento_monto = subtotal * (descuento_valor / 100)
@@ -1073,7 +1072,7 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             "producto_id": lote["producto_id"],
             "producto": lote["nombre"],
             "cantidad": cantidad,
-            "precio": precio,  # Siempre el precio unitario sin IVA si es desglosado
+            "precio": precio,  # Precio unitario con IVA; neto se calcula en DTE
             "descuento": descuento_valor,
             "descuento_tipo": descuento_tipo,
             "descuento_monto": descuento_monto,


### PR DESCRIPTION
## Summary
- keep consumer-final item price gross to let DTE compute base and IVA
- update item recording to store IVA-included unit price
- remove subtotal division when IVA is desglosado so DTE handles all netting

## Testing
- `pytest` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a61fb99578832395374c8783ac12ee