### PR TITLE
Handle exempt and non-subject items in DTE JSON

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1660,37 +1660,59 @@ def generar_dte_json(
         monto_descu = d8(D(str(d.get("descuento") or 0)))
         if monto_descu < 0:
             monto_descu = D("0")
-        if tipo_dte == "01":
-            origen = (
-                extra.get("origen_precios")
-                or ("bruto" if precios_incluyen_iva else "neto")
-            ).lower()
-            if origen == "neto":
-                precio = d4(precio_raw * D("1.13"))
-            else:
-                precio = d4(precio_raw)
-            line_total = d4(cant * precio - monto_descu)
-            venta_gravada = line_total
-            iva_val = money(line_total * D("0.13") / D("1.13"))
-            line_total = venta_gravada
-        elif precios_incluyen_iva:
-            total_final = d8(cant * precio_raw - monto_descu)
-            if total_final < 0:
-                total_final = D("0")
-            base_total = money(total_final / D("1.13"))
-            iva_val = money(total_final - base_total)
-            base_total = money(total_final - iva_val)
-            precio = money(total_final / cant)
-            venta_gravada = base_total
-            line_total = base_total + iva_val
-        else:
+        tipo_fiscal_item = str(d.get("tipo_fiscal", "")).lower()
+        if tipo_fiscal_item == "venta exenta":
             precio = precio_raw
-            base = d8(cant * precio - monto_descu)
-            if base < 0:
-                base = D("0")
-            venta_gravada = d2(base)
-            iva_val = d8(venta_gravada * D("0.13")) if venta_gravada > 0 else D("0")
-            line_total = venta_gravada + iva_val
+            line_total = d8(cant * precio - monto_descu)
+            if line_total < 0:
+                line_total = D("0")
+            venta_gravada = D("0")
+            venta_exenta = d2(line_total)
+            venta_no_suj = D("0")
+            iva_val = D("0")
+        elif tipo_fiscal_item == "venta no sujeta":
+            precio = precio_raw
+            line_total = d8(cant * precio - monto_descu)
+            if line_total < 0:
+                line_total = D("0")
+            venta_gravada = D("0")
+            venta_exenta = D("0")
+            venta_no_suj = d2(line_total)
+            iva_val = D("0")
+        else:
+            if tipo_dte == "01":
+                origen = (
+                    extra.get("origen_precios")
+                    or ("bruto" if precios_incluyen_iva else "neto")
+                ).lower()
+                if origen == "neto":
+                    precio = d4(precio_raw * D("1.13"))
+                else:
+                    precio = d4(precio_raw)
+                line_total = d4(cant * precio - monto_descu)
+                venta_gravada = line_total
+                iva_val = money(line_total * D("0.13") / D("1.13"))
+                line_total = venta_gravada
+            elif precios_incluyen_iva:
+                total_final = d8(cant * precio_raw - monto_descu)
+                if total_final < 0:
+                    total_final = D("0")
+                base_total = money(total_final / D("1.13"))
+                iva_val = money(total_final - base_total)
+                base_total = money(total_final - iva_val)
+                precio = money(total_final / cant)
+                venta_gravada = base_total
+                line_total = base_total + iva_val
+            else:
+                precio = precio_raw
+                base = d8(cant * precio - monto_descu)
+                if base < 0:
+                    base = D("0")
+                venta_gravada = d2(base)
+                iva_val = d8(venta_gravada * D("0.13")) if venta_gravada > 0 else D("0")
+                line_total = venta_gravada + iva_val
+            venta_exenta = D("0")
+            venta_no_suj = D("0")
         items_total += line_total
         iva_total += iva_val
         try:
@@ -1727,8 +1749,8 @@ def generar_dte_json(
             "uniMedida": uni_medida,
             "precioUni": precio,
             "montoDescu": d2(monto_descu),
-            "ventaNoSuj": money(0),
-            "ventaExenta": money(0),
+            "ventaNoSuj": venta_no_suj,
+            "ventaExenta": venta_exenta,
             "ventaGravada": venta_gravada,
             "psv": money(0),
             "noGravado": money(0),

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -107,7 +107,7 @@ def test_generar_dte_json_basic(tmp_path):
     )
     db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
 
-    data = dte_module.generar_dte_json(db, venta_id)
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
 
     idf = data["identificacion"]
     res = data["resumen"]
@@ -199,6 +199,94 @@ def test_generar_dte_json_usa_cod_estable_punto(tmp_path):
     emisor = data["emisor"]
     assert emisor["codEstable"] == "0002"
     assert emisor["codPuntoVenta"] == "0005"
+
+
+def test_generar_dte_json_tipo_fiscal(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: datos
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+    dte_module._load_datos_negocio = lambda: datos
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod1", "P1", None, vend_id, None, 0, 0, 0, 10)
+    prod1 = db.cursor.lastrowid
+    db.add_producto("Prod2", "P2", None, vend_id, None, 0, 0, 0, 20)
+    prod2 = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01",
+        30,
+        cliente_id=cliente_id,
+        extra={"precios_incluyen_iva": False},
+    )
+    db.add_detalle_venta(
+        venta_id,
+        prod1,
+        1,
+        10,
+        tipo_fiscal="venta exenta",
+        vendedor_id=vend_id,
+    )
+    db.add_detalle_venta(
+        venta_id,
+        prod2,
+        1,
+        20,
+        tipo_fiscal="venta no sujeta",
+        vendedor_id=vend_id,
+    )
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    items = data["cuerpoDocumento"]
+    res = data["resumen"]
+    D = Decimal
+    assert D(str(items[0]["ventaExenta"])) == D("10")
+    assert D(str(items[0]["ventaNoSuj"])) == D("0")
+    assert D(str(items[0]["ventaGravada"])) == D("0")
+    assert D(str(items[0]["ivaItem"])) == D("0")
+    assert D(str(items[1]["ventaNoSuj"])) == D("20")
+    assert D(str(items[1]["ventaExenta"])) == D("0")
+    assert D(str(items[1]["ventaGravada"])) == D("0")
+    assert D(str(items[1]["ivaItem"])) == D("0")
+    assert D(str(res["totalExenta"])) == D("10")
+    assert D(str(res["totalNoSuj"])) == D("20")
+    assert D(str(res["totalGravada"])) == D("0")
+    assert D(str(res["totalIva"])) == D("0")
 
 def test_generar_dte_json_precios_incluyen_iva_default(tmp_path):
     import dte as dte_module


### PR DESCRIPTION
## Summary
- support "venta exenta" and "venta no sujeta" per item when generating DTE JSON
- track exenta and no sujeta totals and skip IVA calculation accordingly
- add regression test covering exenta and non-subject lines

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_tipo_fiscal -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5cedbda4883238bd323984026d184