### PR TITLE
Use dynamic emitter address from saved business data

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -18,6 +18,7 @@ import os
 import shutil
 
 from utils import jws
+from svfe.config import CAT012_DEPARTAMENTOS, CAT013_MUNICIPIOS
 
 getcontext().prec = 4
 
@@ -2907,12 +2908,29 @@ class DatosNegocioDialog(QDialog):
         layout.addLayout(form)
         layout.addLayout(btns)
         self.setLayout(layout)
-        self.btn_guardar.clicked.connect(self.accept)
+        self.btn_guardar.clicked.connect(self._on_save)
         self.btn_cancelar.clicked.connect(self.reject)
         if datos:
             self.set_data(datos)
 
+    def _on_save(self):
+        try:
+            self.get_data()
+        except ValueError as exc:
+            QMessageBox.warning(self, "Validación", str(exc))
+            return
+        self.accept()
+
     def get_data(self):
+        departamento = str(self.departamento.currentData() or "").zfill(2)
+        municipio = str(self.municipio.currentData() or "")
+        complemento = self.complemento.text()
+        if departamento not in CAT012_DEPARTAMENTOS:
+            raise ValueError("Departamento inválido")
+        if municipio not in CAT013_MUNICIPIOS:
+            raise ValueError("Municipio inválido")
+        if not complemento:
+            raise ValueError("Dirección requerida")
         return {
             "nit": self.nit.text(),
             "nrc": self.nrc.text(),
@@ -2925,13 +2943,9 @@ class DatosNegocioDialog(QDialog):
             "telefono": self.telefono.text(),
             "correo": self.correo.text(),
             "direccion": {
-                "departamento": self.departamento.currentData()
-                if self.departamento.currentData() in DEPARTAMENTOS_SET
-                else "",
-                "municipio": self.municipio.currentData()
-                if self.municipio.currentData() in MUNICIPIOS_SET
-                else "",
-                "complemento": self.complemento.text(),
+                "departamento": departamento,
+                "municipio": municipio,
+                "complemento": complemento,
             },
         }
 

--- a/dte.py
+++ b/dte.py
@@ -1374,7 +1374,14 @@ def generar_dte_json(
         "telefono": datos.get("telefono"),
         "correo": datos.get("correo"),
     }
-    emisor["direccion"] = svfe_config.get_emisor_direccion()
+    svfe_config.DATOS_NEGOCIO_PATH = DATOS_NEGOCIO_PATH
+    datos_cfg = svfe_config.load_datos_negocio()
+    dir_emisor = datos_cfg.get("direccion") or {}
+    emisor["direccion"] = {
+        "departamento": str(dir_emisor["departamento"]).zfill(2),
+        "municipio": str(dir_emisor["municipio"]),  # respetar dígitos tal cual
+        "complemento": dir_emisor.get("complemento") or "SIN DIRECCION",
+    }
     emisor.setdefault("codEstableMH", cod_estable)
     emisor.setdefault("codEstable", cod_estable)
     emisor.setdefault("codPuntoVentaMH", cod_punto)
@@ -1852,24 +1859,14 @@ def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool | None = None
     )
     emisor.setdefault("descActividad", negocio.get("descActividad"))
     emisor.setdefault("tipoEstablecimiento", "01")
