### PR TITLE
Centralize reception URL handling for DTE submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,15 @@ bloque de configuración similar al siguiente:
   }
 }
 ```
-La URL debe incluir la ruta `/fesv/recepciondte`; si sólo se especifica el
-dominio, la aplicación la agregará automáticamente. La función
-`transmitir_dte(db, venta_id)` utilizará estos datos para enviar el DTE
-inmediatamente después de firmarlo en modo normal, o registrará un evento
-pendiente en modo de contingencia.
+`dte_api.url` es la **fuente primaria** de la URL de recepción. La ruta
+`/fesv/recepciondte` se añadirá automáticamente si solo se indica el host. El
+archivo `config_negocio.json` puede proveer valores de respaldo
+(`recepcion_url`, `url` o `endpoint`), pero siempre serán **sobrescritos** por lo
+configurado en `datos_negocio.json`.
+
+La función `transmitir_dte(db, venta_id)` utilizará la URL resultante para
+enviar el DTE inmediatamente después de firmarlo en modo normal, o registrará
+un evento pendiente en modo de contingencia.
 
 ### Condición de operación
 
@@ -207,14 +211,15 @@ configura el campo `ambiente` y las URLs en `config_negocio.json`:
   },
   "produccion": {
     "auth_url": "https://api.factura.gob.sv/auth",
-    "recepcion_url": "https://api.dtes.mh.gob.sv/recepciondte/api/recepciondte"
+    "recepcion_url": "https://api.dtes.mh.gob.sv/fesv/recepciondte"
   }
 }
 ```
-
-La aplicación buscará `auth_url` y `recepcion_url` dentro del bloque del
-ambiente seleccionado (`pruebas` o `produccion`). Al cambiar `ambiente` a
-`produccion` la aplicación utilizará los servicios productivos.
+Los valores de `recepcion_url` actúan como respaldo y serán reemplazados si se
+define `dte_api.url` en `datos_negocio.json`. La aplicación buscará `auth_url`
+y `recepcion_url` dentro del bloque del ambiente seleccionado (`pruebas` o
+`produccion`). Al cambiar `ambiente` a `produccion` la aplicación utilizará los
+servicios productivos.
 
 Dentro del mismo bloque puede definirse `api_user` y `api_pwd` para
 especificar el usuario y la contraseña de la API. Estos datos se utilizan

--- a/dialogs.py
+++ b/dialogs.py
@@ -3267,7 +3267,7 @@ class DTEConfigDialog(QDialog):
 
     def get_data(self):
         dte_api = {
-            "url": self.endpoint_hacienda.text(),
+            "url": self.endpoint_hacienda.text().strip(),
             "ambiente": self.ambiente_hacienda.currentText().lower(),
             "token": self.token_hacienda.text(),
             "prefijo_control": self.prefijo_control.text(),
@@ -3284,8 +3284,7 @@ class DTEConfigDialog(QDialog):
             "activo": self.dte_activo.isChecked(),
         }
         urls = {
-            "auth_url": self.auth_url.text(),
-            "recepcion_url": self.recepcion_url.text(),
+            "auth_url": self.auth_url.text().strip(),
             "auth": {
                 "nitUsuario": self.api_user.text().strip(),
                 "pwd": base64.b64encode(self.api_pwd.text().encode()).decode()
@@ -3293,6 +3292,9 @@ class DTEConfigDialog(QDialog):
                 else "",
             },
         }
+        recep = self.recepcion_url.text().strip()
+        if recep:
+            urls["recepcion_url"] = recep
         return dte_api, fe_config, urls
 class TrabajadorDialog(QDialog):
     def __init__(self, trabajador=None, parent=None):

--- a/dte.py
+++ b/dte.py
@@ -273,10 +273,6 @@ def _load_datos_negocio():
                 data = json.load(fh)
             dte_api = data.get("dte_api")
             if isinstance(dte_api, dict):
-                url = dte_api.get("url", "")
-                if url and "/fesv/recepciondte" not in url:
-                    dte_api["url"] = url.rstrip("/") + "/fesv/recepciondte"
-
                 # Extract branch and point-of-sale codes from the control prefix
                 prefijo = dte_api.get("prefijo_control")
                 if isinstance(prefijo, str):
