### PR TITLE
Skip DTE field validation for envelopes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1734,6 +1734,14 @@ def validate_dte_json(
     # Normalización omitida para preservar códigos con ceros a la izquierda
     # ("01", etc.) que ``_normalize_payload`` convertiría a enteros.
     required = ["identificacion", "emisor", "receptor", "cuerpoDocumento", "resumen"]
+
+    # Cuando ``payload`` representa un sobre de recepción (envelope) ya
+    # firmado, no incluye los campos de un DTE tradicional.  Evitamos la
+    # validación de campos obligatorios en este caso para permitir el envío
+    # directo del sobre a Hacienda.
+    if "documento" in payload and not any(k in payload for k in required):
+        return
+
     missing = [key for key in required if key not in payload]
     if missing:
         raise ValueError("Faltan campos obligatorios: " + ", ".join(missing))

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -416,3 +416,18 @@ def test_fecha_hora_format(dte_metadata_factory, db_fixture):
     dte["identificacion"]["horEmi"] = "25:00:00"
     with pytest.raises(ValueError):
         validate_dte_json(dte, db=db_fixture)
+
+
+def test_validate_allows_envelope(db_fixture):
+    """Un sobre de recepción sin estructura completa de DTE es válido."""
+    sobre = {
+        "ambiente": "00",
+        "idEnvio": 1,
+        "version": 1,
+        "tipoDte": "01",
+        "codigoGeneracion": str(uuid.uuid4()).upper(),
+        "documento": "header.payload.signature",
+    }
+
+    # No debe lanzar ``ValueError`` aunque falten campos de un DTE tradicional
+    validate_dte_json(sobre, db=db_fixture)


### PR DESCRIPTION
## Summary
- allow `validate_dte_json` to bypass required field checks when payload is a reception envelope
- add regression test to ensure envelopes pass validation

## Testing
- `pytest tests/test_dte_validation.py::test_validate_allows_envelope -q`
- `npm test`
- `pytest` *(fails: Interrupted: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ebf4eb54832387b1efb02a67602c