### PR TITLE
Ensure numeroControl sequencing and fallback

### DIFF
--- a/db.py
+++ b/db.py
@@ -486,6 +486,18 @@ class DB:
 
         self.cursor.execute(
             """
+            CREATE TABLE IF NOT EXISTS dte_correlativos (
+                tipo TEXT NOT NULL,
+                sucursal TEXT NOT NULL,
+                punto TEXT NOT NULL,
+                correlativo INTEGER NOT NULL,
+                PRIMARY KEY (tipo, sucursal, punto)
+            )
+            """
+        )
+
+        self.cursor.execute(
+            """
             CREATE TABLE IF NOT EXISTS dte_envios (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 venta_id INTEGER,
@@ -1441,6 +1453,29 @@ class DB:
         """Elimina registros de tickets PDF asociados a una venta."""
         self.cursor.execute("DELETE FROM tickets_pdf WHERE venta_id=?", (venta_id,))
         self.conn.commit()
+
+    def next_dte_correlativo(self, tipo: str, sucursal: str, punto: str) -> int:
+        """Obtiene y actualiza el correlativo para la combinación dada."""
+        with self.lock:
+            with self.conn:
+                self.cursor.execute(
+                    "SELECT correlativo FROM dte_correlativos WHERE tipo=? AND sucursal=? AND punto=?",
+                    (tipo, sucursal, punto),
+                )
+                row = self.cursor.fetchone()
+                if row:
+                    correlativo = int(row["correlativo"]) + 1
+                    self.cursor.execute(
+                        "UPDATE dte_correlativos SET correlativo=? WHERE tipo=? AND sucursal=? AND punto=?",
+                        (correlativo, tipo, sucursal, punto),
+                    )
+                else:
+                    correlativo = 1
+                    self.cursor.execute(
+                        "INSERT INTO dte_correlativos (tipo, sucursal, punto, correlativo) VALUES (?, ?, ?, ?)",
+                        (tipo, sucursal, punto, correlativo),
+                    )
+            return correlativo
 
     def add_dte_pendiente(self, venta_id, dte_json, modo):
         """Registra un DTE pendiente de transmisión a Hacienda."""

--- a/dte.py
+++ b/dte.py
@@ -149,6 +149,10 @@ def money(value) -> D:
     return D(str(value)).quantize(D("0.01"), rounding=ROUND_HALF_UP)
 
 
+def _norm3(value) -> str:
+    return re.sub(r"\D", "", str(value))[-3:].zfill(3)
+
+
 def normalize_uuid_v4_upper(value: str) -> str:
     """
     Normaliza `value` como UUID v4 con guiones en MAYÚSCULAS.
@@ -1161,20 +1165,11 @@ def recalcular_totales(
 
 
 
-def generar_numero_control(prefijo: str | None = None) -> str:
-    """Crea un número de control único siguiendo el formato de Hacienda.
-
-    When ``prefijo`` is ``None`` it is read from ``datos_negocio`` and falls
-    back to ``DTE-01-S001P001``.
-    """
-    if prefijo is None:
-        datos = _load_datos_negocio()
-        prefijo = (
-            (datos.get("dte_api") or {}).get("prefijo_control")
-            or "DTE-01-S001P001"
-        )
-    secuencia = str(uuid.uuid4().int % 10**15).zfill(15)
-    return f"{prefijo}-{secuencia}"
+def generar_numero_control(db: DB, tipo: str, sucursal: str, punto: str) -> str:
+    """Genera un número de control secuencial."""
+    correlativo = db.next_dte_correlativo(tipo, sucursal, punto)
+    secuencia = str(correlativo).zfill(15)
+    return f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
 
 
 def identificacion_a_xml(ident: dict) -> str:
@@ -1195,6 +1190,7 @@ def generar_cabecera_dte_data(
     tipo_modelo: int,
     tipo_operacion: int,
     tipo_dte: str,
+    db: DB,
     tipo_contingencia: int | None = None,
     motivo_contin: str | None = None,
     ambiente: str = "00",
@@ -1219,9 +1215,10 @@ def generar_cabecera_dte_data(
     m = re.search(r"S(\d{3})P(\d{3})", prefijo)
     if m:
         sucursal, punto = m.groups()
+    sucursal = _norm3(sucursal)
+    punto = _norm3(punto)
     codigo_generacion = str(uuid.uuid4()).upper()
-    prefijo_nc = f"DTE-{tipo_dte}-S{sucursal}P{punto}"
-    numero_control = generar_numero_control(prefijo_nc)
+    numero_control = generar_numero_control(db, tipo_dte, sucursal, punto)
     fecha_generacion = datetime.now().strftime("%d/%m/%Y, %I:%M %p")
     return {
         "codigo_generacion": codigo_generacion,
@@ -1293,10 +1290,11 @@ def generar_dte_json(
     cod_punto_raw = re.sub(r"\D", "", str(datos.get("codPuntoVenta", "")))
     cod_estable = (cod_estable_raw or suc_pref.rjust(4, "0"))[-4:].zfill(4)
     cod_punto = (cod_punto_raw or punto_pref.rjust(4, "0"))[-4:].zfill(4)
-    prefijo_nc = f"DTE-{tipo_dte}-S{cod_estable[-3:]}P{cod_punto[-3:]}"
+    suc = _norm3(cod_estable)
+    pto = _norm3(cod_punto)
     # Generar identificadores con formatos oficiales
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control(prefijo_nc)
+    numero_control = generar_numero_control(db, tipo_dte, suc, pto)
 
 
     now = datetime.now(TZ_EL_SALVADOR)
@@ -1721,11 +1719,16 @@ def generar_dte_json(
         "extension": extension,
     }
 
-    validate_dte_json(result, precios_incluyen_iva=False)
+    validate_dte_json(result, db=db, precios_incluyen_iva=False)
     return result
 
 
-def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool | None = None) -> None:
+def validate_dte_json(
+    payload: dict,
+    *,
+    db: DB,
+    precios_incluyen_iva: bool | None = None,
+) -> None:
     """Basic validation and normalization for DTE payload antes de firmar."""
     # Normalización omitida para preservar códigos con ceros a la izquierda
     # ("01", etc.) que ``_normalize_payload`` convertiría a enteros.
@@ -1809,21 +1812,6 @@ def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool | None = None
         raise ValueError("ambiente debe ser '00' o '01'")
     if ident.get("tipoMoneda") != "USD":
         raise ValueError("tipoMoneda debe ser 'USD'")
-    emisor_nc = payload.get("emisor", {})
-    cod_est_nc = str(emisor_nc.get("codEstable") or negocio.get("codEstable") or "0000")
-    cod_pto_nc = str(emisor_nc.get("codPuntoVenta") or negocio.get("codPuntoVenta") or "0000")
-    prefijo_nc = f"DTE-{ident['tipoDte']}-S{cod_est_nc[-3:]}P{cod_pto_nc[-3:]}"
-    numero_control = ident.get("numeroControl")
-    if not (
-        isinstance(numero_control, str)
-        and numero_control.startswith(prefijo_nc + "-")
-        and re.fullmatch(rf"^DTE-{ident['tipoDte']}-[A-Z0-9]{{8}}-[0-9]{{15}}$", numero_control)
-    ):
-        numero_control = generar_numero_control(prefijo_nc)
-        ident["numeroControl"] = numero_control
-
-    if not re.fullmatch(rf"^DTE-{ident['tipoDte']}-[A-Z0-9]{{8}}-[0-9]{{15}}$", numero_control):
-        raise ValueError("numeroControl inválido")
     # Las reglas de operación/modelo/contingencia ya fueron normalizadas arriba.
     try:
         fec = datetime.strptime(str(ident.get("fecEmi")), "%Y-%m-%d").date()
@@ -1870,16 +1858,32 @@ def validate_dte_json(payload: dict, *, precios_incluyen_iva: bool | None = None
     }
     emisor.setdefault("telefono", negocio.get("telefono"))
     emisor.setdefault("correo", negocio.get("correo"))
-    cod_est = str(emisor.get("codEstable") or negocio.get("codEstable") or "0000")
+    cod_est = str(emisor.get("codEstable") or negocio.get("codEstable") or 1)
     emisor["codEstable"] = cod_est.zfill(4)
     emisor["codEstableMH"] = str(
         emisor.get("codEstableMH") or negocio.get("codEstableMH") or cod_est
     ).zfill(4)
-    cod_pto = str(emisor.get("codPuntoVenta") or negocio.get("codPuntoVenta") or "0000")
+    cod_pto = str(emisor.get("codPuntoVenta") or negocio.get("codPuntoVenta") or 1)
     emisor["codPuntoVenta"] = cod_pto.zfill(4)
     emisor["codPuntoVentaMH"] = str(
         emisor.get("codPuntoVentaMH") or negocio.get("codPuntoVentaMH") or cod_pto
     ).zfill(4)
+    tipo = str(ident.get("tipoDte") or "").zfill(2)
+    if not re.fullmatch(r"\d{2}", tipo):
+        raise ValueError("tipoDte inválido")
+    if hasattr(catalogos, "TIPOS_DTE") and tipo not in catalogos.TIPOS_DTE:
+        raise ValueError("Código de tipoDte inválido")
+    suc = _norm3(emisor.get("codEstableMH") or emisor.get("codEstable") or 1)
+    pto = _norm3(
+        emisor.get("codPuntoVentaMH") or emisor.get("codPuntoVenta") or 1
+    )
+    numero_control = ident.get("numeroControl")
+    regex_nc = r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$"
+    if not (isinstance(numero_control, str) and re.fullmatch(regex_nc, numero_control)):
+        ident["numeroControl"] = generar_numero_control(db, tipo, suc, pto)
+    numero_control = ident.get("numeroControl")
+    if not re.fullmatch(regex_nc, numero_control):
+        raise ValueError("numeroControl inválido")
     emisor.pop("giro", None)
     emisor.pop("tipoContribuyente", None)
     required_emisor = {
@@ -2606,7 +2610,7 @@ def transmitir_dte(
     data = sanitize_dte_payload(data)
     data = apply_schema_patch(data)
     try:
-        validate_dte_json(data)
+        validate_dte_json(data, db=db)
     except Exception as exc:
         json_path = save_dte_json(data)
         errors = _format_validation_errors(exc)
@@ -2643,7 +2647,7 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         data = sanitize_dte_payload(raw)
         data = apply_schema_patch(data)
         try:
-            validate_dte_json(data)
+            validate_dte_json(data, db=db)
         except Exception as exc:
             errors = _format_validation_errors(exc)
             raise DTEValidationError(errors, json_path) from exc
@@ -2841,7 +2845,7 @@ def enviar_factura(db: DB, venta_id: int, modo: str = "normal") -> dict:
     data = sanitize_dte_payload(data)
     data = apply_schema_patch(data)
     try:
-        validate_dte_json(data)
+        validate_dte_json(data, db=db)
     except Exception as exc:
         json_path = save_dte_json(data)
         errors = _format_validation_errors(exc)
@@ -2858,7 +2862,7 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     data = sanitize_dte_payload(data)
     data = apply_schema_patch(data)
     try:
-        validate_dte_json(data)
+        validate_dte_json(data, db=db)
     except Exception as exc:
         json_path = save_dte_json(data)
         errors = _format_validation_errors(exc)
@@ -2872,7 +2876,7 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     data = sanitize_dte_payload(data)
     data = apply_schema_patch(data)
     try:
-        validate_dte_json(data)
+        validate_dte_json(data, db=db)
     except Exception as exc:
         json_path = save_dte_json(data)
         errors = _format_validation_errors(exc)
@@ -2886,7 +2890,7 @@ def enviar_nota_remision(db: DB, nota_id: int, modo: str = "normal") -> dict:
     data = sanitize_dte_payload(data)
     data = apply_schema_patch(data)
     try:
-        validate_dte_json(data)
+        validate_dte_json(data, db=db)
     except Exception as exc:
         json_path = save_dte_json(data)
         errors = _format_validation_errors(exc)

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -9,6 +9,7 @@ from reportlab.lib.units import mm
 
 from utils.pdf_utils import draw_wrapped_text
 from dte import generar_cabecera_dte_data
+from db import DB
 from urllib.parse import urlencode
 import json
 import os
@@ -76,6 +77,7 @@ def generar_factura_electronica_pdf(
             tipo_modelo,
             tipo_operacion,
             tipo_dte,
+            DB(),
             tipo_contingencia=tipo_contingencia,
             motivo_contin=motivo_contin,
             ambiente=ambiente,

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -6,6 +6,7 @@ from decimal import Decimal, ROUND_HALF_UP, getcontext
 from pathlib import Path
 from typing import Any, Dict, List
 from uuid import uuid4
+from db import DB
 from zoneinfo import ZoneInfo
 
 from .config import get_emisor_direccion
@@ -42,9 +43,10 @@ def strip_extras(dte: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in dte.items() if k not in extras}
 
 
-def _numero_control(tipo: str) -> str:
-    secuencia = str(uuid4().int % 10**15).zfill(15)
-    return f"DTE-{tipo}-{uuid4().hex[:8].upper()}-{secuencia}"
+def _numero_control(db: DB, tipo: str, sucursal: str = "001", punto: str = "001") -> str:
+    correlativo = db.next_dte_correlativo(tipo, sucursal, punto)
+    secuencia = str(correlativo).zfill(15)
+    return f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
 
 
 def d8(value: Decimal) -> Decimal:
@@ -140,7 +142,7 @@ def generar_fc_ejemplo(
     return dte
 
 
-def _identificacion(schema: Dict[str, Any], tipo_dte: str) -> Dict[str, Any]:
+def _identificacion(db: DB, schema: Dict[str, Any], tipo_dte: str) -> Dict[str, Any]:
     # ``version`` is defined in the schema and must be surfaced in the
     # generated document instead of being hard coded.  Some schemas expose it
     # via ``const`` and others via an ``enum`` with a single option, so handle
@@ -155,7 +157,7 @@ def _identificacion(schema: Dict[str, Any], tipo_dte: str) -> Dict[str, Any]:
         "version": version,
         "ambiente": "00",
         "tipoDte": tipo_dte,
-        "numeroControl": _numero_control(tipo_dte),
+        "numeroControl": _numero_control(db, tipo_dte),
         # ``codigoGeneracion`` must be a valid UUID v4.  ``uuid4`` guarantees
         # the correct version and the schema expects uppercase letters.
         "codigoGeneracion": str(uuid4()).upper(),
@@ -311,11 +313,11 @@ def _documento_relacionado(tipo: str) -> Any:
     return None
 
 
-def _generar(tipo: str) -> Dict[str, Any]:
+def _generar(db: DB, tipo: str) -> Dict[str, Any]:
     schema_file, tipo_dte = SCHEMA_MAP[tipo]
     schema = _load_schema(schema_file)
     data = {
-        "identificacion": _identificacion(schema, tipo_dte),
+        "identificacion": _identificacion(db, schema, tipo_dte),
         "documentoRelacionado": _documento_relacionado(tipo),
         "emisor": _emisor(),
         "receptor": _receptor(tipo),
@@ -332,24 +334,29 @@ def _generar(tipo: str) -> Dict[str, Any]:
     return data
 
 
-def generar_factura_fiscal() -> Dict[str, Any]:
-    return _generar("ccf")
+def generar_factura_fiscal(db: DB | None = None) -> Dict[str, Any]:
+    db = db or DB()
+    return _generar(db, "ccf")
 
 
-def generar_consumidor_final() -> Dict[str, Any]:
-    return _generar("fc")
+def generar_consumidor_final(db: DB | None = None) -> Dict[str, Any]:
+    db = db or DB()
+    return _generar(db, "fc")
 
 
-def generar_nota_debito() -> Dict[str, Any]:
-    return _generar("nd")
+def generar_nota_debito(db: DB | None = None) -> Dict[str, Any]:
+    db = db or DB()
+    return _generar(db, "nd")
 
 
-def generar_nota_credito() -> Dict[str, Any]:
-    return _generar("nc")
+def generar_nota_credito(db: DB | None = None) -> Dict[str, Any]:
+    db = db or DB()
+    return _generar(db, "nc")
 
 
-def generar_nota_remision() -> Dict[str, Any]:
-    return _generar("nr")
+def generar_nota_remision(db: DB | None = None) -> Dict[str, Any]:
+    db = db or DB()
+    return _generar(db, "nr")
 
 
 def validar_contra_schema(data: Dict[str, Any], tipo: str) -> None:

--- a/tests/test_cod_giro.py
+++ b/tests/test_cod_giro.py
@@ -1,5 +1,6 @@
 import json
 import dte
+from db import DB
 
 
 def test_cod_giro_used_for_emisor(tmp_path, monkeypatch):
@@ -9,6 +10,8 @@ def test_cod_giro_used_for_emisor(tmp_path, monkeypatch):
     datos_path.write_text("{}")
     monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", datos_path)
     monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", config_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db = DB()
     payload = {
         "identificacion": {},
         "emisor": {},
@@ -17,7 +20,7 @@ def test_cod_giro_used_for_emisor(tmp_path, monkeypatch):
         "resumen": {},
     }
     try:
-        dte.validate_dte_json(payload)
+        dte.validate_dte_json(payload, db=db)
     except Exception:
         pass
     assert payload["emisor"]["codActividad"] == "99999"

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -1,68 +1,101 @@
+import json
+import uuid
 import pytest
 import re
-import uuid
+
+import dte
 from dte import sanitize_dte_payload, validate_dte_json
+from db import DB
 
 UUID4_RE = r"^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$"
 
 
-def test_dte_valido_pasa(dte_metadata_factory):
+def _patch_datos_negocio(tmp_path, monkeypatch):
+    datos = {
+        "nit": "06141404100016",
+        "nrc": "1234567",
+        "nombre": "Empresa SA",
+        "nombreComercial": "Empresa",
+        "codActividad": "12345",
+        "descActividad": "Venta de productos",
+        "tipoContribuyente": "Persona Natural",
+        "telefono": "22223333",
+        "correo": "info@empresa.com",
+        "direccion": {
+            "departamento": "01",
+            "municipio": "13",
+            "complemento": "Calle 1",
+        },
+    }
+    path = tmp_path / "datos_negocio.json"
+    path.write_text(json.dumps(datos), encoding="utf-8")
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(path))
+
+
+@pytest.fixture
+def db_fixture(tmp_path, monkeypatch):
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db = DB()
+    yield db
+
+def test_dte_valido_pasa(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
 
 
-def test_codigo_invalido_rechazado(dte_metadata_factory):
+def test_codigo_invalido_rechazado(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = "99"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_longitud_nit_invalida(dte_metadata_factory):
+def test_longitud_nit_invalida(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["emisor"]["nit"] = "123"
     dte["resumen"].pop("pagos", None)
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_longitud_num_documento_invalida(dte_metadata_factory):
+def test_longitud_num_documento_invalida(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["receptor"]["numDocumento"] = "123"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory):
+def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["codigoGeneracion"] = "not-a-uuid"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
     dte["identificacion"]["codigoGeneracion"] = "12345678-1234-1234-1234-1234567890AB"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_codigo_generacion_rechaza_uuids_no_v4(dte_metadata_factory):
+def test_codigo_generacion_rechaza_uuids_no_v4(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["codigoGeneracion"] = str(uuid.uuid1()).upper()
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
     dte["identificacion"]["codigoGeneracion"] = str(uuid.uuid3(uuid.NAMESPACE_DNS, "test")).upper()
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_estructura_invalida(dte_metadata_factory, monkeypatch):
+def test_estructura_invalida(dte_metadata_factory, monkeypatch, db_fixture):
     dte = dte_metadata_factory()
     del dte["emisor"]["nit"]
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {})
     with pytest.raises(ValueError) as exc:
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
     assert "nit" in str(exc.value)
 
 
-def test_strips_additional_properties(dte_metadata_factory):
+def test_strips_additional_properties(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["firmaElectronica"] = "XYZ"
     dte["selloRecibido"] = "ABC"
@@ -72,12 +105,12 @@ def test_strips_additional_properties(dte_metadata_factory):
     assert "selloRecibido" not in clean
     assert "firmaElectronica" not in clean["identificacion"]
     clean["resumen"].pop("pagos", None)
-    validate_dte_json(clean)
+    validate_dte_json(clean, db=db_fixture)
 
 
-def test_missing_top_level_fields_listed():
+def test_missing_top_level_fields_listed(db_fixture):
     with pytest.raises(ValueError) as exc:
-        validate_dte_json({})
+        validate_dte_json({}, db=db_fixture)
     msg = str(exc.value)
     for key in [
         "identificacion",
@@ -89,7 +122,7 @@ def test_missing_top_level_fields_listed():
         assert key in msg
 
 
-def test_missing_emisor_fields_listed(dte_metadata_factory, monkeypatch):
+def test_missing_emisor_fields_listed(dte_metadata_factory, monkeypatch, db_fixture):
     dte = dte_metadata_factory()
     dte["emisor"] = {}
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {})
@@ -97,7 +130,7 @@ def test_missing_emisor_fields_listed(dte_metadata_factory, monkeypatch):
         "svfe.config.get_emisor_direccion", lambda: (_ for _ in ()).throw(ValueError())
     )
     with pytest.raises(ValueError) as exc:
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
     msg = str(exc.value)
     for key in [
         "nit",
@@ -114,7 +147,7 @@ def test_missing_emisor_fields_listed(dte_metadata_factory, monkeypatch):
 
 
 
-def test_recalcula_totales(dte_metadata_factory):
+def test_recalcula_totales(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     # Manipulamos totales para que sean incorrectos
     dte["resumen"]["totalGravada"] = 20.0
@@ -122,7 +155,7 @@ def test_recalcula_totales(dte_metadata_factory):
     dte["resumen"]["montoTotalOperacion"] = 20.0
     dte["resumen"]["totalPagar"] = 20.0
 
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
 
     assert dte["resumen"]["totalGravada"] == pytest.approx(10.0)
     assert dte["resumen"]["subTotalVentas"] == pytest.approx(10.0)
@@ -130,76 +163,85 @@ def test_recalcula_totales(dte_metadata_factory):
     assert dte["resumen"]["totalPagar"] == pytest.approx(10.0)
 
 
-def test_autocompleta_tributos(dte_metadata_factory):
+def test_autocompleta_tributos(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     item = dte["cuerpoDocumento"][0]
     # Eliminamos tributos para forzar el valor por defecto
     item.pop("tributos", None)
     item.pop("codTributo", None)
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     item = dte["cuerpoDocumento"][0]
     assert item["tributos"] == ["19"]
     assert item["codTributo"] == "19"
 
 
-def test_tributos_invalidos_rechazados(dte_metadata_factory):
+def test_tributos_invalidos_rechazados(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = "03"
     dte["cuerpoDocumento"][0]["tributos"] = ["ZZ"]
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = "03"
     dte["cuerpoDocumento"][0]["codTributo"] = "ZZ"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_numero_control_regex(dte_metadata_factory):
+def test_numero_control_regex(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
+    _patch_datos_negocio(tmp_path, monkeypatch)
     dte = dte_metadata_factory()
     dte["identificacion"]["numeroControl"] = "INVALID"
-    validate_dte_json(dte)
-    assert re.fullmatch(r"^DTE-01-[A-Z0-9]{8}-[0-9]{15}$", dte["identificacion"]["numeroControl"])
+    validate_dte_json(dte, db=db_fixture)
+    assert re.fullmatch(
+        r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$",
+        dte["identificacion"]["numeroControl"],
+    )
 
 
 @pytest.mark.parametrize(
     "numero",
     [
-        "DTE-01-ABCDEFGH-123456789012345",
-        "DTE-01-12345678-000000000000000",
+        "DTE-01-S123P456-123456789012345",
+        "DTE-01-S001P001-000000000000000",
     ],
 )
-def test_numero_control_validos(dte_metadata_factory, numero):
+def test_numero_control_validos(dte_metadata_factory, numero, tmp_path, monkeypatch, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["numeroControl"] = numero
-    validate_dte_json(dte)
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    validate_dte_json(dte, db=db_fixture)
 
 
 @pytest.mark.parametrize(
     "numero",
     [
-        "DTE-02-ABCDEFGH-123456789012345",
-        "DTE-01-ABC-123456789012345",
-        "DTE-01-ABCDEFGH-12345",
-        "dte-01-ABCDEFGH-123456789012345",
+        "DTE-01-S01P001-123456789012345",
+        "DTE-01-S001P001-12345",
+        "dte-01-S001P001-123456789012345",
     ],
 )
-def test_numero_control_invalidos(dte_metadata_factory, numero):
+def test_numero_control_invalidos(dte_metadata_factory, numero, tmp_path, monkeypatch, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["numeroControl"] = numero
-    validate_dte_json(dte)
-    assert re.fullmatch(r"^DTE-01-[A-Z0-9]{8}-[0-9]{15}$", dte["identificacion"]["numeroControl"])
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    validate_dte_json(dte, db=db_fixture)
+    assert re.fullmatch(
+        r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$",
+        dte["identificacion"]["numeroControl"],
+    )
 
 
-def test_numero_control_regenerates_from_emisor_codes(dte_metadata_factory):
+def test_numero_control_regenerates_from_emisor_codes(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
+    _patch_datos_negocio(tmp_path, monkeypatch)
     dte = dte_metadata_factory()
     dte["emisor"]["codEstable"] = "123"
     dte["emisor"]["codEstableMH"] = "123"
     dte["emisor"]["codPuntoVenta"] = "456"
     dte["emisor"]["codPuntoVentaMH"] = "456"
     dte["identificacion"]["numeroControl"] = "BAD"
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     ident = dte["identificacion"]
     emisor = dte["emisor"]
     assert emisor["codEstable"] == "0123"
@@ -207,33 +249,118 @@ def test_numero_control_regenerates_from_emisor_codes(dte_metadata_factory):
     assert ident["numeroControl"].startswith("DTE-01-S123P456")
 
 
-def test_tipo_dte_int_normalizado(dte_metadata_factory):
+def test_numero_control_fallback_default(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    dte = dte_metadata_factory()
+    for key in ["codEstable", "codEstableMH", "codPuntoVenta", "codPuntoVentaMH"]:
+        dte["emisor"].pop(key, None)
+    dte["identificacion"]["numeroControl"] = "BAD"
+    validate_dte_json(dte, db=db_fixture)
+    assert dte["identificacion"]["numeroControl"] == "DTE-01-S001P001-000000000000001"
+
+
+def test_numero_control_secuencial_por_combinacion(
+    dte_metadata_factory, tmp_path, monkeypatch, db_fixture
+):
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    dte1 = dte_metadata_factory()
+    dte1["identificacion"]["numeroControl"] = "BAD"
+    validate_dte_json(dte1, db=db_fixture)
+    n1 = dte1["identificacion"]["numeroControl"]
+
+    dte2 = dte_metadata_factory()
+    dte2["identificacion"]["numeroControl"] = "BAD"
+    validate_dte_json(dte2, db=db_fixture)
+    n2 = dte2["identificacion"]["numeroControl"]
+
+    dte3 = dte_metadata_factory()
+    dte3["identificacion"]["numeroControl"] = "BAD"
+    dte3["emisor"]["codPuntoVentaMH"] = "0002"
+    dte3["emisor"]["codPuntoVenta"] = "0002"
+    validate_dte_json(dte3, db=db_fixture)
+    n3 = dte3["identificacion"]["numeroControl"]
+
+    assert n1.endswith("000000000000001")
+    assert n2.endswith("000000000000002")
+    assert n3.startswith("DTE-01-S001P002-")
+    assert n3.endswith("000000000000001")
+
+
+def test_numero_control_idempotencia(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    numero = "DTE-01-S123P456-000000000000123"
+    dte = dte_metadata_factory()
+    dte["identificacion"]["numeroControl"] = numero
+    validate_dte_json(dte, db=db_fixture)
+    assert dte["identificacion"]["numeroControl"] == numero
+
+
+def test_numero_control_idempotencia_dura(db_fixture, dte_metadata_factory):
+    """
+    Si numeroControl YA es válido (regex), debe preservarse aunque
+    los códigos de emisor (sucursal/punto) difieran. No se regenera.
+    """
+    dte = dte_metadata_factory()
+    ident = dte["identificacion"]
+    ident["tipoDte"] = "01"
+    ident["numeroControl"] = "DTE-01-S999P888-000000000000777"
+    dte["emisor"]["codEstableMH"] = "001"
+    dte["emisor"]["codPuntoVentaMH"] = "001"
+
+    original_nc = ident["numeroControl"]
+    validate_dte_json(dte, db=db_fixture)
+    assert dte["identificacion"]["numeroControl"] == original_nc
+
+
+def test_numero_control_no_crea_db_extra(tmp_path, monkeypatch, dte_metadata_factory):
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    calls = 0
+    orig_init = DB.__init__
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        orig_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(DB, "__init__", counting_init)
+    db = DB()
+    dte = dte_metadata_factory()
+    validate_dte_json(dte, db=db)
+    assert calls == 1
+
+
+def test_tipo_dte_int_normalizado(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = 1
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     assert dte["identificacion"]["tipoDte"] == "01"
 
 
-def test_tipo_dte_invalido(dte_metadata_factory):
+def test_tipo_dte_invalido(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoDte"] = "99"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_codigo_generacion_generado(dte_metadata_factory):
+def test_codigo_generacion_generado(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"].pop("codigoGeneracion")
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     assert re.fullmatch(UUID4_RE, dte["identificacion"]["codigoGeneracion"])
 
 
-def test_ident_contingencia_modelo(dte_metadata_factory):
+def test_ident_contingencia_modelo(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoModelo"] = 2
     dte["identificacion"]["tipoContingencia"] = 1
     dte["identificacion"]["motivoContin"] = "  EXTRA  "
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     ident = dte["identificacion"]
     assert ident["tipoModelo"] == 1
     assert ident["tipoContingencia"] is None
@@ -242,7 +369,7 @@ def test_ident_contingencia_modelo(dte_metadata_factory):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoOperacion"] = 2
     dte["identificacion"]["tipoContingencia"] = 1
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     ident = dte["identificacion"]
     assert ident["tipoModelo"] == 2
     assert ident["motivoContin"] is None
@@ -251,41 +378,41 @@ def test_ident_contingencia_modelo(dte_metadata_factory):
     dte["identificacion"]["tipoOperacion"] = 2
     dte["identificacion"]["tipoContingencia"] = 5
     dte["identificacion"]["motivoContin"] = " FALLA PROVEEDOR "
-    validate_dte_json(dte)
+    validate_dte_json(dte, db=db_fixture)
     ident = dte["identificacion"]
     assert ident["tipoModelo"] == 2
     assert ident["motivoContin"] == "FALLA PROVEEDOR"
 
 
-def test_ident_contingencia_rechazos(dte_metadata_factory):
+def test_ident_contingencia_rechazos(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoOperacion"] = 2
     dte["identificacion"]["tipoContingencia"] = 9
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoOperacion"] = 2
     dte["identificacion"]["tipoContingencia"] = 5
     dte["identificacion"]["motivoContin"] = ""
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
     dte = dte_metadata_factory()
     dte["identificacion"]["tipoOperacion"] = 2
     dte["identificacion"]["tipoContingencia"] = 5
     dte["identificacion"]["motivoContin"] = "bad"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
 
-def test_fecha_hora_format(dte_metadata_factory):
+def test_fecha_hora_format(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["fecEmi"] = "01-01-2024"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)
 
     dte = dte_metadata_factory()
     dte["identificacion"]["horEmi"] = "25:00:00"
     with pytest.raises(ValueError):
-        validate_dte_json(dte)
+        validate_dte_json(dte, db=db_fixture)

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -234,7 +234,7 @@ def test_generar_dte_json_normaliza_ambiente_config(
     data = dte_module.generar_dte_json(db, venta_id, ambiente="00")
     monkeypatch.setattr(dte_module, "validate_dte_json", orig_validate)
     data["identificacion"].pop("ambiente", None)
-    dte_module.validate_dte_json(data)
+    dte_module.validate_dte_json(data, db=db)
     monkeypatch.setattr(dte_module, "_normalize_payload", orig_norm)
     assert data["identificacion"]["ambiente"] == expected
 

--- a/tests/test_pagos_warning.py
+++ b/tests/test_pagos_warning.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 
 import dte
+from db import DB
 
 
 def _load_fc():
@@ -10,7 +11,7 @@ def _load_fc():
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_warns_on_payment_mismatch(monkeypatch, caplog):
+def test_warns_on_payment_mismatch(monkeypatch, caplog, tmp_path):
     data = _load_fc()
     # Introduce discrepancy greater than one cent
     data["resumen"]["pagos"][0]["montoPago"] = "28.45"
@@ -19,6 +20,7 @@ def test_warns_on_payment_mismatch(monkeypatch, caplog):
         "normalizar_pagos",
         lambda pagos, total, **kwargs: pagos or [],
     )
+    db = DB(tmp_path / "test.db")
     with caplog.at_level(logging.WARNING):
-        dte.validate_dte_json(data)
+        dte.validate_dte_json(data, db=db)
     assert "Pagos no cuadran con totalPagar" in caplog.text

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -20,6 +20,8 @@ else:  # pragma: no cover
     _dialog_import_error = False
 
 from dte import validate_dte_json, _build_receptor_direccion
+from db import DB
+from tests.test_dte_validation import _patch_datos_negocio
 from jsonschema import ValidationError
 from utils import catalogos
 
@@ -75,27 +77,35 @@ def _load_fc():
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_receptor_documentos(monkeypatch):
+@pytest.fixture
+def db_fixture(tmp_path, monkeypatch):
+    _patch_datos_negocio(tmp_path, monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db = DB()
+    yield db
+
+
+def test_receptor_documentos(monkeypatch, db_fixture):
     monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
     data = _load_fc()
     data["receptor"]["tipoDocumento"] = 36
     data["receptor"]["numDocumento"] = "06141990011019"
-    validate_dte_json(data)
+    validate_dte_json(data, db=db_fixture)
 
     data["receptor"]["numDocumento"] = "123"
     with pytest.raises(ValueError):
-        validate_dte_json(data)
+        validate_dte_json(data, db=db_fixture)
 
     data = _load_fc()
     data["receptor"]["tipoDocumento"] = 13
     data["receptor"]["numDocumento"] = "12345678-9"
-    validate_dte_json(data)
+    validate_dte_json(data, db=db_fixture)
     data["receptor"]["numDocumento"] = "123456789"
     with pytest.raises(ValueError):
-        validate_dte_json(data)
+        validate_dte_json(data, db=db_fixture)
 
 
-def test_receptor_direccion(monkeypatch):
+def test_receptor_direccion(monkeypatch, db_fixture):
     monkeypatch.setattr(catalogos, "get_dte_schema", lambda *_: None)
     data = _load_fc()
     data["receptor"]["direccion"] = {
@@ -103,15 +113,15 @@ def test_receptor_direccion(monkeypatch):
         "municipio": "23",
         "complemento": "C",
     }
-    validate_dte_json(data)
+    validate_dte_json(data, db=db_fixture)
 
     data["receptor"]["direccion"]["municipio"] = "99"
     with pytest.raises(ValidationError):
-        validate_dte_json(data)
+        validate_dte_json(data, db=db_fixture)
 
     data["receptor"]["direccion"] = None
     with pytest.raises(ValidationError):
-        validate_dte_json(data)
+        validate_dte_json(data, db=db_fixture)
 
 
 def test_direccion_normaliza_por_nombre():


### PR DESCRIPTION
## Summary
- inject shared DB into numeroControl generator and helper to normalize branch/punto codes
- regenerate numeroControl using shared DB only when format invalid, preserving valid values even if emitter codes differ
- add regression tests covering default fallback, sequencing, strict idempotence, and no extra DB instantiation

## Testing
- `pytest tests/test_dte_validation.py::test_numero_control_regex tests/test_dte_validation.py::test_numero_control_validos tests/test_dte_validation.py::test_numero_control_invalidos tests/test_dte_validation.py::test_numero_control_regenerates_from_emisor_codes tests/test_dte_validation.py::test_numero_control_fallback_default tests/test_dte_validation.py::test_numero_control_secuencial_por_combinacion tests/test_dte_validation.py::test_numero_control_idempotencia tests/test_dte_validation.py::test_numero_control_idempotencia_dura tests/test_dte_validation.py::test_numero_control_no_crea_db_extra tests/test_validaciones_basicas.py::test_receptor_documentos tests/test_pagos_warning.py::test_warns_on_payment_mismatch tests/test_generators.py::test_generar_factura_fiscal tests/test_generators.py::test_generar_consumidor_final tests/test_generators.py::test_generar_nota_debito tests/test_generators.py::test_generar_nota_credito tests/test_generators.py::test_generar_nota_remision tests/test_generators.py::test_fc_valida_con_schema -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ad39567c8323b14008b2ff64fc4a