### PR TITLE
Load sales after importing inventory

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,6 +108,7 @@ if __name__ == "__main__":
             window._actualizar_tabla_trabajadores()
             window._actualizar_historial()
             window._cargar_personas_estado()
+            window.sales_tab.load_sales()
             QMessageBox.information(window, "Inventario", "Inventario cargado exitosamente.")
         except (OSError, ValueError, json.JSONDecodeError, sqlite3.Error) as e:
             QMessageBox.critical(window, "Error", f"No se pudo cargar el inventario:\n{e}")


### PR DESCRIPTION
## Summary
- Ensure sales tab loads sales after automatically importing last inventory on startup

## Testing
- `pytest tests/test_load_inventory_ui.py::test_sales_table_populated_after_import -q` *(fails: assert 0 == 1)*


------
https://chatgpt.com/codex/tasks/task_e_68a738e7954483239f95332791de2bd1