### PR TITLE
Preserve Bearer prefix for API tokens

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -233,8 +233,6 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
         info = resp.json()
         body = info.get("body", {}) if isinstance(info, dict) else {}
         token = body.get("token") if info.get("status") == "OK" else None
-        if token and isinstance(token, str) and token.startswith("Bearer "):
-            token = token[7:]
         token_type = body.get("tokenType", "") if body else ""
         expires_in = int(body.get("expiresIn", 0)) if body else 0
         if not token:

--- a/dte.py
+++ b/dte.py
@@ -2500,14 +2500,13 @@ def _post_dte(
     url: str, token: str, jws_token: str, dte_data: dict | None = None
 ) -> dict:
     token = (token or "").strip().strip('"').replace("\r", "").replace("\n", "")
-    token = re.sub(r"^(?:Bearer\s+)+", "", token, flags=re.I)
     if token:
         logger.debug("Token: %s...%s", token[:5], token[-5:])
     else:
         logger.debug("Token: <empty>")
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {token}",
+        "Authorization": token,
     }
     ident = {}
     if isinstance(dte_data, dict):

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -7,7 +7,7 @@ import requests
 import auth
 import sqlite3
 
-LONG_TOKEN = "t" * 400
+LONG_TOKEN = "a" * 120 + "." + "b" * 120 + "." + "c" * 120
 
 
 def write_config(tmp_path, nit="123", pwd="pwd"):
@@ -35,16 +35,16 @@ def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return f"{LONG_TOKEN}{calls['n']}", 120, "Bearer"
+        return f"Bearer {LONG_TOKEN}{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     t1 = auth.get_token(refresh=True)
-    assert t1 == f"{LONG_TOKEN}1"
+    assert t1 == f"Bearer {LONG_TOKEN}1"
     t2 = auth.get_token()
-    assert t2 == f"{LONG_TOKEN}1"
+    assert t2 == f"Bearer {LONG_TOKEN}1"
     assert calls["n"] == 1
     t3 = auth.get_token(refresh=True)
-    assert t3 == f"{LONG_TOKEN}2"
+    assert t3 == f"Bearer {LONG_TOKEN}2"
     assert calls["n"] == 2
 
 
@@ -52,7 +52,7 @@ def test_get_token_expired(monkeypatch, tmp_path):
     setup_paths(monkeypatch, tmp_path)
 
     def fake_request(nit, pwd, url):
-        return f"{LONG_TOKEN}x", 1, "Bearer"
+        return f"Bearer {LONG_TOKEN}x", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     auth.get_token(refresh=True)
@@ -61,11 +61,11 @@ def test_get_token_expired(monkeypatch, tmp_path):
 
     def fake_request2(nit, pwd, url):
         calls["n"] += 1
-        return f"{LONG_TOKEN}{calls['n']}", 1, "Bearer"
+        return f"Bearer {LONG_TOKEN}{calls['n']}", 1, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request2)
     token2 = auth.get_token()
-    assert token2 == f"{LONG_TOKEN}1"
+    assert token2 == f"Bearer {LONG_TOKEN}1"
     assert calls["n"] == 1
 
 
@@ -103,8 +103,8 @@ def test_missing_token_includes_response(monkeypatch):
     assert "Respuesta de autenticación sin token" in msg
 
 
-def test_request_new_token_strips_bearer(monkeypatch):
-    """Se obtiene solo el JWT cuando la respuesta incluye el prefijo Bearer."""
+def test_request_new_token_preserves_bearer(monkeypatch):
+    """El token devuelto mantiene el prefijo Bearer cuando está presente."""
 
     def fake_post(url, data, headers, timeout):
         class Resp:
@@ -128,7 +128,7 @@ def test_request_new_token_strips_bearer(monkeypatch):
     monkeypatch.setattr(auth.requests, "post", fake_post)
     monkeypatch.setattr(auth, "_get_auth_url", lambda: "http://fake")
     token, expires_in, token_type = auth._request_new_token("nit", "pwd")
-    assert token == "ABC.DEF.GHI"
+    assert token == "Bearer ABC.DEF.GHI"
     assert token_type == "Bearer"
     assert expires_in == 60
 
@@ -168,14 +168,14 @@ def test_get_token_with_explicit_credentials(monkeypatch):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return f"{LONG_TOKEN}{calls['n']}", 120, "Bearer"
+        return f"Bearer {LONG_TOKEN}{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     monkeypatch.setattr(auth, "_get_config_nit_and_url", lambda: (None, None))
     t1 = auth.get_token(refresh=True, nit="u", pwd="p")
-    assert t1 == f"{LONG_TOKEN}1"
+    assert t1 == f"Bearer {LONG_TOKEN}1"
     t2 = auth.get_token(nit="u", pwd="p")
-    assert t2 == f"{LONG_TOKEN}1"
+    assert t2 == f"Bearer {LONG_TOKEN}1"
     assert calls["n"] == 1
     auth.get_token(nit="u2", pwd="p2")
     assert calls["n"] == 2
