### PR TITLE
Support percentage discounts and 4-decimal IVA in DTE items

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1198,9 +1198,9 @@ def recalcular_totales(
             linea = d4(bruto - monto_descu)
             if linea < 0:
                 linea = d4(0)
-            esperado_iva = money(linea * D("0.13") / D("1.13"))
+            esperado_iva = d4(linea - (linea / D("1.13")))
             iva_raw = item.get("ivaItem")
-            actual_iva = money(D(str(iva_raw))) if iva_raw is not None else None
+            actual_iva = d4(D(str(iva_raw))) if iva_raw is not None else None
             if iva_raw is not None:
                 if linea > D("0") and actual_iva != esperado_iva:
                     raise ValueError(
@@ -1695,13 +1695,24 @@ def generar_dte_json(
             uni_medida = 59
         if uni_medida not in UNIDADES_MEDIDA_PERMITIDAS:
             uni_medida = 59
-        monto_descu = d4(D(str(d.get("descuento") or 0)))
-        if monto_descu < 0:
-            monto_descu = D("0")
+
+        desc_raw = d4(D(str(d.get("descuento") or 0)))
+        if desc_raw < 0:
+            desc_raw = D("0")
+        desc_tipo = str(d.get("descuento_tipo") or "$")
+
+        def _calc_desc(bruto: D) -> D:
+            if desc_tipo == "%":
+                monto = d4(bruto * desc_raw / D("100"))
+            else:
+                monto = d4(desc_raw)
+            return monto if monto <= bruto else bruto
+
         tipo_fiscal_item = str(d.get("tipo_fiscal", "")).lower()
         if tipo_fiscal_item == "venta exenta":
             precio = d4(precio_raw)
             bruto = d4(cant * precio)
+            monto_descu = _calc_desc(bruto)
             line_total = d4(bruto - monto_descu)
             if line_total < 0:
                 line_total = D("0")
@@ -1714,6 +1725,7 @@ def generar_dte_json(
         elif tipo_fiscal_item == "venta no sujeta":
             precio = d4(precio_raw)
             bruto = d4(cant * precio)
+            monto_descu = _calc_desc(bruto)
             line_total = d4(bruto - monto_descu)
             if line_total < 0:
                 line_total = D("0")
@@ -1734,19 +1746,21 @@ def generar_dte_json(
                 else:
                     precio = d4(precio_raw)
                 bruto = d4(cant * precio)
+                monto_descu = _calc_desc(bruto)
                 line_total = d4(bruto - monto_descu)
-                venta_gravada = line_total
-                iva_val = money(line_total * D("0.13") / D("1.13"))
+                venta_gravada = line_total if line_total > 0 else D("0")
+                iva_val = d4(venta_gravada - (venta_gravada / D("1.13")))
                 line_total = venta_gravada
                 bruto_total += bruto
-                descuentos_total += d4(monto_descu)
+                descuentos_total += monto_descu
             elif precios_incluyen_iva:
                 bruto = d4(cant * precio_raw)
+                monto_descu = _calc_desc(bruto)
                 total_final = d4(bruto - monto_descu)
                 if total_final < 0:
                     total_final = D("0")
                 base_total = money(total_final / D("1.13"))
-                iva_val = money(total_final - base_total)
+                iva_val = d4(total_final - base_total)
                 base_total = money(total_final - iva_val)
                 precio = d4(money(total_final / cant))
                 venta_gravada = base_total
@@ -1756,6 +1770,7 @@ def generar_dte_json(
             else:
                 precio = d4(precio_raw)
                 bruto = d4(cant * precio)
+                monto_descu = _calc_desc(bruto)
                 base = d4(cant * precio - monto_descu)
                 if base < 0:
                     base = D("0")
@@ -1800,14 +1815,14 @@ def generar_dte_json(
             "descripcion": d.get("descripcion"),
             "cantidad": cant,
             "uniMedida": uni_medida,
-            "precioUni": precio,
-            "montoDescu": d2(monto_descu),
+            "precioUni": d4(precio),
+            "montoDescu": d4(monto_descu),
             "ventaNoSuj": venta_no_suj,
             "ventaExenta": venta_exenta,
             "ventaGravada": venta_gravada,
             "psv": money(0),
             "noGravado": money(0),
-            "ivaItem": iva_val,
+            "ivaItem": d4(iva_val),
             "tributos": [trib_code] if trib_code else [],
         }
         if trib_code:

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from decimal import Decimal, getcontext, setcontext
 
 from db import DB
-from dte import generar_dte_json, _write_json, money
+from dte import generar_dte_json, _write_json, money, d4
 
 
 def create_db():
@@ -598,6 +598,7 @@ def test_generar_dte_json_cf_descuento_cant(tmp_path, descuento):
     )
     cliente_id = db.cursor.lastrowid
     gross_total = money(Decimal("3") * Decimal("5.5"))
+    line_total_dec = d4(gross_total - descuento)
     line_total = money(gross_total - descuento)
     venta_id = db.add_venta("2024-01-01", float(line_total), cliente_id=cliente_id)
     db.add_detalle_venta(
@@ -608,16 +609,92 @@ def test_generar_dte_json_cf_descuento_cant(tmp_path, descuento):
     item = data["cuerpoDocumento"][0]
     res = data["resumen"]
 
-    iva_item = money(line_total - (line_total / Decimal("1.13")))
+    iva_item = d4(line_total_dec - (line_total_dec / Decimal("1.13")))
 
     assert Decimal(str(item["precioUni"])) == Decimal("5.50")
-    assert Decimal(str(item["ventaGravada"])) == line_total
+    assert Decimal(str(item["ventaGravada"])) == line_total_dec
     assert Decimal(str(item["ivaItem"])) == iva_item
 
     assert Decimal(str(res["subTotalVentas"])) == gross_total
     assert Decimal(str(res["totalDescu"])) == money(descuento)
     assert Decimal(str(res["subTotal"])) == line_total
-    assert Decimal(str(res["totalIva"])) == iva_item
+    assert Decimal(str(res["totalIva"])) == money(iva_item)
+    assert Decimal(str(res["montoTotalOperacion"])) == line_total
+    assert Decimal(str(res["totalPagar"])) == line_total
+    assert res["tributos"] is None
+
+
+def test_generar_dte_json_cf_descuento_pct(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    gross_total = money(Decimal("3") * Decimal("5.5"))
+    descuento_pct = Decimal("10")
+    desc_monto = d4(gross_total * descuento_pct / Decimal("100"))
+    line_total_dec = d4(gross_total - desc_monto)
+    line_total = money(gross_total - desc_monto)
+    venta_id = db.add_venta("2024-01-01", float(line_total), cliente_id=cliente_id)
+    db.add_detalle_venta(
+        venta_id,
+        pid,
+        3,
+        5.5,
+        vendedor_id=vid,
+        descuento=float(descuento_pct),
+        descuento_tipo="%",
+    )
+
+    data = generar_dte_json(db, venta_id)
+    item = data["cuerpoDocumento"][0]
+    res = data["resumen"]
+
+    iva_item = d4(line_total_dec - (line_total_dec / Decimal("1.13")))
+
+    assert Decimal(str(item["precioUni"])) == Decimal("5.50")
+    assert Decimal(str(item["montoDescu"])) == desc_monto
+    assert Decimal(str(item["ventaGravada"])) == line_total_dec
+    assert Decimal(str(item["ivaItem"])) == iva_item
+
+    assert Decimal(str(res["subTotalVentas"])) == gross_total
+    assert Decimal(str(res["totalDescu"])) == money(desc_monto)
+    assert Decimal(str(res["subTotal"])) == line_total
+    assert Decimal(str(res["totalIva"])) == money(iva_item)
     assert Decimal(str(res["montoTotalOperacion"])) == line_total
     assert Decimal(str(res["totalPagar"])) == line_total
     assert res["tributos"] is None

--- a/tests/test_iva_por_item.py
+++ b/tests/test_iva_por_item.py
@@ -29,7 +29,7 @@ def test_calculo_iva_item():
     item = payload["cuerpoDocumento"][0]
     resumen = payload["resumen"]
     assert D(str(item["ventaGravada"])) == D("13.00")
-    assert D(str(item["ivaItem"])) == D("1.50")
+    assert D(str(item["ivaItem"])) == D("1.4956")
     assert D(str(resumen["totalIva"])) == D("1.50")
 
 
@@ -51,7 +51,7 @@ def test_fc_precio_incluye_iva_default():
     item = payload["cuerpoDocumento"][0]
     resumen = payload["resumen"]
     assert D(str(item["ventaGravada"])) == D("13.00")
-    assert D(str(item["ivaItem"])) == D("1.50")
+    assert D(str(item["ivaItem"])) == D("1.4956")
     assert D(str(resumen["totalGravada"])) == D("13.00")
     assert D(str(resumen["totalIva"])) == D("1.50")
     assert D(str(resumen["totalPagar"])) == D("13.00")


### PR DESCRIPTION
## Summary
- handle line discounts as percentage or amount and cap them at line gross
- compute item IVA with 4-decimal precision and propagate to summary
- test discount percentage and updated IVA calculations

## Testing
- `pytest -q tests/test_generar_dte_json.py::test_generar_dte_json_cf_descuento_cant tests/test_generar_dte_json.py::test_generar_dte_json_cf_descuento_pct tests/test_iva_por_item.py::test_calculo_iva_item -o addopts='' -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68b5f6a82a988323bcb5a6faefba0cd6