-    direccion = emisor.get("direccion")
-    if not isinstance(direccion, dict):
-        try:
-            direccion = svfe_config.get_emisor_direccion()
-        except Exception:
-            direccion = {}
-    depto = direccion.get("departamento")
-    if depto is not None:
-        depto = _map_departamento(depto)
-    municipio = direccion.get("municipio")
-    if municipio is not None:
-        municipio = _map_municipio(municipio, depto)
-    direccion = {
-        "departamento": depto,
-        "municipio": municipio,
-        "complemento": direccion.get("complemento"),
+    svfe_config.DATOS_NEGOCIO_PATH = DATOS_NEGOCIO_PATH
+    datos_cfg = svfe_config.load_datos_negocio()
+    dir_emisor = datos_cfg.get("direccion") or {}
+    emisor["direccion"] = {
+        "departamento": str(dir_emisor["departamento"]).zfill(2),
+        "municipio": str(dir_emisor["municipio"]),
+        "complemento": dir_emisor.get("complemento") or "SIN DIRECCION",
     }
-    emisor["direccion"] = direccion
     emisor.setdefault("telefono", negocio.get("telefono"))
     emisor.setdefault("correo", negocio.get("correo"))
     cod_est = str(emisor.get("codEstable") or negocio.get("codEstable") or "0000")

--- a/svfe/config.py
+++ b/svfe/config.py
@@ -4,79 +4,81 @@ import json
 from pathlib import Path
 from typing import Dict
 
-DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(1, 15)}
-MUNICIPIO_RANGES = {
-    "05": ("01", "22"),
-    "06": ("01", "19"),
+from paths import DATOS_NEGOCIO_PATH as _DATOS_NEGOCIO_PATH
+
+# CAT-012 Departamento (strings de 2 dígitos)
+CAT012_DEPARTAMENTOS = {
+    "00","01","02","03","04","05","06","07","08","09","10","11","12","13","14"
 }
 
+# CAT-013 Municipio (tal como lo entrega Hacienda; mantener códigos numéricos tal cual)
+CAT013_MUNICIPIOS = {
+    "00","10","11","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","34","35","36"
+}
 
-def _map_departamento(nombre: str | None) -> str:
-    if nombre is None:
-        raise ValueError("Departamento requerido")
-    nombre = str(nombre)
-    if nombre.isdigit():
-        nombre = nombre.zfill(2)
-    if nombre not in DEPARTAMENTO_CODES:
-        raise ValueError("Departamento inválido")
-    return nombre
+# Exposed path for monkeypatching in tests
+DATOS_NEGOCIO_PATH = _DATOS_NEGOCIO_PATH
 
 
-def _map_municipio(nombre: str | None, departamento: str | None = None) -> str:
-    if nombre is None:
-        raise ValueError("Municipio requerido")
-    nombre = str(nombre)
-    if not nombre.isdigit() or len(nombre) != 2:
-        raise ValueError("Municipio inválido")
-    if departamento:
-        dep_code = _map_departamento(departamento)
-        start, end = MUNICIPIO_RANGES.get(dep_code, ("00", "99"))
-        if nombre < start or nombre > end:
-            raise ValueError("Municipio inválido para el departamento")
-    return nombre
-
-# Path to company configuration holding the emitter address codes
-CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "company.json"
-
-
-def get_emisor_direccion() -> Dict[str, str]:
-    """Return the emitter address configuration.
-
-    The configuration must provide ``departamento`` and ``municipio`` as
-    two-digit strings plus a ``complemento``. If the file is missing or the
-    values do not meet these requirements, ``ValueError`` is raised.
+def load_datos_negocio() -> dict:
+    """
+    Lee paths.DATOS_NEGOCIO_PATH (UTF-8) y retorna el JSON completo.
+    Exige data["direccion"] con:
+      - "departamento": str de 2 dígitos en CAT-012 (incluye "00")
+      - "municipio":   str en CAT-013 (incluye "00"); conservar tal cual (2 o 3 dígitos según catálogo)
+      - "complemento": str no vacío
+    Normaliza:
+      - departamento: str -> zfill(2)
+      - municipio: str -> si es numérico, sin perder dígitos (NO castear a int; NO quitar ceros válidos)
+    Valida contra los catálogos provistos abajo.
+    Si falta algo o es inválido, lanzar ValueError con mensaje claro.
     """
 
+    path = Path(DATOS_NEGOCIO_PATH)
     try:
-        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception as exc:  # pragma: no cover - defensive
-        raise ValueError("Config de dirección del emisor inválida") from exc
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError("datos_negocio.json inválido") from exc
 
-    emisor = data.get("emisor", {})
-    departamento = emisor.get("departamento")
-    municipio = emisor.get("municipio")
-    complemento = emisor.get("complemento")
+    direccion = data.get("direccion")
+    if not isinstance(direccion, dict):
+        raise ValueError("Falta dirección del negocio")
 
-    if (
-        not isinstance(departamento, str)
-        or not isinstance(municipio, str)
-        or not isinstance(complemento, str)
-        or len(departamento) != 2
-        or len(municipio) != 2
-    ):
-        raise ValueError("Config de dirección del emisor inválida")
+    departamento = str(direccion.get("departamento"))
+    municipio = str(direccion.get("municipio"))
+    complemento = direccion.get("complemento")
 
-    try:
-        departamento = _map_departamento(departamento)
-        municipio = _map_municipio(municipio, departamento)
-    except Exception as exc:  # pragma: no cover - invalid codes
-        raise ValueError("Config de dirección del emisor inválida") from exc
+    departamento = departamento.zfill(2)
+    if departamento not in CAT012_DEPARTAMENTOS:
+        raise ValueError("Departamento inválido")
 
-    return {
+    if municipio not in CAT013_MUNICIPIOS:
+        raise ValueError("Municipio inválido")
+
+    if not isinstance(complemento, str) or not complemento:
+        raise ValueError("Complemento inválido")
+
+    data["direccion"] = {
         "departamento": departamento,
         "municipio": municipio,
         "complemento": complemento,
     }
+    return data
 
 
-__all__ = ["get_emisor_direccion", "CONFIG_PATH", "MUNICIPIO_RANGES"]
+def get_emisor_direccion() -> Dict[str, str]:
+    """
+    Wrapper de compatibilidad:
+    return load_datos_negocio()["direccion"]
+    """
+
+    return load_datos_negocio()["direccion"]
+
+
+__all__ = [
+    "load_datos_negocio",
+    "get_emisor_direccion",
+    "CAT012_DEPARTAMENTOS",
+    "CAT013_MUNICIPIOS",
+    "DATOS_NEGOCIO_PATH",
+]

--- a/tests/test_svfe_config.py
+++ b/tests/test_svfe_config.py
@@ -1,44 +1,40 @@
+import json
 import pytest
 
 from svfe import config
 
 
-def test_get_emisor_direccion_valid(monkeypatch, tmp_path):
-    cfg = tmp_path / "company.json"
-    cfg.write_text(
-        '{"emisor":{"departamento":"12","municipio":"34","complemento":"C"}}',
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+def _write(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_load_datos_negocio_valid(monkeypatch, tmp_path):
+    datos = tmp_path / "datos_negocio.json"
+    _write(datos, {"direccion": {"departamento": "01", "municipio": "10", "complemento": "C"}})
+    monkeypatch.setattr(config, "DATOS_NEGOCIO_PATH", datos)
+    assert config.load_datos_negocio()["direccion"] == {
+        "departamento": "01",
+        "municipio": "10",
+        "complemento": "C",
+    }
     assert config.get_emisor_direccion() == {
-        "departamento": "12",
-        "municipio": "34",
+        "departamento": "01",
+        "municipio": "10",
         "complemento": "C",
     }
 
 
-def test_get_emisor_direccion_invalid(monkeypatch, tmp_path):
-    cfg = tmp_path / "company.json"
-    cfg.write_text(
-        '{"emisor":{"departamento":"1","municipio":"34","complemento":"C"}}',
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+def test_load_datos_negocio_invalid(monkeypatch, tmp_path):
+    datos = tmp_path / "datos_negocio.json"
+    _write(datos, {"direccion": {"departamento": "99", "municipio": "10", "complemento": "C"}})
+    monkeypatch.setattr(config, "DATOS_NEGOCIO_PATH", datos)
     with pytest.raises(ValueError):
-        config.get_emisor_direccion()
+        config.load_datos_negocio()
 
 
-def test_get_emisor_direccion_invalid_municipio(monkeypatch, tmp_path):
-    cfg = tmp_path / "company.json"
-    cfg.write_text(
-        '{"emisor":{"departamento":"05","municipio":"99","complemento":"C"}}',
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+def test_load_datos_negocio_invalid_municipio(monkeypatch, tmp_path):
+    datos = tmp_path / "datos_negocio.json"
+    _write(datos, {"direccion": {"departamento": "01", "municipio": "99", "complemento": "C"}})
+    monkeypatch.setattr(config, "DATOS_NEGOCIO_PATH", datos)
     with pytest.raises(ValueError):
-        config.get_emisor_direccion()
-
-
-def test_catalogo_muni_por_depto():
-    assert config.MUNICIPIO_RANGES["05"] == ("01", "22")
-    assert config.MUNICIPIO_RANGES["06"] == ("01", "19")
+        config.load_datos_negocio()


### PR DESCRIPTION
## Summary
- load and validate business address codes from `datos_negocio.json`
- ensure DTE emitter pulls address saved via UI
- validate address fields in DatosNegocioDialog before saving

## Testing
- `python -m py_compile svfe/config.py dte.py dialogs.py tests/test_svfe_config.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a65e48fc9083238899662e892d213b