### PR TITLE
feat: custom decimal json encoder

### DIFF
--- a/tests/test_stable_stringify.py
+++ b/tests/test_stable_stringify.py
@@ -21,3 +21,12 @@ def test_stable_stringify_handles_float_precisely(value, expected):
 def test_stable_stringify_handles_decimal():
     """Decimals should serialize without negative zero artifacts."""
     assert stable_stringify({"monto": Decimal("10.3")}) == '{"monto":10.3}'
+
+
+def test_decimal_encoder_preserves_trailing_zeros():
+    """Decimals retain their explicit scale when serialized."""
+    assert stable_stringify({"monto": Decimal("1.50")}) == '{"monto":1.50}'
+    assert (
+        stable_stringify({"gravadas": Decimal("13.0000")})
+        == '{"gravadas":13.0000}'
+    )

--- a/utils/stable_json.py
+++ b/utils/stable_json.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 import hashlib
 import os
-from decimal import Decimal, ROUND_HALF_UP
+import re
+from decimal import Decimal
 from typing import Any, Iterator, Tuple
 
 
@@ -37,25 +38,33 @@ def stable_stringify(value: Any, indent: int | None = None) -> str:
             normalized,
             ensure_ascii=False,
             separators=(",", ":"),
-            default=_json_default,
+            cls=DecimalEncoder,
         )
     return json.dumps(
         normalized,
         ensure_ascii=False,
         indent=indent,
-        default=_json_default,
+        cls=DecimalEncoder,
     )
 
 
-def _json_default(obj: Any) -> float:
-    """Conversión predeterminada para tipos no estándar en JSON."""
-    if isinstance(obj, Decimal):
-        # Permite hasta cuatro decimales manteniendo 0 como ``0.0``
-        q = obj.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
-        if q == 0:
-            q = Decimal("0")
-        return float(q)
-    raise TypeError(f"Tipo no serializable: {type(obj)}")
+class DecimalEncoder(json.JSONEncoder):
+    """Encode :class:`decimal.Decimal` preserving trailing zeros.
+
+    ``format(value, 'f')`` renders the decimal in fixed-point notation,
+    so numbers like ``Decimal('1.50')`` are serialized as ``1.50`` and
+    ``Decimal('13.0000')`` as ``13.0000``.  The encoded JSON contains
+    numbers without surrounding quotes.
+    """
+
+    def default(self, obj: Any) -> Any:  # type: ignore[override]
+        if isinstance(obj, Decimal):
+            return f"__decimal__:{format(obj, 'f')}"
+        return super().default(obj)
+
+    def encode(self, o: Any) -> str:  # type: ignore[override]
+        s = super().encode(o)
+        return re.sub(r'"__decimal__:([^"\n]+)"', r"\1", s)
 
 
 def _sha256(s: str) -> str:


### PR DESCRIPTION
## Summary
- replace default decimal conversion with `DecimalEncoder` to preserve trailing zeros in JSON serialization
- update `stable_stringify` to use the new encoder and add tests for decimal formatting

## Testing
- `pytest tests/test_stable_stringify.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4e681502c8323a9ee5f6b3ac14de2