### PR TITLE
Validate bearer token format and log auth header

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2663,10 +2663,10 @@ def build_auth_header(
     if auth:
         # 1) Authorization explícito
         if auth.get("authorization"):
-            headers["Authorization"] = str(auth["authorization"])
+            headers["Authorization"] = str(auth["authorization"]).strip()
         # 2) Bearer
         elif auth.get("access_token") or auth.get("bearer"):
-            token = auth.get("access_token") or auth.get("bearer")
+            token = (auth.get("access_token") or auth.get("bearer") or "").strip()
             headers["Authorization"] = f"Bearer {token}" if token else ""
         # 3) Basic
         elif auth.get("basic_user") and auth.get("basic_password"):
@@ -2680,6 +2680,11 @@ def build_auth_header(
         # 5) Mezclar headers extra
         if isinstance(auth.get("headers"), dict):
             headers.update(auth["headers"])
+
+    auth_value = headers.get("Authorization")
+    if auth_value and auth_value.startswith("Bearer"):
+        if not re.fullmatch(r"Bearer\s+\S+", auth_value):
+            raise ValueError("Invalid bearer token")
 
     # Metadatos de trazabilidad:
     if app_version:
@@ -2731,6 +2736,12 @@ def _post_dte(
         "User-Agent": ua,
         **auth_headers,
     }
+
+    auth_val = headers.get("Authorization", "")
+    if auth_val:
+        logger.debug("Authorization header: %s...%s", auth_val[:5], auth_val[-5:])
+    else:
+        logger.debug("Authorization header: <empty>")
 
     try:
         print(json.dumps(sobre, ensure_ascii=False))

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -199,6 +199,28 @@ def test_post_dte_rejects_invalid_path(monkeypatch):
         _post_dte(bad_url, "Bearer TOKEN", token, meta)
 
 
+def test_post_dte_rejects_double_bearer(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=20):
+        raise AssertionError("should not post")
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    meta = {"ambiente": "00", "version": 2, "tipoDte": "01", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    with pytest.raises(ValueError):
+        _post_dte(dte.DEFAULT_RECEPCION_URL, "Bearer TOKEN", token, meta)
+
+
+def test_post_dte_rejects_token_with_newline(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=20):
+        raise AssertionError("should not post")
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    meta = {"ambiente": "00", "version": 2, "tipoDte": "01", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    with pytest.raises(ValueError):
+        _post_dte(dte.DEFAULT_RECEPCION_URL, "TO\nKEN", token, meta)
+
+
 def test_post_dte_handles_non_json(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=20):
         class R:


### PR DESCRIPTION
## Summary
- validate Bearer tokens strictly in `build_auth_header`
- log truncated Authorization header in `_post_dte`
- test rejection of Bearer tokens with double prefix or newlines

## Testing
- `pytest --no-cov tests/test_dte_transmision.py::test_post_dte_rejects_double_bearer tests/test_dte_transmision.py::test_post_dte_rejects_token_with_newline -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7aca81db48323b091c7b1f781b71f