### PR TITLE
Use branch and point config for DTE control numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,19 @@ otros parámetros dentro de `datos_negocio.json` bajo el bloque `dte_api`:
 {
   "dte_api": {
     "token": "TOKEN",
-    "prefijo_control": "DTE-01-S001P001",
     "modo_transmision": "1 - Normal"
+  }
+}
+```
+
+Los códigos de sucursal y punto de venta utilizados para formar el número de
+control se establecen en `config_negocio.json`:
+
+```json
+{
+  "facturacion": {
+    "sucursal": 1,
+    "puntoVenta": 1
   }
 }
 ```

--- a/config_negocio.json
+++ b/config_negocio.json
@@ -12,5 +12,9 @@
       "nitUsuario": "000868547",
       "pwd": "T3Jpb24hN1BpYW5vOEx1eiM="
     }
+  },
+  "facturacion": {
+    "sucursal": 1,
+    "puntoVenta": 1
   }
 }

--- a/dte.py
+++ b/dte.py
@@ -175,6 +175,29 @@ def _norm3(value) -> str:
     return re.sub(r"\D", "", str(value))[-3:].zfill(3)
 
 
+def _load_facturacion() -> tuple[str, str, str, str]:
+    """Carga sucursal y punto de venta desde ``config_negocio.json``.
+
+    Devuelve una tupla con las representaciones rellenadas:
+    ``(suc3, pto3, suc4, pto4)``.
+    """
+
+    sucursal = punto = 1
+    try:
+        with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+            cfg = json.load(fh)
+        fact = cfg.get("facturacion", {})
+        sucursal = int(fact.get("sucursal", 1))
+        punto = int(fact.get("puntoVenta", 1))
+    except Exception:
+        pass
+    if sucursal not in range(1, 6):
+        sucursal = 1
+    if punto not in range(1, 6):
+        punto = 1
+    return f"{sucursal:03d}", f"{punto:03d}", f"{sucursal:04d}", f"{punto:04d}"
+
+
 def normalize_uuid_v4_upper(value: str) -> str:
     """
     Normaliza `value` como UUID v4 con guiones en MAYÚSCULAS.
@@ -293,18 +316,11 @@ def _load_datos_negocio():
         try:
             with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
-            dte_api = data.get("dte_api")
-            if isinstance(dte_api, dict):
-                # Extract branch and point-of-sale codes from the control prefix
-                prefijo = dte_api.get("prefijo_control")
-                if isinstance(prefijo, str):
-                    m = re.search(r"S([A-Za-z0-9]{3})P([A-Za-z0-9]{3})", prefijo)
-                    if m:
-                        suc, punto = m.groups()
-                        data.setdefault("codEstable", suc.zfill(4))
-                        data.setdefault("codEstableMH", suc.zfill(4))
-                        data.setdefault("codPuntoVenta", punto.zfill(4))
-                        data.setdefault("codPuntoVentaMH", punto.zfill(4))
+            _, _, suc4, pto4 = _load_facturacion()
+            data.setdefault("codEstable", suc4)
+            data.setdefault("codEstableMH", suc4)
+            data.setdefault("codPuntoVenta", pto4)
+            data.setdefault("codPuntoVentaMH", pto4)
 
             # Ensure cod_giro is available and mirrors codActividad
             cod_giro = data.get("cod_giro")
@@ -1202,8 +1218,9 @@ def recalcular_totales(
 
 
 
-def generar_numero_control(db: DB, tipo: str, sucursal: str, punto: str) -> str:
+def generar_numero_control(db: DB, tipo: str) -> str:
     """Genera un número de control secuencial."""
+    sucursal, punto, _, _ = _load_facturacion()
     correlativo = db.next_dte_correlativo(tipo, sucursal, punto)
     secuencia = str(correlativo).zfill(15)
     return f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
@@ -1246,16 +1263,8 @@ def generar_cabecera_dte_data(
         tipo_modelo = 2
 
     datos = _load_datos_negocio()
-    prefijo = datos.get("dte_api", {}).get("prefijo_control", "")
-    sucursal = "001"
-    punto = "001"
-    m = re.search(r"S(\d{3})P(\d{3})", prefijo)
-    if m:
-        sucursal, punto = m.groups()
-    sucursal = _norm3(sucursal)
-    punto = _norm3(punto)
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control(db, tipo_dte, sucursal, punto)
+    numero_control = generar_numero_control(db, tipo_dte)
     fecha_generacion = datetime.now().strftime("%d/%m/%Y, %I:%M %p")
     return {
         "codigo_generacion": codigo_generacion,
@@ -1320,18 +1329,12 @@ def generar_dte_json(
     datos = _load_datos_negocio()
 
 
-    prefijo = str(datos.get("dte_api", {}).get("prefijo_control", ""))
-    m = re.match(r"^DTE-\d{2}-S(\d{3})P(\d{3})$", prefijo)
-    suc_pref, punto_pref = m.groups() if m else ("001", "001")
-    cod_estable_raw = re.sub(r"\D", "", str(datos.get("codEstable", "")))
-    cod_punto_raw = re.sub(r"\D", "", str(datos.get("codPuntoVenta", "")))
-    cod_estable = (cod_estable_raw or suc_pref.rjust(4, "0"))[-4:].zfill(4)
-    cod_punto = (cod_punto_raw or punto_pref.rjust(4, "0"))[-4:].zfill(4)
+    _, _, cod_estable, cod_punto = _load_facturacion()
     suc = _norm3(cod_estable)
     pto = _norm3(cod_punto)
     # Generar identificadores con formatos oficiales
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control(db, tipo_dte, suc, pto)
+    numero_control = generar_numero_control(db, tipo_dte)
 
 
     now = datetime.now(TZ_EL_SALVADOR)
@@ -1915,29 +1918,25 @@ def validate_dte_json(
     }
     emisor.setdefault("telefono", negocio.get("telefono"))
     emisor.setdefault("correo", negocio.get("correo"))
-    cod_est = str(emisor.get("codEstable") or negocio.get("codEstable") or 1)
-    emisor["codEstable"] = cod_est.zfill(4)
-    emisor["codEstableMH"] = str(
-        emisor.get("codEstableMH") or negocio.get("codEstableMH") or cod_est
-    ).zfill(4)
-    cod_pto = str(emisor.get("codPuntoVenta") or negocio.get("codPuntoVenta") or 1)
-    emisor["codPuntoVenta"] = cod_pto.zfill(4)
-    emisor["codPuntoVentaMH"] = str(
-        emisor.get("codPuntoVentaMH") or negocio.get("codPuntoVentaMH") or cod_pto
-    ).zfill(4)
+    _, _, cod_est, cod_pto = _load_facturacion()
+    emisor["codEstable"] = cod_est
+    emisor["codEstableMH"] = cod_est
+    emisor["codPuntoVenta"] = cod_pto
+    emisor["codPuntoVentaMH"] = cod_pto
     tipo = str(ident.get("tipoDte") or "").zfill(2)
     if not re.fullmatch(r"\d{2}", tipo):
         raise ValueError("tipoDte inválido")
     if hasattr(catalogos, "TIPOS_DTE") and tipo not in catalogos.TIPOS_DTE:
         raise ValueError("Código de tipoDte inválido")
-    suc = _norm3(emisor.get("codEstableMH") or emisor.get("codEstable") or 1)
-    pto = _norm3(
-        emisor.get("codPuntoVentaMH") or emisor.get("codPuntoVenta") or 1
-    )
     numero_control = ident.get("numeroControl")
     regex_nc = r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$"
-    if not (isinstance(numero_control, str) and re.fullmatch(regex_nc, numero_control)):
-        ident["numeroControl"] = generar_numero_control(db, tipo, suc, pto)
+    match = (
+        re.fullmatch(regex_nc, numero_control)
+        if isinstance(numero_control, str)
+        else None
+    )
+    if not match or match.group(1) != tipo or match.group(2) != _norm3(cod_est) or match.group(3) != _norm3(cod_pto):
+        ident["numeroControl"] = generar_numero_control(db, tipo)
     numero_control = ident.get("numeroControl")
     if not re.fullmatch(regex_nc, numero_control):
         raise ValueError("numeroControl inválido")

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -251,20 +251,24 @@ def test_numero_control_invalidos(dte_metadata_factory, numero, tmp_path, monkey
     )
 
 
-def test_numero_control_regenerates_from_emisor_codes(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
+def test_numero_control_uses_config_facturacion(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
     _patch_datos_negocio(tmp_path, monkeypatch)
-    dte = dte_metadata_factory()
-    dte["emisor"]["codEstable"] = "123"
-    dte["emisor"]["codEstableMH"] = "123"
-    dte["emisor"]["codPuntoVenta"] = "456"
-    dte["emisor"]["codPuntoVentaMH"] = "456"
-    dte["identificacion"]["numeroControl"] = "BAD"
-    validate_dte_json(dte, db=db_fixture)
-    ident = dte["identificacion"]
-    emisor = dte["emisor"]
-    assert emisor["codEstable"] == "0123"
-    assert emisor["codPuntoVenta"] == "0456"
-    assert ident["numeroControl"].startswith("DTE-01-S123P456")
+    cfg = {"facturacion": {"sucursal": 2, "puntoVenta": 5}}
+    cfg_path = tmp_path / "config_negocio.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setattr(dte, "CONFIG_NEGOCIO_PATH", str(cfg_path))
+    dte_obj = dte_metadata_factory()
+    dte_obj["emisor"]["codEstable"] = "9999"
+    dte_obj["emisor"]["codEstableMH"] = "9999"
+    dte_obj["emisor"]["codPuntoVenta"] = "9999"
+    dte_obj["emisor"]["codPuntoVentaMH"] = "9999"
+    dte_obj["identificacion"]["numeroControl"] = "BAD"
+    validate_dte_json(dte_obj, db=db_fixture)
+    ident = dte_obj["identificacion"]
+    emisor = dte_obj["emisor"]
+    assert emisor["codEstable"] == "0002"
+    assert emisor["codPuntoVenta"] == "0005"
+    assert ident["numeroControl"].startswith("DTE-01-S002P005-")
 
 
 def test_numero_control_fallback_default(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -24,6 +24,7 @@ def test_generar_dte_json_basic(tmp_path):
         "descActividad": "Comercio",
         "telefono": "22222222",
         "correo": "test@example.com",
+        "direccion": {"departamento": "01", "municipio": "13", "complemento": "Dir"},
     }
     tmp_file = tmp_path / "datos_negocio.json"
     tmp_file.write_text(json.dumps(datos))
@@ -94,12 +95,16 @@ def test_generar_dte_json_usa_cod_estable_punto(tmp_path):
         "descActividad": "Comercio",
         "telefono": "22222222",
         "correo": "test@example.com",
-        "codEstable": "2",
-        "codPuntoVenta": 5,
+        "direccion": {"departamento": "01", "municipio": "13", "complemento": "Dir"},
     }
-    tmp_file = tmp_path / "datos_negocio.json"
-    tmp_file.write_text(json.dumps(datos))
-    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    datos_path = tmp_path / "datos_negocio.json"
+    datos_path.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(datos_path)
+
+    cfg = {"facturacion": {"sucursal": 2, "puntoVenta": 5}}
+    cfg_path = tmp_path / "config_negocio.json"
+    cfg_path.write_text(json.dumps(cfg))
+    dte_module.CONFIG_NEGOCIO_PATH = str(cfg_path)
 
     db = create_db()
     db.add_vendedor("V1")


### PR DESCRIPTION
## Summary
- add `facturacion.sucursal` and `facturacion.puntoVenta` to configuration
- derive DTE control numbers and emisor codes from branch and point settings
- update documentation and tests for new control number scheme

## Testing
- `pytest` *(fails: ValueError: Falta dirección del negocio, decimal.InvalidOperation, etc.)*
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_usa_cod_estable_punto tests/test_dte_validation.py::test_numero_control_uses_config_facturacion`


------
https://chatgpt.com/codex/tasks/task_e_68a8712184708323bbb58dbc73ffafcd