### PR TITLE
Permitir totales con cuatro decimales

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1103,12 +1103,17 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         "numPagoElectronico",
         "tributos",
     }
+    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
     for key, val in list(resumen.items()):
         if key in excl:
             continue
         if isinstance(val, Decimal):
-            if val != money(val):
-                raise ValidationError(f"{key} debe ser múltiplo de 0.01")
+            if key in special_d4_fields:
+                if val != d4(val):
+                    raise ValidationError(f"{key} debe ser múltiplo de 0.0001")
+            else:
+                if val != money(val):
+                    raise ValidationError(f"{key} debe ser múltiplo de 0.01")
             if val == D("0") and val.as_tuple().sign:
                 resumen[key] = D("0")
 
@@ -1231,9 +1236,9 @@ def recalcular_totales(
         resumen[key] = value
         modificados.append(key)
 
-    _set_resumen("totalNoSuj", money(0))
-    _set_resumen("totalExenta", money(0))
-    _set_resumen("totalGravada", money(venta_gravada_sum))
+    _set_resumen("totalNoSuj", d4(0))
+    _set_resumen("totalExenta", d4(0))
+    _set_resumen("totalGravada", d4(venta_gravada_sum))
     _set_resumen("subTotalVentas", money(venta_gravada_sum))
     _set_resumen("descuNoSuj", money(0))
     _set_resumen("descuExenta", money(0))
@@ -1855,20 +1860,22 @@ def generar_dte_json(
             f"Advertencia: el total a pagar {resumen.get('totalPagar',0):.2f} difiere del calculado {calc_total_commission:.2f}"
         )
     # SERIALIZE-GUARD BEGIN
-    for k in (
-        "totalIva",
-        "montoTotalOperacion",
-        "totalPagar",
-        "totalGravada",
-        "totalExenta",
-        "totalNoSuj",
-        "totalNoGravado",
-    ):
+    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):
         if k in resumen:
             val = D(str(resumen[k]))
             if val != money(val):
                 raise ValidationError(
                     f"{k} debe ser múltiplo de 0.01 (recibido={resumen[k]})"
+                )
+            if val == D("0") and val.as_tuple().sign:
+                resumen[k] = D("0")
+    for k in special_d4_fields:
+        if k in resumen:
+            val = D(str(resumen[k]))
+            if val != d4(val):
+                raise ValidationError(
+                    f"{k} debe ser múltiplo de 0.0001 (recibido={resumen[k]})"
                 )
             if val == D("0") and val.as_tuple().sign:
                 resumen[k] = D("0")
@@ -2424,7 +2431,7 @@ def validate_dte_json(
     ident = payload.get("identificacion", {})
     if ident.get("tipoDte") == "01":
         for i in payload.get("cuerpoDocumento", []):
-            linea = money(
+            linea = d4(
                 D(str(i.get("cantidad") or 0))
                 * D(str(i.get("precioUni") or 0))
                 - D(str(i.get("montoDescu") or 0))
@@ -2463,20 +2470,22 @@ def validate_dte_json(
                 p["plazo"] = ""
 
     # Verificación de centavos exactos en totales clave
-    for k in (
-        "totalIva",
-        "montoTotalOperacion",
-        "totalPagar",
-        "totalGravada",
-        "totalExenta",
-        "totalNoSuj",
-        "totalNoGravado",
-    ):
+    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):
         if k in resumen:
             val = D(str(resumen[k]))
             if val != money(val):
                 raise ValidationError(
                     f"{k} debe ser múltiplo de 0.01 (recibido={resumen[k]})"
+                )
+            if val == D("0") and val.as_tuple().sign:
+                resumen[k] = D("0")
+    for k in special_d4_fields:
+        if k in resumen:
+            val = D(str(resumen[k]))
+            if val != d4(val):
+                raise ValidationError(
+                    f"{k} debe ser múltiplo de 0.0001 (recibido={resumen[k]})"
                 )
             if val == D("0") and val.as_tuple().sign:
                 resumen[k] = D("0")
@@ -2554,6 +2563,7 @@ def validate_dte_json(
             item[k] = _zero_or(item.get(k, D("0")), qfn)
 
     resumen = payload.get("resumen", {})
+    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
     for k, v in list(resumen.items()):
         if k in {
             "totalLetras",
@@ -2564,7 +2574,8 @@ def validate_dte_json(
         }:
             continue
         if isinstance(v, Decimal):
-            resumen[k] = _zero_or(v, money)
+            qfn = d4 if k in special_d4_fields else money
+            resumen[k] = _zero_or(v, qfn)
 
     if resumen.get("tributos"):
         for t in resumen["tributos"]:

--- a/tests/test_dte_rounding.py
+++ b/tests/test_dte_rounding.py
@@ -20,14 +20,21 @@ def test_item_and_total_rounding():
     assert str(iva) == '3.10050000'
     assert decimal_places(iva) <= 8
 
-    resumen = calcular_resumen(venta, {'total': venta + iva}, fiscal={'iva': iva}, extra={"precios_incluyen_iva": False})
+    resumen = calcular_resumen(
+        venta,
+        {'total': venta + iva},
+        fiscal={'iva': iva},
+        extra={"precios_incluyen_iva": False},
+        tipo_dte="03",
+    )
 
     assert f"{d2(resumen['totalGravada']):.2f}" == '23.85'
     assert f"{d2(resumen['totalIva']):.2f}" == '3.10'
     assert f"{d2(resumen['totalPagar']):.2f}" == '26.95'
 
-    for key in ['totalGravada', 'totalIva', 'totalPagar']:
+    for key in ['totalIva', 'totalPagar']:
         assert decimal_places(resumen[key]) <= 2
+    assert decimal_places(resumen['totalGravada']) <= 4
 
 
 def test_pagos_rounding_adjusts_last_payment():

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -7,6 +7,7 @@ import dte
 from dte import sanitize_dte_payload, validate_dte_json
 from utils.catalogos import TRIBUTO_IVA
 from db import DB
+from utils.monto import D
 
 UUID4_RE = r"^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$"
 
@@ -451,3 +452,15 @@ def test_validate_allows_envelope(db_fixture):
 
     # No debe lanzar ``ValueError`` aunque falten campos de un DTE tradicional
     validate_dte_json(sobre, db=db_fixture)
+
+
+def test_totales_permiten_cuatro_decimales(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    item = dte["cuerpoDocumento"][0]
+    item["precioUni"] = D("1.2345")
+    item["ventaGravada"] = D("1.2345")
+    item["ivaItem"] = D("0.14")
+    dte.setdefault("extra", {})["precios_incluyen_iva"] = True
+    validate_dte_json(dte, db=db_fixture)
+    assert str(dte["cuerpoDocumento"][0]["precioUni"]) == "1.2345"
+    assert str(dte["resumen"]["totalGravada"]) == "1.2345"


### PR DESCRIPTION
## Summary
- Permitir que totalGravada, totalExenta y totalNoSuj conserven hasta cuatro decimales durante la validación
- Ajustar la verificación final para aceptar campos de cuatro decimales y normalizar precios unitarios
- Añadir pruebas para validar campos con cuatro decimales y ajustar redondeo de totales

## Testing
- `pytest tests/test_dte_validation.py::test_totales_permiten_cuatro_decimales -q`
- `pytest tests/test_dte_rounding.py::test_item_and_total_rounding -q`


------
https://chatgpt.com/codex/tasks/task_e_68b53108950883239f77740cbb30c9b3