### PR TITLE
Handle tokens with existing Bearer prefix

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2954,7 +2954,11 @@ def build_auth_header(
         # 2) Bearer
         elif auth.get("access_token") or auth.get("bearer"):
             token = auth.get("access_token") or auth.get("bearer")
-            headers["Authorization"] = f"Bearer {token}" if token else ""
+            token = str(token).strip()
+            if token.lower().startswith("bearer "):
+                headers["Authorization"] = token
+            else:
+                headers["Authorization"] = f"Bearer {token}" if token else ""
         # 3) Basic
         elif auth.get("basic_user") and auth.get("basic_password"):
             creds = f"{auth['basic_user']}:{auth['basic_password']}"

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -178,6 +178,39 @@ def test_post_dte_normalizes_bearer(monkeypatch):
     assert captured["body"]["documento"].count(".") >= 2
 
 
+def test_post_dte_handles_prefixed_token(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        captured["headers"] = headers
+        captured["url"] = url
+        captured["body"] = json
+
+        class R:
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {}
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    meta = {"ambiente": "00", "version": 2, "tipoDte": "01", "codigoGeneracion": "ABC"}
+    token = make_jws({"identificacion": meta})
+    _post_dte(dte.DEFAULT_RECEPCION_URL, "Bearer TOKEN", token, meta)
+    assert captured["headers"]["Authorization"] == "Bearer TOKEN"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["headers"]["Accept"] == "application/json"
+    assert captured["headers"]["User-Agent"] == "Vertex-DTE/1.0"
+    assert captured["url"] == dte.DEFAULT_RECEPCION_URL
+    assert captured["body"]["documento"] == token
+    assert captured["body"]["documento"].count(".") >= 2
+
+
 def test_post_dte_rejects_invalid_path(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=20):
         class R:


### PR DESCRIPTION
## Summary
- avoid duplicating `Bearer` in auth headers when token already includes it
- add test covering tokens with prefixed `Bearer`

## Testing
- `pytest tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio -q`
- `pytest tests/test_dte_transmision.py::test_post_dte_normalizes_bearer -q`
- `pytest tests/test_dte_transmision.py::test_post_dte_handles_prefixed_token -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fd43768c8323833005d6cc8ae08d