### PR TITLE
Corrige cálculo de totales en DTE tipo 01

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -982,8 +982,10 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     total_no_suj = money(fiscal.get("ventas_no_sujetas", 0))
     total_no_gravado = money(fiscal.get("no_gravado", 0))
     if tipo_dte == "01":
-        total_gravada = items_total
-        total_iva = money(fiscal.get("iva", items_total - (items_total / D("1.13"))))
+        total_gravada = money(max(items_total - total_exenta - total_no_suj, D("0")))
+        total_iva = money(
+            fiscal.get("iva", total_gravada - (total_gravada / D("1.13")))
+        )
     elif precios_incluyen_iva:
         total_gravada = money(
             fiscal.get("sumas", (items_total - total_exenta - total_no_suj) / D("1.13"))
@@ -1000,7 +1002,7 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     descu_gravada = money(fiscal.get("descu_gravada", fiscal.get("descuentos", 0)))
 
     if tipo_dte == "01":
-        sub_total_ventas = money(total_gravada + total_no_suj + total_exenta)
+        sub_total_ventas = money(items_total)
         total_descu = money(descu_no_suj + descu_exenta + descu_gravada)
         sub_total = money(sub_total_ventas - total_descu)
         monto_total_operacion = sub_total

--- a/tests/test_resumen_fc.py
+++ b/tests/test_resumen_fc.py
@@ -28,6 +28,17 @@ def test_resumen_sin_gravada_sin_tributos():
     assert resumen['tributos'] is None
 
 
+def test_resumen_fc_exenta_nosuj_no_doble_conteo():
+    items_total = D('10.00')
+    fiscal = {
+        'ventas_exentas': D('2.00'),
+        'ventas_no_sujetas': D('3.00'),
+    }
+    resumen = calcular_resumen(items_total, {}, fiscal=fiscal, tipo_dte='01')
+    assert D(str(resumen['totalGravada'])) == D('5.00')
+    assert D(str(resumen['subTotalVentas'])) == D('10.00')
+
+
 def test_pagos_contado_default():
     pagos = normalizar_pagos([], D('10.00'), condicion=1)
     assert pagos == [


### PR DESCRIPTION
## Summary
- Evita sumar nuevamente ventas exentas y no sujetas en DTE tipo 01
- Ajusta subTotalVentas para usar el total del detalle
- Añade prueba que verifica que no haya doble conteo

## Testing
- `pytest tests/test_resumen_fc.py`
- `pytest tests/test_dte_rounding.py`
- `pytest` *(errores: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b5d8a9677883238c778efb1c667863