### PR TITLE
Ensure stable JSON serialization for DTE signing

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from db import DB
 import requests
 from utils import jws
+from utils.stable_json import stable_stringify, save_file
 import auth
 from jsonschema import ValidationError, RefResolver
 from utils import catalogos
@@ -2406,11 +2407,10 @@ def _assert_no_ejemplo(path: str) -> None:
 
 def _write_json(path: str, data):
     _assert_no_ejemplo(path)
-    with open(path, "w", encoding="utf-8") as fh:
-        if isinstance(data, str):
-            fh.write(data)
-        else:
-            json.dump(data, fh, ensure_ascii=False)
+    if isinstance(data, str):
+        save_file(path, data, add_final_newline=not path.endswith(".jws"))
+    else:
+        save_file(path, stable_stringify(data, indent=2))
 
 
 def _save_signed_dte(dte_data: dict, jws_token: str) -> None:

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -156,12 +156,8 @@ def generate_invoice_pdf(manager, venta_id):
         tipo_contingencia=tipo_contingencia,
         motivo_contin=motivo_contin,
     )
-    with open(json_path, 'w', encoding='utf-8') as fh:
-        json.dump(json_data, fh, ensure_ascii=False, indent=2)
     if tipo_operacion == 2:
         manager.db.add_dte_pendiente(venta_id, json_data, str(tipo_operacion))
