### PR TITLE
Valida ausencia de espacios en documentos de sobre de recepción

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2564,8 +2564,12 @@ def construir_sobre_recepcion(documento: str, dte_data: dict | None = None) -> d
     detalle correspondiente.
     """
 
-    if not isinstance(documento, str) or documento.count(".") != 2:
+    if not isinstance(documento, str):
         return {"estado": "Error", "detalle": "documento inválido"}
+    if documento.count(".") != 2:
+        return {"estado": "Error", "detalle": "documento inválido"}
+    if any(ch in documento for ch in (" ", "\n", "\r", "\t")):
+        return {"estado": "Error", "detalle": "documento con espacios"}
 
     meta: dict[str, object] = {}
     payload_meta: dict[str, object] = {}

--- a/tests/test_construir_sobre_recepcion_whitespace.py
+++ b/tests/test_construir_sobre_recepcion_whitespace.py
@@ -1,0 +1,16 @@
+import dte
+
+
+def test_construir_sobre_recepcion_rejects_whitespace():
+    cases = [
+        "a. b.c",
+        "a.b.c\n",
+        "a.b.c\r",
+        "a.b.\tc",
+    ]
+    for token in cases:
+        assert dte.construir_sobre_recepcion(token) == {
+            "estado": "Error",
+            "detalle": "documento con espacios",
+        }
+


### PR DESCRIPTION
## Summary
- Rechaza documentos con caracteres de espacio o control en `construir_sobre_recepcion`
- Agrega prueba que verifica el error para documentos con espacios

## Testing
- `pytest tests/test_construir_sobre_recepcion_whitespace.py tests/test_sign_and_save_sobre.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7aca7300483239c411c3075c2c1b9