### PR TITLE
feat: enhance DTE reception

### DIFF
--- a/DTE.js
+++ b/DTE.js
@@ -1,0 +1,234 @@
+import fs from "fs";
+import path from "path";
+import axios from "axios";
+
+/**
+ * @typedef {Object} IdStore
+ * @property {(key: string) => Promise<number>} nextId
+ * @property {(key: string, id: number) => Promise<void>} [setLastId]
+*/
+
+/**
+ * File-backed implementation of IdStore. Stores last idEnvio per key
+ * (e.g., per client+ambiente).
+ */
+export class FileIdStore {
+  constructor(filePath = ".dte-state.json") {
+    this.filePath = filePath;
+    this._queue = Promise.resolve();
+  }
+
+  async _read() {
+    try {
+      const raw = await fs.promises.readFile(this.filePath, "utf8");
+      return JSON.parse(raw);
+    } catch {
+      return { clientes: {} };
+    }
+  }
+
+  async _write(state) {
+    await fs.promises.writeFile(this.filePath, JSON.stringify(state, null, 2));
+  }
+
+  /**
+   * Get next idEnvio for a key, incrementing stored value.
+   * @param {string} key
+   * @returns {Promise<number>}
+   */
+  nextId(key) {
+    this._queue = this._queue.then(async () => {
+      const state = await this._read();
+      const current = state.clientes?.[key]?.idEnvio || 0;
+      const next = current + 1;
+      state.clientes[key] = { idEnvio: next };
+      await this._write(state);
+      return next;
+    });
+    return this._queue;
+  }
+
+  /**
+   * Ensure stored idEnvio is at least `id` for the key.
+   * @param {string} key
+   * @param {number} id
+   */
+  setLastId(key, id) {
+    this._queue = this._queue.then(async () => {
+      const state = await this._read();
+      const current = state.clientes?.[key]?.idEnvio || 0;
+      if (id > current) {
+        state.clientes[key] = { idEnvio: id };
+        await this._write(state);
+      }
+    });
+    return this._queue;
+  }
+}
+
+function readMaybeFile(input) {
+  if (typeof input === "string" && fs.existsSync(input)) {
+    const ext = path.extname(input).toLowerCase();
+    const raw = fs.readFileSync(input, "utf8");
+    if (ext === ".json") return JSON.parse(raw);
+    if (ext === ".jws" || ext === ".txt") return raw.trim();
+  }
+  return input;
+}
+
+function isBase64Url(str) {
+  return /^[A-Za-z0-9_-]+$/.test(str);
+}
+
+/**
+ * Validate coherence between DTE and envelope.
+ * @param {object} dte
+ * @param {object} peticion
+ * @param {string} ambiente
+ */
+export function validatePeticion(dte, peticion, ambiente) {
+  const id = dte?.identificacion || {};
+  const same = (a, b) => String(a) === String(b);
+  if (!same(peticion.version, id.version)) {
+    throw new Error("version del sobre no coincide con la del DTE.");
+  }
+  if (peticion.tipoDte !== id.tipoDte) {
+    throw new Error("tipoDte del sobre no coincide con el del DTE.");
+  }
+  if (peticion.codigoGeneracion !== id.codigoGeneracion) {
+    throw new Error("codigoGeneracion del sobre no coincide con el del DTE.");
+  }
+  if (id.ambiente && ambiente && id.ambiente !== ambiente) {
+    throw new Error("ambiente de opciones difiere del DTE.");
+  }
+}
+
+/**
+ * Build envelope (peticion) for DTE reception.
+ * @param {*} dteInput
+ * @param {*} jwsInput
+ * @param {*} options
+ * @returns {Promise<object>}
+ */
+export async function buildPeticion(dteInput, jwsInput, options = {}) {
+  const dte = readMaybeFile(dteInput);
+  const jws = readMaybeFile(jwsInput);
+
+  if (!dte || !dte.identificacion) {
+    throw new Error("DTE inválido: falta nodo 'identificacion'.");
+  }
+  const parts = typeof jws === "string" ? jws.split(".") : [];
+  if (parts.length !== 3 || parts.some((p) => !p || !isBase64Url(p))) {
+    throw new Error("JWS inválido: debe ser string compacta con 3 segmentos base64url.");
+  }
+  if (!options.token || typeof options.token !== "string" || !options.token.trim()) {
+    throw new Error("Falta token Bearer.");
+  }
+  if (!options.clientId || typeof options.clientId !== "string" || !options.clientId.trim()) {
+    throw new Error("Falta clientId.");
+  }
+  if (!options.ambiente || !["00", "01"].includes(options.ambiente)) {
+    throw new Error("ambiente debe ser '00' o '01'.");
+  }
+
+  const store = options.idStore || new FileIdStore();
+  const key = `${options.clientId}:${options.ambiente}`;
+  let idEnvio;
+  if (options.idEnvio !== undefined) {
+    if (!Number.isInteger(options.idEnvio) || options.idEnvio < 1) {
+      throw new Error("idEnvio inválido.");
+    }
+    idEnvio = options.idEnvio;
+    if (store.setLastId) await store.setLastId(key, idEnvio);
+  } else {
+    idEnvio = await store.nextId(key);
+  }
+
+  const { version, tipoDte, codigoGeneracion } = dte.identificacion;
+  const peticion = {
+    ambiente: options.ambiente,
+    idEnvio,
+    version,
+    tipoDte,
+    codigoGeneracion,
+    documento: jws
+  };
+
+  validatePeticion(dte, peticion, options.ambiente);
+  return peticion;
+}
+
+/**
+ * Send envelope to Hacienda API.
+ * @param {object} peticion
+ * @param {object} options
+ * @returns {Promise<object>}
+ */
+export async function sendRecepcionDTE(peticion, options = {}) {
+  const ambiente = options.ambiente;
+  const baseUrl =
+    options.baseUrl ||
+    (ambiente === "01" ? "https://api.dtes.mh.gob.sv" : "https://apitest.dtes.mh.gob.sv");
+  const url = `${baseUrl.replace(/\/+$/, "")}/fesv/recepciondte`;
+  const raw = (options.token || "").trim();
+  const token = raw.startsWith("Bearer ") ? raw.slice(7).trim() : raw;
+  const timeout = options.timeoutMs ?? (ambiente === "01" ? 45000 : 30000);
+  const ua = options.userAgent || `Vertex-DTE/1.0 (${options.clientId}; env=${ambiente})`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": ua,
+    "Content-Type": "application/json"
+  };
+
+  const delays = [500, 1500];
+  const transient = [429, 502, 503, 504];
+  let attempt = 0;
+  for (;;) {
+    try {
+      const resp = await axios.post(url, peticion, { headers, timeout });
+      const data = resp.data || {};
+      const resumen = {
+        statusHttp: resp.status,
+        estado: data.estado,
+        codigoGeneracion: data.codigoGeneracion,
+        selloRecibido: data.selloRecibido,
+        fhProcesamiento: data.fhProcesamiento,
+        observaciones: data.observaciones
+      };
+      const brief = Array.isArray(resumen.observaciones)
+        ? resumen.observaciones.slice(0, 5)
+        : resumen.observaciones;
+      console.info("Recepción DTE ->", { ...resumen, observaciones: brief });
+      return resumen;
+    } catch (err) {
+      const status = err.response?.status;
+      if (transient.includes(status) && attempt < delays.length) {
+        const wait = delays[attempt++];
+        await new Promise((r) => setTimeout(r, wait));
+        continue;
+      }
+      if (err.response) {
+        const data = err.response.data || {};
+        const message = data.mensaje ? ` - ${data.mensaje}` : "";
+        const e = new Error(`Error recepción DTE: ${status}${message}`);
+        e.statusHttp = status;
+        if (data.observaciones) e.observaciones = data.observaciones;
+        throw e;
+      }
+      throw err;
+    }
+  }
+}
+
+// CLI usage
+if (process.argv[1] && path.basename(process.argv[1]) === path.basename(new URL(import.meta.url).pathname)) {
+  (async () => {
+    const [, , dtePath, jwsPath, clientId, ambiente, token] = process.argv;
+    const idStore = new FileIdStore();
+    const opts = { clientId, ambiente, token, idStore };
+    const peticion = await buildPeticion(dtePath, jwsPath, opts);
+    const resumen = await sendRecepcionDTE(peticion, opts);
+    console.log(resumen);
+  })();
+}
+

