### PR TITLE
Delegate invoice PDF generation to utility function

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -25,7 +25,6 @@ import re
 
 from ticket_pdf import generar_ticket_personalizado
 from factura_sv import (
-    generar_factura_electronica_pdf,
     generar_nota_credito_pdf,
     generar_nota_debito_pdf,
     generar_nota_remision_pdf,
@@ -37,8 +36,8 @@ from dte import (
     transmitir_dte,
 )
 from utils.monto import monto_a_texto_sv
-from utils.docs import get_document_paths, build_invoice_json
-import uuid
+from utils.docs import get_document_paths
+from utils.doc_generation import generate_invoice_pdf
 from utils.email_sender import EmailSender
 from paths import DATOS_NEGOCIO_PATH
 import tempfile
@@ -1045,130 +1044,7 @@ class FacturacionTab(QWidget):
         self._show_pdf_preview(pdf_path)
 
     def _generate_invoice_pdf(self, venta_id):
-        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
-        if not venta:
-            return None
-
-        credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
-        detalles = self.manager.db.get_detalles_venta(venta_id)
-
-        venta_data = dict(venta)
-        if credito_info:
-            venta_data.update(credito_info)
-
-        if venta_data.get("vendedor_id"):
-            trabajador = self.manager.db.get_trabajador(venta_data["vendedor_id"])
-            if trabajador:
-                venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
-
-        sumas = descuentos = 0
-        ventas_exentas = ventas_no_sujetas = iva = 0
-        for d in detalles:
-            base_total = d.get("precio_unitario", 0) * d.get("cantidad", 0)
-            desc = d.get("descuento", 0)
-            if d.get("descuento_tipo") == "%":
-                desc = base_total * d.get("descuento", 0) / 100
-            base = base_total - desc
-            iva_item = d.get("iva", 0)
-            tipo = d.get("tipo_fiscal", "").lower()
-            if tipo == "venta exenta":
-                d["ventas_exentas"] = base
-                ventas_exentas += base
-            elif tipo == "venta no sujeta":
-                d["ventas_no_sujetas"] = base
-                ventas_no_sujetas += base
-            else:
-                d["ventas_gravadas"] = base
-                sumas += base_total
-                descuentos += desc
-                iva += iva_item
-
-        subtotal = (sumas - descuentos) + iva
-        total = subtotal + ventas_exentas + ventas_no_sujetas
-        venta_data.update(
-            {
-                "sumas": sumas,
-                "descuentos": descuentos,
-                "iva": iva,
-                "ventas_exentas": ventas_exentas,
-                "ventas_no_sujetas": ventas_no_sujetas,
-                "subtotal": subtotal,
-                "total": total,
-            }
-        )
-        if not venta_data.get("total_letras"):
-            try:
-                venta_data["total_letras"] = monto_a_texto_sv(total)
-            except Exception:
-                venta_data["total_letras"] = ""
-
-        cliente = None
-        if venta.get("cliente_id"):
-            cliente = next((c for c in self.manager._clientes if c["id"] == venta["cliente_id"]), None)
-        distribuidor = None
-        if venta.get("Distribuidor_id"):
-            distribuidor = next(
-                (d for d in self.manager._Distribuidores if d["id"] == venta["Distribuidor_id"]),
-                None,
-            )
-
-        extra = venta_data.get("extra") or {}
-        if isinstance(extra, str):
-            try:
-                extra = json.loads(extra)
-            except Exception:
-                extra = {}
-        if not venta_data.get("venta_a_cuenta_de"):
-            venta_data["venta_a_cuenta_de"] = extra.get("venta_a_cuenta_de", "")
-        if not venta_data.get("documento_venta_a_cuenta"):
-            venta_data["documento_venta_a_cuenta"] = extra.get("documento_venta_a_cuenta", "")
-        dte_json = extra.get("dteJson") or extra.get("dte_json") or {}
-        ident = dte_json.get("identificacion", {})
-        codigo_generacion = venta_data.get("codigo_generacion") or ident.get("codigoGeneracion", "")
-        numero_control = venta_data.get("numero_control") or dte_json.get("numeroControl", "")
-        sello_recepcion = venta_data.get("sello_recepcion") or extra.get("selloRecibido", "")
-        tipo_operacion = venta_data.get("tipo_operacion") or ident.get("tipoOperacion")
-        if tipo_operacion is None:
-            tipo_operacion = 1
-        tipo_contingencia = venta_data.get("tipo_contingencia") or ident.get("tipoContingencia")
-        fecha_generacion = venta_data.get("fecha_generacion") or ident.get("fecGeneracion", "")
-
-        if tipo_operacion == 1 and not sello_recepcion:
-            sello_recepcion = f"SELLO-{uuid.uuid4().hex[:8]}"
-            venta_data["sello_recepcion"] = sello_recepcion
-        venta_data["tipo_operacion"] = tipo_operacion
-        tipo_modelo = 2 if tipo_operacion == 2 else 1
-        
-        tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
-        doc_key = "CreditoFiscal" if credito_info else "ConsumidorFinal"
-        cliente_nombre = cliente.get("nombre") if cliente else ""
-        file_path, json_path = get_document_paths(
-            venta_data.get("fecha"), cliente_nombre, numero_control or venta_id, doc_key
-        )
-
-        generar_factura_electronica_pdf(
-            venta_data,
-            detalles,
-            cliente or {},
-            distribuidor or {},
-            tipo_doc,
-            archivo=file_path,
-            codigo_generacion=codigo_generacion,
-            numero_control=numero_control,
-            sello_recepcion=sello_recepcion,
-            tipo_modelo=tipo_modelo,
-            tipo_operacion=tipo_operacion,
-            fecha_generacion=fecha_generacion,
-            tipo_contingencia=tipo_contingencia,
-            ambiente=ident.get("ambiente", "00"),
-        )
-        json_data = build_invoice_json(venta_data, cliente or {}, detalles)
-        with open(json_path, 'w', encoding='utf-8') as fh:
-            json.dump(json_data, fh, ensure_ascii=False, indent=2)
-        if tipo_operacion == 2:
-            self.manager.db.add_dte_pendiente(venta_id, json_data, str(tipo_operacion))
-        self.manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
-        return file_path
+        return generate_invoice_pdf(self.manager, venta_id)
 
     def _generate_ticket_pdf(self, venta_id):
         """Generate and store the ticket PDF for the given sale."""

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -6,8 +6,8 @@ from PyQt5.QtWidgets import QTableWidgetItem, QMessageBox
 
 import dte
 from sales_tab import SalesTab
-from utils import docs
 from utils.doc_generation import generate_invoice_pdf
+import facturacion_tab
 
 class FakeDB:
     def __init__(self):
@@ -53,6 +53,39 @@ def test_generate_invoice_creates_json(tmp_path):
     monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
 
     generate_invoice_pdf(man, 1)
+    monkeypatch.undo()
+
+    assert pdf_path.exists()
+    assert json_path.exists()
+
+    data = json.load(open(json_path))
+    ident = data.get("identificacion", {})
+    assert ident.get("codigoGeneracion")
+    assert ident.get("numeroControl")
+    assert data.get("cuerpoDocumento")
+    assert data.get("resumen", {}).get("totalPagar") == 10
+
+
+def test_facturacion_tab_generate_invoice_creates_json(tmp_path):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    man = Manager(db)
+    tab = facturacion_tab.FacturacionTab.__new__(facturacion_tab.FacturacionTab)
+    tab.manager = man
+
+    pdf_path = tmp_path / "fact.pdf"
+    json_path = tmp_path / "fact.json"
+
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf_path), str(json_path)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+
+    tab._generate_invoice_pdf(1)
     monkeypatch.undo()
 
     assert pdf_path.exists()


### PR DESCRIPTION
## Summary
- Use `utils.doc_generation.generate_invoice_pdf` in `FacturacionTab` instead of inline logic
- Import utility at top and drop duplicate summary calculations
- Add integration test ensuring invoice JSON contains required fields

## Testing
- `pytest tests/test_invoice_json_save.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b4cec2a81483239863b701eed2c911