### PR TITLE
Keep tributos field for consumer invoices

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -108,7 +108,7 @@ def sanitize_dte_payload(data: dict, schema: dict | None = None) -> dict:
         "extension",
         "apendice",
         "codTributo",
-        "tributos",
+        "tributos",  # e.g. resumen.tributos must remain even if None
     }
 
     def _remove_nulls(value, parent_key=None):
@@ -1815,7 +1815,10 @@ def generar_dte_json(
                 val = D("0")
             t["valor"] = val
     else:
-        resumen.pop("tributos", None)
+        if tipo_dte != "01":
+            resumen.pop("tributos", None)
+        else:
+            resumen["tributos"] = None
 
     if resumen.get("pagos"):
         if resumen.get("condicionOperacion") == 2:

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -975,9 +975,64 @@ def test_item_tributo_guard(tmp_path):
     resumen = data["resumen"]
     assert item.get("codTributo") is None
     assert item.get("tributos") in (None, [])
-    assert resumen.get("tributos") is None
+    assert "tributos" in resumen
+    assert resumen["tributos"] is None
     from decimal import Decimal as D
     assert D(str(resumen["totalIva"])) == D(str(item["ivaItem"]))
+
+
+def test_consumer_invoice_preserves_tributos_in_final_json(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01", 11.3, cliente_id=cliente_id, extra={"precios_incluyen_iva": False}
+    )
+    db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
+
+    data = dte_module.generar_dte_json(db, venta_id)
+    data = dte_module.apply_schema_patch(data)
+    schema = dte_module.catalogos.get_dte_schema("01")
+    clean = dte_module.sanitize_dte_payload(data, schema)
+    resumen = clean["resumen"]
+    assert "tributos" in resumen
+    assert resumen["tributos"] is None
 
 
 def test_item_no_tributo_when_exento(tmp_path):


### PR DESCRIPTION
## Summary
- ensure `sanitize_dte_payload` preserves `resumen["tributos"]` even when `None`
- test that the sanitized consumer-invoice JSON keeps `"tributos": null` in `resumen`

## Testing
- `pytest tests/test_generar_dte_json.py::test_item_tributo_guard -q`
- `pytest tests/test_generar_dte_json.py::test_consumer_invoice_preserves_tributos_in_final_json -q`
- `pytest tests/test_resumen_fc.py::test_resumen_sin_gravada_sin_tributos -q`
- `pytest tests/test_dte_payload_cleanup.py::test_sanitize_dte_payload_removes_none_recursively -q`


------
https://chatgpt.com/codex/tasks/task_e_68acef5a9cb08323bedb6a449c587245