--- a/DTE.spec.js
+++ b/DTE.spec.js
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+import path from "path";
+import axios from "axios";
+import { buildPeticion, sendRecepcionDTE, FileIdStore, validatePeticion } from "./DTE.js";
+
+const sampleDte = {
+  identificacion: {
+    version: "1.0",
+    tipoDte: "01",
+    codigoGeneracion: "ABC123",
+    ambiente: "00"
+  }
+};
+
+const validJws = "aaa.bbb.ccc";
+
+describe("buildPeticion validations", () => {
+  it("rechaza JWS inválido", async () => {
+    await expect(
+      buildPeticion(sampleDte, "invalido", { token: "t", clientId: "c", ambiente: "00" })
+    ).rejects.toThrow();
+    await expect(
+      buildPeticion(sampleDte, "a.b.c$", { token: "t", clientId: "c", ambiente: "00" })
+    ).rejects.toThrow();
+    await expect(
+      buildPeticion(sampleDte, "a..c", { token: "t", clientId: "c", ambiente: "00" })
+    ).rejects.toThrow();
+  });
+
+  it("rechaza token vacío", async () => {
+    await expect(
+      buildPeticion(sampleDte, validJws, { token: "", clientId: "c", ambiente: "00" })
+    ).rejects.toThrow("Falta token");
+  });
+
+  it("rechaza ambiente inválido", async () => {
+    await expect(
+      buildPeticion(sampleDte, validJws, { token: "t", clientId: "c", ambiente: "02" })
+    ).rejects.toThrow("ambiente");
+  });
+
+  it("falla si sobre y DTE no coinciden", () => {
+    const peticion = {
+      ambiente: "00",
+      idEnvio: 1,
+      version: "2.0",
+      tipoDte: "01",
+      codigoGeneracion: "ABC123",
+      documento: validJws
+    };
+    expect(() => validatePeticion(sampleDte, peticion, "00")).toThrow("version");
+  });
+
+  it("falla si ambiente difiere del DTE", async () => {
+    const dte = { identificacion: { ...sampleDte.identificacion, ambiente: "01" } };
+    await expect(
+      buildPeticion(dte, validJws, { token: "t", clientId: "c", ambiente: "00" })
+    ).rejects.toThrow("ambiente");
+  });
+
+  it("acepta version numérica equivalente", () => {
+    const dte = { identificacion: { ...sampleDte.identificacion, version: 1 } };
+    const peticion = {
+      ambiente: "00",
+      idEnvio: 1,
+      version: "1",
+      tipoDte: dte.identificacion.tipoDte,
+      codigoGeneracion: dte.identificacion.codigoGeneracion,
+      documento: validJws
+    };
+    expect(() => validatePeticion(dte, peticion, "00")).not.toThrow();
+  });
+});
+
+describe("FileIdStore", () => {
+  let tmpFile;
+  let store;
+  beforeEach(() => {
+    tmpFile = path.join(os.tmpdir(), `dte-state-${Math.random()}`);
+    store = new FileIdStore(tmpFile);
+  });
+
+  it("genera ids incrementales por cliente y respeta idEnvio manual", async () => {
+    expect(await store.nextId("A:00")).toBe(1);
+    expect(await store.nextId("A:00")).toBe(2);
+    expect(await store.nextId("A:01")).toBe(1);
+
+    await buildPeticion(sampleDte, validJws, {
+      token: "t",
+      clientId: "A",
+      ambiente: "00",
+      idStore: store,
+      idEnvio: 5
+    });
+    expect(await store.nextId("A:00")).toBe(6);
+  });
+});
+
+describe("sendRecepcionDTE", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("arma URL y headers y retorna resumen", async () => {
+    vi.spyOn(axios, "post").mockResolvedValue({
+      status: 200,
+      data: {
+        estado: "RECIBIDO",
+        codigoGeneracion: "ABC123",
+        selloRecibido: "SELLO",
+        fhProcesamiento: "2024-01-01",
+        observaciones: ["ok"]
+      }
+    });
+    const peticion = await buildPeticion(sampleDte, validJws, {
+      token: "Bearer TKN",
+      clientId: "C1",
+      ambiente: "00"
+    });
+    const resumen = await sendRecepcionDTE(peticion, {
+      token: "Bearer TKN",
+      clientId: "C1",
+      ambiente: "00"
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://apitest.dtes.mh.gob.sv/fesv/recepciondte",
+      peticion,
+      {
+        headers: {
+          Authorization: "Bearer TKN",
+          "User-Agent": "Vertex-DTE/1.0 (C1; env=00)",
+          "Content-Type": "application/json"
+        },
+        timeout: 30000
+      }
+    );
+    expect(resumen.estado).toBe("RECIBIDO");
+  });
+
+  it("usa timeout y User-Agent según ambiente", async () => {
+    vi.spyOn(axios, "post").mockResolvedValue({ status: 200, data: {} });
+    const dteProd = { identificacion: { ...sampleDte.identificacion, ambiente: "01" } };
+    const peticion = await buildPeticion(dteProd, validJws, {
+      token: "Bearer TKN",
+      clientId: "C1",
+      ambiente: "01"
+    });
+    await sendRecepcionDTE(peticion, { token: "Bearer TKN", clientId: "C1", ambiente: "01" });
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://api.dtes.mh.gob.sv/fesv/recepciondte",
+      peticion,
+      {
+        headers: {
+          Authorization: "Bearer TKN",
+          "User-Agent": "Vertex-DTE/1.0 (C1; env=01)",
+          "Content-Type": "application/json"
+        },
+        timeout: 45000
+      }
+    );
+  });
+
+  it("loggea observaciones resumidas", async () => {
+    vi.spyOn(axios, "post").mockResolvedValue({
+      status: 200,
+      data: {
+        estado: "RECIBIDO",
+        codigoGeneracion: "ABC123",
+        selloRecibido: "SELLO",
+        fhProcesamiento: "2024-01-01",
+        observaciones: ["a", "b", "c", "d", "e", "f"]
+      }
+    });
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const peticion = await buildPeticion(sampleDte, validJws, {
+      token: "t",
+      clientId: "c",
+      ambiente: "00"
+    });
+    const resumen = await sendRecepcionDTE(peticion, { token: "t", clientId: "c", ambiente: "00" });
+    expect(resumen.observaciones).toHaveLength(6);
+    expect(info).toHaveBeenCalledWith("Recepción DTE ->", {
+      statusHttp: 200,
+      estado: "RECIBIDO",
+      codigoGeneracion: "ABC123",
+      selloRecibido: "SELLO",
+      fhProcesamiento: "2024-01-01",
+      observaciones: ["a", "b", "c", "d", "e"]
+    });
+    info.mockRestore();
+  });
+
+  it("reintenta en 503 y termina ok", async () => {
+    vi.useFakeTimers();
+    const post = vi.spyOn(axios, "post");
+    post
+      .mockRejectedValueOnce({ response: { status: 503 } })
+      .mockRejectedValueOnce({ response: { status: 503 } })
+      .mockResolvedValueOnce({ status: 200, data: {} });
+    const peticion = await buildPeticion(sampleDte, validJws, { token: "t", clientId: "c", ambiente: "00" });
+    const promise = sendRecepcionDTE(peticion, { token: "t", clientId: "c", ambiente: "00" });
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(1500);
+    await promise;
+    expect(post).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it("reintenta en 429 y termina ok", async () => {
+    vi.useFakeTimers();
+    const post = vi.spyOn(axios, "post");
+    post
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockResolvedValueOnce({ status: 200, data: {} });
+    const peticion = await buildPeticion(sampleDte, validJws, { token: "t", clientId: "c", ambiente: "00" });
+    const promise = sendRecepcionDTE(peticion, { token: "t", clientId: "c", ambiente: "00" });
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(1500);
+    await promise;
+    expect(post).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it("propaga error 400 sin incluir token", async () => {
+    const token = "SECRET";
+    vi.spyOn(axios, "post").mockRejectedValue({
+      response: { status: 400, data: { mensaje: "malo", observaciones: ["oops"] } }
+    });
+    const peticion = await buildPeticion(sampleDte, validJws, { token, clientId: "c", ambiente: "00" });
+    try {
+      await sendRecepcionDTE(peticion, { token, clientId: "c", ambiente: "00" });
+      throw new Error("should fail");
+    } catch (err) {
+      expect(err.message).toContain("400");
+      expect(err.message).not.toContain(token);
+      expect(err.observaciones).toEqual(["oops"]);
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "gestor-de-inventario-ui",
+      "dependencies": {
+        "axios": "^1.11.0"
+      },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
         "@vue/test-utils": "^2.4.3",
@@ -1326,6 +1329,23 @@
         "node": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1351,6 +1371,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -1404,6 +1437,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "10.0.1",
@@ -1521,6 +1566,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -1529,6 +1583,20 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1575,6 +1643,51 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1646,6 +1759,26 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1663,6 +1796,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1678,6 +1827,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -1686,6 +1844,43 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1723,6 +1918,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -1936,6 +2182,36 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2216,6 +2492,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "gestor-de-inventario-ui",
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "send:dte": "node DTE.js ./ejemplos/dte.json ./ejemplos/dte.jws CLIENTE_A 00 \"$DTE_TOKEN\""
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
@@ -10,5 +11,8 @@
     "jsdom": "^26.1.0",
     "vitest": "^0.34.6",
     "vue": "^3.3.4"
+  },
+  "dependencies": {
+    "axios": "^1.11.0"
   }
 }


### PR DESCRIPTION
## Summary
- normalize Authorization header when token already contains `Bearer`
- compare DTE `version` values by string representation
- reject JWS with empty base64url segments and extend tests
- persist `idEnvio` per client/environment and truncate logged observations
- retry `429`/`5xx` with env-based timeout and user agent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a775084dd083238892f0f840036a00