### PR TITLE
Move sale state button to sales tab and show details

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -2735,6 +2735,57 @@ class VendedorDialog(QDialog):
                     QMessageBox.warning(self, "Nombre duplicado", "Ya existe un vendedor con ese nombre.")
                     return
         super().accept()
+
+
+class VentaDetalleDialog(QDialog):
+    def __init__(self, venta, detalles, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Detalle de Venta")
+        layout = QVBoxLayout()
+
+        vendedores = []
+        productos = []
+        clientes = []
+        if parent and hasattr(parent, "manager"):
+            vendedores = getattr(parent.manager, "_vendedores", [])
+            productos = getattr(parent.manager, "_products", [])
+            clientes = getattr(parent.manager, "_clientes", [])
+        vendedores_dict = {v["id"]: v["nombre"] for v in vendedores}
+        productos_dict = {p["id"]: p["nombre"] for p in productos}
+        clientes_dict = {c["id"]: c.get("nombre", "") for c in clientes}
+
+        vendedor_nombre = vendedores_dict.get(venta.get("vendedor_id"), "Desconocido")
+        cliente_nombre = clientes_dict.get(venta.get("cliente_id"), "Desconocido")
+
+        layout.addWidget(QLabel(f"Fecha: {venta.get('fecha', '')}"))
+        layout.addWidget(QLabel(f"Cliente: {cliente_nombre}"))
+        layout.addWidget(QLabel(f"Vendedor: {vendedor_nombre}"))
+        layout.addWidget(QLabel(f"Total: ${venta.get('total', 0):.2f}"))
+
+        table = QTableWidget(len(detalles), 7)
+        table.setHorizontalHeaderLabels([
+            "Producto", "Cantidad", "Precio U.", "Subtotal", "Descuento", "IVA", "Comisión"
+        ])
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setSelectionBehavior(QTableWidget.SelectRows)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        for i, d in enumerate(detalles):
+            nombre_producto = d.get("descripcion") or productos_dict.get(d.get("producto_id"), "Desconocido")
+            precio_unitario = d.get("precio_unitario", 0)
+            subtotal = d.get("cantidad", 0) * precio_unitario
+            table.setItem(i, 0, QTableWidgetItem(nombre_producto))
+            table.setItem(i, 1, QTableWidgetItem(str(d.get("cantidad", ""))))
+            table.setItem(i, 2, QTableWidgetItem(f"${precio_unitario:.2f}"))
+            table.setItem(i, 3, QTableWidgetItem(f"${subtotal:.2f}"))
+            table.setItem(i, 4, QTableWidgetItem(f"${d.get('descuento', 0):.2f}"))
+            table.setItem(i, 5, QTableWidgetItem(f"${d.get('iva', 0):.2f}"))
+            table.setItem(i, 6, QTableWidgetItem(f"${d.get('comision', 0):.2f}"))
+        table.resizeColumnsToContents()
+        layout.addWidget(table)
+        self.setLayout(layout)
+
+
 class CompraDetalleDialog(QDialog):
     def __init__(self, compra, detalles, parent=None):
         super().__init__(parent)

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -160,7 +160,6 @@ class FacturacionTab(QWidget):
         btns = QHBoxLayout()
         self.btn_credito = QPushButton("Nota de crédito")
         self.btn_debito = QPushButton("Nota de débito")
-        self.btn_estado = QPushButton("Estado")
         self.btn_enviar = QPushButton("Enviar")
         self.btn_enviar.setEnabled(False)
         self.btn_abrir_pdf = QPushButton("Abrir PDF")
@@ -170,7 +169,6 @@ class FacturacionTab(QWidget):
         )
         btns.addWidget(self.btn_credito)
         btns.addWidget(self.btn_debito)
-        btns.addWidget(self.btn_estado)
         btns.addWidget(self.btn_enviar)
         btns.addWidget(self.btn_abrir_pdf)
         btns.addWidget(self.btn_eliminar)
@@ -199,7 +197,6 @@ class FacturacionTab(QWidget):
         
         self.btn_credito.clicked.connect(lambda: self.create_nota("credito"))
         self.btn_debito.clicked.connect(lambda: self.create_nota("debito"))
-        self.btn_estado.clicked.connect(self.change_estado)
         self.btn_enviar.clicked.connect(self.send_selected_invoice)
         self.btn_abrir_pdf.clicked.connect(self.open_pdf)
         self.btn_eliminar.clicked.connect(self.delete_files)
@@ -836,25 +833,6 @@ class FacturacionTab(QWidget):
 
         QMessageBox.information(self, "Nota", "Nota registrada")
         self.load_invoices()
