### PR TITLE
Preserve decimal precision in DTE serialization

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1647,10 +1647,10 @@ def generar_dte_json(
                 or ("bruto" if precios_incluyen_iva else "neto")
             ).lower()
             if origen == "neto":
-                precio = money(precio_raw * D("1.13"))
+                precio = d4(precio_raw * D("1.13"))
             else:
-                precio = money(precio_raw)
-            line_total = money(cant * precio - monto_descu)
+                precio = d4(precio_raw)
+            line_total = d4(cant * precio - monto_descu)
             venta_gravada = line_total
             iva_val = money(line_total * D("0.13") / D("1.13"))
             line_total = venta_gravada
@@ -1902,10 +1902,9 @@ def generar_dte_json(
             ultimo = resumen["pagos"][-1]
             ult_m = D(str(ultimo.get("montoPago") or 0))
             ultimo["montoPago"] = money(ult_m + delta)
-
-    def _float_money(value: D) -> float:
-        val = float(money(value))
-        return 0.0 if val == -0.0 else val
+    def _quantize_money(value: D) -> D:
+        dec = money(value)
+        return D("0.0") if dec == 0 else dec
 
     for k, v in list(resumen.items()):
         if k in {
@@ -1916,15 +1915,15 @@ def generar_dte_json(
             "tributos",
         }:
             continue
-        resumen[k] = _float_money(v)
+        resumen[k] = _quantize_money(D(str(v)))
 
     if resumen.get("tributos"):
         for t in resumen["tributos"]:
-            t["valor"] = _float_money(D(str(t["valor"])))
+            t["valor"] = _quantize_money(D(str(t["valor"])))
 
     if resumen.get("pagos"):
         for p in resumen["pagos"]:
-            p["montoPago"] = _float_money(D(str(p["montoPago"])))
+            p["montoPago"] = _quantize_money(D(str(p["montoPago"])))
     # SERIALIZE-GUARD END
 
     extension = None
@@ -2477,11 +2476,6 @@ def validate_dte_json(
                 raise ValidationError("montoPago debe ser múltiplo de 0.01")
             if val == D("0") and val.as_tuple().sign:
                 p["montoPago"] = D("0")
-
-    def _float_money(value: D) -> float:
-        val = float(money(value))
-        return 0.0 if val == -0.0 else val
-
     # --- Catálogo validations ---
     ident = payload.get("identificacion", {})
     tipo_dte = ident.get("tipoDte")
@@ -2550,15 +2544,15 @@ def validate_dte_json(
         }:
             continue
         if isinstance(v, Decimal):
-            resumen[k] = _float_money(v)
+            resumen[k] = _zero_or(v, money)
 
     if resumen.get("tributos"):
         for t in resumen["tributos"]:
-            t["valor"] = _float_money(t["valor"])
+            t["valor"] = _zero_or(t["valor"], money)
 
     if resumen.get("pagos"):
         for p in resumen["pagos"]:
-            p["montoPago"] = _float_money(p["montoPago"])
+            p["montoPago"] = _zero_or(p["montoPago"], money)
 
     payload["resumen"] = resumen
 

--- a/tests/test_decimal_serialization.py
+++ b/tests/test_decimal_serialization.py
@@ -1,0 +1,77 @@
+from decimal import Decimal as D
+import json
+
+from db import DB
+from dte import generar_dte_json
+from utils.stable_json import stable_stringify
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_trailing_zeros_preserved(tmp_path):
+    import dte as dte_module
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: datos
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 13)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01",
+        13,
+        cliente_id=cliente_id,
+        extra={"precios_incluyen_iva": True},
+    )
+    db.add_detalle_venta(venta_id, prod_id, 1, 13, vendedor_id=vend_id)
+
+    data = generar_dte_json(db, venta_id)
+    item = data["cuerpoDocumento"][0]
+    resumen = data["resumen"]
+
+    assert isinstance(item["precioUni"], D)
+    assert isinstance(item["montoDescu"], D)
+    assert isinstance(item["ivaItem"], D)
+    assert isinstance(resumen["totalIva"], D)
+
+    json_str = stable_stringify(data)
+    assert "\"montoDescu\":0.0" in json_str
+    assert "\"precioUni\":13.0000" in json_str
+    assert "\"ivaItem\":1.50" in json_str
+    assert "\"totalIva\":1.50" in json_str


### PR DESCRIPTION
## Summary
- keep monetary fields as `Decimal` until final encoding
- support four-decimal unit prices and quantize totals without converting to float
- add test ensuring serialized invoices retain significant trailing zeros

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1 missing)*
- `pytest tests/test_decimal_serialization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e91680008323a3f2763700cdac9d