### PR TITLE
feat: enrich invoice json and validate schema

### DIFF
--- a/utils/docs.py
+++ b/utils/docs.py
@@ -2,11 +2,16 @@ import json
 import os
 import re
 from datetime import datetime
+from decimal import Decimal
+
+from jsonschema import Draft7Validator, ValidationError
 
 from dte import _map_departamento, _map_municipio
 
 # Base path is repository root two levels up from this file
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+CONFIG_NEGOCIO_PATH = os.path.join(BASE_DIR, "config_negocio.json")
+SCHEMA_FC_PATH = os.path.join(BASE_DIR, "svfe-json-schemas", "fe-fc-v1.json")
 
 FOLDERS = {
     'ConsumidorFinal': os.path.join(BASE_DIR, 'facturas_consumidor_final'),
@@ -58,7 +63,7 @@ def get_document_paths(date, cliente, identifier, doc_type, root=None):
     return pdf_path, json_path
 
 
-def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
+def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH, validate=True):
     """Create an invoice JSON following the template structure."""
     try:
         with open(template_path, 'r', encoding='utf-8') as fh:
@@ -78,12 +83,16 @@ def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
         ident['codigoGeneracion'] = venta['codigo_generacion']
     if venta.get('fecha'):
         try:
-            ident['fecEmi'] = datetime.fromisoformat(venta['fecha']).strftime('%Y-%m-%d')
+            dt = datetime.fromisoformat(str(venta['fecha']))
+            ident['fecEmi'] = dt.strftime('%Y-%m-%d')
+            ident['horEmi'] = dt.strftime('%H:%M:%S')
         except ValueError:
             ident['fecEmi'] = str(venta['fecha'])[:10]
+            ident['horEmi'] = str(venta.get('hora') or '00:00:00')[:8]
     ident.setdefault('version', 1)
     ident.setdefault('ambiente', venta.get('ambiente', '00'))
     ident.setdefault('tipoMoneda', 'USD')
+    ident.setdefault('tipoDte', venta.get('tipo_dte', '01'))
     if venta.get('tipo_operacion') is not None:
         ident['tipoOperacion'] = venta['tipo_operacion']
         ident['tipoModelo'] = 2 if venta['tipo_operacion'] == 2 else 1
@@ -93,6 +102,21 @@ def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
         ident['motivoContin'] = venta['motivo_contin']
     data['identificacion'] = ident
 
+    # Populate emisor from configuration if available
+    emisor = data.get('emisor', {})
+    try:
+        with open(CONFIG_NEGOCIO_PATH, 'r', encoding='utf-8') as fh:
+            cfg = json.load(fh)
+        cfg_emisor = cfg.get('emisor') or {
+            k: v for k, v in cfg.items()
+            if k not in ('ambiente', 'pruebas', 'produccion')
+        }
+        if isinstance(cfg_emisor, dict):
+            emisor.update(cfg_emisor)
+    except Exception:
+        pass
+    data['emisor'] = emisor
+
     rec = data.get('receptor', {})
     if cliente:
         if cliente.get('nombre'):
@@ -101,26 +125,96 @@ def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
             rec['direccion'] = cliente['direccion']
         if cliente.get('nit'):
             rec['nit'] = cliente['nit']
+        if cliente.get('tipoDocumento'):
+            rec['tipoDocumento'] = cliente['tipoDocumento']
+        if cliente.get('numDocumento'):
+            rec['numDocumento'] = cliente['numDocumento']
+        if cliente.get('departamento'):
+            rec['departamento'] = _map_departamento(cliente['departamento'])
+        if cliente.get('municipio'):
+            rec['municipio'] = _map_municipio(
+                cliente['municipio'], cliente.get('departamento')
+            )
     data['receptor'] = rec
 
     cuerpo = []
     for idx, det in enumerate(detalles or [], 1):