-
-    def change_estado(self):
-        venta_id = self._selected_venta()
-        if venta_id is None:
-            QMessageBox.warning(self, "Estado", "Seleccione una venta")
-            return
-        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
-        if not venta:
-            QMessageBox.warning(self, "Estado", "No se encontró la venta seleccionada")
-            return
-        from dialogs import EstadoVentaDialog
-        dialog = EstadoVentaDialog(venta.get("estado", "Pagada"), self)
-        if dialog.exec_():
-            estado = dialog.get_estado()
-            self.manager.db.update_venta_estado(venta_id, estado)
-            self.load_invoices()
-            parent = self.parent()
-            if parent and hasattr(parent, "sales_tab"):
-                parent.sales_tab.load_sales()
 
     def delete_files(self):
         """Elimina PDF y JSON asociados a la venta seleccionada."""

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -105,6 +105,10 @@ class SalesTab(QWidget):
         self.sales_table.itemSelectionChanged.connect(self.show_sale)
         left_layout.addWidget(self.sales_table)
 
+        self.btn_estado = QPushButton("Estado")
+        self.btn_estado.clicked.connect(self.show_sale_details)
+        left_layout.addWidget(self.btn_estado)
+
         self.new_invoice_btn = QPushButton("+ Generar nueva factura manual")
         self.new_invoice_btn.clicked.connect(self.generate_manual_invoice)
         left_layout.addWidget(self.new_invoice_btn)
@@ -302,6 +306,21 @@ class SalesTab(QWidget):
         self.email_label.setText(f"Correo destinatario: {cliente_email}")
         self._update_preview(venta_id)
         self._update_email_preview()
+
+    def show_sale_details(self):
+        if self.sales_table.currentRow() < 0:
+            QMessageBox.warning(self, "Estado", "Seleccione una venta")
+            return
+        row = self.sales_table.currentRow()
+        venta_id = int(self.sales_table.item(row, 0).text())
+        venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
+        if not venta:
+            QMessageBox.warning(self, "Estado", "No se encontró la venta seleccionada")
+            return
+        detalles = self.manager.db.get_detalles_venta(venta_id)
+        from dialogs import VentaDetalleDialog
+        dialog = VentaDetalleDialog(venta, detalles, self)
+        dialog.exec_()
 
     def _clear_preview_files(self):
         """Remove temporary preview image without deleting stored PDFs."""

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -56,32 +56,6 @@ def test_create_ticket_saves_files(qt_app, tmp_path, monkeypatch):
     assert save_path.with_suffix(".json").exists()
 
 
-def test_change_estado_updates_table(qt_app, monkeypatch, tmp_path):
-    db = DB(":memory:")
-    venta_id, cid = _create_sale(db)
-    pdf_path = tmp_path / "doc.pdf"
-    pdf_path.write_text("pdf")
-    pdf_path.with_suffix(".json").write_text("{}")
-    db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
-    tab = _make_tab(db, cid)
-    monkeypatch.setattr(tab, "_selected_venta", lambda: venta_id)
-
-    class DummyDlg:
-        def __init__(self, estado, parent=None):
-            pass
-        def exec_(self):
-            return QDialog.Accepted
-        def get_estado(self):
-            return "Anulada"
-    monkeypatch.setattr("dialogs.EstadoVentaDialog", DummyDlg)
-    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", lambda *a, **k: None)
-
-    tab.change_estado()
-    assert tab.table.item(0, 4).text() == "Anulada"
-    row = db.cursor.execute("SELECT estado FROM ventas WHERE id=?", (venta_id,)).fetchone()
-    assert row["estado"] == "Anulada"
-
-
 def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)

--- a/tests/test_sales_tab_details.py
+++ b/tests/test_sales_tab_details.py
@@ -1,0 +1,63 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+from PyQt5.QtWidgets import QApplication, QDialog
+
+from sales_tab import SalesTab
+from db import DB
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+
+def _create_sale(db):
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "C1", None, vid, None, 0, 10, 10, 1)
+    pid = db.cursor.lastrowid
+    db.add_cliente("C", "", "", "", "", "", "c@x.com", "", "", "")
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, vendedor_id=vid)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id, cid, vid
+
+
+def _make_tab(db, cid, vid):
+    man = SimpleNamespace(
+        db=db,
+        _clientes=[{"id": cid, "nombre": "C"}],
+        _vendedores=[{"id": vid, "nombre": "V1"}],
+        _products=[],
+    )
+    tab = SalesTab(man, check_smtp=False)
+    tab.load_sales()
+    return tab
+
+
+def test_show_sale_details_opens_dialog(qt_app, monkeypatch):
+    db = DB(":memory:")
+    venta_id, cid, vid = _create_sale(db)
+    tab = _make_tab(db, cid, vid)
+    tab.sales_table.selectRow(0)
+
+    captured = {}
+
+    class DummyDlg:
+        def __init__(self, venta, detalles, parent=None):
+            captured["venta"] = venta
+            captured["detalles"] = detalles
+            captured["exec"] = False
+        def exec_(self):
+            captured["exec"] = True
+            return QDialog.Accepted
+
+    monkeypatch.setattr("dialogs.VentaDetalleDialog", DummyDlg)
+
+    tab.show_sale_details()
+    assert captured.get("exec")
+    assert captured["venta"]["id"] == venta_id
+    assert captured["detalles"]


### PR DESCRIPTION
## Summary
- relocate sale state button from invoice tab to sales tab
- display full sale details in new dialog
- cover sale detail view with unit test

## Testing
- `pytest` *(fails: tests missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68b61ef8ff0483238452dde455b04e36