### PR TITLE
Build DTE control number prefix inside generator

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1208,7 +1208,8 @@ def generar_cabecera_dte_data(
     if m:
         sucursal, punto = m.groups()
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control(tipo_dte, sucursal, punto)
+    prefijo_nc = f"DTE-{tipo_dte}-S{sucursal}P{punto}"
+    numero_control = generar_numero_control(prefijo_nc)
     fecha_generacion = datetime.now().strftime("%d/%m/%Y, %I:%M %p")
     return {
         "codigo_generacion": codigo_generacion,


### PR DESCRIPTION
## Summary
- Build `prefijo_nc` from `tipo_dte`, `sucursal` and `punto` inside `generar_cabecera_dte_data`
- Pass the computed prefix to `generar_numero_control`

## Testing
- `pytest tests/test_dte* tests/test_generar_dte_json.py tests/test_all_dtes.py tests/test_identificacion_xml.py` *(fails: Faltan campos obligatorios en emisor...)*
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic tests/test_generar_dte_json.py::test_generar_dte_json_usa_cod_estable_punto`

------
https://chatgpt.com/codex/tasks/task_e_68a64a50820c832394da2f2912fa2f60