### PR TITLE
feat: support versioned DTE signing with validation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from db import DB
 import requests
 from utils import jws
+from utils import versioned_dte
 from utils.stable_json import stable_stringify, save_file
 import auth
 from jsonschema import ValidationError, RefResolver
@@ -2664,24 +2665,16 @@ def _write_json(path: str, data):
 
 
 def _save_signed_dte(dte_data: dict, jws_token: str) -> None:
-    """Guarda el JSON original y el JWS en ``/dtes/{anio}/``."""
+    """Guarda el JSON y JWS usando estructura versionada por hash."""
     try:
-        fecha = (
-            dte_data.get("identificacion", {}).get("fecEmi") or fecha_emision_hoy_str()
-        )
-        year = str(fecha)[:4]
-        base_dir = os.path.join(os.path.dirname(__file__), "dtes", year)
-        os.makedirs(base_dir, exist_ok=True)
-        nombre = (
-            dte_data.get("identificacion", {}).get("numeroControl") or uuid.uuid4().hex
-        )
-        json_path = os.path.join(base_dir, f"{nombre}.json")
-        _write_json(json_path, dte_data)
-        jws_path = os.path.join(base_dir, f"{nombre}.jws")
-        _write_json(jws_path, jws_token)
+        base_dir = os.path.join(os.path.dirname(__file__), "dtes")
+        version_dir, _ = versioned_dte.ensure_version(dte_data, base_dir)
+        jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
         sobre = construir_sobre_recepcion(jws_token, dte_data)
         if sobre.get("estado") != "Error":
-            sobre_path = os.path.join(base_dir, f"{nombre}_sobre_hacienda.json")
+            sobre_path = os.path.join(
+                version_dir, jws_name.replace(".jws", "_sobre_hacienda.json")
+            )
             _write_json(sobre_path, sobre)
     except Exception:
         pass
@@ -2697,20 +2690,11 @@ class DTEValidationError(Exception):
 
 
 def save_dte_json(dte_data: dict) -> str:
-    """Guarda ``dte_data`` en ``/dtes/{anio}/`` y devuelve la ruta."""
+    """Guarda ``dte_data`` en estructura versionada y devuelve la ruta."""
     try:
-        fecha = (
-            dte_data.get("identificacion", {}).get("fecEmi") or fecha_emision_hoy_str()
-        )
-        year = str(fecha)[:4]
-        base_dir = os.path.join(os.path.dirname(__file__), "dtes", year)
-        os.makedirs(base_dir, exist_ok=True)
-        nombre = (
-            dte_data.get("identificacion", {}).get("numeroControl") or uuid.uuid4().hex
-        )
-        json_path = os.path.join(base_dir, f"{nombre}.json")
-        _write_json(json_path, dte_data)
-        return json_path
+        base_dir = os.path.join(os.path.dirname(__file__), "dtes")
+        version_dir, _ = versioned_dte.ensure_version(dte_data, base_dir)
+        return os.path.join(version_dir, "documento.json")
     except Exception:
         return ""
 
