### PR TITLE
Desglosar IVA en factura de crédito fiscal con precios incluidos

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1087,8 +1087,16 @@ def recalcular_totales(
     """
 
     extra_conf = data.get("extra") or {}
-    precios_flag = _precios_incluyen_iva_from(extra_conf, precios_incluyen_iva)
     tipo_dte = str(data.get("identificacion", {}).get("tipoDte", ""))
+    precios_flag = _precios_incluyen_iva_from(extra_conf, precios_incluyen_iva)
+    if (
+        tipo_dte == "01"
+        and "precios_incluyen_iva" not in extra_conf
+        and precios_incluyen_iva is None
+    ):
+        precios_flag = True
+        extra_conf["precios_incluyen_iva"] = True
+        data["extra"] = extra_conf
     cuerpo = data.get("cuerpoDocumento", [])
     resumen = data.get("resumen", {})
 
@@ -1491,9 +1499,15 @@ def generar_dte_json(
     total_exenta_sum = D("0")
     total_no_suj_sum = D("0")
     total_no_gravado_sum = D("0")
-    precios_incluyen_iva = _precios_incluyen_iva_from(
-        extra, kwargs.get("precios_incluyen_iva")
-    )
+    override_precio_flag = kwargs.get("precios_incluyen_iva")
+    precios_incluyen_iva = _precios_incluyen_iva_from(extra, override_precio_flag)
+    if (
+        tipo_dte == "01"
+        and "precios_incluyen_iva" not in extra
+        and override_precio_flag is None
+    ):
+        precios_incluyen_iva = True
+        extra["precios_incluyen_iva"] = True
     for idx, d in enumerate(detalles, 1):
         try:
             cant = d8(D(str(d.get("cantidad") or 0)))

--- a/tests/test_iva_por_item.py
+++ b/tests/test_iva_por_item.py
@@ -4,7 +4,7 @@ from dte import recalcular_totales
 from utils.stable_json import stable_stringify
 
 
-def _build_payload(precio, *, precios_incluyen_iva):
+def _build_payload(precio, *, precios_incluyen_iva=None):
     payload = {
         "identificacion": {"tipoDte": "01"},
         "cuerpoDocumento": [
@@ -18,7 +18,10 @@ def _build_payload(precio, *, precios_incluyen_iva):
         ],
         "resumen": {},
     }
-    recalcular_totales(payload, precios_incluyen_iva=precios_incluyen_iva)
+    if precios_incluyen_iva is None:
+        recalcular_totales(payload)
+    else:
+        recalcular_totales(payload, precios_incluyen_iva=precios_incluyen_iva)
     return payload
 
 
@@ -52,3 +55,17 @@ def test_serializacion_sin_tributos():
     assert D(str(resumen["totalIva"])) == iva_suma
     json_str = stable_stringify(payload)
     assert "-0.00" not in json_str
+
+
+def test_fc_precio_incluye_iva_default():
+    payload = _build_payload("13.00")
+    item = payload["cuerpoDocumento"][0]
+    resumen = payload["resumen"]
+    assert D(str(item["ventaGravada"])) == D("11.50")
+    assert D(str(item["ivaItem"])) == D("1.50")
+    assert D(str(resumen["totalGravada"])) == D("11.50")
+    assert D(str(resumen["totalIva"])) == D("1.50")
+    assert D(str(resumen["totalPagar"])) == D("13.00")
+    assert item.get("codTributo") is None
+    assert item.get("tributos") is None
+    assert resumen.get("tributos") is None


### PR DESCRIPTION
## Summary
- asumir precios con IVA incluido en FC si no se especifica lo contrario
- desglosar IVA y totales en items y resumen sin tributos
- probar cálculo de 13.00 → 11.50 + 1.50 en factura crédito fiscal

## Testing
- `pytest tests/test_iva_por_item.py -q`
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_precios_incluyen_iva_default -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b65174e083238e98c950864a6e06