### PR TITLE
Sanitize DTE payloads to drop null fields before transmission

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -83,11 +83,22 @@ def _strip_additional_properties(value, schema):
 def sanitize_dte_payload(data: dict, schema: dict | None = None) -> dict:
     """Return ``data`` excluding properties not allowed by ``schema``.
 
-    When ``schema`` is ``None`` the FC v1 schema is used.
+    Además, de forma recursiva se eliminan las claves cuyo valor sea ``None``.
+    Cuando ``schema`` es ``None`` se usa el esquema ``FC_SCHEMA``.
     """
+
+    def _remove_nulls(value):
+        """Recursively drop keys or items with ``None`` values."""
+        if isinstance(value, dict):
+            return {k: _remove_nulls(v) for k, v in value.items() if v is not None}
+        if isinstance(value, list):
+            return [_remove_nulls(v) for v in value if v is not None]
+        return value
+
     if schema is None:
         schema = FC_SCHEMA
-    return _strip_additional_properties(data, schema)
+    cleaned = _strip_additional_properties(data, schema)
+    return _remove_nulls(cleaned)
 
 
 def apply_schema_patch(data: dict) -> dict:
@@ -2724,6 +2735,8 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
     except ValueError as exc:
         logger.error("ERROR: DTE inválido: %s", exc)
         raise ValueError(f"DTE inválido: {exc}") from exc
+    # Ensure the payload is sanitized and free of ``None`` values before signing
+    data = sanitize_dte_payload(data)
 
     signed = jws.sign_json(data)
 

--- a/tests/test_dte_payload_cleanup.py
+++ b/tests/test_dte_payload_cleanup.py
@@ -1,0 +1,51 @@
+import dte
+
+
+def _has_none(data):
+    if data is None:
+        return True
+    if isinstance(data, dict):
+        return any(_has_none(v) for v in data.values())
+    if isinstance(data, list):
+        return any(_has_none(v) for v in data)
+    return False
+
+
+def test_sanitize_dte_payload_removes_none_recursively(dte_metadata_factory):
+    dte_payload = dte_metadata_factory()
+    dte_payload["emisor"]["codActividad"] = None
+    dte_payload["documentoRelacionado"] = None
+    clean = dte.sanitize_dte_payload(dte_payload)
+    assert "codActividad" not in clean["emisor"]
+    assert "documentoRelacionado" not in clean
+    assert not _has_none(clean)
+
+
+def test_enviar_documento_uses_clean_payload(monkeypatch, dte_metadata_factory):
+    payload = dte_metadata_factory()
+    payload["emisor"]["codActividad"] = None
+    payload["documentoRelacionado"] = None
+
+    captured = {}
+
+    from tests.conftest import make_jws
+
+    def fake_sign(data):
+        captured["data"] = data
+        return make_jws(data)
+
+    monkeypatch.setattr(dte.jws, "sign_json", fake_sign)
+    monkeypatch.setattr(dte.auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(dte, "_post_dte", lambda url, token, jws, meta: {"estado": "Transmitido"})
+    monkeypatch.setattr(dte.auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {})
+
+    class DummyDB:
+        def registrar_envio_dte(self, *args, **kwargs):
+            pass
+
+    dte._enviar_documento(DummyDB(), 1, payload, "normal")
+
+    assert "codActividad" not in captured["data"]["emisor"]
+    assert "documentoRelacionado" not in captured["data"]
+    assert not _has_none(captured["data"])


### PR DESCRIPTION
## Summary
- Strip `None` values from DTE payloads recursively in `sanitize_dte_payload`
- Ensure `_enviar_documento` signs and sends a sanitized payload
- Add tests verifying no null fields are sent in DTE transmission

## Testing
- `pytest tests/test_dte_payload_cleanup.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a64dd402f8832387ae8823c19ed7ad