### PR TITLE
Refactor save workflow for invoices

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -29,8 +29,6 @@ from factura_sv import generar_factura_electronica_pdf
 from utils.email_sender import EmailSender
 from utils.email_builder import build_email
 from dialogs import ManualInvoiceDialog
-from dte import transmitir_dte
-import dte
 from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
 import tempfile
 import subprocess
@@ -129,11 +127,11 @@ class SalesTab(QWidget):
         preview_layout.addWidget(self.info_label)
 
         btn_layout = QHBoxLayout()
-        self.btn_guardar = QPushButton("Guardar y enviar")
+        self.btn_guardar = QPushButton("Guardar factura")
         self.btn_enviar = QPushButton("Solo enviar por correo")
         btn_layout.addWidget(self.btn_guardar)
         btn_layout.addWidget(self.btn_enviar)
-        self.btn_guardar.clicked.connect(self.save_and_send)
+        self.btn_guardar.clicked.connect(self.save_invoice)
         self.btn_enviar.clicked.connect(self.send_email)
         preview_layout.addLayout(btn_layout)
 
@@ -522,38 +520,20 @@ class SalesTab(QWidget):
     def _generate_ticket_pdf(self, venta_id):
         return generate_ticket_pdf(self.manager, venta_id)
 
-    def _show_validation_errors(self, errors, json_path):
-        msg = QMessageBox(self)
-        msg.setWindowTitle("Enviar a Hacienda")
-        msg.setIcon(QMessageBox.Warning)
-        msg.setText("El DTE contiene errores de validación:")
-        msg.setInformativeText("\n".join(f"- {e}" for e in errors))
-        open_btn = msg.addButton("Abrir reporte", QMessageBox.ActionRole)
-        msg.addButton(QMessageBox.Close)
-        msg.exec_()
-        if msg.clickedButton() == open_btn and json_path:
-            report_path = os.path.splitext(json_path)[0] + ".md"
-            with open(report_path, "w", encoding="utf-8") as fh:
-                fh.write("# Errores de validación\n\n")
-                for e in errors:
-                    fh.write(f"- {e}\n")
-            QDesktopServices.openUrl(QUrl.fromLocalFile(report_path))
-
-    def save_and_send(self):
-        """Generate the document for the selected sale and transmit it."""
+    def save_invoice(self):
+        """Generate and store the document for the selected sale."""
         if self.sales_table.currentRow() < 0:
-            QMessageBox.warning(self, "Guardar y enviar", "Seleccione una venta primero.")
+            QMessageBox.warning(self, "Guardar factura", "Seleccione una venta primero.")
             return
 
         row = self.sales_table.currentRow()
         venta_id = int(self.sales_table.item(row, 0).text())
         venta = self.manager.db.get_venta_by_id(venta_id)
         if not venta or int(venta.get("id", 0)) != venta_id:
-            QMessageBox.warning(self, "Guardar y enviar", "No se encontró la venta seleccionada.")
+            QMessageBox.warning(self, "Guardar factura", "No se encontró la venta seleccionada.")
             return
         credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
         doc_type = "Factura"
-        tipo_dte = "01"
         if not credito_info and not venta.get("cliente_id"):
             box = QMessageBox(self)
             box.setWindowTitle("Tipo de documento")
@@ -566,7 +546,6 @@ class SalesTab(QWidget):
             if clicked == ticket_btn:
                 file_path = self._generate_ticket_pdf(venta_id)
                 doc_type = "Ticket"
-                tipo_dte = "03"
             elif clicked == factura_btn:
                 file_path = self._generate_invoice_pdf(venta_id)
             else:
@@ -574,65 +553,9 @@ class SalesTab(QWidget):
         else:
             file_path = self._generate_invoice_pdf(venta_id)
         if not file_path:
-            QMessageBox.warning(self, "Guardar y enviar", "No se pudo generar el documento.")
+            QMessageBox.warning(self, "Guardar factura", "No se pudo generar el documento.")
             return
