### PR TITLE
docs: reference Configuración menu for manual DTE signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ especifica otra URL.
 
 ### Firmar un DTE manualmente
 
-Desde el menú **Archivo** de la aplicación puedes escoger la opción
+Desde el menú **Configuración** de la aplicación puedes escoger la opción
 "**Firmar DTE...**" para seleccionar un archivo `.json` previamente
 generado y enviarlo al servicio local de firmado. El resultado se guarda
 como archivo `.jws` en la ubicación que elijas sin modificar el JSON


### PR DESCRIPTION
## Summary
- update manual DTE signing instructions to reference the Configuración menu

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; 39 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acaece468483239358f6d6f75ccf5e