@@ -2389,19 +2385,69 @@ def generar_nota_remision_json(db: DB, nota_id: int) -> dict:
     return data
 
 
+def _normalize_recepcion_url(raw: str) -> str:
+    """Normaliza y valida ``raw`` como URL de recepción de Hacienda.
+
+    - ``strip()`` y eliminación de espacios, saltos de línea o tabulaciones
+    - Si falta el esquema se asume ``https``
+    - Hosts oficiales sin path obtienen ``/fesv/recepciondte``
+    - Colapsa dobles slashes y remueve el slash final
+    - Cadena vacía → ``DEFAULT_RECEPCION_URL``
+    - Rechaza dominios que contengan ``sandbox``
+    """
+
+    raw = "" if raw is None else str(raw)
+    raw = re.sub(r"\s+", "", raw.strip())
+    if not raw:
+        return DEFAULT_RECEPCION_URL
+    if "://" not in raw:
+        raw = "https://" + raw
+    pu = urlparse(raw)
+    host = pu.netloc.lower()
+    if "sandbox" in host:
+        raise ValueError("sandbox no permitido")
+    path = pu.path or ""
+    if host in {"apitest.dtes.mh.gob.sv", "api.dtes.mh.gob.sv"} and path in ("", "/"):
+        path = "/fesv/recepciondte"
+    path = "/" + path.lstrip("/")
+    path = re.sub("/+", "/", path).rstrip("/")
+    return f"{pu.scheme}://{host}{path}"
+
+
 def _load_dte_api_config():
-    """Lee configuración de URLs y ambiente desde ``datos_negocio.json``."""
+    """Carga configuración consolidada para la recepción de DTE."""
+
+    datos = _load_datos_negocio()
+    dte_api = datos.get("dte_api") or {}
+    raw_datos_url = dte_api.get("url") or dte_api.get("endpoint")
+    ambiente = dte_api.get("ambiente") or datos.get("ambiente")
+
+    cfg_recep = cfg_url = cfg_endpoint = None
     try:
-        with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        dte_api = data.get("dte_api") or {}
-        ambiente = dte_api.get("ambiente") or data.get("ambiente") or "pruebas"
-        url = (dte_api.get("url") or "").strip() or DEFAULT_RECEPCION_URL
-        logger.info("Recepción configurada → %s", url)
-        return {"ambiente": ambiente, "url": url}
+        with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+            cfg = json.load(fh)
+        ambiente = ambiente or cfg.get("ambiente")
+        env = cfg.get(ambiente or "pruebas", {})
+        cfg_recep = env.get("recepcion_url")
+        cfg_url = env.get("url")
+        cfg_endpoint = env.get("endpoint")
     except Exception:
-        logger.info("Recepción configurada → %s", DEFAULT_RECEPCION_URL)
-        return {"ambiente": "pruebas", "url": DEFAULT_RECEPCION_URL}
+        pass
+
+    raw_cfg_url = cfg_recep or cfg_url or cfg_endpoint
+    ambiente = ambiente or "pruebas"
+    logger.debug("Cargando configuración DTE desde %s", DATOS_NEGOCIO_PATH)
+    logger.debug(
+        "Crudos: dte_api.url=%r dte_api.endpoint=%r cfg.recepcion_url=%r cfg.url=%r cfg.endpoint=%r",
+        dte_api.get("url"),
+        dte_api.get("endpoint"),
+        cfg_recep,
+        cfg_url,
+        cfg_endpoint,
+    )
+    url = _normalize_recepcion_url(raw_datos_url or raw_cfg_url)
+    logger.info("Recepción configurada → %s", url)
+    return {"ambiente": ambiente, "url": url}
 
 
 def _assert_no_ejemplo(path: str) -> None:
