### PR TITLE
Limit JSON decimals to four

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1680,9 +1680,9 @@ def generar_dte_json(
         if cant <= 0:
             cant = d1(D("1"))
         try:
-            precio_raw = d8(D(str(d.get("precio_unitario") or 0)))
+            precio_raw = d4(D(str(d.get("precio_unitario") or 0)))
         except Exception:
-            precio_raw = d8(D(0))
+            precio_raw = d4(D(0))
         try:
             tipo_item = int(d.get("tipoItem", 1))
         except Exception:
@@ -1695,14 +1695,14 @@ def generar_dte_json(
             uni_medida = 59
         if uni_medida not in UNIDADES_MEDIDA_PERMITIDAS:
             uni_medida = 59
-        monto_descu = d8(D(str(d.get("descuento") or 0)))
+        monto_descu = d4(D(str(d.get("descuento") or 0)))
         if monto_descu < 0:
             monto_descu = D("0")
         tipo_fiscal_item = str(d.get("tipo_fiscal", "")).lower()
         if tipo_fiscal_item == "venta exenta":
-            precio = precio_raw
-            bruto = d8(cant * precio)
-            line_total = d8(bruto - monto_descu)
+            precio = d4(precio_raw)
+            bruto = d4(cant * precio)
+            line_total = d4(bruto - monto_descu)
             if line_total < 0:
                 line_total = D("0")
             bruto_total += bruto
@@ -1712,9 +1712,9 @@ def generar_dte_json(
             venta_no_suj = D("0")
             iva_val = D("0")
         elif tipo_fiscal_item == "venta no sujeta":
-            precio = precio_raw
-            bruto = d8(cant * precio)
-            line_total = d8(bruto - monto_descu)
+            precio = d4(precio_raw)
+            bruto = d4(cant * precio)
+            line_total = d4(bruto - monto_descu)
             if line_total < 0:
                 line_total = D("0")
             bruto_total += bruto
@@ -1741,26 +1741,26 @@ def generar_dte_json(
                 bruto_total += bruto
                 descuentos_total += d4(monto_descu)
             elif precios_incluyen_iva:
-                bruto = d8(cant * precio_raw)
-                total_final = d8(bruto - monto_descu)
+                bruto = d4(cant * precio_raw)
+                total_final = d4(bruto - monto_descu)
                 if total_final < 0:
                     total_final = D("0")
                 base_total = money(total_final / D("1.13"))
                 iva_val = money(total_final - base_total)
                 base_total = money(total_final - iva_val)
-                precio = money(total_final / cant)
+                precio = d4(money(total_final / cant))
                 venta_gravada = base_total
                 line_total = base_total + iva_val
                 bruto_total += bruto
                 descuentos_total += monto_descu
             else:
-                precio = precio_raw
-                bruto = d8(cant * precio)
-                base = d8(cant * precio - monto_descu)
+                precio = d4(precio_raw)
+                bruto = d4(cant * precio)
+                base = d4(cant * precio - monto_descu)
                 if base < 0:
                     base = D("0")
                 venta_gravada = d2(base)
-                iva_val = d8(venta_gravada * D("0.13")) if venta_gravada > 0 else D("0")
+                iva_val = d4(venta_gravada * D("0.13")) if venta_gravada > 0 else D("0")
                 line_total = venta_gravada + iva_val
                 bruto_total += bruto
                 descuentos_total += monto_descu

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -28,7 +28,7 @@ SCHEMA_MAP: Dict[str, tuple[str, str]] = {
     "nr": ("fe-nr-v3.json", "04"),
 }
 
-D8 = Decimal("0.00000001")
+D4 = Decimal("0.0001")
 D2 = Decimal("0.01")
 D = Decimal
 IVA = D("0.13")
@@ -50,9 +50,9 @@ def _numero_control(db: DB, tipo: str, sucursal: str = "001", punto: str = "001"
     return f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
 
 
-def d8(value: Decimal) -> Decimal:
-    """Quantize ``value`` to eight decimal places using ``ROUND_HALF_UP``."""
-    return value.quantize(D8, rounding=ROUND_HALF_UP)
+def d4(value: Decimal) -> Decimal:
+    """Quantize ``value`` to four decimal places using ``ROUND_HALF_UP``."""
+    return value.quantize(D4, rounding=ROUND_HALF_UP)
 
 
 def d2(value: Decimal) -> Decimal:
@@ -70,10 +70,10 @@ def generar_fc_ejemplo(
     precio: Decimal = D("9.54"),
     gravado: bool = True,
 ) -> dict:
-    venta = d8(cantidad * precio)
-    iva8 = d8(venta * IVA) if gravado else d8(D("0"))
+    venta = d4(cantidad * precio)
+    iva = d4(venta * IVA) if gravado else d4(D("0"))
     total_base = d2(venta)
-    total_iva = d2(iva8)
+    total_iva = d2(iva)
     total_pagar = d2(total_base + total_iva)
 
     item = {
@@ -82,21 +82,21 @@ def generar_fc_ejemplo(
         "numeroDocumento": None,
         "codigo": "SKU001",
         "descripcion": "Producto X",
-        "cantidad": d8(cantidad),
+        "cantidad": d4(cantidad),
         "uniMedida": 59,
-        "precioUni": d8(precio),
-        "montoDescu": D("0.00000000"),
-        "ventaNoSuj": D("0.00000000"),
-        "ventaExenta": D("0.00000000"),
-        "ventaGravada": D("0.00000000"),
+        "precioUni": d4(precio),
+        "montoDescu": D("0.0000"),
+        "ventaNoSuj": D("0.0000"),
+        "ventaExenta": D("0.0000"),
+        "ventaGravada": D("0.0000"),
         "codTributo": None,
         "tributos": None,
-        "psv": D("0.00000000"),
-        "noGravado": D("0.00000000"),
+        "psv": D("0.0000"),
+        "noGravado": D("0.0000"),
     }
     if gravado:
         item["ventaGravada"] = venta
-        item["ivaItem"] = iva8
+        item["ivaItem"] = iva
     else:
         item["ventaExenta"] = venta
 
@@ -228,12 +228,12 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
     cantidad = Decimal("2.5")
     if tipo == "fc":
         precio = Decimal("10.78")  # precio con IVA incluido
-        venta = d8(cantidad * precio)
+        venta = d4(cantidad * precio)
         iva_item = d2(venta - (venta / Decimal("1.13")))
     else:
         precio = Decimal("9.54")
-        venta = d8(cantidad * precio)
-        iva_item = d8(venta * Decimal("0.13"))
+        venta = d4(cantidad * precio)
+        iva_item = d4(venta * Decimal("0.13"))
     numero_documento = None
     tipo_item = 4 if tipo == "fc" else 1
     uni_medida = 99 if tipo == "fc" else 59
@@ -243,15 +243,15 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
         "numeroDocumento": numero_documento,
         "codigo": "SKU001",
         "descripcion": "Producto de prueba",
-        "cantidad": d8(cantidad),
+        "cantidad": d4(cantidad),
         "uniMedida": uni_medida,
-        "precioUni": d8(precio),
-        "montoDescu": d8(Decimal("0")),
-        "ventaNoSuj": d8(Decimal("0")),
-        "ventaExenta": d8(Decimal("0")),
+        "precioUni": d4(precio),
+        "montoDescu": d4(Decimal("0")),
+        "ventaNoSuj": d4(Decimal("0")),
+        "ventaExenta": d4(Decimal("0")),
         "ventaGravada": venta,
-        "psv": d8(Decimal("0")),
-        "noGravado": d8(Decimal("0")),
+        "psv": d4(Decimal("0")),
+        "noGravado": d4(Decimal("0")),
         "ivaItem": iva_item,
     }
     if tipo == "fc":

--- a/svfe/json_compare.py
+++ b/svfe/json_compare.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 import json
 from typing import Any, Dict, List
 
-DEC8 = Decimal("0.00000001")
+DEC4 = Decimal("0.0001")
 DEC2 = Decimal("0.01")
 
 ITEM_KEYS = {
@@ -56,7 +56,7 @@ def _norm_value(value: Any, key: str | None) -> Any:
             dec = Decimal(str(value))
         except Exception:
             return value
-        quant = DEC8 if key in ITEM_KEYS else DEC2
+        quant = DEC4 if key in ITEM_KEYS else DEC2
         return str(dec.quantize(quant, rounding=ROUND_HALF_UP))
 
     if isinstance(value, Decimal):

--- a/tests/goldens/ccf.json
+++ b/tests/goldens/ccf.json
@@ -2,21 +2,21 @@
   "apendice": null,
   "cuerpoDocumento": [
     {
-      "cantidad": "2.50000000",
+      "cantidad": "2.5000",
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
-      "montoDescu": "0E-8",
-      "noGravado": "0E-8",
+      "montoDescu": "0.0000",
+      "noGravado": "0.0000",
       "numItem": 1,
       "numeroDocumento": null,
-      "precioUni": "9.54000000",
-      "psv": "0E-8",
+      "precioUni": "9.5400",
+      "psv": "0.0000",
       "tipoItem": 1,
       "tributos": [],
       "uniMedida": 59,
-      "ventaExenta": "0E-8",
-      "ventaGravada": "23.85000000",
-      "ventaNoSuj": "0E-8"
+      "ventaExenta": "0.0000",
+      "ventaGravada": "23.8500",
+      "ventaNoSuj": "0.0000"
     }
   ],
   "documentoRelacionado": null,

--- a/tests/goldens/fc.json
+++ b/tests/goldens/fc.json
@@ -2,22 +2,22 @@
   "apendice": null,
   "cuerpoDocumento": [
     {
-      "cantidad": "2.50000000",
+      "cantidad": "2.5000",
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
       "ivaItem": "3.10",
-      "montoDescu": "0E-8",
-      "noGravado": "0E-8",
+      "montoDescu": "0.0000",
+      "noGravado": "0.0000",
       "numItem": 1,
       "numeroDocumento": null,
-      "precioUni": "10.78000000",
-      "psv": "0E-8",
+      "precioUni": "10.7800",
+      "psv": "0.0000",
       "tipoItem": 4,
       "tributos": null,
       "uniMedida": 99,
-      "ventaExenta": "0E-8",
-      "ventaGravada": "26.95000000",
-      "ventaNoSuj": "0E-8"
+      "ventaExenta": "0.0000",
+      "ventaGravada": "26.9500",
+      "ventaNoSuj": "0.0000"
     }
   ],
   "documentoRelacionado": null,

--- a/tests/goldens/nc.json
+++ b/tests/goldens/nc.json
@@ -2,19 +2,19 @@
   "apendice": null,
   "cuerpoDocumento": [
     {
-      "cantidad": "2.50000000",
+      "cantidad": "2.5000",
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
-      "montoDescu": "0E-8",
+      "montoDescu": "0.0000",
       "numItem": 1,
       "numeroDocumento": "123",
-      "precioUni": "9.54000000",
+      "precioUni": "9.5400",
       "tipoItem": 1,
       "tributos": [],
       "uniMedida": 59,
-      "ventaExenta": "0E-8",
-      "ventaGravada": "23.85000000",
-      "ventaNoSuj": "0E-8"
+      "ventaExenta": "0.0000",
+      "ventaGravada": "23.8500",
+      "ventaNoSuj": "0.0000"
     }
   ],
   "documentoRelacionado": [

--- a/tests/goldens/nd.json
+++ b/tests/goldens/nd.json
@@ -2,19 +2,19 @@
   "apendice": null,
   "cuerpoDocumento": [
     {
-      "cantidad": "2.50000000",
+      "cantidad": "2.5000",
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
-      "montoDescu": "0E-8",
+      "montoDescu": "0.0000",
       "numItem": 1,
       "numeroDocumento": "123",
-      "precioUni": "9.54000000",
+      "precioUni": "9.5400",
       "tipoItem": 1,
       "tributos": [],
       "uniMedida": 59,
-      "ventaExenta": "0E-8",
-      "ventaGravada": "23.85000000",
-      "ventaNoSuj": "0E-8"
+      "ventaExenta": "0.0000",
+      "ventaGravada": "23.8500",
+      "ventaNoSuj": "0.0000"
     }
   ],
   "documentoRelacionado": [

--- a/tests/goldens/nr.json
+++ b/tests/goldens/nr.json
@@ -2,19 +2,19 @@
   "apendice": null,
   "cuerpoDocumento": [
     {
-      "cantidad": "2.50000000",
+      "cantidad": "2.5000",
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
-      "montoDescu": "0E-8",
+      "montoDescu": "0.0000",
       "numItem": 1,
       "numeroDocumento": null,
-      "precioUni": "9.54000000",
+      "precioUni": "9.5400",
       "tipoItem": 1,
       "tributos": [],
       "uniMedida": 59,
-      "ventaExenta": "0E-8",
-      "ventaGravada": "23.85000000",
-      "ventaNoSuj": "0E-8"
+      "ventaExenta": "0.0000",
+      "ventaGravada": "23.8500",
+      "ventaNoSuj": "0.0000"
     }
   ],
   "documentoRelacionado": [

--- a/tests/test_all_dtes.py
+++ b/tests/test_all_dtes.py
@@ -28,11 +28,11 @@ GEN_MAP = {
     "nr": generar_nota_remision,
 }
 
-D8 = Decimal("0.00000001")
+D4 = Decimal("0.0001")
 D2 = Decimal("0.01")
 
-def _q8(x: Decimal) -> Decimal:
-    return x.quantize(D8, rounding=ROUND_HALF_UP)
+def _q4(x: Decimal) -> Decimal:
+    return x.quantize(D4, rounding=ROUND_HALF_UP)
 
 def _q2(x: Decimal) -> Decimal:
     return x.quantize(D2, rounding=ROUND_HALF_UP)
@@ -88,7 +88,7 @@ def _assert_base(data: dict, tipo: str) -> None:
     item = data["cuerpoDocumento"][0]
     resumen = data["resumen"]
     if tipo == "fc":
-        assert str(item["ventaGravada"]) == "26.95000000"
+        assert str(item["ventaGravada"]) == "26.9500"
         iva = _q2(item["ventaGravada"] - (item["ventaGravada"] / Decimal("1.13")))
         assert str(iva) == "3.10"
         assert str(resumen["totalGravada"]) == "26.95"
@@ -96,9 +96,9 @@ def _assert_base(data: dict, tipo: str) -> None:
         assert str(total) == "26.95"
         assert str(_q2(resumen["totalIva"])) == "3.10"
     else:
-        assert str(item["ventaGravada"]) == "23.85000000"
-        iva = _q8(item["ventaGravada"] * Decimal("0.13"))
-        assert str(iva) == "3.10050000"
+        assert str(item["ventaGravada"]) == "23.8500"
+        iva = _q4(item["ventaGravada"] * Decimal("0.13"))
+        assert str(iva) == "3.1005"
         assert str(resumen["totalGravada"]) == "23.85"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"

--- a/tests/test_fc_schema.py
+++ b/tests/test_fc_schema.py
@@ -10,7 +10,7 @@ def test_fc_min_valido():
     payload = strip_extras(dte)
     validate_against_schema(payload, "fc")
     item = payload["cuerpoDocumento"][0]
-    assert str(item["ventaGravada"]) == "26.95000000"
+    assert str(item["ventaGravada"]) == "26.9500"
     assert str(item["ivaItem"]) == "3.10"
     assert str(payload["resumen"]["totalGravada"]) == "26.95"
     assert str(payload["resumen"]["totalIva"]) == "3.10"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -20,7 +20,7 @@ def _assert_base(data):
     resumen = data["resumen"]
     if resumen.get("totalGravada") == Decimal("26.95"):
         # consumidor final
-        assert str(item["ventaGravada"]) == "26.95000000"
+        assert str(item["ventaGravada"]) == "26.9500"
         iva = (item["ventaGravada"] - (item["ventaGravada"] / Decimal("1.13"))).quantize(Decimal("0.01"))
         if "ivaItem" in item:
             assert str(item["ivaItem"]) == str(iva)
@@ -29,10 +29,10 @@ def _assert_base(data):
         assert str(total) == "26.95"
         assert str(resumen["totalIva"]) == "3.10"
     else:
-        assert str(item["ventaGravada"]) == "23.85000000"
+        assert str(item["ventaGravada"]) == "23.8500"
         venta = item["ventaGravada"]
-        iva = (venta * Decimal("0.13")).quantize(Decimal("0.00000001"))
-        assert str(iva) == "3.10050000"
+        iva = (venta * Decimal("0.13")).quantize(Decimal("0.0001"))
+        assert str(iva) == "3.1005"
         if "ivaItem" in item:
             assert str(item["ivaItem"]) == str(iva)
         assert str(resumen["totalGravada"]) == "23.85"


### PR DESCRIPTION
## Summary
- ensure DTE item pricing is quantized to four decimals
- round generator outputs and JSON normalization to four decimal precision
- update tests and golden fixtures for new rounding behavior

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ea8337308323a9b09658867fb071