### PR TITLE
test: ensure jws body sent

### DIFF
--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -9,6 +9,7 @@ from dte import (
     enviar_nota_credito,
     enviar_evento_contingencia,
     enviar_evento_anulacion,
+    _post_dte,
     DTEValidationError,
 )
 import auth
@@ -259,6 +260,39 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     assert payload["codigoGeneracion"] == "NC1"
     assert "idEnvio" in payload
     assert headers["Authorization"] == "Bearer JWT"
+
+
+def test_post_dte_sends_raw_jws_body(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        captured["body"] = json["documento"]
+
+        class R:
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {}
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    meta = {
+        "ambiente": "00",
+        "version": 2,
+        "tipoDte": "01",
+        "codigoGeneracion": "ABC",
+    }
+    token = make_jws({"identificacion": meta})
+    _post_dte("http://example.com", "TOKEN", token, meta)
+
+    assert captured["body"] == token
+    assert "\n" not in captured["body"]
 
 
 def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):


### PR DESCRIPTION
## Summary
- add regression test ensuring `_post_dte` sends the raw JWS token without extra JSON or newline

## Testing
- `pytest tests/test_envio_documentos.py::test_post_dte_sends_raw_jws_body -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a6a7d10df88323af89c8bb8d812715