### PR TITLE
Send raw JWS payload to Hacienda

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2551,9 +2551,6 @@ def _post_dte(
     if missing:
         raise AssertionError("Faltan campos requeridos: " + ", ".join(missing))
 
-    ambiente = "00"
-    version = str(version)
-    id_envio = int(uuid.uuid4()) & 0x7FFFFFFF or 1
     documento = str(jws_token)
     assert documento.count(".") == 2, "documento JWS malformado"
     codigo = "" if codigo is None else str(codigo)
@@ -2565,42 +2562,13 @@ def _post_dte(
     else:
         assert tipo_dte in {1, 3, 4, 5, 6, 7, 8, 9, 11, 14, 15}, "tipoDte inválido"
 
-    payload = {
-        "ambiente": ambiente,
-        "version": version,
-        "idEnvio": int(id_envio),
-        "tipoDte": tipo_dte,
-        "documento": documento,
-    }
-    if codigo:
-        payload["codigoGeneracion"] = codigo
-    assert payload.get("codigoGeneracion") == codigo, "codigoGeneracion no coincide"
-
-    required = {
-        "ambiente": str,
-        "version": str,
-        "idEnvio": int,
-        "documento": str,
-    }
-    if "codigoGeneracion" in payload:
-        required["codigoGeneracion"] = str
-
-    for field, expected in required.items():
-        assert field in payload, f"{field} requerido"
-        assert isinstance(
-            payload[field], expected
-        ), f"{field} debe ser {expected.__name__}"
-
-    assert "tipoDte" in payload, "tipoDte requerido"
-    assert isinstance(payload["tipoDte"], (int, str)), "tipoDte debe ser int o str"
-
-    assert payload["idEnvio"] > 0
     auth_header = headers.get("Authorization")
     if token:
         assert re.fullmatch(
             r"Bearer [^\s]+", auth_header
         ), "Authorization header malformado"
-    resp = requests.post(url, headers=headers, json=payload, timeout=20)
+
+    resp = requests.post(url, headers=headers, data=documento, timeout=20)
     resp_text = getattr(resp, "text", "")
     status_code = getattr(resp, "status_code", "N/A")
     if isinstance(status_code, int) and status_code >= 400:

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -103,8 +103,8 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_post(url, json=None, headers=None, timeout=20):
-        calls.append((url, headers, json))
+    def fake_post(url, data=None, headers=None, timeout=20):
+        calls.append((url, headers, data))
 
         class R:
             status_code = 200
@@ -132,15 +132,11 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
     assert token_calls["count"] == 1
     assert sign_calls["count"] == 1
     assert len(calls) == 1
-    url, headers, payload = calls[0]
+    url, headers, body = calls[0]
     assert url == f"http://{ambiente}.example.com"
     assert headers["Authorization"] == "Bearer JWT"
-    assert payload["documento"] in sign_calls["tokens"]
-    assert payload["tipoDte"] == 1
-    assert payload["version"] == "2"
-    assert payload["ambiente"] == "00"
-    assert payload["codigoGeneracion"] == "ABC"
-    assert "idEnvio" in payload
+    assert headers["Content-Type"] == "application/json"
+    assert body in sign_calls["tokens"]
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
     ).fetchone()
@@ -151,7 +147,7 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
 def test_post_dte_uses_bearer(monkeypatch):
     captured = {}
 
-    def fake_post(url, json=None, headers=None, timeout=20):
+    def fake_post(url, data=None, headers=None, timeout=20):
         captured["headers"] = headers
         class R:
             status_code = 200
@@ -170,7 +166,7 @@ def test_post_dte_uses_bearer(monkeypatch):
 
 
 def test_post_dte_handles_non_json(monkeypatch):
-    def fake_post(url, json=None, headers=None, timeout=20):
+    def fake_post(url, data=None, headers=None, timeout=20):
         class R:
             status_code = 200
             text = "error"
@@ -191,7 +187,7 @@ def test_post_dte_handles_non_json(monkeypatch):
 
 
 def test_post_dte_rejects_mismatch(monkeypatch):
-    def fake_post(url, json=None, headers=None, timeout=20):
+    def fake_post(url, data=None, headers=None, timeout=20):
         class R:
             status_code = 200
             text = ""
@@ -214,7 +210,7 @@ def test_post_dte_rejects_mismatch(monkeypatch):
 def test_post_dte_missing_fields(monkeypatch):
     calls = {"count": 0}
 
-    def fake_post(url, json=None, headers=None, timeout=20):
+    def fake_post(url, data=None, headers=None, timeout=20):
         calls["count"] += 1
         class R:
             status_code = 200
@@ -233,7 +229,7 @@ def test_post_dte_missing_fields(monkeypatch):
 
 
 def test_post_dte_invalid_tipo(monkeypatch):
-    def fake_post(url, json=None, headers=None, timeout=20):
+    def fake_post(url, data=None, headers=None, timeout=20):
         class R:
             status_code = 200
             text = ""

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -86,8 +86,8 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
 
     calls = []
 
-    def fake_post(url, json=None, headers=None, timeout=20):
-        calls.append((url, headers, json))
+    def fake_post(url, data=None, headers=None, timeout=20):
+        calls.append((url, headers, data))
         data = responses.pop(0)
 
         class R:
@@ -123,15 +123,11 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
 
     assert sign_calls["count"] == 2
     assert len(calls) == 2
-    for url, headers, payload in calls:
+    for url, headers, body in calls:
         assert url == "http://example.com"
-        assert payload["documento"] in sign_calls["tokens"]
-        assert payload["tipoDte"] == 1
-        assert payload["version"] == "2"
-        assert payload["ambiente"] == "00"
-        assert payload["codigoGeneracion"] == "ABC"
-        assert "idEnvio" in payload
+        assert body in sign_calls["tokens"]
         assert headers["Authorization"] == "Bearer JWT"
+        assert headers["Content-Type"] == "application/json"
 
 
 def test_no_envia_si_validacion_falla(monkeypatch):
@@ -140,7 +136,7 @@ def test_no_envia_si_validacion_falla(monkeypatch):
 
     sent = []
 
-    def fake_post(url, json=None, headers=None, timeout=20):
+    def fake_post(url, data=None, headers=None, timeout=20):
         sent.append(True)
 
     monkeypatch.setattr("dte.requests.post", fake_post)
@@ -223,8 +219,8 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_post(url, json=None, headers=None, timeout=20):
-        calls.append((url, headers, json))
+    def fake_post(url, data=None, headers=None, timeout=20):
+        calls.append((url, headers, data))
 
         class R:
             status_code = 200
@@ -250,15 +246,11 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     assert row["estado"] == "Transmitido"
     assert sign_calls["count"] == 1
     assert len(calls) == 1
-    url, headers, payload = calls[0]
+    url, headers, body = calls[0]
     assert url == "http://example.com"
-    assert payload["documento"] in sign_calls["tokens"]
-    assert payload["tipoDte"] == 1
-    assert payload["version"] == "2"
-    assert payload["ambiente"] == "00"
-    assert payload["codigoGeneracion"] == "NC1"
-    assert "idEnvio" in payload
+    assert body in sign_calls["tokens"]
     assert headers["Authorization"] == "Bearer JWT"
+    assert headers["Content-Type"] == "application/json"
 
 
 def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
@@ -279,8 +271,8 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
 
     calls = []
 
-    def fake_post(url, json=None, headers=None, timeout=20):
-        calls.append((url, headers, json))
+    def fake_post(url, data=None, headers=None, timeout=20):
+        calls.append((url, headers, data))
 
         class R:
             status_code = 200
@@ -321,15 +313,11 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
     assert row["estado"] == "Rechazado"
     assert sign_calls["count"] == 1
     assert len(calls) == 1
-    url, headers, payload = calls[0]
+    url, headers, body = calls[0]
     assert url == "http://example.com"
-    assert payload["documento"] == sign_calls["token"]
-    assert payload["tipoDte"] == "CON"
-    assert payload["version"] == "2"
-    assert payload["ambiente"] == "00"
-    assert payload["codigoGeneracion"] == "EV1"
-    assert "idEnvio" in payload
+    assert body == sign_calls["token"]
     assert headers["Authorization"] == "Bearer JWT"
+    assert headers["Content-Type"] == "application/json"
 
 
 def test_enviar_evento_anulacion(monkeypatch, tmp_path):
@@ -350,8 +338,8 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_post(url, json=None, headers=None, timeout=20):
-        calls.append((url, headers, json))
+    def fake_post(url, data=None, headers=None, timeout=20):
+        calls.append((url, headers, data))
 
         class R:
             status_code = 200
@@ -386,13 +374,9 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     assert row["estado"] == "Transmitido"
     assert sign_calls["count"] == 1
     assert len(calls) == 1
-    url, headers, payload = calls[0]
+    url, headers, body = calls[0]
     assert url == "http://example.com"
-    assert payload["documento"] == sign_calls["token"]
-    assert payload["tipoDte"] == "ANU"
-    assert payload["version"] == "2"
-    assert payload["ambiente"] == "00"
-    assert payload["codigoGeneracion"] == "EV2"
-    assert "idEnvio" in payload
+    assert body == sign_calls["token"]
     assert headers["Authorization"] == "Bearer JWT"
+    assert headers["Content-Type"] == "application/json"
 

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -133,7 +133,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
 
     def fake_post(url, *a, **k):
         headers = k.get("headers", {})
-        calls.append((url, headers, k.get("json")))
+        calls.append((url, headers, k.get("data")))
         if url == auth_url:
             return Resp(
                 {


### PR DESCRIPTION
## Summary
- Send the JWS token directly in `_post_dte` requests instead of wrapping it in a JSON envelope
- Keep `Content-Type: application/json` header when posting to Hacienda
- Update transmission tests to expect raw JWS bodies

## Testing
- `pytest` *(fails: 39 errors during collection)*
- `pytest tests/test_envio_documentos.py tests/test_dte_transmision.py`
- `pytest tests/test_envio_hacienda.py::test_transmision_exitosa`


------
https://chatgpt.com/codex/tasks/task_e_68a6a7ceb56c832383aeee1aab4b964d