### PR TITLE
Use four-decimal precision for DTE summary amounts

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1615,6 +1615,11 @@ def generar_dte_json(
     ):
         precios_incluyen_iva = True
         extra["precios_incluyen_iva"] = True
+
+    def _zero_or_d4(value: D) -> D:
+        dec = d4(value)
+        return D("0.0") if dec == 0 else dec
+
     for idx, d in enumerate(detalles, 1):
         try:
             cant = d8(D(str(d.get("cantidad") or 0)))
@@ -1729,6 +1734,8 @@ def generar_dte_json(
             else:
                 item_data.pop("codTributo", None)
                 item_data["tributos"] = []
+        for key in ("ventaNoSuj", "ventaExenta", "ventaGravada"):
+            item_data[key] = _zero_or_d4(D(str(item_data[key])))
         total_no_suj_sum += D(str(item_data["ventaNoSuj"]))
         total_exenta_sum += D(str(item_data["ventaExenta"]))
         total_gravada_sum += D(str(item_data["ventaGravada"]))
@@ -1736,9 +1743,9 @@ def generar_dte_json(
         cuerpo.append(item_data)
 
     items_total = money(items_total)
-    total_no_suj_sum = money(total_no_suj_sum)
-    total_exenta_sum = money(total_exenta_sum)
-    total_gravada_sum = money(total_gravada_sum)
+    total_no_suj_sum = _zero_or_d4(total_no_suj_sum)
+    total_exenta_sum = _zero_or_d4(total_exenta_sum)
+    total_gravada_sum = _zero_or_d4(total_gravada_sum)
     total_no_gravado_sum = money(total_no_gravado_sum)
     total_iva_sum = money(iva_total)
 
@@ -1756,6 +1763,10 @@ def generar_dte_json(
         extra=extra,
         tipo_dte=tipo_dte,
     )
+
+    resumen["totalNoSuj"] = _zero_or_d4(total_no_suj_sum)
+    resumen["totalExenta"] = _zero_or_d4(total_exenta_sum)
+    resumen["totalGravada"] = _zero_or_d4(total_gravada_sum)
 
     # Las siguientes validaciones se omiten para permitir diferencias entre el
     # resumen y el cuerpo del documento sin lanzar ``ValidationError``.
@@ -1906,6 +1917,8 @@ def generar_dte_json(
         dec = money(value)
         return D("0.0") if dec == 0 else dec
 
+    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+
     for k, v in list(resumen.items()):
         if k in {
             "totalLetras",
@@ -1915,7 +1928,8 @@ def generar_dte_json(
             "tributos",
         }:
             continue
-        resumen[k] = _quantize_money(D(str(v)))
+        qfn = _zero_or_d4 if k in special_d4_fields else _quantize_money
+        resumen[k] = qfn(D(str(v)))
 
     if resumen.get("tributos"):
         for t in resumen["tributos"]:
@@ -1944,7 +1958,8 @@ def generar_dte_json(
     # Se omite la validación de esquema para permitir la generación sin
     # restricciones adicionales.
     # validate_dte_json(copy.deepcopy(result), db=db, precios_incluyen_iva=False)
-    return result
+    json_result = stable_stringify(result)
+    return json.loads(json_result, parse_float=Decimal)
 
 
 def validate_dte_json(

--- a/tests/test_all_dtes.py
+++ b/tests/test_all_dtes.py
@@ -91,7 +91,7 @@ def _assert_base(data: dict, tipo: str) -> None:
         assert str(item["ventaGravada"]) == "26.95000000"
         iva = _q2(item["ventaGravada"] - (item["ventaGravada"] / Decimal("1.13")))
         assert str(iva) == "3.10"
-        assert str(resumen["totalGravada"]) == "26.95"
+        assert str(resumen["totalGravada"]) == "26.9500"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         assert str(_q2(resumen["totalIva"])) == "3.10"
@@ -99,7 +99,7 @@ def _assert_base(data: dict, tipo: str) -> None:
         assert str(item["ventaGravada"]) == "23.85000000"
         iva = _q8(item["ventaGravada"] * Decimal("0.13"))
         assert str(iva) == "3.10050000"
-        assert str(resumen["totalGravada"]) == "23.85"
+        assert str(resumen["totalGravada"]) == "23.8500"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         total_iva = resumen.get("totalIva")

--- a/tests/test_fc_schema.py
+++ b/tests/test_fc_schema.py
@@ -12,6 +12,6 @@ def test_fc_min_valido():
     item = payload["cuerpoDocumento"][0]
     assert str(item["ventaGravada"]) == "26.95000000"
     assert str(item["ivaItem"]) == "3.10"
-    assert str(payload["resumen"]["totalGravada"]) == "26.95"
+    assert str(payload["resumen"]["totalGravada"]) == "26.9500"
     assert str(payload["resumen"]["totalIva"]) == "3.10"
     assert str(payload["resumen"]["totalPagar"]) == "26.95"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -24,7 +24,7 @@ def _assert_base(data):
         iva = (item["ventaGravada"] - (item["ventaGravada"] / Decimal("1.13"))).quantize(Decimal("0.01"))
         if "ivaItem" in item:
             assert str(item["ivaItem"]) == str(iva)
-        assert str(resumen["totalGravada"]) == "26.95"
+        assert str(resumen["totalGravada"]) == "26.9500"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         assert str(resumen["totalIva"]) == "3.10"
@@ -35,7 +35,7 @@ def _assert_base(data):
         assert str(iva) == "3.10050000"
         if "ivaItem" in item:
             assert str(item["ivaItem"]) == str(iva)
-        assert str(resumen["totalGravada"]) == "23.85"
+        assert str(resumen["totalGravada"]) == "23.8500"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         total_iva = resumen.get("totalIva")


### PR DESCRIPTION
## Summary
- ensure venta gravada, exenta and no sujeta keep four decimal places in DTE JSON
- serialize DTE payload with `stable_stringify` to avoid losing trailing zeros
- adjust tests for new four-decimal formatting

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eed4d9ec8323ae24f68095d1c932