-    if not os.path.exists(json_path):
-        raise IOError(f"No se pudo guardar JSON en {json_path}")
     try:
         resumen = json_data.get("resumen", {})
         condicion = normalize_condicion_operacion(
@@ -177,6 +173,8 @@ def generate_invoice_pdf(manager, venta_id):
         sign_and_save(json_data, json_path)
     except Exception:
         pass
+    if not os.path.exists(json_path):
+        raise IOError(f"No se pudo guardar JSON en {json_path}")
     manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
     return file_path
 
@@ -215,10 +213,6 @@ def generate_ticket_pdf(manager, venta_id):
         if not venta_data.get("numero_control"):
             venta_data["numero_control"] = uuid.uuid4().hex[:8].upper()
         ticket_json = build_invoice_json(venta_data, cliente or {}, detalles)
-    with open(json_path, "w", encoding="utf-8") as fh:
-        json.dump(ticket_json, fh, ensure_ascii=False, indent=2)
-    if not os.path.exists(json_path):
-        raise IOError(f"No se pudo guardar JSON en {json_path}")
     try:
         resumen = ticket_json.get("resumen", {})
         condicion = normalize_condicion_operacion(
@@ -234,5 +228,7 @@ def generate_ticket_pdf(manager, venta_id):
         sign_and_save(ticket_json, json_path)
     except Exception:
         pass
+    if not os.path.exists(json_path):
+        raise IOError(f"No se pudo guardar JSON en {json_path}")
     manager.db.add_ticket_pdf(venta_id, filename)
     return filename

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -4,6 +4,13 @@ import base64
 import requests
 import logging
 
+from utils.stable_json import (
+    stable_stringify,
+    save_file,
+    assert_same_payload,
+    validar_montos,
+)
+
 logger = logging.getLogger(__name__)
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config_negocio.json")
 DEFAULT_SIGN_URL = "http://127.0.0.1:8080/firma/firmardocumento/"
@@ -76,11 +83,13 @@ def _ensure_cert_file(nit: str) -> None:
 
 
 def sign_json(
-    payload: dict,
+    payload: dict | str,
     nit: str | None = None,
     passwordPri: str | None = None,
     activo: bool = True,
     url: str | None = None,
+    version: str | None = None,
+    tipo_dte: str | None = None,
 ) -> str:
     """Sign ``payload`` using the external ``svfe-api-firmador`` service."""
     if nit is None or passwordPri is None:
@@ -89,14 +98,22 @@ def sign_json(
         raise RuntimeError("NIT del certificado no configurado")
     _ensure_cert_file(nit)
     url = url or _get_sign_url()
-    ident = payload.get("identificacion", {})
-    version = ident.get("version")
-    tipo_dte = ident.get("tipoDte")
+    if isinstance(payload, str):
+        payload_str = payload
+    else:
+        payload_dict = payload
+        payload_str = stable_stringify(payload_dict)
+        if version is None or tipo_dte is None:
+            ident = payload_dict.get("identificacion", {})
+            if version is None:
+                version = ident.get("version")
+            if tipo_dte is None:
+                tipo_dte = ident.get("tipoDte")
     body = {
         "nit": nit,
         "activo": activo,
         "passwordPri": passwordPri,
-        "dteJson": payload,
+        "dteJson": payload_str,
     }
     if version is not None:
         body["version"] = version
@@ -106,10 +123,8 @@ def sign_json(
         response = requests.post(url, json=body, timeout=SIGN_TIMEOUT)
         status_code = getattr(response, "status_code", "N/A")
         resp_text = getattr(response, "text", "")
-        print(status_code)
-        print(resp_text)
         if isinstance(status_code, int) and status_code >= 400:
-            logger.error("Respuesta del firmador %s: %s", status_code, resp_text)
+            logger.error("Respuesta del firmador %s", status_code)
         else:
             logger.debug("Respuesta del firmador %s: %s", status_code, resp_text)
         response.raise_for_status()
@@ -136,9 +151,31 @@ def sign_and_save(
     activo: bool = True,
     url: str | None = None,
 ) -> str:
-    """Sign ``payload`` and store the JWS next to ``json_path``."""
-    token = sign_json(payload, nit, passwordPri, activo, url)
+    """Sign ``payload`` and store both JSON and JWS files.
+
+    The JSON written to ``json_path`` uses a stable alphabetical key order
+    and indentation for readability.  The external signer receives the
+    compact representation without indentation ensuring both outputs are
+    derived from the same serialized string.
+    """
+    json_pretty = stable_stringify(payload, indent=2)
+    save_file(json_path, json_pretty)
+    if os.getenv("STABLE_JSON_CHECK") == "1":
+        validar_montos(payload)
+        assert_same_payload(payload)
+    payload_compact = stable_stringify(payload)
+    ident = payload.get("identificacion", {})
+    version = ident.get("version")
+    tipo_dte = ident.get("tipoDte")
+    token = sign_json(
+        payload_compact,
+        nit,
+        passwordPri,
+        activo,
+        url,
+        version=version,
+        tipo_dte=tipo_dte,
+    )
     jws_path = os.path.splitext(json_path)[0] + ".jws"
-    with open(jws_path, "w", encoding="utf-8") as fh:
-        fh.write(token)
+    save_file(jws_path, token, add_final_newline=False)
     return jws_path

--- a/utils/stable_json.py
+++ b/utils/stable_json.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Iterator, Tuple
+
+
+def stable_stringify(value: Any, indent: int | None = None) -> str:
+    """Serialize ``value`` to JSON with stable alphabetical key order.
+
+    The function normalizes ``value`` by sorting dictionary keys
+    recursively. ``indent`` controls pretty-printing; when ``None`` the
+    result is compact without extra spaces.  Cyclic references raise
+    ``ValueError``.
+    """
+
+    seen: set[int] = set()
+
+    def order(obj: Any) -> Any:
+        if obj is None:
+            return obj
+        if not isinstance(obj, (dict, list)):
+            return obj
+        oid = id(obj)
+        if oid in seen:
+            raise ValueError("Ciclo detectado en JSON")
+        seen.add(oid)
+        if isinstance(obj, list):
+            return [order(item) for item in obj]
+        return {k: order(obj[k]) for k in sorted(obj)}
+
+    normalized = order(value)
+    if indent is None:
+        return json.dumps(
+            normalized,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            default=_json_default,
+        )
+    return json.dumps(
+        normalized,
+        ensure_ascii=False,
+        indent=indent,
+        default=_json_default,
+    )
+
+
+def _json_default(obj: Any) -> float:
+    if isinstance(obj, Decimal):
+        return float(obj.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP))
+    raise TypeError(f"Tipo no serializable: {type(obj)}")
+
+
+def _sha256(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def assert_same_payload(dte: dict) -> None:
+    compact = stable_stringify(dte)
+    recompact = stable_stringify(json.loads(compact))
+    if _sha256(compact) != _sha256(recompact):
+        raise RuntimeError("JSON no estable al re-serializar (no determinista)")
+    pretty = stable_stringify(dte, indent=2)
+    if _sha256(stable_stringify(json.loads(pretty))) != _sha256(compact):
+        raise RuntimeError("El JSON guardado difiere del payload firmado (estructura)")
+
+
+def _walk(prefix: str, obj: Any) -> Iterator[Tuple[str, Any]]:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            new_prefix = f"{prefix}.{k}" if prefix else k
+            yield from _walk(new_prefix, v)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            new_prefix = f"{prefix}[{i}]"
+            yield from _walk(new_prefix, v)
+    else:
+        yield prefix, obj
+
+
+def validar_montos(dte_dict: Any) -> None:
+    for clave, valor in _walk("", dte_dict):
+        if isinstance(valor, Decimal):
+            if (valor * 10) % 1 != 0:
+                raise ValueError(f"El campo {clave} = {valor} no es múltiplo de 0.1")
+
+
+def save_file(path: str, content: str, add_final_newline: bool = True) -> None:
+    """Persist ``content`` to ``path`` atomically using UTF-8 encoding.
+
+    ``add_final_newline`` controls whether a trailing newline is appended
+    when missing. JWS outputs should pass ``False`` to avoid altering the
+    token.
+    """
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8", newline="\n") as fh:
+        if add_final_newline and not content.endswith("\n"):
+            fh.write(content + "\n")
+        else:
+            fh.write(content)
+    os.replace(tmp, path)


### PR DESCRIPTION
## Summary
- normalize Decimal values to 1-decimal floats using `ROUND_HALF_UP` during stable JSON serialization
- add optional payload and monetary validations when `STABLE_JSON_CHECK=1`
- avoid logging signer response bodies on errors to keep JWS tokens out of logs

## Testing
- `python -m py_compile utils/stable_json.py utils/jws.py utils/doc_generation.py dte.py`
- `pytest` *(fails: ImportError: libGL.so.1; ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a6739eaa708323b3f3530ca2959e3c