### PR TITLE
Desglose automático de IVA en PDFs de crédito fiscal

### DIFF
--- a/tests/test_credito_fiscal_pdf_iva.py
+++ b/tests/test_credito_fiscal_pdf_iva.py
@@ -1,0 +1,80 @@
+import json
+import uuid
+import pytest
+
+from utils.doc_generation import generate_invoice_pdf
+from utils.docs import build_invoice_json
+
+
+class FakeDB:
+    def __init__(self):
+        self._ventas = []
+        self.detalles = {}
+        self.credito = {}
+
+    def get_ventas(self):
+        return self._ventas
+
+    def get_venta_credito_fiscal(self, vid):
+        return self.credito.get(vid)
+
+    def get_detalles_venta(self, vid):
+        return self.detalles.get(vid, [])
+
+    def get_trabajador(self, vid):
+        return None
+
+    def add_factura_pdf(self, *a):
+        pass
+
+
+class Manager:
+    def __init__(self, db):
+        self.db = db
+        self._Distribuidores = []
+        self._clientes = []
+        self._vendedores = []
+
+
+def test_credito_fiscal_pdf_calcula_iva(tmp_path, monkeypatch):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 11.3}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    db.credito[1] = {"sumas": 10, "descuentos": 0, "iva": 0, "subtotal": 0, "ventas_exentas": 0, "ventas_no_sujetas": 0}
+    man = Manager(db)
+
+    pdf_path = tmp_path / "fact.pdf"
+    json_path = tmp_path / "fact.json"
+
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf_path), str(json_path)
+
+    def fake_generar(db_, vid, **_):
+        venta = next(v for v in db_.get_ventas() if v["id"] == vid)
+        detalles = db_.get_detalles_venta(vid)
+        data = build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident["codigoGeneracion"] = uuid.uuid4().hex
+        ident["numeroControl"] = uuid.uuid4().hex[:8].upper()
+        data.setdefault("resumen", {})["totalPagar"] = venta.get("total")
+        return data
+
+    captured = {}
+
+    def fake_pdf(venta_d, detalles_d, cliente, distribuidor, tipo_doc, archivo="", **_):
+        captured["venta"] = venta_d
+        captured["detalles"] = detalles_d
+        with open(archivo, "wb") as fh:
+            fh.write(b"pdf")
+
+    monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
+    monkeypatch.setattr("utils.doc_generation.generar_factura_electronica_pdf", fake_pdf)
+
+    generate_invoice_pdf(man, 1)
+
+    assert pytest.approx(captured["venta"]["iva"], 0.01) == 1.3
+    assert pytest.approx(captured["detalles"][0]["iva"], 0.01) == 1.3
+    assert pytest.approx(captured["detalles"][0]["ventas_gravadas"], 0.01) == 10

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -7,7 +7,7 @@ import dte
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado
 from dte import generar_ticket_json, generar_dte_json
-from utils.monto import monto_a_texto_sv
+from utils.monto import monto_a_texto_sv, iva_item
 from utils.docs import get_document_paths, build_invoice_json
 from utils.jws import sign_and_save
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
@@ -41,7 +41,7 @@ def generate_invoice_pdf(manager, venta_id):
         if d.get("descuento_tipo") == "%":
             desc = base_total * d.get("descuento", 0) / 100
         base = base_total - desc
-        iva_item = d.get("iva", 0)
+        iva_item_val = d.get("iva", 0)
         tipo = d.get("tipo_fiscal", "").lower()
         if tipo == "venta exenta":
             d["ventas_exentas"] = base
@@ -50,10 +50,13 @@ def generate_invoice_pdf(manager, venta_id):
             d["ventas_no_sujetas"] = base
             ventas_no_sujetas += base
         else:
+            if credito_info and not iva_item_val:
+                iva_item_val = float(iva_item(base))
+                d["iva"] = iva_item_val
             d["ventas_gravadas"] = base
             sumas += base_total
             descuentos += desc
-            iva += iva_item
+            iva += iva_item_val
 
     subtotal = (sumas - descuentos) + iva
     total = subtotal + ventas_exentas + ventas_no_sujetas


### PR DESCRIPTION
## Summary
- Calcula automáticamente el IVA en la generación de PDFs de crédito fiscal
- Añade prueba unitaria que verifica el desglose correcto del IVA

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1, ModuleNotFoundError: fastapi)*
- `PYTEST_ADDOPTS= pytest tests/test_credito_fiscal_pdf_iva.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4e7717fa083238833ee6830e23f56