### PR TITLE
Ensure stable signing and newline-free JWS output

### DIFF
--- a/tests/test_dtejson_object.py
+++ b/tests/test_dtejson_object.py
@@ -1,0 +1,30 @@
+import os
+
+import utils.jws as jws
+
+
+def test_sign_json_sends_dtejson_as_object(monkeypatch):
+    monkeypatch.setenv("SEND_DTEJSON_AS_OBJECT", "1")
+    monkeypatch.setattr(jws, "SEND_DTEJSON_AS_OBJECT", True)
+    monkeypatch.setattr(jws, "_ensure_cert_file", lambda nit: None)
+
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["json"] = json
+        class R:
+            status_code = 200
+            text = "OK"
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"status": "OK", "body": "<JWS>"}
+        return R()
+
+    monkeypatch.setattr(jws.requests, "post", fake_post)
+
+    payload = '{"identificacion":{"version":"1","tipoDte":"01"}}'
+    token = jws.sign_json(payload, nit="X", passwordPri="Y")
+
+    assert token == "<JWS>"
+    assert isinstance(captured["json"]["dteJson"], dict)

--- a/tests/test_jws_no_newline.py
+++ b/tests/test_jws_no_newline.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from utils.jws import sign_and_save
+
+
+def test_sign_and_save_writes_jws_without_newline(monkeypatch, tmp_path):
+    """Ensure sign_and_save writes JWS files without a trailing newline."""
+    payload = {"identificacion": {"version": 1, "tipoDte": "01"}}
+
+    def fake_sign_json(*args, **kwargs):
+        return "TOKEN\n"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign_json)
+
+    json_path = tmp_path / "payload.json"
+    jws_path = Path(sign_and_save(payload, str(json_path)))
+
+    content = jws_path.read_bytes()
+    assert content == b"TOKEN"
+    assert not content.endswith(b"\n"), "JWS file should not end with a newline"

--- a/tests/test_stable_stringify.py
+++ b/tests/test_stable_stringify.py
@@ -1,0 +1,20 @@
+import pytest
+from decimal import Decimal
+
+from utils.stable_json import stable_stringify
+
+
+@pytest.mark.parametrize("value,expected", [
+    (10.1, '{"monto":10.1}'),
+    (10.2, '{"monto":10.2}'),
+    (10.3, '{"monto":10.3}'),
+    (10.4, '{"monto":10.4}'),
+])
+def test_stable_stringify_handles_float_precisely(value, expected):
+    """stable_stringify must not introduce floating point artifacts."""
+    assert stable_stringify({"monto": value}) == expected
+
+
+def test_stable_stringify_handles_decimal():
+    """Decimals should serialize to a single decimal place without artifacts."""
+    assert stable_stringify({"monto": Decimal("10.3")}) == '{"monto":10.3}'

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -14,7 +14,9 @@ from utils.stable_json import (
 logger = logging.getLogger(__name__)
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config_negocio.json")
 DEFAULT_SIGN_URL = "http://127.0.0.1:8080/firma/firmardocumento/"
-SIGN_TIMEOUT = 10
+SIGN_TIMEOUT = float(os.getenv("SIGN_TIMEOUT", "10"))
+
+SEND_DTEJSON_AS_OBJECT = os.getenv("SEND_DTEJSON_AS_OBJECT", "1") == "1"
 
 # Directory where the signing service expects certificate files (.crt)
 # Allow overriding via environment variable and strip any hidden characters.
@@ -98,27 +100,35 @@ def sign_json(
         raise RuntimeError("NIT del certificado no configurado")
     _ensure_cert_file(nit)
     url = url or _get_sign_url()
+
     if isinstance(payload, str):
         payload_str = payload
+        try:
+            payload_obj = json.loads(payload_str)
+        except Exception as exc:
+            raise ValueError("payload_str no es JSON válido") from exc
     else:
-        payload_dict = payload
-        payload_str = stable_stringify(payload_dict)
-        if version is None or tipo_dte is None:
-            ident = payload_dict.get("identificacion", {})
-            if version is None:
-                version = ident.get("version")
-            if tipo_dte is None:
-                tipo_dte = ident.get("tipoDte")
+        payload_obj = payload
+        payload_str = stable_stringify(payload_obj)
+
+    if (version is None or tipo_dte is None) and isinstance(payload_obj, dict):
+        ident = payload_obj.get("identificacion", {})
+        if version is None:
+            version = ident.get("version")
+        if tipo_dte is None:
+            tipo_dte = ident.get("tipoDte")
+
     body = {
         "nit": nit,
         "activo": activo,
         "passwordPri": passwordPri,
-        "dteJson": payload_str,
+        "dteJson": payload_obj if SEND_DTEJSON_AS_OBJECT else payload_str,
     }
     if version is not None:
         body["version"] = version
     if tipo_dte is not None:
         body["tipoDte"] = tipo_dte
+
     try:
         response = requests.post(url, json=body, timeout=SIGN_TIMEOUT)
         status_code = getattr(response, "status_code", "N/A")
@@ -135,6 +145,7 @@ def sign_json(
         raise RuntimeError(f"Error HTTP {status} al firmar: {exc.response.text}") from exc
     except requests.RequestException as exc:
         raise RuntimeError(f"Error al firmar: {exc}") from exc
+
     data = response.json()
     if isinstance(data, dict):
         if data.get("status") == "OK":
@@ -159,11 +170,11 @@ def sign_and_save(
     derived from the same serialized string.
     """
     json_pretty = stable_stringify(payload, indent=2)
+    payload_compact = stable_stringify(payload)
     save_file(json_path, json_pretty)
     if os.getenv("STABLE_JSON_CHECK") == "1":
         validar_montos(payload)
         assert_same_payload(payload)
-    payload_compact = stable_stringify(payload)
     ident = payload.get("identificacion", {})
     version = ident.get("version")
     tipo_dte = ident.get("tipoDte")
@@ -176,6 +187,7 @@ def sign_and_save(
         version=version,
         tipo_dte=tipo_dte,
     )
+    token = token.rstrip("\n")
     jws_path = os.path.splitext(json_path)[0] + ".jws"
     save_file(jws_path, token, add_final_newline=False)
     return jws_path


### PR DESCRIPTION
## Summary
- strip trailing newline before saving JWS files and keep signer responses in debug-only logs
- derive pretty and compact JSON from the same source so signed payloads match stored JSON
- send `dteJson` as a JSON object to avoid conversion errors and add regression tests
- add tests ensuring `stable_stringify` serializes decimals without artifacts and `.jws` files lack trailing newlines

## Testing
- `python -m py_compile utils/jws.py`
- `pytest tests/test_stable_stringify.py -q --no-cov`
- `pytest tests/test_jws_no_newline.py -q --no-cov`
- `pytest tests/test_envio_hacienda.py::test_transmision_exitosa -q --no-cov`
- `pytest tests/test_dtejson_object.py -q --no-cov`
- `pytest tests/test_send_jws.py -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a68b59affc8323a08ddc517de5cc4a