-        cuerpo.append({
+        cantidad = det.get('cantidad') or 0
+        precio = det.get('precio_unitario') or 0
+        venta_gravada = det.get('ventaGravada') or det.get('venta_gravada')
+        if venta_gravada is None:
+            venta_gravada = float(Decimal(str(cantidad)) * Decimal(str(precio)))
+        iva_item = det.get('ivaItem') or det.get('iva_item')
+        if iva_item is None:
+            base = Decimal(str(venta_gravada)) / Decimal('1.13') if venta_gravada else Decimal('0')
+            iva_item = float(Decimal(str(venta_gravada)) - base)
+        item = {
             'numItem': idx,
+            'tipoItem': det.get('tipoItem') or 1,
+            'numeroDocumento': det.get('numeroDocumento'),
+            'cantidad': cantidad,
+            'codigo': det.get('codigo'),
+            'codTributo': det.get('codTributo'),
+            'uniMedida': det.get('uniMedida') or 59,
             'descripcion': det.get('descripcion'),
-            'cantidad': det.get('cantidad'),
-            'precioUni': det.get('precio_unitario'),
-        })
+            'precioUni': precio,
+            'montoDescu': det.get('montoDescu') or 0,
+            'ventaNoSuj': det.get('ventaNoSuj') or 0,
+            'ventaExenta': det.get('ventaExenta') or 0,
+            'ventaGravada': venta_gravada or 0,
+            'tributos': det.get('tributos') or [],
+            'psv': det.get('psv') or 0,
+            'noGravado': det.get('noGravado') or 0,
+            'ivaItem': iva_item or 0,
+        }
+        cuerpo.append(item)
     data['cuerpoDocumento'] = cuerpo
 
     resumen = data.get('resumen', {})
-    if venta.get('total') is not None:
-        resumen['totalPagar'] = venta['total']
-    if venta.get('subtotal') is not None:
-        resumen['subTotalVentas'] = venta['subtotal']
-        resumen['subTotal'] = venta['subtotal']
+    total = venta.get('total')
+    if total is not None:
+        resumen['totalPagar'] = total
+    subtotal = venta.get('subtotal')
+    if subtotal is not None:
+        resumen['subTotalVentas'] = subtotal
+        resumen['subTotal'] = subtotal
     if venta.get('total_letras'):
         resumen['totalLetras'] = venta['total_letras']
+
+    gravada_sum = sum(Decimal(str(i.get('ventaGravada') or 0)) for i in cuerpo)
+    iva_sum = sum(Decimal(str(i.get('ivaItem') or 0)) for i in cuerpo)
+
+    resumen.setdefault('totalNoSuj', 0)
+    resumen.setdefault('totalExenta', 0)
+    resumen.setdefault('totalGravada', float(gravada_sum))
+    resumen.setdefault('subTotalVentas', float(gravada_sum))
+    resumen.setdefault('descuNoSuj', 0)
+    resumen.setdefault('descuExenta', 0)
+    resumen.setdefault('descuGravada', 0)
+    resumen.setdefault('porcentajeDescuento', 0)
+    resumen.setdefault('totalDescu', 0)
+    resumen.setdefault('tributos', None)
+    resumen.setdefault('subTotal', float(gravada_sum))
+    resumen.setdefault('ivaRete1', 0)
+    resumen.setdefault('reteRenta', 0)
+    resumen.setdefault('montoTotalOperacion', float(gravada_sum))
+    resumen.setdefault('totalNoGravado', 0)
+    resumen.setdefault('totalPagar', float(resumen.get('totalPagar', gravada_sum)))
+    resumen.setdefault('totalLetras', '')
+    resumen.setdefault('totalIva', float(iva_sum))
+    resumen.setdefault('saldoFavor', 0)
+    resumen.setdefault('condicionOperacion', venta.get('condicion_operacion', 1))
+    pagos = resumen.get('pagos')
+    if not pagos:
+        pagos = [{
+            'codigo': '01',
+            'montoPago': resumen.get('totalPagar', 0),
+            'referencia': None,
+            'plazo': None,
+            'periodo': None,
+        }]
+    resumen['pagos'] = pagos
+    resumen.setdefault('numPagoElectronico', None)
     data['resumen'] = resumen
 
     # Normalise emisor address codes if present
@@ -135,6 +229,14 @@ def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
             )
             emisor['direccion'] = dir_emi
         data['emisor'] = emisor
+
+    if validate and cuerpo:
+        try:
+            with open(SCHEMA_FC_PATH, 'r', encoding='utf-8') as fh:
+                schema = json.load(fh)
+            Draft7Validator(schema).validate(data)
+        except ValidationError as exc:
+            raise ValueError(f"DTE inválido: {exc.message}") from exc
 
     return data
 


### PR DESCRIPTION
## Summary
- expand invoice builder to populate identification, emisor, receptor, line items and summary totals
- validate invoices against fe-fc-v1.json schema before saving

## Testing
- `pytest` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9d6e7408323946d45dd02443e62