@@ -187,7 +187,7 @@ def test_delete_token(monkeypatch, tmp_path):
 
     def fake_request(nit, pwd, url):
         calls["n"] += 1
-        return f"{LONG_TOKEN}{calls['n']}", 120, "Bearer"
+        return f"Bearer {LONG_TOKEN}{calls['n']}", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     auth.get_token(refresh=True)
@@ -197,7 +197,7 @@ def test_delete_token(monkeypatch, tmp_path):
         cur.execute("SELECT value FROM tokens WHERE key='access_token'")
         assert cur.fetchone() is None
     t2 = auth.get_token()
-    assert t2 == f"{LONG_TOKEN}2"
+    assert t2 == f"Bearer {LONG_TOKEN}2"
     assert calls["n"] == 2
 
 
@@ -218,11 +218,11 @@ def test_reauth_logs_nit_and_url(monkeypatch, tmp_path, caplog):
     def fake_request(nit, pwd, url):
         assert nit == "123"
         assert url == "http://auth.example"
-        return f"{LONG_TOKEN}1", 120, "Bearer"
+        return f"Bearer {LONG_TOKEN}1", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     token = auth.get_token(refresh=True)
-    assert token == f"{LONG_TOKEN}1"
+    assert token == f"Bearer {LONG_TOKEN}1"
     assert "Reautenticando con NIT 123 y URL http://auth.example" in caplog.text
 
 
