### PR TITLE
Ajusta tributos en facturas consumidor final

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -105,6 +105,8 @@ def sanitize_dte_payload(data: dict, schema: dict | None = None) -> dict:
         "ventaTercero",
         "extension",
         "apendice",
+        "codTributo",
+        "tributos",
     }
 
     def _remove_nulls(value, parent_key=None):
@@ -1004,15 +1006,21 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         resumen["condicionOperacion"] = _parse_condicion_operacion(condicion)
 
     if total_gravada > D("0"):
-        resumen["tributos"] = [
-            {
-                "codigo": TRIBUTO_IVA,
-                "descripcion": "Impuesto al Valor Agregado 13%",
-                "valor": total_iva,
-            }
-        ]
+        if tipo_dte == "01":
+            resumen["tributos"] = None
+        else:
+            resumen["tributos"] = [
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": "Impuesto al Valor Agregado 13%",
+                    "valor": total_iva,
+                }
+            ]
     else:
-        resumen.pop("tributos", None)
+        if tipo_dte == "01":
+            resumen["tributos"] = None
+        else:
+            resumen.pop("tributos", None)
         resumen["totalIva"] = money(0)
 
     if "pagos" in resumen:
@@ -1207,7 +1215,8 @@ def recalcular_totales(
         resumen["totalLetras"] = total_letras
         modificados.append("totalLetras")
 
-    if venta_gravada_sum > D("0"):
+    tipo_dte = str(data.get("identificacion", {}).get("tipoDte", ""))
+    if venta_gravada_sum > D("0") and tipo_dte != "01":
         trib = [
             {
                 "codigo": TRIBUTO_IVA,
@@ -1219,7 +1228,11 @@ def recalcular_totales(
             resumen["tributos"] = trib
             modificados.append("tributos")
     else:
-        if "tributos" in resumen:
+        if tipo_dte == "01":
+            if resumen.get("tributos") is not None:
+                resumen["tributos"] = None
+                modificados.append("tributos")
+        elif "tributos" in resumen:
             del resumen["tributos"]
             modificados.append("tributos")
 
@@ -1616,13 +1629,17 @@ def generar_dte_json(
         }
         if trib_code:
             item_data["codTributo"] = trib_code
-        if D(str(item_data.get("ventaGravada") or 0)) > 0:
-            if not item_data["tributos"]:
-                item_data["codTributo"] = TRIBUTO_IVA
-                item_data["tributos"] = [TRIBUTO_IVA]
+        if tipo_dte == "01":
+            item_data["codTributo"] = None
+            item_data["tributos"] = None
         else:
-            item_data.pop("codTributo", None)
-            item_data["tributos"] = []
+            if D(str(item_data.get("ventaGravada") or 0)) > 0:
+                if not item_data["tributos"]:
+                    item_data["codTributo"] = TRIBUTO_IVA
+                    item_data["tributos"] = [TRIBUTO_IVA]
+            else:
+                item_data.pop("codTributo", None)
+                item_data["tributos"] = []
         total_no_suj_sum += D(str(item_data["ventaNoSuj"]))
         total_exenta_sum += D(str(item_data["ventaExenta"]))
         total_gravada_sum += D(str(item_data["ventaGravada"]))
@@ -2154,7 +2171,10 @@ def validate_dte_json(
         item.setdefault("ventaGravada", cero)
         item.setdefault("noGravado", cero)
         item.setdefault("psv", cero)
-        item.setdefault("tributos", [])
+        if tipo_dte == "01":
+            item["tributos"] = None
+        else:
+            item.setdefault("tributos", [])
         if iva_key:
             item.setdefault(iva_key, cero)
 
@@ -2203,30 +2223,34 @@ def validate_dte_json(
         if cod_tri is not None:
             cod_tri = str(cod_tri).upper()
 
-        invalid = [
-            t
-            for t in tributos
-            if t not in TRIBUTOS_PERMITIDOS_ITEM and t != TRIBUTO_IVA
-        ]
-        if cod_tri and cod_tri not in TRIBUTOS_PERMITIDOS_ITEM and cod_tri != TRIBUTO_IVA:
-            invalid.append(cod_tri)
-        if invalid:
-            raise ValueError(
-                f"Código(s) de tributo inválido(s): {', '.join(invalid)}"
-            )
-
-        if venta_gravada_val <= 0:
-            item["tributos"] = []
-            item.pop("codTributo", None)
-        elif tributos:
-            item["tributos"] = tributos
-            if len(tributos) == 1:
-                item["codTributo"] = tributos[0]
-            else:
-                item.pop("codTributo", None)
+        if tipo_dte == "01":
+            item["codTributo"] = None
+            item["tributos"] = None
         else:
-            item["tributos"] = []
-            item.pop("codTributo", None)
+            invalid = [
+                t
+                for t in tributos
+                if t not in TRIBUTOS_PERMITIDOS_ITEM and t != TRIBUTO_IVA
+            ]
+            if cod_tri and cod_tri not in TRIBUTOS_PERMITIDOS_ITEM and cod_tri != TRIBUTO_IVA:
+                invalid.append(cod_tri)
+            if invalid:
+                raise ValueError(
+                    f"Código(s) de tributo inválido(s): {', '.join(invalid)}"
+                )
+
+            if venta_gravada_val <= 0:
+                item["tributos"] = []
+                item.pop("codTributo", None)
+            elif tributos:
+                item["tributos"] = tributos
+                if len(tributos) == 1:
+                    item["codTributo"] = tributos[0]
+                else:
+                    item.pop("codTributo", None)
+            else:
+                item["tributos"] = []
+                item.pop("codTributo", None)
 
         if iva_key:
             if precios_flag and item.get(iva_key) not in (None, 0, D("0")):
@@ -2247,6 +2271,8 @@ def validate_dte_json(
     payload["cuerpoDocumento"] = cuerpo
 
     resumen = payload.get("resumen", {})
+    if ident.get("tipoDte") == "01":
+        resumen["tributos"] = None
     for k, v in resumen.items():
         if k == "condicionOperacion":
             continue

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -89,7 +89,8 @@ def generar_fc_ejemplo(
         "ventaNoSuj": D("0.00000000"),
         "ventaExenta": D("0.00000000"),
         "ventaGravada": D("0.00000000"),
-        "tributos": [],
+        "codTributo": None,
+        "tributos": None,
         "psv": D("0.00000000"),
         "noGravado": D("0.00000000"),
     }
@@ -134,8 +135,10 @@ def generar_fc_ejemplo(
             "totalNoSuj": d2(D("0")),
             "totalExenta": total_base if not gravado else d2(D("0")),
             "totalGravada": total_base if gravado else d2(D("0")),
-            "montoIva": total_iva,
+            "totalIva": total_iva,
+            "montoTotalOperacion": total_pagar,
             "totalPagar": total_pagar,
+            "tributos": None,
         },
     }
     return dte
@@ -245,8 +248,12 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
         "psv": d8(Decimal("0")),
         "noGravado": d8(Decimal("0")),
         "ivaItem": iva_item,
-        "tributos": [],
     }
+    if tipo == "fc":
+        item["tributos"] = None
+    else:
+        item["codTributo"] = TRIBUTO_IVA
+        item["tributos"] = [TRIBUTO_IVA]
     return [item]
 
 
@@ -288,18 +295,19 @@ def _resumen(tipo: str) -> Dict[str, Any]:
     }
     if tipo == "fc":
         data["totalIva"] = iva
+        data["tributos"] = None
     else:
         data["ivaPerci1"] = d2(Decimal("0"))
-    if venta > D("0"):
-        data["tributos"] = [
-            {
-                "codigo": TRIBUTO_IVA,
-                "descripcion": "Impuesto al Valor Agregado 13%",
-                "valor": iva,
-            }
-        ]
-    else:
-        data["tributos"] = None
+        if venta > D("0"):
+            data["tributos"] = [
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": "Impuesto al Valor Agregado 13%",
+                    "valor": iva,
+                }
+            ]
+        else:
+            data["tributos"] = None
     return data
 
 

--- a/tests/test_dte_payload_cleanup.py
+++ b/tests/test_dte_payload_cleanup.py
@@ -26,7 +26,15 @@ def test_sanitize_dte_payload_removes_none_recursively(dte_metadata_factory):
     assert "codActividad" not in clean["emisor"]
     for key in REQUIRED_NULL_FIELDS:
         assert key in clean and clean[key] is None
+    item0 = clean["cuerpoDocumento"][0]
+    assert item0["codTributo"] is None
+    assert item0["tributos"] is None
+    assert clean["resumen"]["tributos"] is None
     clean_no_required = {k: v for k, v in clean.items() if k not in REQUIRED_NULL_FIELDS}
+    for item in clean_no_required.get("cuerpoDocumento", []):
+        item.pop("codTributo", None)
+        item.pop("tributos", None)
+    clean_no_required.get("resumen", {}).pop("tributos", None)
     assert not _has_none(clean_no_required)
 
 
@@ -54,7 +62,15 @@ def test_enviar_factura_sanitizes_payload(monkeypatch, dte_metadata_factory):
     assert "codActividad" not in captured["data"]["emisor"]
     for key in REQUIRED_NULL_FIELDS:
         assert key in captured["data"] and captured["data"][key] is None
+    item0 = captured["data"]["cuerpoDocumento"][0]
+    assert item0["codTributo"] is None
+    assert item0["tributos"] is None
+    assert captured["data"]["resumen"]["tributos"] is None
     captured_no_required = {
         k: v for k, v in captured["data"].items() if k not in REQUIRED_NULL_FIELDS
     }
+    for item in captured_no_required.get("cuerpoDocumento", []):
+        item.pop("codTributo", None)
+        item.pop("tributos", None)
+    captured_no_required.get("resumen", {}).pop("tributos", None)
     assert not _has_none(captured_no_required)

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -171,19 +171,21 @@ def test_no_iva_en_items(dte_metadata_factory, db_fixture):
     item.pop("codTributo", None)
     validate_dte_json(dte, db=db_fixture)
     item = dte["cuerpoDocumento"][0]
-    assert item["tributos"] == []
-    assert "codTributo" not in item
+    assert item["tributos"] is None
+    assert item["codTributo"] is None
 
 
-def test_rechaza_iva_en_items(dte_metadata_factory, db_fixture):
+def test_iva_en_items_se_normaliza(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["cuerpoDocumento"][0]["codTributo"] = TRIBUTO_IVA
-    with pytest.raises(ValueError):
-        validate_dte_json(dte, db=db_fixture)
+    validate_dte_json(dte, db=db_fixture)
+    item = dte["cuerpoDocumento"][0]
+    assert item["tributos"] is None and item["codTributo"] is None
     dte = dte_metadata_factory()
     dte["cuerpoDocumento"][0]["tributos"] = [TRIBUTO_IVA]
-    with pytest.raises(ValueError):
-        validate_dte_json(dte, db=db_fixture)
+    validate_dte_json(dte, db=db_fixture)
+    item = dte["cuerpoDocumento"][0]
+    assert item["tributos"] is None and item["codTributo"] is None
 
 
 def test_tributos_invalidos_rechazados(dte_metadata_factory, db_fixture):

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -33,6 +33,10 @@ def test_generar_dte_json_basic(tmp_path):
     tmp_file = tmp_path / "datos_negocio.json"
     tmp_file.write_text(json.dumps(datos))
     dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+    dte_module._load_datos_negocio = lambda: datos
 
     db = create_db()
     db.add_vendedor("V1")
@@ -156,6 +160,11 @@ def test_generar_dte_json_precios_incluyen_iva_default(tmp_path):
         "descActividad": "Comercio",
         "telefono": "22222222",
         "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
     }
     tmp_file = tmp_path / "datos_negocio.json"
     tmp_file.write_text(json.dumps(datos))
@@ -337,20 +346,6 @@ def test_dte_sum_mismatch_warning(capsys):
 
 def test_generar_ticket_json_tipo(tmp_path):
     import dte as dte_module
-
-    datos = {
-        "nit": "06141990011019",
-        "nrc": "1234567-8",
-        "nombre": "Mi Negocio",
-        "nombreComercial": "Mi Negocio",
-        "cod_giro": "123456",
-        "descActividad": "Comercio",
-        "telefono": "22222222",
-        "correo": "test@example.com",
-    }
-    tmp_file = tmp_path / "datos_negocio.json"
-    tmp_file.write_text(json.dumps(datos))
-    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
 
     db = create_db()
     db.add_vendedor("V1")
@@ -618,7 +613,7 @@ def test_receptor_defaults(tmp_path):
     db = create_db()
     db.add_vendedor("V1")
     vend_id = db.cursor.lastrowid
-    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
     db.add_cliente(
         "Cliente",
@@ -673,7 +668,7 @@ def test_credit_payment_defaults(tmp_path):
     db = create_db()
     db.add_vendedor("V1")
     vend_id = db.cursor.lastrowid
-    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
     db.add_cliente(
         "Cliente",
@@ -733,7 +728,7 @@ def test_item_tributo_guard(tmp_path):
     db = create_db()
     db.add_vendedor("V1")
     vend_id = db.cursor.lastrowid
-    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
     db.add_cliente(
         "Cliente",
@@ -755,8 +750,12 @@ def test_item_tributo_guard(tmp_path):
 
     data = dte_module.generar_dte_json(db, venta_id)
     item = data["cuerpoDocumento"][0]
-    assert item["codTributo"] == "20"
-    assert item["tributos"] == ["20"]
+    resumen = data["resumen"]
+    assert item["codTributo"] is None
+    assert item["tributos"] is None
+    assert resumen["tributos"] is None
+    from decimal import Decimal as D
+    assert D(str(resumen["totalIva"])) == D(str(item["ivaItem"]))
 
 
 def test_item_no_tributo_when_exento(tmp_path):
@@ -784,7 +783,7 @@ def test_item_no_tributo_when_exento(tmp_path):
     db = create_db()
     db.add_vendedor("V1")
     vend_id = db.cursor.lastrowid
-    db.add_producto("Prod", "P1", vend_id, None, 0, 0, 0, 10)
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
     prod_id = db.cursor.lastrowid
     db.add_cliente(
         "Cliente",
@@ -816,8 +815,90 @@ def test_item_no_tributo_when_exento(tmp_path):
     res.pop("tributos", None)
     dte_module.validate_dte_json(data, db=db)
     item = data["cuerpoDocumento"][0]
-    assert "codTributo" not in item
-    assert item.get("tributos") == []
+    assert item["codTributo"] is None
+    assert item.get("tributos") is None
+
+
+def test_credito_fiscal_incluye_tributo(tmp_path):
+    import dte as dte_module
+    from utils.catalogos import TRIBUTO_IVA
+    from decimal import Decimal as D
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "1234567-8",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "1234567-8",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+    dte_module._load_datos_negocio = lambda: datos
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "0614-000000-102-5",
+        "",
+        "giro",
+        "",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cid,
+        "2024-01-01",
+        10,
+        "123",
+        "0614-000000-102-5",
+        "giro",
+        sumas=10,
+        descuentos=0,
+        iva=0,
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    item = data["cuerpoDocumento"][0]
+    resumen = data["resumen"]
+    assert item["codTributo"] == TRIBUTO_IVA
+    assert item["tributos"] == [TRIBUTO_IVA]
+    assert resumen["tributos"][0]["codigo"] == TRIBUTO_IVA
+    assert D(str(resumen["totalIva"])) == D(str(item["ivaItem"]))
 
 
 def test_resumen_tributo_codigo_str(tmp_path):


### PR DESCRIPTION
## Summary
- Preserva codTributo y tributos como `null` al sanitizar DTEs de consumidor final
- Refuerza validación para forzar tributos `null` en FC y mantener tributo 20 en otros DTE
- Alinea generadores y pruebas con el nuevo tratamiento de tributos

## Testing
- `pytest` *(fails: 39 errors during collection)*
- `pytest tests/test_generar_dte_json.py::test_item_tributo_guard tests/test_generar_dte_json.py::test_credito_fiscal_incluye_tributo tests/test_generar_dte_json.py::test_item_no_tributo_when_exento tests/test_dte_validation.py::test_no_iva_en_items tests/test_dte_validation.py::test_iva_en_items_se_normaliza tests/test_dte_payload_cleanup.py::test_sanitize_dte_payload_removes_none_recursively tests/test_dte_payload_cleanup.py::test_enviar_factura_sanitizes_payload`

------
https://chatgpt.com/codex/tasks/task_e_68a89216c808832398ac22132ef55549