### PR TITLE
Check sku index only when column exists

### DIFF
--- a/db.py
+++ b/db.py
@@ -286,9 +286,6 @@ class DB:
         self.cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_productos_nombre ON productos(nombre)"
         )
-        self.cursor.execute(
-            "CREATE INDEX IF NOT EXISTS idx_productos_sku ON productos(sku)"
-        )
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS ventas (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -586,6 +583,12 @@ class DB:
         ]
         for table, definition in columns:
             self.add_column_if_missing(table, definition)
+        # Create index for SKU only if the column exists
+        self.cursor.execute("PRAGMA table_info(productos)")
+        if any(row[1] == "sku" for row in self.cursor.fetchall()):
+            self.cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_productos_sku ON productos(sku)"
+            )
         # Índices únicos para campos de texto
         self.cursor.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_clientes_codigo ON clientes(codigo)"


### PR DESCRIPTION
## Summary
- Ensure `idx_productos_sku` index is created only after verifying `sku` column
- Avoid OperationalError on old databases missing `sku`

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file; ModuleNotFoundError: No module named 'fastapi')*
- `python - <<'PY'
from db import DB
DB()
print('DB initialized successfully')
PY`
- `python - <<'PY'
import sqlite3, pathlib
from db import DB
path = pathlib.Path('tmp_old.db')
if path.exists():
    path.unlink()
conn = sqlite3.connect(path)
cur = conn.cursor()
cur.execute('''CREATE TABLE productos (
    id INTEGER PRIMARY KEY,
    nombre TEXT,
    codigo TEXT,
    vendedor_id INTEGER,
    Distribuidor_id INTEGER,
    precio REAL,
    stock INTEGER,
    precio_compra REAL DEFAULT 0
)''')
conn.commit()
conn.close()
DB(path)
conn = sqlite3.connect(path)
cur = conn.cursor()
cur.execute('PRAGMA table_info(productos)')
cols = [row[1] for row in cur.fetchall()]
cur.execute('PRAGMA index_list(productos)')
idxs = [row[1] for row in cur.fetchall()]
print('cols:', cols)
print('indexes:', idxs)
conn.close()
path.unlink()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a88337ef908323ae5c53820d4736de