### PR TITLE
Pass DTE type into control number generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1075,8 +1075,9 @@ def recalcular_totales(
     # IVA-FIX END
 
 
-def generar_numero_control(prefijo: str = "DTE-01-S001P001") -> str:
+def generar_numero_control(tipo_dte: str, sucursal: str, punto: str) -> str:
     """Crea un número de control único siguiendo el formato de Hacienda."""
+    prefijo = f"DTE-{str(tipo_dte).zfill(2)}-S{str(sucursal).zfill(3)}P{str(punto).zfill(3)}"
     secuencia = str(uuid.uuid4().int % 10**15).zfill(15)
     return f"{prefijo}-{secuencia}"
 
@@ -1084,6 +1085,7 @@ def generar_numero_control(prefijo: str = "DTE-01-S001P001") -> str:
 def generar_cabecera_dte_data(
     tipo_modelo: int,
     tipo_operacion: int,
+    tipo_dte: str,
     tipo_contingencia: int | None = None,
     motivo_contin: str | None = None,
     ambiente: str = "00",
@@ -1101,8 +1103,15 @@ def generar_cabecera_dte_data(
     else:
         tipo_modelo = 2
 
+    datos = _load_datos_negocio()
+    prefijo = datos.get("dte_api", {}).get("prefijo_control", "")
+    sucursal = "001"
+    punto = "001"
+    m = re.search(r"S(\d{3})P(\d{3})", prefijo)
+    if m:
+        sucursal, punto = m.groups()
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control()
+    numero_control = generar_numero_control(tipo_dte, sucursal, punto)
     fecha_generacion = datetime.now().strftime("%d/%m/%Y, %I:%M %p")
     return {
         "codigo_generacion": codigo_generacion,
@@ -1166,8 +1175,14 @@ def generar_dte_json(
 
     datos = _load_datos_negocio()
 
+    prefijo = datos.get("dte_api", {}).get("prefijo_control", "")
+    sucursal = "001"
+    punto = "001"
+    m = re.search(r"S(\d{3})P(\d{3})", prefijo)
+    if m:
+        sucursal, punto = m.groups()
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control()
+    numero_control = generar_numero_control(tipo_dte, sucursal, punto)
 
     now = datetime.now(TZ_EL_SALVADOR)
     fecha = fecha_emision_hoy_str(now)

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -69,10 +69,13 @@ def generar_factura_electronica_pdf(
         ambiente_cfg = ambiente_cfg.lower()
         ambiente = "01" if ambiente_cfg.startswith("produc") else "00"
 
+    tipo_dte = "01" if tipo_documento.upper() == "CONSUMIDOR FINAL" else "03"
+
     if not codigo_generacion or not numero_control or not fecha_generacion:
         cab = generar_cabecera_dte_data(
             tipo_modelo,
             tipo_operacion,
+            tipo_dte,
             tipo_contingencia=tipo_contingencia,
             motivo_contin=motivo_contin,
             ambiente=ambiente,
@@ -150,7 +153,7 @@ def generar_factura_electronica_pdf(
     qr_value = build_qr_value(
         qr_env,
         codigo_generacion,
-        "01" if tipo_documento.upper() == "CONSUMIDOR FINAL" else "03",
+        tipo_dte,
         numero_control,
     )
     qr_code = qr.QrCodeWidget(qr_value)


### PR DESCRIPTION
## Summary
- require `tipo_dte` when building DTE header data
- generate control number using explicit DTE type, branch and point of sale
- ensure invoice PDF generator supplies the correct `tipo_dte`

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic --no-cov`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a62751b3c88323863556e100ee858a