### PR TITLE
Exclude IVA from resumen tributos for consumer invoices

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -937,6 +937,10 @@ def armar_tributos(tributos_raw, tipo_dte):
                 "valor": valor,
             }
         )
+    if tipo_dte == "01" and any(t["codigo"] == TRIBUTO_IVA for t in result):
+        raise ValueError(
+            "Código 20 (IVA) no permitido en resumen.tributos para consumidor final"
+        )
     return result or None
 
 
@@ -1010,17 +1014,35 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
             condicion = fiscal.get("condicion_pago")
         resumen["condicionOperacion"] = _parse_condicion_operacion(condicion)
 
-    if tipo_dte == "01":
-        resumen["tributos"] = armar_tributos(
-            [{"codigo": TRIBUTO_IVA, "valor": resumen.get("totalIva", total_iva)}],
-            tipo_dte,
-        )
-    elif total_gravada > D("0"):
-        resumen["tributos"] = armar_tributos(
-            [{"codigo": TRIBUTO_IVA, "valor": total_iva}],
-            tipo_dte,
-        )
-    else:
+    # Consolidar tributos adicionales desde ``extra`` o ``fiscal``
+    trib_raw = []
+    for src in (extra.get("tributos"), fiscal.get("tributos")):
+        if not src:
+            continue
+        if isinstance(src, dict):
+            src = [src]
+        trib_raw.extend(src)
+
+    suma_por_codigo: dict[str, D] = {}
+    for t in trib_raw:
+        codigo = str(t.get("codigo", "")).upper()
+        if codigo == TRIBUTO_IVA:
+            if tipo_dte == "01":
+                raise ValueError(
+                    "Código 20 (IVA) no permitido en resumen.tributos para consumidor final"
+                )
+            continue
+        if not codigo:
+            continue
+        valor = money(t.get("valor", 0))
+        suma_por_codigo[codigo] = money(suma_por_codigo.get(codigo, D("0")) + valor)
+
+    tributos_list = [{"codigo": c, "valor": v} for c, v in suma_por_codigo.items()]
+    if tipo_dte != "01" and total_gravada > D("0"):
+        tributos_list.append({"codigo": TRIBUTO_IVA, "valor": total_iva})
+
+    resumen["tributos"] = armar_tributos(tributos_list, tipo_dte)
+    if tipo_dte != "01" and total_gravada <= D("0") and not tributos_list:
         resumen.pop("tributos", None)
         resumen["totalIva"] = money(0)
 
