### PR TITLE
feat: enable sending JWS files

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -156,7 +156,7 @@ class FacturacionTab(QWidget):
         self.btn_estado = QPushButton("Estado")
         self.btn_enviar = QPushButton("Enviar")
         self.btn_enviar.setEnabled(False)
-        self.btn_enviar_json = QPushButton("Enviar JSON...")
+        self.btn_enviar_jws = QPushButton("Enviar JWS...")
         self.btn_eliminar = QPushButton("Eliminar")
         self.btn_eliminar.setStyleSheet(
             "background-color: #b71c1c; color: #fff; border-radius: 6px;"
@@ -166,7 +166,7 @@ class FacturacionTab(QWidget):
         btns.addWidget(self.btn_debito)
         btns.addWidget(self.btn_estado)
         btns.addWidget(self.btn_enviar)
-        btns.addWidget(self.btn_enviar_json)
+        btns.addWidget(self.btn_enviar_jws)
         btns.addWidget(self.btn_eliminar)
         btns.addStretch(1)
         left_layout.addLayout(btns)
@@ -196,7 +196,7 @@ class FacturacionTab(QWidget):
         self.btn_debito.clicked.connect(lambda: self.create_nota("debito"))
         self.btn_estado.clicked.connect(self.change_estado)
         self.btn_enviar.clicked.connect(self.send_selected_invoice)
-        self.btn_enviar_json.clicked.connect(self.send_json)
+        self.btn_enviar_jws.clicked.connect(self.send_jws)
         self.btn_eliminar.clicked.connect(self.delete_files)
 
     def _toggle_date_filter(self, checked):
@@ -590,27 +590,38 @@ class FacturacionTab(QWidget):
                         self, "Enviar a Hacienda", str(exc)
                     )
 
-    def send_json(self):
+    def send_jws(self):
         fname, _ = QFileDialog.getOpenFileName(
             self,
-            "Seleccionar JSON",
+            "Seleccionar JWS",
             "",
-            "JSON (*.json)",
+            "JWS (*.jws *.json)",
             options=QFileDialog.DontUseNativeDialog,
         )
         if not fname:
             return
         try:
             with open(fname, "r", encoding="utf-8") as fh:
-                json.load(fh)
+                content = fh.read()
         except Exception as exc:
-            QMessageBox.critical(self, "Enviar a Hacienda", f"Error al leer JSON: {exc}")
+            QMessageBox.critical(self, "Enviar a Hacienda", f"Error al leer archivo: {exc}")
             return
+
+        is_json = True
         try:
-            resp = dte.transmitir_dte_orphan(self.manager.db, fname)
-            if resp.get("estado") == "Error":
+            json.loads(content)
+        except Exception:
+            is_json = False
+
+        try:
+            if is_json:
+                resp = dte.transmitir_dte_orphan(self.manager.db, fname)
+            else:
+                resp = dte.enviar_dte_a_hacienda(content)
+
+            if resp.get("estado") in ("Error", "Rechazado"):
                 QMessageBox.critical(
-                    self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                    self, "Enviar a Hacienda", resp.get("detalle") or resp.get("errores", "Error")
                 )
             else:
                 QMessageBox.information(

--- a/tests/test_send_jws.py
+++ b/tests/test_send_jws.py
@@ -1,14 +1,45 @@
-import json
-from pathlib import Path
 from types import SimpleNamespace
-
-import pytest
 
 import facturacion_tab
 from db import DB
 
 
-def test_send_json_success(monkeypatch, qt_app, tmp_path):
+def test_send_jws_token(monkeypatch, qt_app, tmp_path):
+    jws_path = tmp_path / "doc.jws"
+    token = "header.payload.signature"
+    jws_path.write_text(token)
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+
+    monkeypatch.setattr(
+        facturacion_tab.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: (str(jws_path), None),
+    )
+
+    called = {}
+
+    def fake_send(token_):
+        called["token"] = token_
+        return {"estado": "Transmitido"}
+
+    monkeypatch.setattr(facturacion_tab.dte, "enviar_dte_a_hacienda", fake_send)
+    infos = {}
+    monkeypatch.setattr(
+        facturacion_tab.QMessageBox,
+        "information",
+        lambda *a, **k: infos.setdefault("called", True),
+    )
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+
+    tab.send_jws()
+
+    assert called["token"] == token
+    assert "called" in infos
+
+
+def test_send_jws_json(monkeypatch, qt_app, tmp_path):
     json_path = tmp_path / "doc.json"
     json_path.write_text("{}")
     db = DB(":memory:")
@@ -36,39 +67,8 @@ def test_send_json_success(monkeypatch, qt_app, tmp_path):
     )
     monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
 
-    tab.send_json()
+    tab.send_jws()
 
     assert called["path"] == str(json_path)
     assert "called" in infos
 
-
-def test_send_json_invalid(monkeypatch, qt_app, tmp_path):
-    json_path = tmp_path / "doc.json"
-    json_path.write_text("{ invalid")
-    db = DB(":memory:")
-    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
-    tab = facturacion_tab.FacturacionTab(man)
-
-    monkeypatch.setattr(
-        facturacion_tab.QFileDialog,
-        "getOpenFileName",
-        lambda *a, **k: (str(json_path), None),
-    )
-
-    called = {}
-    monkeypatch.setattr(
-        facturacion_tab.dte,
-        "transmitir_dte_orphan",
-        lambda *a, **k: called.setdefault("called", True),
-    )
-    crit = {}
-    monkeypatch.setattr(
-        facturacion_tab.QMessageBox,
-        "critical",
-        lambda *a, **k: crit.setdefault("called", True),
-    )
-
-    tab.send_json()
-
-    assert "called" in crit
-    assert "called" not in called


### PR DESCRIPTION
## Summary
- rename JSON send button to JWS and hook up new `send_jws`
- implement JWS/JSON dispatcher to send tokens or files as needed
- add tests for `send_jws` handling of JWS tokens and JSON documents

## Testing
- `pytest tests/test_send_jws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66e15f4388323a7989bb28200efb7