@@ -2565,14 +2611,14 @@ def _post_dte(
     else:
         assert tipo_dte in {1, 3, 4, 5, 6, 7, 8, 9, 11, 14, 15}, "tipoDte inválido"
 
-    auth_header = headers.get("Authorization")
     if token:
-        assert re.fullmatch(
-            r"Bearer [^\s]+", auth_header
-        ), "Authorization header malformado"
+        assert re.fullmatch(r"Bearer\s+\S+", token), "Authorization header malformado"
 
     pu = urlparse(url)
-    assert pu.netloc == "apitest.dtes.mh.gob.sv", f"Host inválido: {url}"
+    assert pu.netloc in {
+        "apitest.dtes.mh.gob.sv",
+        "api.dtes.mh.gob.sv",
+    }, f"Host inválido: {url}"
     assert pu.path.rstrip("/") == "/fesv/recepciondte", f"Path inválido: {url}"
     logger.info("POST recepcion → %s", url)
     body = str(jws_token).strip().encode("utf-8")
@@ -2673,13 +2719,15 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         "codigoGeneracion": ident.get("codigoGeneracion"),
     }
     config = _load_dte_api_config()
-    url = config.get("url") or DEFAULT_RECEPCION_URL
+    url = config["url"]
     token = auth.get_token()
     auth_host = auth.get_last_auth_host()
     recep_host = urlparse(url).netloc
     if auth_host and recep_host != auth_host:
