### PR TITLE
Guardar sobre junto a archivos de DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2558,28 +2558,36 @@ def _decode_jws_payload(token: str) -> dict:
 def construir_sobre_recepcion(documento: str, dte_data: dict | None = None) -> dict:
     """Retorna el body listo para ``POST /fesv/recepciondte``.
 
-    Si ``documento`` parece un JWS se extraen los metadatos desde su payload.
-    Cuando no es un JWS válido o la decodificación falla, los metadatos se
-    obtienen de ``dte_data``.  Valida campos requeridos y formatos.  En caso de
-    error devuelve ``{"estado": "Error", "detalle": "<mensaje>"}``.
+    Valida que ``documento`` sea una JWS compacta y que los metadatos
+    proporcionados en ``dte_data`` coincidan con los embebidos en el payload.
+    Cuando la validación falla se devuelve ``{"estado": "Error"}`` con el
+    detalle correspondiente.
     """
 
-    meta: dict[str, object] = {}
+    if not isinstance(documento, str) or documento.count(".") != 2:
+        return {"estado": "Error", "detalle": "documento inválido"}
 
-    if isinstance(documento, str) and documento.count(".") == 2:
-        try:
-            payload = _decode_jws_payload(documento)
-            meta = payload.get("identificacion") or payload.get("identificador") or payload
-        except Exception:
-            meta = {}
+    meta: dict[str, object] = {}
+    payload_meta: dict[str, object] = {}
+    try:
+        payload = _decode_jws_payload(documento)
+        payload_meta = (
+            payload.get("identificacion")
+            or payload.get("identificador")
+            or payload
+        )
+        meta.update(payload_meta)
+    except Exception:
+        pass
 
     if isinstance(dte_data, dict):
         ident = dte_data.get("identificacion") or dte_data.get("identificador") or dte_data
-        if meta:
-            for k, v in ident.items():
-                meta.setdefault(k, v)
-        else:
-            meta = ident
+        for field in ("ambiente", "version", "tipoDte", "codigoGeneracion"):
+            if field in payload_meta and field in ident:
+                if str(payload_meta[field]) != str(ident[field]):
+                    return {"estado": "Error", "detalle": f"{field} no coincide"}
+        for k, v in ident.items():
+            meta.setdefault(k, v)
 
     try:
         ambiente = str(meta["ambiente"])
@@ -2605,6 +2613,8 @@ def construir_sobre_recepcion(documento: str, dte_data: dict | None = None) -> d
     id_envio = meta.get("idEnvio", 1)
     try:
         id_envio = int(id_envio)
+        if id_envio < 1:
+            raise ValueError
     except Exception:
         return {"estado": "Error", "detalle": "idEnvio inválido"}
 

--- a/tests/test_sign_and_save_sobre.py
+++ b/tests/test_sign_and_save_sobre.py
@@ -1,0 +1,30 @@
+import json
+
+from utils.jws import sign_and_save
+
+
+def test_sign_and_save_creates_sobre(monkeypatch, tmp_path):
+    payload = {
+        "identificacion": {
+            "version": 1,
+            "tipoDte": "01",
+            "codigoGeneracion": "ABC123",
+            "ambiente": "00",
+        }
+    }
+
+    monkeypatch.setattr("utils.jws.sign_json", lambda *a, **k: "a.b.c")
+
+    json_path = tmp_path / "doc.json"
+    sign_and_save(payload, str(json_path))
+
+    sobre_path = json_path.with_name(json_path.stem + "-sobre.json")
+    assert sobre_path.exists(), "sobre no guardado"
+    data = json.loads(sobre_path.read_text(encoding="utf-8"))
+    assert data["documento"] == "a.b.c"
+    ident = payload["identificacion"]
+    assert data["codigoGeneracion"] == ident["codigoGeneracion"]
+    assert data["version"] == ident["version"]
+    assert data["tipoDte"] == ident["tipoDte"]
+    assert data["ambiente"] == ident["ambiente"]
+    assert data["idEnvio"] >= 1

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -11,6 +11,8 @@ from utils.stable_json import (
     validar_montos,
 )
 
+import dte
+
 logger = logging.getLogger(__name__)
 CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config_negocio.json")
 DEFAULT_SIGN_URL = "http://127.0.0.1:8080/firma/firmardocumento/"
@@ -190,4 +192,14 @@ def sign_and_save(
     token = token.rstrip("\n")
     jws_path = os.path.splitext(json_path)[0] + ".jws"
     save_file(jws_path, token, add_final_newline=False)
+    try:
+        sobre = dte.construir_sobre_recepcion(token, payload)
+        if isinstance(sobre, dict) and sobre.get("estado") != "Error":
+            sobre_path = os.path.splitext(json_path)[0] + "-sobre.json"
+            save_file(
+                sobre_path,
+                json.dumps(sobre, ensure_ascii=False, indent=2),
+            )
+    except Exception as exc:
+        logger.error("Error guardando sobre para %s: %s", json_path, exc)
     return jws_path


### PR DESCRIPTION
## Summary
- Construye y valida el sobre de recepción y lo guarda atómicamente como `<base>-sobre.json` junto al PDF/JSON/JWS
- Restablece la interfaz existente de envío de JWS sin cambios adicionales

## Testing
- `pytest tests/test_sign_and_save_sobre.py -q`
- `pytest tests/test_send_jws.py::test_send_jws_token -q`
- `pytest tests/test_send_jws.py::test_send_jws_json -q`
- `pytest tests/test_facturacion_tab_actions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78767c7908323a2655f9d3df48fc2