@@ -1167,11 +1189,34 @@ def recalcular_totales(
     monto_total_operacion = money(venta_gravada_sum + total_iva_sum)
     _set_resumen("montoTotalOperacion", monto_total_operacion)
     _set_resumen("totalPagar", monto_total_operacion)
+    trib_raw = resumen.get("tributos")
     if tipo_dte == "01":
-        trib = armar_tributos([{"codigo": TRIBUTO_IVA, "valor": total_iva_sum}], tipo_dte)
-        if resumen.get("tributos") != trib:
-            resumen["tributos"] = trib
-            modificados.append("tributos")
+        suma: dict[str, D] = {}
+        for t in trib_raw or []:
+            codigo = str(t.get("codigo", "")).upper()
+            if codigo == TRIBUTO_IVA:
+                raise ValueError(
+                    "Código 20 (IVA) no permitido en resumen.tributos para consumidor final"
+                )
+            if not codigo:
+                continue
+            valor = money(t.get("valor", 0))
+            suma[codigo] = money(suma.get(codigo, D("0")) + valor)
+        trib = armar_tributos([{ "codigo": c, "valor": v} for c, v in suma.items()], tipo_dte)
+    else:
+        suma: dict[str, D] = {}
+        for t in trib_raw or []:
+            codigo = str(t.get("codigo", "")).upper()
+            if not codigo or codigo == TRIBUTO_IVA:
+                continue
+            valor = money(t.get("valor", 0))
+            suma[codigo] = money(suma.get(codigo, D("0")) + valor)
+        if venta_gravada_sum > D("0"):
+            suma[TRIBUTO_IVA] = total_iva_sum
+        trib = armar_tributos([{ "codigo": c, "valor": v} for c, v in suma.items()], tipo_dte)
+    if resumen.get("tributos") != trib:
+        resumen["tributos"] = trib
+        modificados.append("tributos")
     total_pagar = resumen["totalPagar"]
     try:
         total_letras = monto_a_texto_sv(total_pagar)
@@ -2300,19 +2345,6 @@ def validate_dte_json(
     cambios = recalcular_totales(payload, precios_incluyen_iva=precios_flag)
     if cambios:
         print("Advertencia: se corrigieron campos de resumen: " + ", ".join(cambios))
-
-    if tipo_dte == "01":
-        tributos = resumen.get("tributos") or []
-        codigos = {t.get("codigo") for t in tributos}
-        if TRIBUTO_IVA not in codigos:
-            tributos.append(
-                {
-                    "codigo": TRIBUTO_IVA,
-                    "descripcion": catalogos.TRIBUTOS.get(TRIBUTO_IVA),
-                    "valor": resumen.get("totalIva", D("0")),
-                }
-            )
-        resumen["tributos"] = tributos
 
     ident = payload.get("identificacion", {})
     if ident.get("tipoDte") == "01":

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -1172,3 +1172,81 @@ def test_resumen_tributo_codigo_str(tmp_path):
     res = data["resumen"]
     assert res["tributos"][0]["codigo"] == "20"
     assert isinstance(res["tributos"][0]["codigo"], str)
+
+
+def test_generar_dte_json_cons_final_otros_tributos(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    extra = {"tributos": [{"codigo": "59", "valor": 1.0}]}
+    venta_id = db.add_venta("2024-01-01", 11.0, cliente_id=cliente_id, extra=extra)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = generar_dte_json(db, venta_id)
+    res = data["resumen"]
+    assert res["tributos"][0]["codigo"] == "59"
+    assert all(t["codigo"] != "20" for t in res["tributos"])
+
+
+def test_generar_dte_json_cons_final_rechaza_iva_en_tributos(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    db = DB(str(db_path))
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    extra = {"tributos": [{"codigo": "20", "valor": 1.0}]}
+    venta_id = db.add_venta("2024-01-01", 11.0, cliente_id=cliente_id, extra=extra)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    with pytest.raises(ValueError):
+        generar_dte_json(db, venta_id)

--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -561,7 +561,22 @@ CONDICION_OPERACION = {int(k): v for k, v in _CATS["CAT-016"].items()}
 FORMA_PAGO = _CATS["CAT-017"]
 
 # Conjuntos derivados
-TRIBUTOS_PERMITIDOS_RESUMEN = {TRIBUTO_IVA}
+# Códigos permitidos en el resumen según el esquema oficial del DTE
+TRIBUTOS_PERMITIDOS_RESUMEN_SCHEMA = {
+    TRIBUTO_IVA,
+    "C3",
+    "59",
+    "71",
+    "D1",
+    "C8",
+    "D5",
+    "D4",
+    "C5",
+    "C6",
+    "C7",
+    "19",
+}
+TRIBUTOS_PERMITIDOS_RESUMEN = set(TRIBUTOS_PERMITIDOS_RESUMEN_SCHEMA)
 TRIBUTOS_PERMITIDOS_ITEM = set(TRIBUTOS_POR_ITEM_ESPECIALES)
 
 # Mapa general de catálogos para acceso dinámico
@@ -625,7 +640,7 @@ def register_code(cat: str, code: str, label: str) -> None:
     dest[code] = label
     if cat == "TRIBUTOS":
         TRIBUTOS[code] = label
-        if code == TRIBUTO_IVA:
+        if code in TRIBUTOS_PERMITIDOS_RESUMEN_SCHEMA:
             TRIBUTOS_PERMITIDOS_RESUMEN.add(code)
         if code in TRIBUTOS_POR_ITEM_ESPECIALES:
             TRIBUTOS_PERMITIDOS_ITEM.add(code)


### PR DESCRIPTION
## Summary
- restrict resumen tributes to schema-listed codes
- reject IVA in consumer invoice summaries and validate existing data
- test ensuring IVA code 20 triggers validation for consumidor final

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_cons_final_otros_tributos -q`
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_cons_final_rechaza_iva_en_tributos -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd85cb0448323994d1a08e5ab4935