-        raise ValueError(
-            f"Host de recepción {recep_host} difiere de autenticación {auth_host}"
+        logger.warning(
+            "Auth host %s ≠ recepción %s (esto es normal en prod)",
+            auth_host,
+            recep_host,
         )
     try:
         respuesta = _post_dte(url, token, jws_token, meta)
@@ -2713,7 +2761,7 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
 def enviar_dte_a_hacienda(jws_token: str) -> dict:
     """Transmite un DTE ya firmado (JWS) al entorno de pruebas de Hacienda."""
     config = _load_dte_api_config()
-    url = config.get("url") or DEFAULT_RECEPCION_URL
+    url = config["url"]
     payload = _decode_jws_payload(jws_token)
     ident = payload.get("identificacion") or payload.get("identificador") or {}
     meta = {
@@ -2764,7 +2812,7 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
     if not data.get("resumen", {}).get("totalLetras"):
         raise ValueError("El total en letras es obligatorio")
 
-    url = config.get("url") or DEFAULT_RECEPCION_URL
+    url = config["url"]
     ident = data.get("identificacion") or data.get("identificador") or {}
     meta = {
         "ambiente": ident.get("ambiente"),
@@ -2782,8 +2830,10 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
     auth_host = auth.get_last_auth_host()
     recep_host = urlparse(url).netloc
     if auth_host and recep_host != auth_host:
-        raise ValueError(
-            f"Host de recepción {recep_host} difiere de autenticación {auth_host}"
+        logger.warning(
+            "Auth host %s ≠ recepción %s (esto es normal en prod)",
+            auth_host,
+            recep_host,
         )
     try:
         resumen = data.get("resumen", {})
@@ -2906,7 +2956,7 @@ def enviar_nota_remision(db: DB, nota_id: int, modo: str = "normal") -> dict:
 def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     """Firma y envía un evento a Hacienda."""
     config = _load_dte_api_config()
-    url = config.get("url") or DEFAULT_RECEPCION_URL
+    url = config["url"]
     signed = jws.sign_json(data)
     token = auth.get_token()
 

--- a/tests/test_dte_api_url.py
+++ b/tests/test_dte_api_url.py
@@ -1,20 +1,132 @@
 import json
-from urllib.parse import urlparse
+import pytest
+
 import dte
+from tests.conftest import make_jws
 
 
-def test_load_datos_negocio_appends_recepcion_path(tmp_path, monkeypatch):
-    datos_path = tmp_path / "datos_negocio.json"
-    datos_path.write_text(json.dumps({"dte_api": {"url": "https://apitest.dtes.mh.gob.sv"}}))
+class DummyResp:
+    status_code = 200
+    text = ""
+
+    def json(self):
+        return {}
+
+    def raise_for_status(self):
+        pass
+
+
+def _ok_post(*args, **kwargs):
+    return DummyResp()
+
+
+def _make_meta():
+    return {
+        "ambiente": "00",
+        "version": 1,
+        "tipoDte": "01",
+        "codigoGeneracion": "X",
+    }
+
+
+def _make_token():
+    return make_jws({"identificacion": _make_meta()})
+
+
+def test_host_desnudo_pruebas(monkeypatch, tmp_path):
+    datos = {"dte_api": {"url": "https://apitest.dtes.mh.gob.sv"}}
+    datos_path = tmp_path / "datos.json"
+    datos_path.write_text(json.dumps(datos))
     monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
-    data = dte._load_datos_negocio()
-    pu = urlparse(data["dte_api"]["url"])
-    assert pu.path.rstrip("/") == "/fesv/recepciondte"
+    monkeypatch.setattr(dte.requests, "post", _ok_post)
+    cfg = dte._load_dte_api_config()
+    assert cfg["url"] == "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"
+    _ = dte._post_dte(cfg["url"], "Bearer T", _make_token(), _make_meta())
 
 
-def test_load_dte_api_config_uses_default(monkeypatch, tmp_path):
-    datos_path = tmp_path / "datos_negocio.json"
-    datos_path.write_text(json.dumps({"dte_api": {"url": ""}}))
+def test_host_desnudo_produccion(monkeypatch, tmp_path):
+    datos = {"dte_api": {"url": "https://api.dtes.mh.gob.sv"}}
+    datos_path = tmp_path / "datos.json"
+    datos_path.write_text(json.dumps(datos))
     monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
+    monkeypatch.setattr(dte.requests, "post", _ok_post)
+    cfg = dte._load_dte_api_config()
+    assert cfg["url"] == "https://api.dtes.mh.gob.sv/fesv/recepciondte"
+    _ = dte._post_dte(cfg["url"], "Bearer T", _make_token(), _make_meta())
+
+
+def test_path_presente_trailing_slash(monkeypatch, tmp_path):
+    datos = {
+        "dte_api": {"url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte/"}
+    }
+    datos_path = tmp_path / "datos.json"
+    datos_path.write_text(json.dumps(datos))
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
+    monkeypatch.setattr(dte.requests, "post", _ok_post)
+    cfg = dte._load_dte_api_config()
+    assert cfg["url"].rstrip("/") == "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"
+    assert cfg["url"].split("://", 1)[1].count("//") == 0
+    _ = dte._post_dte(cfg["url"], "Bearer T", _make_token(), _make_meta())
+
+
+def test_datos_negocio_tiene_prioridad(monkeypatch, tmp_path):
+    datos = {"dte_api": {"url": "https://apitest.dtes.mh.gob.sv"}}
+    datos_path = tmp_path / "datos.json"
+    datos_path.write_text(json.dumps(datos))
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
+    cfg_path = tmp_path / "config.json"
+    cfg = {
+        "ambiente": "pruebas",
+        "pruebas": {"recepcion_url": "https://api.dtes.mh.gob.sv"},
+    }
+    cfg_path.write_text(json.dumps(cfg))
+    monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", str(cfg_path))
+    monkeypatch.setattr(dte.requests, "post", _ok_post)
+    cfg = dte._load_dte_api_config()
+    assert cfg["url"].startswith("https://apitest.dtes.mh.gob.sv")
+
+
+def test_fallback_default(monkeypatch, tmp_path):
+    datos_path = tmp_path / "datos.json"
+    datos_path.write_text("{}")
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"ambiente": "pruebas", "pruebas": {}}))
+    monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", str(cfg_path))
     cfg = dte._load_dte_api_config()
     assert cfg["url"] == dte.DEFAULT_RECEPCION_URL
+
+
+def test_normalize_adds_scheme():
+    assert (
+        dte._normalize_recepcion_url("api.dtes.mh.gob.sv")
+        == "https://api.dtes.mh.gob.sv/fesv/recepciondte"
+    )
+
+
+def test_post_dte_sets_required_headers(monkeypatch):
+    captured = {}
+
+    def fake_post(url, data=None, headers=None, timeout=20):
+        captured["headers"] = headers
+        return DummyResp()
+
+    monkeypatch.setattr(dte.requests, "post", fake_post)
+    _ = dte._post_dte(dte.DEFAULT_RECEPCION_URL, "Bearer T", _make_token(), _make_meta())
+    assert captured["headers"]["Content-Type"] == "application/jose"
+    assert captured["headers"]["Accept"] == "application/json"
+
+
+def test_normalize_rejects_sandbox():
+    with pytest.raises(ValueError):
+        dte._normalize_recepcion_url("https://sandbox.dtes.mh.gob.sv")
+
+
+def test_logging_final_url(monkeypatch, tmp_path, caplog):
+    datos = {"dte_api": {"url": "https://apitest.dtes.mh.gob.sv"}}
+    datos_path = tmp_path / "datos.json"
+    datos_path.write_text(json.dumps(datos))
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(datos_path))
+    caplog.set_level("INFO")
+    dte._load_dte_api_config()
+    assert any("Recepción configurada" in r.message for r in caplog.records)

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -233,7 +233,7 @@ def test_post_dte_rejects_mismatch(monkeypatch):
     token = make_jws({"identificacion": meta})
     with pytest.raises(ValueError):
         _post_dte(
-            "http://example.com",
+            dte.DEFAULT_RECEPCION_URL,
             "Bearer TOKEN",
             token,
             {**meta, "codigoGeneracion": "XYZ"},

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import pytest
 import requests
 import auth
@@ -68,7 +69,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
 
     monkeypatch.setattr(auth, "get_token", fake_token)
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "apitest.dtes.mh.gob.sv")
-    monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+    monkeypatch.setattr("dte.validate_dte_json", lambda d, db=None: None)
     monkeypatch.setattr(
         "dte.generar_dte_json",
         lambda db_obj, vid: {
@@ -191,7 +192,7 @@ def test_http_error_negativo(monkeypatch, tmp_path, status):
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
-    monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+    monkeypatch.setattr("dte.validate_dte_json", lambda d, db=None: None)
 
     class Resp:
         status_code = status
@@ -226,7 +227,7 @@ def test_firma_fallida_negativo(monkeypatch, tmp_path):
 
     monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "example.com")
-    monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+    monkeypatch.setattr("dte.validate_dte_json", lambda d, db=None: None)
 
     def fail(*a, **k):
         raise RuntimeError("firma")
@@ -362,16 +363,38 @@ def test_timeout_no_modifica_extra(monkeypatch, tmp_path):
     assert not extra
 
 
-def test_recepcion_url_host_mismatch(monkeypatch, tmp_path):
+def test_recepcion_url_host_mismatch(monkeypatch, tmp_path, caplog):
     db = DB(":memory:")
     venta = create_sale(db)
     monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "auth.example")
