### PR TITLE
Permitir enviar DTE órfano

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2652,6 +2652,91 @@ def transmitir_dte(
     return resp
 
 
+def _is_jws_token(data) -> bool:
+    """Devuelve ``True`` si ``data`` parece ser un JWS firmado."""
+    if isinstance(data, str):
+        return data.count(".") >= 2
+    if isinstance(data, dict):
+        return all(k in data for k in ("payload", "signature"))
+    return False
+
+
+def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
+    """Transmite un DTE desde ``json_path`` registrando el resultado."""
+    with open(json_path, "r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+
+    if _is_jws_token(raw):
+        if isinstance(raw, dict):
+            jws_token = ".".join(
+                [raw.get("protected", ""), raw.get("payload", ""), raw.get("signature", "")]
+            )
+        else:
+            jws_token = raw
+        payload = _decode_jws_payload(jws_token)
+    else:
+        data = sanitize_dte_payload(raw)
+        data = apply_schema_patch(data)
+        try:
+            validate_dte_json(data)
+        except Exception as exc:
+            errors = _format_validation_errors(exc)
+            raise DTEValidationError(errors, json_path) from exc
+        ident = data.get("identificacion") or data.get("identificador") or {}
+        ident["fecEmi"] = fecha_emision_hoy_str()
+        ident["horEmi"] = datetime.now(TZ_EL_SALVADOR).strftime("%H:%M:%S")
+        if "identificacion" in data:
+            data["identificacion"] = ident
+        elif "identificador" in data:
+            data["identificador"] = ident
+        payload = data
+        jws_token = jws.sign_json(data)
+
+    ident = payload.get("identificacion") or payload.get("identificador") or {}
+    meta = {
+        "ambiente": ident.get("ambiente"),
+        "version": ident.get("version"),
+        "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
+        "codigoGeneracion": ident.get("codigoGeneracion"),
+    }
+    config = _load_dte_api_config()
+    url = config.get("url") or DEFAULT_RECEPCION_URL
+    token = auth.get_token()
+    auth_host = auth.get_last_auth_host()
+    recep_host = urlparse(url).netloc
+    if auth_host and recep_host != auth_host:
+        raise ValueError(
+            f"Host de recepción {recep_host} difiere de autenticación {auth_host}"
+        )
+    try:
+        respuesta = _post_dte(url, token, jws_token, meta)
+        sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
+        estado = (
+            respuesta.get("estado")
+            or respuesta.get("estadoDte")
+            or respuesta.get("descripcionEstado")
+            or "Transmitido"
+        )
+        detalle = respuesta.get("detalle")
+    except Exception:
+        db.registrar_envio_dte(None, "orphan", "Rechazado", "")
+        raise
+
+    db.registrar_envio_dte(
+        None,
+        "orphan",
+        estado,
+        sello,
+        json.dumps(respuesta, ensure_ascii=False),
+    )
+    if estado == "Rechazado":
+        respuesta["errores"] = _parse_error_response(respuesta)
+    res = {"estado": estado, "sello": sello}
+    if detalle:
+        res["detalle"] = detalle
+    return res
+
+
 def enviar_dte_a_hacienda(jws_token: str) -> dict:
     """Transmite un DTE ya firmado (JWS) al entorno de pruebas de Hacienda."""
     url = "https://sandbox.dtes.mh.gob.sv/recepciondte/api/recepciondte"

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -503,7 +503,13 @@ class FacturacionTab(QWidget):
 
     def _update_send_btn(self):
         entry = self._selected_entry()
-        enabled = bool(entry and entry.get("row_type") in ("venta", "ticket"))
+        enabled = False
+        if entry:
+            rtype = entry.get("row_type")
+            if rtype in ("venta", "ticket"):
+                enabled = True
+            elif rtype == "orphan" and entry.get("json") and entry.get("estado") != "Incompleta":
+                enabled = True
         self.btn_enviar.setEnabled(enabled)
 
     def _show_validation_errors(self, errors, json_path):
@@ -541,24 +547,45 @@ class FacturacionTab(QWidget):
                 self._send_invoice_email(venta_id)
             elif entry.get("row_type") == "ticket":
                 self._send_ticket_email(venta_id)
+            elif entry.get("row_type") == "orphan":
+                self._send_orphan_email(entry)
         if dialog.hacienda_cb.isChecked():
-            tipo = "03" if entry.get("row_type") == "ticket" else "01"
-            try:
-                resp = transmitir_dte(self.manager.db, venta_id, tipo_dte=tipo)
-                if resp.get("estado") == "Error":
+            if entry.get("row_type") == "orphan":
+                json_path = entry.get("json")
+                try:
+                    resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
+                    if resp.get("estado") == "Error":
+                        QMessageBox.critical(
+                            self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                        )
+                    else:
+                        QMessageBox.information(
+                            self, "Enviar a Hacienda", "Documento enviado"
+                        )
+                except dte.DTEValidationError as exc:
+                    self._show_validation_errors(exc.errors, exc.json_path)
+                except Exception as exc:
                     QMessageBox.critical(
-                        self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                        self, "Enviar a Hacienda", str(exc)
                     )
-                else:
-                    QMessageBox.information(
-                        self, "Enviar a Hacienda", "Documento enviado"
+            else:
+                tipo = "03" if entry.get("row_type") == "ticket" else "01"
+                try:
+                    resp = transmitir_dte(self.manager.db, venta_id, tipo_dte=tipo)
+                    if resp.get("estado") == "Error":
+                        QMessageBox.critical(
+                            self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                        )
+                    else:
+                        QMessageBox.information(
+                            self, "Enviar a Hacienda", "Documento enviado"
+                        )
+                except dte.DTEValidationError as exc:
+                    self._show_validation_errors(exc.errors, exc.json_path)
+                except Exception as exc:
+                    QMessageBox.critical(
+                        self, "Enviar a Hacienda", str(exc)
                     )
-            except dte.DTEValidationError as exc:
-                self._show_validation_errors(exc.errors, exc.json_path)
-            except Exception as exc:
-                QMessageBox.critical(
-                    self, "Enviar a Hacienda", str(exc)
-                )
 
     def _send_invoice_email(self, venta_id):
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
@@ -619,6 +646,55 @@ class FacturacionTab(QWidget):
             subject,
             body,
             [pdf_path, json_path],
+        )
+        self.email_thread.finished.connect(self._on_email_sent)
+        self.email_thread.start()
+
+    def _send_orphan_email(self, entry):
+        json_path = entry.get("json")
+        pdf_path = entry.get("pdf")
+        dest, ok = QInputDialog.getText(
+            self, "Enviar por correo", "Correo del destinatario:")
+        if not ok or not dest:
+            return
+        if not json_path or not os.path.exists(json_path):
+            QMessageBox.warning(self, "Enviar por correo", "No se encontró el JSON.")
+            return
+        attachments = [json_path]
+        if pdf_path and os.path.exists(pdf_path):
+            attachments.insert(0, pdf_path)
+        else:
+            QMessageBox.warning(
+                self, "Enviar por correo", "No se encontró PDF. Solo se adjuntará el JSON."
+            )
+        creds = {}
+        if os.path.exists(DATOS_NEGOCIO_PATH):
+            try:
+                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+                    creds = json.load(f)
+            except Exception:
+                creds = {}
+        server = creds.get("smtp_server")
+        port = creds.get("smtp_port")
+        user = creds.get("email_usuario")
+        password = os.getenv("INVENTARIO_EMAIL_PASSWORD") or creds.get("email_contrasena")
+        if not all([server, port, user, password]):
+            QMessageBox.warning(self, "Enviar por correo", "Credenciales SMTP incompletas.")
+            return
+        subject = "Factura"
+        body = (
+            "Adjunto se envía la representación gráfica en PDF y el documento firmado en formato JSON"
+        )
+        self.btn_enviar.setEnabled(False)
+        self.email_thread = EmailSender(
+            server,
+            port,
+            user,
+            password,
+            dest,
+            subject,
+            body,
+            attachments,
         )
         self.email_thread.finished.connect(self._on_email_sent)
         self.email_thread.start()

--- a/tests/test_orphan_send.py
+++ b/tests/test_orphan_send.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PyQt5.QtWidgets import QDialog
+
+import dte
+import facturacion_tab
+from db import DB
+from tests.conftest import make_jws
+
+
+def test_transmitir_dte_orphan_signs(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    data = {
+        "identificacion": {
+            "ambiente": "00",
+            "version": "1",
+            "tipoDte": "01",
+            "codigoGeneracion": "ABC",
+        },
+        "resumen": {"totalLetras": "c"},
+    }
+    json_path = tmp_path / "dte.json"
+    json_path.write_text(json.dumps(data))
+    called = {}
+    monkeypatch.setattr(dte, "sanitize_dte_payload", lambda d: called.setdefault("san", True) or d)
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: called.setdefault("patch", True) or d)
+    monkeypatch.setattr(dte, "validate_dte_json", lambda d: called.setdefault("val", True))
+    monkeypatch.setattr(dte.jws, "sign_json", lambda d: called.setdefault("sign", True) or "SIGNED")
+    monkeypatch.setattr(dte.auth, "get_token", lambda: "T")
+    monkeypatch.setattr(dte.auth, "get_last_auth_host", lambda: "example.com")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example.com"})
+    captured = {}
+    def fake_post(url, token, jws_token, meta):
+        captured.update({"jws": jws_token, "meta": meta})
+        return {"estado": "Transmitido", "sello": "S"}
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+    resp = dte.transmitir_dte_orphan(db, str(json_path))
+    assert called["sign"]
+    assert captured["jws"] == "SIGNED"
+    row = db.cursor.execute("SELECT estado, sello FROM dte_envios").fetchone()
+    assert row["estado"] == "Transmitido" and row["sello"] == "S"
+    assert resp["estado"] == "Transmitido"
+
+
+def test_transmitir_dte_orphan_uses_jws(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    token = make_jws({"identificacion": {"ambiente": "00", "version": "1", "tipoDte": "01", "codigoGeneracion": "ABC"}})
+    json_path = tmp_path / "signed.json"
+    json_path.write_text(json.dumps(token))
+    monkeypatch.setattr(dte.jws, "sign_json", lambda d: (_ for _ in ()).throw(RuntimeError("no sign")))
+    monkeypatch.setattr(dte.auth, "get_token", lambda: "T")
+    monkeypatch.setattr(dte.auth, "get_last_auth_host", lambda: "example.com")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example.com"})
+    captured = {}
+    def fake_post(url, token, jws_token, meta):
+        captured["jws"] = jws_token
+        return {"estado": "Transmitido", "sello": "S"}
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+    resp = dte.transmitir_dte_orphan(db, str(json_path))
+    assert captured["jws"] == token
+    row = db.cursor.execute("SELECT estado FROM dte_envios").fetchone()
+    assert row["estado"] == "Transmitido"
+    assert resp["estado"] == "Transmitido"
+
+
+def test_send_orphan_invoice(monkeypatch, qt_app, tmp_path):
+    pdf_path = tmp_path / "20240101_Test_ConsumidorFinal.pdf"
+    pdf_path.write_text("PDF")
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text("{}")
+
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(tmp_path))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "cf"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+    tab = facturacion_tab.FacturacionTab(man)
+    tab.table.selectRow(0)
+    assert tab.btn_enviar.isEnabled()
+
+    class DummyCheck:
+        def __init__(self): self._checked = True
+        def setChecked(self, v): self._checked = v
+        def isChecked(self): return self._checked
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+        def exec_(self):
+            return QDialog.Accepted
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    creds_path = tmp_path / "creds.json"
+    creds_path.write_text(json.dumps({
+        "smtp_server": "s",
+        "smtp_port": 25,
+        "email_usuario": "u",
+        "email_contrasena": "p",
+    }))
+    monkeypatch.setattr(facturacion_tab, "DATOS_NEGOCIO_PATH", str(creds_path))
+
+    monkeypatch.setattr(facturacion_tab.QInputDialog, "getText", lambda *a, **k: ("dest@example.com", True))
+
+    sent = {}
+    class FakeSender:
+        def __init__(self, *args):
+            sent["attachments"] = args[-1]
+            self.finished = SimpleNamespace(connect=lambda fn: setattr(self, "_fn", fn))
+        def start(self):
+            self._fn(True, "ok")
+    monkeypatch.setattr(facturacion_tab, "EmailSender", FakeSender)
+
+    called = {}
+    def fake_transmit(db_, path):
+        called["path"] = path
+        return {"estado": "Transmitido"}
+    monkeypatch.setattr(facturacion_tab.dte, "transmitir_dte_orphan", fake_transmit)
+
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+
+    tab.send_selected_invoice()
+    assert json_path in map(Path, sent["attachments"])
+    assert called["path"] == str(json_path)


### PR DESCRIPTION
## Summary
- Permite transmitir DTEs huérfanos, firmándolos si es necesario y registrando el envío
- Habilita el botón Enviar para archivos órfanos con JSON válido y soporta envío por correo
- Añade pruebas para transmisión y envío de DTEs órfanos

## Testing
- `pytest` *(fails: libGL.so.1 missing, fastapi missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a65feafb388323ad39de2d60caeff8