-        QMessageBox.information(self, "Guardar y enviar", f"{doc_type} guardado en {file_path}")
-        modo = venta.get("modo_transmision")
-        if modo is None:
-            try:
-                with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
-                    cfg = json.load(fh)
-                modo = cfg.get("dte_api", {}).get("modo_transmision")
-            except Exception:
-                modo = None
-        modo = (
-            "contingencia"
-            if isinstance(modo, str) and "contingencia" in modo.lower()
-            else "normal"
-        )
-        if modo == "contingencia":
-            QMessageBox.information(
-                self,
-                "Guardar y enviar",
-                "Modo contingencia: el DTE no se enviará a Hacienda.",
-            )
-        envio_ok = False
-        try:
-            resp = transmitir_dte(
-                self.manager.db, venta_id, modo=modo, tipo_dte=tipo_dte
-            )
-            estado = (resp or {}).get("estado", "")
-            if estado.lower() in ("rechazado", "error"):
-                self.status_label.setText("Estado actual: Error")
-                self.gen_label.setText(
-                    "Generado: " + datetime.now().strftime("%Y-%m-%d %H:%M")
-                )
-                if estado.lower() == "error":
-                    QMessageBox.warning(
-                        self, "Enviar a Hacienda", resp.get("detalle", "Error")
-                    )
-            else:
-                self.status_label.setText("Estado actual: Enviado")
-                self.sent_label.setText(
-                    "Último envío: " + datetime.now().strftime("%Y-%m-%d %H:%M")
-                )
-                envio_ok = True
-        except dte.DTEValidationError as e:
-            self.status_label.setText("Estado actual: Error")
-            self.gen_label.setText(
-                "Generado: " + datetime.now().strftime("%Y-%m-%d %H:%M")
-            )
-            self._show_validation_errors(e.errors, e.json_path)
-        except Exception as e:
-            self.status_label.setText("Estado actual: Error")
-            self.gen_label.setText(
-                "Generado: " + datetime.now().strftime("%Y-%m-%d %H:%M")
-            )
-            QMessageBox.warning(self, "Enviar a Hacienda", str(e))
-
-        # Después de guardar y transmitir, también enviar por correo si la transmisión fue exitosa
-        if envio_ok:
-            self.send_email()
+        QMessageBox.information(self, "Guardar factura", f"{doc_type} guardado en {file_path}")
 
     def save_ticket(self):
         """Generate a simple ticket PDF for the selected sale."""

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -83,7 +83,7 @@ def _setup_tab(venta, cliente, producto, monkeypatch=None):
     return db, tab
 
 
