### PR TITLE
Improve DTE JSON error handling

### DIFF
--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -2,7 +2,7 @@ import pytest
 
 import json
 from pathlib import Path
-from decimal import Decimal
+from decimal import Decimal, getcontext, setcontext
 
 from db import DB
 from dte import generar_dte_json, _write_json, money
@@ -10,6 +10,50 @@ from dte import generar_dte_json, _write_json, money
 
 def create_db():
     return DB(":memory:")
+
+
+def test_generate_invoice_pdf_error_visible(monkeypatch):
+    from utils.doc_generation import generate_invoice_pdf
+    class FakeDB:
+        def __init__(self):
+            self._ventas = [{"id": 1, "fecha": "2024-01-01", "total": 10}]
+            self.detalles = {1: [{"cantidad": 1, "precio_unitario": 10}]}
+
+        def get_ventas(self):
+            return self._ventas
+
+        def get_venta_credito_fiscal(self, vid):
+            return None
+
+        def get_detalles_venta(self, vid):
+            return self.detalles.get(vid, [])
+
+        def get_trabajador(self, vid):
+            return None
+
+        def add_factura_pdf(self, *a):
+            pass
+
+    class Manager:
+        def __init__(self, db):
+            self.db = db
+            self._Distribuidores = []
+            self._clientes = []
+            self._vendedores = []
+
+    man = Manager(FakeDB())
+
+    def fail(*a, **k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fail)
+
+    ctx = getcontext().copy()
+    try:
+        with pytest.raises(ValueError):
+            generate_invoice_pdf(man, 1)
+    finally:
+        setcontext(ctx)
 
 
 def test_generar_dte_json_basic(tmp_path):

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -46,11 +46,23 @@ def test_generate_invoice_creates_json(tmp_path):
 
     pdf_path = tmp_path / "fact.pdf"
     json_path = tmp_path / "fact.json"
+
     def fake_paths(date, cliente, identifier, doc_type, root=None):
         pdf_path.parent.mkdir(parents=True, exist_ok=True)
         return str(pdf_path), str(json_path)
+
+    def fake_generar(db_, vid, **_):
+        venta = next(v for v in db_.get_ventas() if v["id"] == vid)
+        detalles = db_.get_detalles_venta(vid)
+        data = docs.build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident.setdefault("codigoGeneracion", uuid.uuid4().hex)
+        ident.setdefault("numeroControl", uuid.uuid4().hex[:8].upper())
+        return data
+
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
 
     generate_invoice_pdf(man, 1)
     monkeypatch.undo()
@@ -80,7 +92,17 @@ def test_generate_invoice_pdf_saves_sobre(tmp_path, monkeypatch):
         pdf_path.parent.mkdir(parents=True, exist_ok=True)
         return str(pdf_path), str(json_path)
 
+    def fake_generar(db_, vid, **_):
+        venta = next(v for v in db_.get_ventas() if v["id"] == vid)
+        detalles = db_.get_detalles_venta(vid)
+        data = docs.build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident.setdefault("codigoGeneracion", uuid.uuid4().hex)
+        ident.setdefault("numeroControl", uuid.uuid4().hex[:8].upper())
+        return data
+
     monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
     monkeypatch.setattr("utils.jws.sign_json", lambda *a, **k: "TOKEN")
     monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda *a, **k: {"estado": "OK"})
 
@@ -113,6 +135,22 @@ def test_generate_invoice_pdf_saves_sobre(tmp_path, monkeypatch):
     base = sobre[0].name.replace("_sobre_hacienda.json", "")
     assert (base_dir / f"{base}.json").exists()
     assert (base_dir / f"{base}.jws").exists()
+
+
+def test_generate_invoice_pdf_propagates_error(monkeypatch):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    man = Manager(db)
+
+    def fail(*a, **k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fail)
+
+    with pytest.raises(ValueError):
+        generate_invoice_pdf(man, 1)
 
 
 def test_save_ticket_creates_json(qt_app, tmp_path):

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -125,11 +125,9 @@ def generate_invoice_pdf(manager, venta_id):
             tipo_contingencia=tipo_contingencia,
             motivo_contin=motivo_contin,
         )
-    except Exception:
-        json_data = build_invoice_json(venta_data, cliente or {}, detalles)
-        ident = json_data.setdefault("identificacion", {})
-        ident.setdefault("codigoGeneracion", uuid.uuid4().hex)
-        ident.setdefault("numeroControl", uuid.uuid4().hex[:8].upper())
+    except ValueError:
+        logger.exception("Error al generar el DTE real")
+        raise
     ident = json_data.get("identificacion", {})
     codigo_generacion = ident.get("codigoGeneracion")
     numero_control = ident.get("numeroControl")


### PR DESCRIPTION
## Summary
- raise ValueError when DTE JSON generation fails instead of silently building a placeholder
- update invoice JSON save tests to mock DTE generation and check error propagation
- add regression test ensuring generate_invoice_pdf propagates DTE generation errors

## Testing
- `pytest tests/test_invoice_json_save.py::test_generate_invoice_creates_json tests/test_invoice_json_save.py::test_generate_invoice_pdf_saves_sobre tests/test_invoice_json_save.py::test_generate_invoice_pdf_propagates_error tests/test_invoice_json_save.py::test_save_ticket_creates_json tests/test_generar_dte_json.py::test_generate_invoice_pdf_error_visible -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ceb7d49c832391e7a3c2f3974c78