### PR TITLE
fix: allow NRC without dash in validation

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -60,9 +60,9 @@ def validar_email(email):
     return bool(re.match(r"^[^@]+@[^@]+\.[^@]+$", email))
 
 def validar_nrc(nrc):
-    """Valida el formato del NRC salvadoreño (######-#)."""
+    """Valida el formato del NRC salvadoreño (solo dígitos, sin guiones)."""
     import re
-    return bool(re.match(r"^\d{6}-\d$", nrc))
+    return bool(re.fullmatch(r"\d{1,8}", nrc))
 
 def validar_telefono(telefono):
     """Valida números de teléfono salvadoreños con o sin código de país."""

--- a/tests/test_cliente_dialog.py
+++ b/tests/test_cliente_dialog.py
@@ -49,7 +49,7 @@ def test_invalid_fields(monkeypatch, qt_app, field, value):
     dialog = make_dialog(db)
 
     dialog.nombre_edit.setText('Nombre')
-    dialog.nrc_edit.setText('123456-7')
+    dialog.nrc_edit.setText('1234567')
     dialog.nit_edit.setText('1234-123456-123-1')
     dialog.telefono_edit.setText('1234-5678')
     dialog.email_edit.setText('test@example.com')
@@ -73,7 +73,7 @@ def test_duplicate_nit(monkeypatch, qt_app):
     dialog = make_dialog(db)
 
     dialog.nombre_edit.setText('Nombre')
-    dialog.nrc_edit.setText('123456-7')
+    dialog.nrc_edit.setText('1234567')
     dialog.nit_edit.setText('1234-123456-123-1')
     dialog.telefono_edit.setText('1234-5678')
     dialog.email_edit.setText('test@example.com')

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -29,7 +29,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
             "nombre": "ACME",
             "nombreComercial": "ACME",
             "nit": "0614-123456-102-3",
-            "nrc": "123456-7",
+            "nrc": "1234567",
             "codActividad": "0000",
             "descActividad": "Giro",
             "tipoContribuyente": "Persona Jurídica",

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -17,7 +17,7 @@ def test_generar_dte_json_basic(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -106,7 +106,7 @@ def test_generar_dte_json_usa_cod_estable_punto(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -161,7 +161,7 @@ def test_generar_dte_json_precios_incluyen_iva_default(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -213,7 +213,7 @@ def test_generar_dte_json_precios_incluyen_iva_unitario(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -267,7 +267,7 @@ def test_generar_dte_json_cons_final_precio_neto(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -320,7 +320,7 @@ def test_generar_dte_json_precios_incluyen_iva_multiple_cant(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -374,7 +374,7 @@ def test_generar_dte_json_precios_incluyen_iva_origen_neto(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -431,7 +431,7 @@ def test_generar_dte_json_normaliza_ambiente_config(
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -713,7 +713,7 @@ def test_generar_dte_json_receptor_extra_preserva_direccion(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -766,7 +766,7 @@ def test_generar_dte_json_municipio_fuera_depto(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -815,7 +815,7 @@ def test_receptor_defaults(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -870,7 +870,7 @@ def test_credit_payment_defaults(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -930,7 +930,7 @@ def test_item_tributo_guard(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -985,7 +985,7 @@ def test_item_no_tributo_when_exento(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -1048,7 +1048,7 @@ def test_credito_fiscal_incluye_tributo(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -1062,7 +1062,7 @@ def test_credito_fiscal_incluye_tributo(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -1128,7 +1128,7 @@ def test_resumen_tributo_codigo_str(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "1234567-8",
+        "nrc": "12345678",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -40,10 +40,10 @@ def test_validar_nit(nit, expected):
 
 
 @pytest.mark.parametrize("nrc, expected", [
-    ("123456-7", True),
-    ("000001-0", True),
-    ("12345-7", False),
-    ("123456-78", False),
+    ("1234567", True),
+    ("0000010", True),
+    ("123456789", False),
+    ("123456a", False),
 ])
 @pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_nrc(nrc, expected):

--- a/tests/test_validar_todo_integration.py
+++ b/tests/test_validar_todo_integration.py
@@ -26,7 +26,7 @@ def datos_negocio_incompleto(tmp_path):
 def datos_negocio_completo(tmp_path):
     data = {
         "nit": "0614-000000-102-2",
-        "nrc": "123456-7",
+        "nrc": "1234567",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "codActividad": "0000",


### PR DESCRIPTION
## Summary
- permit NRC values without dashes in validation helper
- adjust tests and fixtures to use digit-only NRC values

## Testing
- `pytest -q`
- `pytest tests/test_validaciones_basicas.py tests/test_envio_hacienda.py tests/test_validar_todo_integration.py tests/test_generar_dte_json.py -q`
- `pytest tests/test_validaciones_basicas.py::test_validar_nrc -q`


------
https://chatgpt.com/codex/tasks/task_e_68acbf0d96108323b759a4f467f5000e