-    monkeypatch.setattr("dte.validate_dte_json", lambda d: None)
+    monkeypatch.setattr("dte.validate_dte_json", lambda d, db=None: None)
     monkeypatch.setattr(
         "dte._load_datos_negocio",
         lambda: {"dte_api": {"url": dte.DEFAULT_RECEPCION_URL, "ambiente": "pruebas"}},
     )
-    with pytest.raises(ValueError):
+    monkeypatch.setattr(
+        dte,
+        "generar_dte_json",
+        lambda db, vid: {
+            "identificacion": {
+                "ambiente": "00",
+                "version": "1",
+                "tipoDte": "01",
+                "codigoGeneracion": "ABC",
+            },
+            "resumen": {"totalLetras": "X"},
+        },
+    )
+    called = {}
+
+    def fake_post(url, token, jws_token, meta):
+        called["url"] = url
+        return {"estado": "Transmitido", "sello": "S"}
+
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+    with caplog.at_level(logging.WARNING):
         transmitir_dte(db, venta)
+    assert "Auth host auth.example ≠ recepción apitest.dtes.mh.gob.sv" in caplog.text
+    assert called["url"].endswith("/fesv/recepciondte")


### PR DESCRIPTION
## Summary
- Normalize and whitelist Hacienda reception endpoints with `/fesv/recepciondte`
- Load reception URL from `datos_negocio.json` with `config_negocio.json` fallback and document precedence
- Warn instead of erroring when auth and reception hosts differ, keeping production flows intact

## Testing
- `python -m py_compile dte.py tests/test_envio_hacienda.py`
- `pytest` *(fails: 39 errors during collection)*
- `pytest tests/test_dte_api_url.py tests/test_envio_hacienda.py::test_recepcion_url_host_mismatch -q`

------
https://chatgpt.com/codex/tasks/task_e_68a72334906883238763960deb6e5662