### PR TITLE
Handle trailing newlines in JWS tokens

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2851,6 +2851,9 @@ def construir_sobre_recepcion(documento: str, dte_data: dict | None = None) -> d
     error devuelve ``{"estado": "Error", "detalle": "<mensaje>"}``.
     """
 
+    if isinstance(documento, str):
+        documento = documento.strip()
+
     meta: dict[str, object] = {}
     payload = None
 
@@ -3178,6 +3181,7 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
 
 def enviar_dte_a_hacienda(jws_token: str) -> dict:
     """Transmite un DTE ya firmado (JWS) al entorno de pruebas de Hacienda."""
+    jws_token = jws_token.strip()
     config = _load_dte_api_config()
     url = config["url"]
     payload = _decode_jws_payload(jws_token)

--- a/tests/test_dte_trailing_newline.py
+++ b/tests/test_dte_trailing_newline.py
@@ -1,0 +1,60 @@
+import dte
+import auth
+
+
+def test_enviar_dte_a_hacienda_strips_newline(monkeypatch):
+    captured = {}
+
+    def fake_decode(token):
+        captured["decoded"] = token
+        return {
+            "identificacion": {
+                "ambiente": "00",
+                "version": 1,
+                "tipoDte": "01",
+                "codigoGeneracion": "X",
+            }
+        }
+
+    def fake_post(url, token, jws_token, meta):
+        captured["posted"] = jws_token
+        return {"estado": "Transmitido"}
+
+    monkeypatch.setattr(dte, "_decode_jws_payload", fake_decode)
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example.com"})
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer TOKEN")
+
+    token = "AAA.BBB.CCC\n"
+    resp = dte.enviar_dte_a_hacienda(token)
+
+    assert captured["decoded"] == "AAA.BBB.CCC"
+    assert captured["posted"] == "AAA.BBB.CCC"
+    assert resp["estado"] == "Transmitido"
+
+
+def test_construir_sobre_recepcion_strips_newline(monkeypatch):
+    captured = {}
+
+    def fake_decode(token):
+        captured["decoded"] = token
+        return {
+            "identificacion": {
+                "ambiente": "00",
+                "version": 1,
+                "tipoDte": "01",
+                "codigoGeneracion": "X",
+            }
+        }
+
+    monkeypatch.setattr(dte, "_decode_jws_payload", fake_decode)
+
+    token = "AAA.BBB.CCC\n"
+    sobre = dte.construir_sobre_recepcion(token)
+
+    assert captured["decoded"] == "AAA.BBB.CCC"
+    assert sobre["documento"] == "AAA.BBB.CCC"
+    assert sobre["ambiente"] == "00"
+    assert sobre["version"] == 1
+    assert sobre["tipoDte"] == "01"
+    assert sobre["codigoGeneracion"] == "X"


### PR DESCRIPTION
## Summary
- strip JWS tokens before decoding or posting to Hacienda
- trim incoming documents when building reception envelopes
- test JWS transmission and envelope construction with trailing newlines

## Testing
- `pytest tests/test_dte_trailing_newline.py -q --disable-warnings --no-cov`
- `pytest tests/test_enviar_dte_url.py -q --disable-warnings --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b50fa15ef08323902d1ffebb3c60fc