### PR TITLE
Keep tributos field for consumer invoices

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1815,7 +1815,10 @@ def generar_dte_json(
                 val = D("0")
             t["valor"] = val
     else:
-        resumen.pop("tributos", None)
+        if tipo_dte != "01":
+            resumen.pop("tributos", None)
+        else:
+            resumen["tributos"] = None
 
     if resumen.get("pagos"):
         if resumen.get("condicionOperacion") == 2:

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -975,7 +975,8 @@ def test_item_tributo_guard(tmp_path):
     resumen = data["resumen"]
     assert item.get("codTributo") is None
     assert item.get("tributos") in (None, [])
-    assert resumen.get("tributos") is None
+    assert "tributos" in resumen
+    assert resumen["tributos"] is None
     from decimal import Decimal as D
     assert D(str(resumen["totalIva"])) == D(str(item["ivaItem"]))
 


### PR DESCRIPTION
## Summary
- ensure `generar_dte_json` keeps `resumen["tributos"]` when `tipo_dte` is "01"
- test that consumer invoices include the `tributos` key set to `None`

## Testing
- `pytest tests/test_generar_dte_json.py::test_item_tributo_guard -q`
- `pytest tests/test_resumen_fc.py::test_resumen_sin_gravada_sin_tributos -q`
- `pytest tests/test_dte_payload_cleanup.py::test_sanitize_dte_payload_removes_none_recursively -q`


------
https://chatgpt.com/codex/tasks/task_e_68acef5a9cb08323bedb6a449c587245