### PR TITLE
Use null for missing document numbers

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1609,10 +1609,17 @@ def generar_dte_json(
         if trib_code and trib_code not in TRIBUTOS_PERMITIDOS_ITEM:
             raise ValueError(f"Código de tributo inválido en ítem: {trib_code}")
 
+        num_doc = d.get("numeroDocumento")
+        if isinstance(num_doc, str):
+            if num_doc.strip().upper() in {"NA", "N/A", ""}:
+                num_doc = None
+        elif not num_doc:
+            num_doc = None
+
         item_data = {
             "numItem": idx,
             "tipoItem": tipo_item,
-            "numeroDocumento": "NA",
+            "numeroDocumento": num_doc,
             "codigo": d.get("codigo") or "SKU-NA",
             "descripcion": d.get("descripcion"),
             "cantidad": cant,
@@ -2162,7 +2169,14 @@ def validate_dte_json(
         if item["uniMedida"] not in UNIDADES_MEDIDA_PERMITIDAS:
             item["uniMedida"] = 59
 
-        item["numeroDocumento"] = item.get("numeroDocumento") or "NA"
+        num_doc = item.get("numeroDocumento")
+        if isinstance(num_doc, str):
+            if num_doc.strip().upper() in {"NA", "N/A", ""}:
+                num_doc = None
+        elif not num_doc:
+            num_doc = None
+        item["numeroDocumento"] = num_doc
+
         item["codigo"] = item.get("codigo") or "SKU-NA"
         cero = D("0")
         item.setdefault("montoDescu", cero)

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -79,7 +79,7 @@ def generar_fc_ejemplo(
     item = {
         "numItem": 1,
         "tipoItem": 1,
-        "numeroDocumento": "NA",
+        "numeroDocumento": None,
         "codigo": "SKU001",
         "descripcion": "Producto X",
         "cantidad": d8(cantidad),
@@ -229,7 +229,7 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
     precio = Decimal("9.54")
     venta = d8(cantidad * precio)
     iva_item = d8(venta * Decimal("0.13"))
-    numero_documento = "NA" if tipo == "fc" else None
+    numero_documento = None
     tipo_item = 4 if tipo == "fc" else 1
     uni_medida = 99 if tipo == "fc" else 59
     item = {

--- a/tests/goldens/fc.json
+++ b/tests/goldens/fc.json
@@ -9,7 +9,7 @@
       "montoDescu": "0E-8",
       "noGravado": "0E-8",
       "numItem": 1,
-      "numeroDocumento": "NA",
+      "numeroDocumento": null,
       "precioUni": "9.54000000",
       "psv": "0E-8",
       "tipoItem": 4,


### PR DESCRIPTION
## Summary
- Sanitize item document numbers, replacing placeholder values with `null`
- Generate DTE examples and schemas with `numeroDocumento` set to `null` when absent
- Update golden DTE data to expect `null` document numbers

## Testing
- `python -m py_compile dte.py svfe/generators.py tests/goldens/fc.json`
- `pytest` *(fails: ImportError: libGL.so.1; ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a153348c83238c6f76c05930a115