-def test_transmit_success_email_fail(
+def test_save_invoice_does_not_send_or_transmit(
     qt_app,
     pdf_json_files,
     monkeypatch,
@@ -102,67 +102,22 @@ def test_transmit_success_email_fail(
         return str(p)
 
     monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
-    monkeypatch.setattr(
-        SalesTab,
-        "_check_smtp_credentials",
-        lambda self: {"server": "s", "port": 25, "user": "u", "password": "p"},
-    )
-
-    def fake_transmitir(db_obj, venta_id, modo="normal", tipo_dte="01"):
-        db_obj.registrar_envio_dte(venta_id, modo, "Transmitido", "S")
-        return {"estado": "Transmitido"}
-
-    monkeypatch.setattr("sales_tab.transmitir_dte", fake_transmitir)
-
-    init_calls = []
-
-    def fake_init(self, server, port, user, password, to_addr, subject, body, attachments):
-        init_calls.append(to_addr)
-        self.to_addr = to_addr
-        self.subject = subject
-        self.attachments = attachments if isinstance(attachments, list) else [attachments]
-        self.finished = DummySignal()
-
-    monkeypatch.setattr("utils.email_sender.EmailSender.__init__", fake_init, raising=False)
-
-    send_called = {}
-
-    def fake_send(self):
-        send_called["called"] = True
-        raise smtplib.SMTPException("fail")
-
-    def fake_start(self):
-        try:
-            self.send()
-        except smtplib.SMTPException as e:
-            self.finished.emit(False, str(e))
-
-    monkeypatch.setattr("utils.email_sender.EmailSender.send", fake_send, raising=False)
-    monkeypatch.setattr("utils.email_sender.EmailSender.start", fake_start)
-
-    smtp_calls = []
-
-    class DummySMTP:
-        def __init__(self, *a, **k):
-            smtp_calls.append((a, k))
-
-    monkeypatch.setattr(smtplib, "SMTP", DummySMTP)
+    called = {}
+    monkeypatch.setattr("dte.transmitir_dte", lambda *a, **k: called.setdefault("tx", True))
+    monkeypatch.setattr(SalesTab, "send_email", lambda self: called.setdefault("email", True))
     monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
-    monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: None)
 
     tab.sales_table.selectRow(0)
-    tab.save_and_send()
-    qt_app.processEvents()
+    tab.save_invoice()
 
-    assert send_called.get("called")
-    assert db.envios and db.envios[0]["estado"] == "Transmitido"
     assert pdf.exists()
-    assert len(init_calls) == 1
-    assert not smtp_calls
+    assert db.saved == (1, "Factura", str(pdf))
+    assert "tx" not in called
+    assert "email" not in called
 
 
-def test_email_exitoso(
+def test_send_email_exitoso(
     qt_app,
     pdf_json_files,
     monkeypatch,
@@ -186,11 +141,6 @@ def test_email_exitoso(
         SalesTab,
         "_check_smtp_credentials",
         lambda self: {"server": "s", "port": 25, "user": "u", "password": "p"},
-    )
-
-    monkeypatch.setattr(
-        "sales_tab.transmitir_dte",
-        lambda db_obj, venta_id, modo="normal", tipo_dte="01": {"estado": "Transmitido"},
     )
 
     captured = {}
@@ -230,7 +180,8 @@ def test_email_exitoso(
     monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: None)
 
     tab.sales_table.selectRow(0)
-    tab.save_and_send()
+    tab.save_invoice()
+    tab.send_email()
     qt_app.processEvents()
 
     assert captured["to"] == "cli@example.com"
@@ -244,7 +195,7 @@ def test_email_exitoso(
     assert not smtp_calls
 
 
-def test_transmit_fail_no_email(
+def test_save_invoice_fail_no_email(
     qt_app,
     pdf_json_files,
     monkeypatch,
@@ -263,21 +214,18 @@ def test_transmit_fail_no_email(
         return str(p)
 
     monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
-    monkeypatch.setattr(
-        "sales_tab.transmitir_dte", lambda *a, **k: {"estado": "error"}
-    )
-
     called = {}
 
-    def fake_send(self):
-        called["called"] = True
+    def fake_gen(manager, vid, p=pdf):
+        return None
 
-    monkeypatch.setattr(SalesTab, "send_email", fake_send)
+    monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
+    monkeypatch.setattr(SalesTab, "send_email", lambda self: called.setdefault("email", True))
     monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
 
     tab.sales_table.selectRow(0)
-    tab.save_and_send()
+    tab.save_invoice()
 
-    assert "called" not in called
+    assert "email" not in called
 

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -128,7 +128,7 @@ def test_send_email_builds_message_and_marks_status(
     }
 
 
-def test_save_and_send_generates_files_and_registers(
+def test_save_invoice_generates_files_and_registers(
     qt_app,
     pdf_json_files,
     monkeypatch,
@@ -149,20 +149,23 @@ def test_save_and_send_generates_files_and_registers(
         return str(pdf)
 
     monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
-    monkeypatch.setattr(SalesTab, "send_email", lambda self: None)
-    monkeypatch.setattr("sales_tab.transmitir_dte", lambda *a, **k: {"estado": "recibido"})
+    called = {}
+    monkeypatch.setattr("dte.transmitir_dte", lambda *a, **k: called.setdefault("tx", True))
+    monkeypatch.setattr(SalesTab, "send_email", lambda self: called.setdefault("email", True))
     monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
 
     tab.sales_table.selectRow(0)
-    tab.save_and_send()
+    tab.save_invoice()
 
     assert pdf.exists()
     assert pdf.with_suffix(".json").exists()
     assert db.saved == (1, "Factura", str(pdf))
+    assert "tx" not in called
+    assert "email" not in called
 
 
-def test_save_and_send_contingencia_no_http(
+def test_save_invoice_contingencia_no_transmit(
     qt_app,
     pdf_json_files,
     monkeypatch,
@@ -185,25 +188,8 @@ def test_save_and_send_contingencia_no_http(
         return str(pdf)
 
     monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
-    monkeypatch.setattr(SalesTab, "send_email", lambda self: None)
-    monkeypatch.setattr("dte._load_dte_api_config", lambda: {})
-
-    post_called = {"count": 0}
-
-    def fake_post(*a, **k):
-        post_called["count"] += 1
-        return {}
-
-    monkeypatch.setattr("dte._post_dte", fake_post)
-
-    transmit_args = {}
-
-    def fake_transmitir(db_, vid, modo="normal", tipo_dte="01"):
-        transmit_args["modo"] = modo
-        return dte.transmitir_dte(db_, vid, modo=modo, tipo_dte=tipo_dte)
-
-    monkeypatch.setattr("sales_tab.transmitir_dte", fake_transmitir)
-
+    called = {}
+    monkeypatch.setattr("dte.transmitir_dte", lambda *a, **k: called.setdefault("tx", True))
     mensajes = []
 
     def fake_info(parent, title, text):
@@ -213,17 +199,16 @@ def test_save_and_send_contingencia_no_http(
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
 
     tab.sales_table.selectRow(0)
-    tab.save_and_send()
+    tab.save_invoice()
 
-    assert transmit_args["modo"] == "contingencia"
-    assert post_called["count"] == 0
+    assert "tx" not in called
     assert any(
-        title == "Guardar y enviar" and text.startswith("Factura guardado")
+        title == "Guardar factura" and text.startswith("Factura guardado")
         for title, text in mensajes
     )
 
 
-def test_save_and_send_contingencia_from_config(
+def test_save_invoice_ignores_config_transmission(
     qt_app,
     tmp_path,
     pdf_json_files,
@@ -247,8 +232,6 @@ def test_save_and_send_contingencia_from_config(
         return str(pdf)
 
     monkeypatch.setattr("sales_tab.generate_invoice_pdf", fake_gen)
-    monkeypatch.setattr(SalesTab, "send_email", lambda self: None)
-    monkeypatch.setattr("dte._load_dte_api_config", lambda: {})
 
     datos_file = tmp_path / "datos_negocio.json"
     datos_file.write_text(
@@ -257,33 +240,10 @@ def test_save_and_send_contingencia_from_config(
     )
     monkeypatch.setattr("sales_tab.DATOS_NEGOCIO_PATH", str(datos_file))
 
-    post_called = {"count": 0}
-
-    def fake_post(*a, **k):
-        post_called["count"] += 1
-        return {}
-
-    monkeypatch.setattr("dte._post_dte", fake_post)
-
-    transmit_args = {}
-
-    def fake_transmitir(db_, vid, modo="normal", tipo_dte="01"):
-        transmit_args["modo"] = modo
-        return dte.transmitir_dte(db_, vid, modo=modo, tipo_dte=tipo_dte)
-
-    monkeypatch.setattr("sales_tab.transmitir_dte", fake_transmitir)
-
-    mensajes = []
-
-    def fake_info(parent, title, text):
-        mensajes.append((title, text))
-
-    monkeypatch.setattr(QMessageBox, "information", fake_info)
-    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+    called = {}
+    monkeypatch.setattr("dte.transmitir_dte", lambda *a, **k: called.setdefault("tx", True))
 
     tab.sales_table.selectRow(0)
-    tab.save_and_send()
+    tab.save_invoice()
 
-    assert transmit_args["modo"] == "contingencia"
-    assert post_called["count"] == 0
-    assert any("contingencia" in text.lower() for _, text in mensajes)
+    assert "tx" not in called


### PR DESCRIPTION
## Summary
- Rename and repurpose `save_and_send` to `save_invoice` with no transmission or auto email
- Update UI to show "Guardar factura" and wire to new method
- Adjust sales tab email tests for new save-only flow and email sending

## Testing
- ⚠️ `QT_QPA_PLATFORM=offscreen pytest tests/test_sales_tab_email.py tests/test_envio_correo.py -q` *(failed: process did not complete in the given environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a678f5f140832386d27dffc326131d