### PR TITLE
Ensure totalGravada uses two decimals

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1103,7 +1103,7 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         "numPagoElectronico",
         "tributos",
     }
-    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    special_d4_fields = {"totalExenta", "totalNoSuj"}
     for key, val in list(resumen.items()):
         if key in excl:
             continue
@@ -1630,6 +1630,10 @@ def generar_dte_json(
         dec = d4(value)
         return D("0.0") if dec == 0 else dec
 
+    def _zero_or_d2(value: D) -> D:
+        dec = d2(value)
+        return D("0.0") if dec == 0 else dec
+
     for idx, d in enumerate(detalles, 1):
         try:
             cant = d1(D(str(d.get("cantidad") or 0)))
@@ -1755,7 +1759,7 @@ def generar_dte_json(
     items_total = money(items_total)
     total_no_suj_sum = _zero_or_d4(total_no_suj_sum)
     total_exenta_sum = _zero_or_d4(total_exenta_sum)
-    total_gravada_sum = _zero_or_d4(total_gravada_sum)
+    total_gravada_sum = _zero_or_d2(total_gravada_sum)
     total_no_gravado_sum = money(total_no_gravado_sum)
     total_iva_sum = money(iva_total)
 
@@ -1776,7 +1780,7 @@ def generar_dte_json(
 
     resumen["totalNoSuj"] = _zero_or_d4(total_no_suj_sum)
     resumen["totalExenta"] = _zero_or_d4(total_exenta_sum)
-    resumen["totalGravada"] = _zero_or_d4(total_gravada_sum)
+    resumen["totalGravada"] = _zero_or_d2(total_gravada_sum)
 
     # Las siguientes validaciones se omiten para permitir diferencias entre el
     # resumen y el cuerpo del documento sin lanzar ``ValidationError``.
@@ -1860,7 +1864,7 @@ def generar_dte_json(
             f"Advertencia: el total a pagar {resumen.get('totalPagar',0):.2f} difiere del calculado {calc_total_commission:.2f}"
         )
     # SERIALIZE-GUARD BEGIN
-    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    special_d4_fields = {"totalExenta", "totalNoSuj"}
     for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):
         if k in resumen:
             val = D(str(resumen[k]))
@@ -1929,7 +1933,7 @@ def generar_dte_json(
         dec = money(value)
         return D("0.0") if dec == 0 else dec
 
-    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    special_d4_fields = {"totalExenta", "totalNoSuj"}
 
     for k, v in list(resumen.items()):
         if k in {
@@ -2470,7 +2474,7 @@ def validate_dte_json(
                 p["plazo"] = ""
 
     # Verificación de centavos exactos en totales clave
-    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    special_d4_fields = {"totalExenta", "totalNoSuj"}
     for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):
         if k in resumen:
             val = D(str(resumen[k]))
@@ -2563,7 +2567,7 @@ def validate_dte_json(
             item[k] = _zero_or(item.get(k, D("0")), qfn)
 
     resumen = payload.get("resumen", {})
-    special_d4_fields = {"totalGravada", "totalExenta", "totalNoSuj"}
+    special_d4_fields = {"totalExenta", "totalNoSuj"}
     for k, v in list(resumen.items()):
         if k in {
             "totalLetras",

--- a/tests/test_all_dtes.py
+++ b/tests/test_all_dtes.py
@@ -91,7 +91,7 @@ def _assert_base(data: dict, tipo: str) -> None:
         assert str(item["ventaGravada"]) == "26.95000000"
         iva = _q2(item["ventaGravada"] - (item["ventaGravada"] / Decimal("1.13")))
         assert str(iva) == "3.10"
-        assert str(resumen["totalGravada"]) == "26.9500"
+        assert str(resumen["totalGravada"]) == "26.95"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         assert str(_q2(resumen["totalIva"])) == "3.10"
@@ -99,7 +99,7 @@ def _assert_base(data: dict, tipo: str) -> None:
         assert str(item["ventaGravada"]) == "23.85000000"
         iva = _q8(item["ventaGravada"] * Decimal("0.13"))
         assert str(iva) == "3.10050000"
-        assert str(resumen["totalGravada"]) == "23.8500"
+        assert str(resumen["totalGravada"]) == "23.85"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         total_iva = resumen.get("totalIva")

--- a/tests/test_dte_rounding.py
+++ b/tests/test_dte_rounding.py
@@ -34,7 +34,7 @@ def test_item_and_total_rounding():
 
     for key in ['totalIva', 'totalPagar']:
         assert decimal_places(resumen[key]) <= 2
-    assert decimal_places(resumen['totalGravada']) <= 4
+    assert decimal_places(resumen['totalGravada']) <= 2
 
 
 def test_pagos_rounding_adjusts_last_payment():

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -5,6 +5,7 @@ import re
 
 import dte
 from dte import sanitize_dte_payload, validate_dte_json
+from jsonschema import ValidationError
 from utils.catalogos import TRIBUTO_IVA
 from db import DB
 from utils.monto import D
@@ -454,13 +455,12 @@ def test_validate_allows_envelope(db_fixture):
     validate_dte_json(sobre, db=db_fixture)
 
 
-def test_totales_permiten_cuatro_decimales(dte_metadata_factory, db_fixture):
+def test_totales_rechazan_mas_de_dos_decimales(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     item = dte["cuerpoDocumento"][0]
     item["precioUni"] = D("1.2345")
     item["ventaGravada"] = D("1.2345")
     item["ivaItem"] = D("0.14")
     dte.setdefault("extra", {})["precios_incluyen_iva"] = True
-    validate_dte_json(dte, db=db_fixture)
-    assert str(dte["cuerpoDocumento"][0]["precioUni"]) == "1.2345"
-    assert str(dte["resumen"]["totalGravada"]) == "1.2345"
+    with pytest.raises(ValidationError):
+        validate_dte_json(dte, db=db_fixture)

--- a/tests/test_fc_schema.py
+++ b/tests/test_fc_schema.py
@@ -12,6 +12,6 @@ def test_fc_min_valido():
     item = payload["cuerpoDocumento"][0]
     assert str(item["ventaGravada"]) == "26.95000000"
     assert str(item["ivaItem"]) == "3.10"
-    assert str(payload["resumen"]["totalGravada"]) == "26.9500"
+    assert str(payload["resumen"]["totalGravada"]) == "26.95"
     assert str(payload["resumen"]["totalIva"]) == "3.10"
     assert str(payload["resumen"]["totalPagar"]) == "26.95"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -24,7 +24,7 @@ def _assert_base(data):
         iva = (item["ventaGravada"] - (item["ventaGravada"] / Decimal("1.13"))).quantize(Decimal("0.01"))
         if "ivaItem" in item:
             assert str(item["ivaItem"]) == str(iva)
-        assert str(resumen["totalGravada"]) == "26.9500"
+        assert str(resumen["totalGravada"]) == "26.95"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         assert str(resumen["totalIva"]) == "3.10"
@@ -35,7 +35,7 @@ def _assert_base(data):
         assert str(iva) == "3.10050000"
         if "ivaItem" in item:
             assert str(item["ivaItem"]) == str(iva)
-        assert str(resumen["totalGravada"]) == "23.8500"
+        assert str(resumen["totalGravada"]) == "23.85"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         total_iva = resumen.get("totalIva")


### PR DESCRIPTION
## Summary
- round resumen.totalGravada to two decimals
- validate that totalGravada rejects more than two decimal places
- update tests for new two-decimal expectation

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b53738a0dc832380d325ab684a171a