### PR TITLE
Add button to transmit standalone DTE JSON

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -156,6 +156,7 @@ class FacturacionTab(QWidget):
         self.btn_estado = QPushButton("Estado")
         self.btn_enviar = QPushButton("Enviar")
         self.btn_enviar.setEnabled(False)
+        self.btn_enviar_json = QPushButton("Enviar JSON...")
         self.btn_eliminar = QPushButton("Eliminar")
         self.btn_eliminar.setStyleSheet(
             "background-color: #b71c1c; color: #fff; border-radius: 6px;"
@@ -165,6 +166,7 @@ class FacturacionTab(QWidget):
         btns.addWidget(self.btn_debito)
         btns.addWidget(self.btn_estado)
         btns.addWidget(self.btn_enviar)
+        btns.addWidget(self.btn_enviar_json)
         btns.addWidget(self.btn_eliminar)
         btns.addStretch(1)
         left_layout.addLayout(btns)
@@ -194,6 +196,7 @@ class FacturacionTab(QWidget):
         self.btn_debito.clicked.connect(lambda: self.create_nota("debito"))
         self.btn_estado.clicked.connect(self.change_estado)
         self.btn_enviar.clicked.connect(self.send_selected_invoice)
+        self.btn_enviar_json.clicked.connect(self.send_json)
         self.btn_eliminar.clicked.connect(self.delete_files)
 
     def _toggle_date_filter(self, checked):
@@ -586,6 +589,37 @@ class FacturacionTab(QWidget):
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", str(exc)
                     )
+
+    def send_json(self):
+        fname, _ = QFileDialog.getOpenFileName(
+            self,
+            "Seleccionar JSON",
+            "",
+            "JSON (*.json)",
+            options=QFileDialog.DontUseNativeDialog,
+        )
+        if not fname:
+            return
+        try:
+            with open(fname, "r", encoding="utf-8") as fh:
+                json.load(fh)
+        except Exception as exc:
+            QMessageBox.critical(self, "Enviar a Hacienda", f"Error al leer JSON: {exc}")
+            return
+        try:
+            resp = dte.transmitir_dte_orphan(self.manager.db, fname)
+            if resp.get("estado") == "Error":
+                QMessageBox.critical(
+                    self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                )
+            else:
+                QMessageBox.information(
+                    self, "Enviar a Hacienda", "Documento enviado"
+                )
+        except dte.DTEValidationError as exc:
+            self._show_validation_errors(exc.errors, exc.json_path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Enviar a Hacienda", str(exc))
 
     def _send_invoice_email(self, venta_id):
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)

--- a/tests/test_send_json.py
+++ b/tests/test_send_json.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import facturacion_tab
+from db import DB
+
+
+def test_send_json_success(monkeypatch, qt_app, tmp_path):
+    json_path = tmp_path / "doc.json"
+    json_path.write_text("{}")
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+
+    monkeypatch.setattr(
+        facturacion_tab.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: (str(json_path), None),
+    )
+
+    called = {}
+
+    def fake_transmit(db_, path):
+        called["path"] = path
+        return {"estado": "Transmitido"}
+
+    monkeypatch.setattr(facturacion_tab.dte, "transmitir_dte_orphan", fake_transmit)
+    infos = {}
+    monkeypatch.setattr(
+        facturacion_tab.QMessageBox,
+        "information",
+        lambda *a, **k: infos.setdefault("called", True),
+    )
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+
+    tab.send_json()
+
+    assert called["path"] == str(json_path)
+    assert "called" in infos
+
+
+def test_send_json_invalid(monkeypatch, qt_app, tmp_path):
+    json_path = tmp_path / "doc.json"
+    json_path.write_text("{ invalid")
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+
+    monkeypatch.setattr(
+        facturacion_tab.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: (str(json_path), None),
+    )
+
+    called = {}
+    monkeypatch.setattr(
+        facturacion_tab.dte,
+        "transmitir_dte_orphan",
+        lambda *a, **k: called.setdefault("called", True),
+    )
+    crit = {}
+    monkeypatch.setattr(
+        facturacion_tab.QMessageBox,
+        "critical",
+        lambda *a, **k: crit.setdefault("called", True),
+    )
+
+    tab.send_json()
+
+    assert "called" in crit
+    assert "called" not in called


### PR DESCRIPTION
## Summary
- add "Enviar JSON" button to Facturación tab
- allow transmitting standalone DTE JSON files and report success or errors
- add tests for sending JSON files via the new button

## Testing
- `pytest tests/test_send_json.py`
- `pytest` *(fails: ERROR tests/test_contingencia_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a6673b5a788323b6db3c91c30a41ec