@@ -2760,16 +2744,26 @@ def construir_sobre_recepcion(documento: str, dte_data: dict | None = None) -> d
     """
 
     meta: dict[str, object] = {}
+    payload = None
 
     if isinstance(documento, str) and documento.count(".") == 2:
         try:
             payload = _decode_jws_payload(documento)
             meta = payload.get("identificacion") or payload.get("identificador") or payload
         except Exception:
+            payload = None
             meta = {}
 
     if isinstance(dte_data, dict):
         ident = dte_data.get("identificacion") or dte_data.get("identificador") or dte_data
+        if payload is not None:
+            ident_payload = payload.get("identificacion") or payload.get("identificador") or payload
+            for key in ("codigoGeneracion", "tipoDte", "version"):
+                if str(ident_payload.get(key)) != str(ident.get(key)):
+                    return {
+                        "estado": "Error",
+                        "detalle": "La firma no corresponde a la versión actual del documento. Vuelva a firmar o seleccione una firma compatible.",
+                    }
         if meta:
             for k, v in ident.items():
                 meta.setdefault(k, v)

--- a/tests/test_versioned_dte.py
+++ b/tests/test_versioned_dte.py
@@ -1,0 +1,63 @@
+import json
+import os
+import jwt
+import pytest
+
+from utils import versioned_dte
+from utils.stable_json import stable_stringify
+
+
+def _sample_dte():
+    return {
+        "identificacion": {
+            "codigoGeneracion": "00000000-0000-4000-8000-000000000001",
+            "tipoDte": "01",
+            "version": 1,
+        }
+    }
+
+
+def test_store_and_promote(tmp_path):
+    data = _sample_dte()
+    version_dir, json_hash = versioned_dte.ensure_version(data, base_dir=tmp_path)
+    token = jwt.encode(data, "secret", algorithm="HS256")
+    jws_name = versioned_dte.add_jws(version_dir, token, origen="manual")
+
+    meta_path = os.path.join(version_dir, "metadata.json")
+    meta = json.load(open(meta_path))
+    assert meta["hashJson"] == json_hash
+    assert meta["firmas"][0]["archivo"] == jws_name
+    assert meta["firmas"][0]["estado"] == "borrador"
+
+    versioned_dte.promote(version_dir, jws_name)
+    meta = json.load(open(meta_path))
+    assert meta["estado"] == "lista"
+    assert meta["firmas"][0]["estado"] == "lista"
+
+
+def test_verify_detects_mismatch(tmp_path):
+    data = _sample_dte()
+    version_dir, _ = versioned_dte.ensure_version(data, base_dir=tmp_path)
+    good_token = jwt.encode(data, "secret", algorithm="HS256")
+    good_name = versioned_dte.add_jws(version_dir, good_token)
+
+    # Verification passes for matching token
+    versioned_dte.verify(version_dir, good_name)
+
+    bad_payload = _sample_dte()
+    bad_payload["identificacion"]["codigoGeneracion"] = "11111111-1111-4111-8111-111111111111"
+    bad_token = jwt.encode(bad_payload, "secret", algorithm="HS256")
+    bad_name = versioned_dte.add_jws(version_dir, bad_token)
+
+    with pytest.raises(ValueError):
+        versioned_dte.verify(version_dir, bad_name)
+
+    # Tamper with JSON after signing
+    json_path = os.path.join(version_dir, "documento.json")
+    obj = json.load(open(json_path))
+    obj["nuevo"] = "cambio"
+    from utils.stable_json import save_file
+
+    save_file(json_path, stable_stringify(obj, indent=2))
+    with pytest.raises(ValueError):
+        versioned_dte.verify(version_dir, good_name)

--- a/utils/stable_json.py
+++ b/utils/stable_json.py
@@ -60,6 +60,11 @@ def _sha256(s: str) -> str:
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
+def hash_json(value: Any) -> str:
+    """Return a deterministic SHA256 hash for ``value`` serialized as JSON."""
+    return _sha256(stable_stringify(value))
+
+
 def assert_same_payload(dte: dict) -> None:
     compact = stable_stringify(dte)
     recompact = stable_stringify(json.loads(compact))

--- a/utils/versioned_dte.py
+++ b/utils/versioned_dte.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime
+
+from .stable_json import stable_stringify, save_file, hash_json
+
+
+def decode_jws_payload(token: str) -> dict:
+    """Return the payload of a compact JWS token."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("JWS malformado")
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    data = base64.urlsafe_b64decode(payload + padding)
+    return json.loads(data.decode("utf-8"))
+
+
+def _version_dir(base: str, codigo: str, json_hash: str, timestamp: str) -> str:
+    return os.path.join(base, codigo, f"{timestamp}-{json_hash}")
+
+
+def ensure_version(dte_json: dict, base_dir: str | None = None) -> tuple[str, str]:
+    """Ensure a directory for the given ``dte_json`` version exists.
+
+    Returns a tuple ``(version_dir, hashJson)``.
+    """
+    ident = dte_json.get("identificacion", {})
+    codigo = ident.get("codigoGeneracion") or "SIN-CODIGO"
+    json_hash = hash_json(dte_json)
+    base_dir = os.path.abspath(base_dir or os.path.join(os.path.dirname(__file__), "..", "dtes"))
+    codigo_dir = os.path.join(base_dir, codigo)
+    os.makedirs(codigo_dir, exist_ok=True)
+    for name in os.listdir(codigo_dir):
+        if name.endswith(f"-{json_hash}"):
+            return os.path.join(codigo_dir, name), json_hash
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    version_dir = _version_dir(base_dir, codigo, json_hash, timestamp)
+    os.makedirs(version_dir, exist_ok=True)
+    save_file(os.path.join(version_dir, "documento.json"), stable_stringify(dte_json, indent=2))
+    meta = {
+        "codigoGeneracion": codigo,
+        "hashJson": json_hash,
+        "timestamp": timestamp,
+        "estado": "borrador",
+        "firmas": [],
+    }
+    save_file(os.path.join(version_dir, "metadata.json"), stable_stringify(meta, indent=2))
+    return version_dir, json_hash
+
+
+def add_jws(version_dir: str, token: str, origen: str = "manual", estado: str = "borrador") -> str:
+    """Store ``token`` under ``version_dir`` registering metadata."""
+    ts = datetime.now().strftime("%Y%m%d%H%M%S")
+    jws_filename = f"documento-{ts}.jws"
+    save_file(os.path.join(version_dir, jws_filename), token, add_final_newline=False)
+    meta_path = os.path.join(version_dir, "metadata.json")
+    try:
+        with open(meta_path, "r", encoding="utf-8") as fh:
+            meta = json.load(fh)
+    except Exception:
+        meta = {"firmas": []}
+    meta.setdefault("firmas", []).append(
+        {
+            "archivo": jws_filename,
+            "fechaFirma": ts,
+            "origen": origen,
+            "estado": estado,
+        }
+    )
+    save_file(meta_path, stable_stringify(meta, indent=2))
+    return jws_filename
+
+
+def promote(version_dir: str, jws_filename: str) -> None:
+    """Mark the pair as ready for sending."""
+    meta_path = os.path.join(version_dir, "metadata.json")
+    with open(meta_path, "r", encoding="utf-8") as fh:
+        meta = json.load(fh)
+    meta["estado"] = "lista"
+    for firma in meta.get("firmas", []):
+        if firma.get("archivo") == jws_filename:
+            firma["estado"] = "lista"
+    save_file(meta_path, stable_stringify(meta, indent=2))
+
+
+def verify(version_dir: str, jws_filename: str) -> None:
+    """Validate that ``jws_filename`` matches the stored JSON version."""
+    json_path = os.path.join(version_dir, "documento.json")
+    with open(json_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    meta_path = os.path.join(version_dir, "metadata.json")
+    try:
+        with open(meta_path, "r", encoding="utf-8") as fh:
+            meta = json.load(fh)
+    except Exception:
+        meta = {}
+    if meta.get("hashJson") != hash_json(data):
+        raise ValueError(
+            "La firma no corresponde a la versión actual del documento. Vuelva a firmar o seleccione una firma compatible."
+        )
+    jws_path = os.path.join(version_dir, jws_filename)
+    with open(jws_path, "r", encoding="utf-8") as fh:
+        token = fh.read()
+    payload = decode_jws_payload(token)
+    ident_payload = payload.get("identificacion") or payload.get("identificador") or payload
+    ident_json = data.get("identificacion") or data.get("identificador") or data
+    for key in ("codigoGeneracion", "tipoDte", "version"):
+        if str(ident_payload.get(key)) != str(ident_json.get(key)):
+            raise ValueError(
+                "La firma no corresponde a la versión actual del documento. Vuelva a firmar o seleccione una firma compatible."
+            )
+
+
+__all__ = [
+    "ensure_version",
+    "add_jws",
+    "promote",
+    "verify",
+    "decode_jws_payload",
+    "hash_json",
+]


### PR DESCRIPTION
## Summary
- add deterministic JSON hashing helper
- store DTE versions and multiple signatures on disk with metadata
- verify JWS vs JSON payload when building sobre

## Testing
- `pytest tests/test_versioned_dte.py -q`
- `pytest` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9c19fc48323a447dd3c01082d12