@@ -240,7 +240,7 @@ def test_reauth_mismatch_nit(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
 
     def fake_request(nit, pwd, url):
-        return f"{LONG_TOKEN}1", 120, "Bearer"
+        return f"Bearer {LONG_TOKEN}1", 120, "Bearer"
 
     monkeypatch.setattr(auth, "_request_new_token", fake_request)
     with pytest.raises(ValueError):
@@ -254,7 +254,7 @@ def test_records_last_auth_host(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
     monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
     monkeypatch.setattr(
-        auth, "_request_new_token", lambda nit, pwd, url: (f"{LONG_TOKEN}1", 120, "Bearer")
+        auth, "_request_new_token", lambda nit, pwd, url: (f"Bearer {LONG_TOKEN}1", 120, "Bearer")
     )
     auth.get_token(refresh=True, nit="user", pwd="pwd")
     assert auth.get_last_auth_host() == "auth.example"

--- a/tests/test_dte_payload_cleanup.py
+++ b/tests/test_dte_payload_cleanup.py
@@ -35,7 +35,7 @@ def test_enviar_documento_uses_clean_payload(monkeypatch, dte_metadata_factory):
         return make_jws(data)
 
     monkeypatch.setattr(dte.jws, "sign_json", fake_sign)
-    monkeypatch.setattr(dte.auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(dte.auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(dte, "_post_dte", lambda url, token, jws, meta: {"estado": "Transmitido"})
     monkeypatch.setattr(dte.auth, "get_last_auth_host", lambda: None)
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {})

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -48,7 +48,7 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
 
     def fake_get_token():
         token_calls["count"] += 1
-        return "JWT"
+        return "Bearer JWT"
 
     monkeypatch.setattr(auth, "get_token", fake_get_token)
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: f"{ambiente}.example.com")
@@ -165,7 +165,7 @@ def test_post_dte_uses_bearer(monkeypatch):
     monkeypatch.setattr("dte.requests.post", fake_post)
     meta = {"ambiente": "00", "version": 2, "tipoDte": "01", "codigoGeneracion": "ABC"}
     token = make_jws({"identificacion": meta})
-    _post_dte("http://example.com", "TOKEN", token, meta)
+    _post_dte("http://example.com", "Bearer TOKEN", token, meta)
     assert captured["headers"]["Authorization"] == "Bearer TOKEN"
 
 
@@ -208,7 +208,12 @@ def test_post_dte_rejects_mismatch(monkeypatch):
     meta = {"ambiente": "00", "version": 2, "tipoDte": "01", "codigoGeneracion": "ABC"}
     token = make_jws({"identificacion": meta})
     with pytest.raises(ValueError):
-        _post_dte("http://example.com", "TOKEN", token, {**meta, "codigoGeneracion": "XYZ"})
+        _post_dte(
+            "http://example.com",
+            "Bearer TOKEN",
+            token,
+            {**meta, "codigoGeneracion": "XYZ"},
+        )
 
 
 def test_post_dte_missing_fields(monkeypatch):
@@ -228,7 +233,7 @@ def test_post_dte_missing_fields(monkeypatch):
     monkeypatch.setattr("dte.requests.post", fake_post)
     token = make_jws({})
     with pytest.raises(AssertionError):
-        _post_dte("http://example.com", "TOKEN", token, {})
+        _post_dte("http://example.com", "Bearer TOKEN", token, {})
     assert calls["count"] == 0
 
 
@@ -250,7 +255,7 @@ def test_post_dte_invalid_tipo(monkeypatch):
     meta = {"ambiente": "00", "version": 2, "tipoDte": "99", "codigoGeneracion": "ABC"}
     token = make_jws({"identificacion": meta})
     with pytest.raises(AssertionError):
-        _post_dte("http://example.com", "TOKEN", token, meta)
+        _post_dte("http://example.com", "Bearer TOKEN", token, meta)
 
 
 def test_consultar_envio_dte():

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -38,7 +38,7 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
     monkeypatch.setattr(
@@ -144,7 +144,7 @@ def test_no_envia_si_validacion_falla(monkeypatch):
         sent.append(True)
 
     monkeypatch.setattr("dte.requests.post", fake_post)
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
 
     sign_calls = {"count": 0}
 
@@ -180,7 +180,7 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda data: None)
     monkeypatch.setattr(
@@ -274,7 +274,7 @@ def test_enviar_evento_contingencia(monkeypatch, caplog, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
 
     calls = []
@@ -345,7 +345,7 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
         return token
 
     monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
 
     calls = []

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -62,7 +62,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
 
     def fake_token():
         tokens["count"] += 1
-        return "JWT"
+        return "Bearer JWT"
 
     monkeypatch.setattr(auth, "get_token", fake_token)
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "recepcion.test")
@@ -139,7 +139,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
                 {
                     "status": "OK",
                     "body": {
-                        "token": "JWT",
+                        "token": "Bearer JWT",
                         "tokenType": "bearer",
                         "expiresIn": 3600,
                     },
@@ -192,7 +192,7 @@ def test_http_error_negativo(monkeypatch, tmp_path, status):
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
@@ -226,7 +226,7 @@ def test_firma_fallida_negativo(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
 
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
@@ -267,7 +267,7 @@ def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
 
     def fake_get_token(refresh: bool = False):
         token_calls.append(refresh)
-        return "JWT_VALIDO"
+        return "Bearer JWT_VALIDO"
 
     monkeypatch.setattr(auth, "get_token", fake_get_token)
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
@@ -281,7 +281,7 @@ def test_transmision_token_401_en_recepcion(monkeypatch, tmp_path):
             return {
                 "status": "OK",
                 "body": {
-                    "token": "JWT_VALIDO",
+                    "token": "Bearer JWT_VALIDO",
                     "tokenType": "bearer",
                     "expiresIn": 3600,
                 },
@@ -339,7 +339,7 @@ def test_timeout_no_modifica_extra(monkeypatch, tmp_path):
     venta = create_sale(db)
 
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
 
@@ -368,7 +368,7 @@ def test_recepcion_url_host_mismatch(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
-    monkeypatch.setattr(auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "auth.example")
     monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
     config = {"ambiente": "pruebas", "pruebas": {"recepcion_url": "http://other.example"}}

--- a/tests/test_url_sanitization.py
+++ b/tests/test_url_sanitization.py
@@ -1,6 +1,7 @@
 import json
 import auth
 import dte
+from tests.conftest import make_jws
 
 
 def test_auth_url_is_stripped(monkeypatch, tmp_path):
@@ -35,8 +36,12 @@ def test_recepcion_url_is_stripped(monkeypatch, tmp_path):
         "pruebas": {"recepcion_url": " http://recepcion.example/path \n"}
     }))
     monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", str(cfg))
-    monkeypatch.setattr(dte.jws, "sign_json", lambda data: "SIGNED")
-    monkeypatch.setattr(dte.auth, "get_token", lambda: "JWT")
+    monkeypatch.setattr(dte.jws, "sign_json", lambda data: make_jws(data))
+    monkeypatch.setattr(dte.auth, "get_token", lambda: "Bearer JWT")
+    monkeypatch.setattr(dte.auth, "get_last_auth_host", lambda: "recepcion.example")
+    monkeypatch.setattr(dte, "validate_dte_json", lambda data: None)
+    monkeypatch.setattr(dte, "normalize_condicion_operacion", lambda x: x)
+    monkeypatch.setattr(dte, "validate_pagos_basico", lambda r, c: None)
     called = {}
 
     def fake_post_dte(url, token, jws_token, dte_data):
@@ -49,6 +54,15 @@ def test_recepcion_url_is_stripped(monkeypatch, tmp_path):
         def registrar_envio_dte(self, *args, **kwargs):
             pass
 
-    dte._enviar_documento(DummyDB(), 1, {}, "normal")
+    payload = {
+        "resumen": {"totalLetras": "X"},
+        "identificacion": {
+            "ambiente": "00",
+            "version": 1,
+            "tipoDte": "01",
+            "codigoGeneracion": "X",
+        },
+    }
+    dte._enviar_documento(DummyDB(), 1, payload, "normal")
     assert called["url"] == "http://recepcion.example/path"
     assert called["url"].strip() == called["url"]


### PR DESCRIPTION
## Summary
- stop stripping the `Bearer` prefix when requesting API tokens
- send DTE requests using the token string verbatim
- update tests to expect and handle tokens with the `Bearer` prefix

## Testing
- `pytest tests/test_auth_module.py tests/test_dte_transmision.py tests/test_envio_documentos.py tests/test_url_sanitization.py tests/test_dte_payload_cleanup.py`
- `pytest` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a7ce6cf0832394d831d87bedec34