### PR TITLE
Skip totalIva for credit fiscal invoices

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -733,7 +733,6 @@ RESUMEN_DEFAULTS = {
         "totalDescu": 0,
         "tributos": None,
         "subTotal": 0,
-        "totalIva": 0,
         "ivaPerci1": 0,
         "ivaRete1": 0,
         "reteRenta": 0,
@@ -1045,29 +1044,29 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         )
 
     resumen = RESUMEN_DEFAULTS.get(tipo_dte, {}).copy()
-    resumen.update(
-        {
-            "totalNoSuj": total_no_suj,
-            "totalExenta": total_exenta,
-            "totalGravada": total_gravada,
-            "subTotalVentas": sub_total_ventas,
-            "descuNoSuj": descu_no_suj,
-            "descuExenta": descu_exenta,
-            "descuGravada": descu_gravada,
-            "totalDescu": total_descu,
-            "subTotal": sub_total,
-            "porcentajeDescuento": porcentaje_desc,
-            "totalNoGravado": total_no_gravado,
-            "totalIva": total_iva,
-            "montoTotalOperacion": monto_total_operacion,
-            "totalPagar": total_pagar,
-            "totalLetras": (
-                monto_a_letras_natural(total_pagar)
-                if tipo_dte == "01"
-                else numero_a_letras(total_pagar)
-            ),
-        }
-    )
+    resumen_fields = {
+        "totalNoSuj": total_no_suj,
+        "totalExenta": total_exenta,
+        "totalGravada": total_gravada,
+        "subTotalVentas": sub_total_ventas,
+        "descuNoSuj": descu_no_suj,
+        "descuExenta": descu_exenta,
+        "descuGravada": descu_gravada,
+        "totalDescu": total_descu,
+        "subTotal": sub_total,
+        "porcentajeDescuento": porcentaje_desc,
+        "totalNoGravado": total_no_gravado,
+        "montoTotalOperacion": monto_total_operacion,
+        "totalPagar": total_pagar,
+        "totalLetras": (
+            monto_a_letras_natural(total_pagar)
+            if tipo_dte == "01"
+            else numero_a_letras(total_pagar)
+        ),
+    }
+    if tipo_dte != "03":
+        resumen_fields["totalIva"] = total_iva
+    resumen.update(resumen_fields)
 
     resumen["ivaRete1"] = money(fiscal.get("iva_rete1", resumen.get("ivaRete1", 0)))
     resumen["reteRenta"] = money(fiscal.get("rete_renta", resumen.get("reteRenta", 0)))
@@ -1111,7 +1110,10 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     resumen["tributos"] = armar_tributos(tributos_list, tipo_dte)
     if tipo_dte != "01" and total_gravada <= D("0") and not tributos_list:
         resumen.pop("tributos", None)
-        resumen["totalIva"] = money(0)
+        if tipo_dte != "03":
+            resumen["totalIva"] = money(0)
+        else:
+            resumen.pop("totalIva", None)
 
     if "pagos" in resumen:
         resumen["pagos"] = normalizar_pagos(
@@ -1303,7 +1305,11 @@ def recalcular_totales(
         _set_resumen("porcentajeDescuento", porcentaje_desc)
         _set_resumen("subTotal", money(venta_gravada_sum))
         _set_resumen("totalNoGravado", money(0))
-        _set_resumen("totalIva", total_iva_sum)
+        if tipo_dte != "03":
+            _set_resumen("totalIva", total_iva_sum)
+        elif "totalIva" in resumen:
+            del resumen["totalIva"]
+            modificados.append("totalIva")
         monto_total_operacion = money(money(venta_gravada_sum) + total_iva_sum)
         _set_resumen("montoTotalOperacion", monto_total_operacion)
         _set_resumen("totalPagar", monto_total_operacion)

--- a/tests/test_credito_fiscal_total_iva.py
+++ b/tests/test_credito_fiscal_total_iva.py
@@ -1,0 +1,62 @@
+import json
+from decimal import Decimal as D
+
+import dte as dte_module
+from tests.test_generar_dte_json import create_db
+
+
+def test_credito_fiscal_resumen_omite_total_iva(tmp_path):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: datos
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01", 5, cliente_id=cliente_id, extra={"precios_incluyen_iva": False}
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 5, vendedor_id=vid)
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    resumen = data["resumen"]
+
+    assert "totalIva" not in resumen
+    trib = resumen["tributos"]
+    assert any(
+        t["codigo"] == "20" and D(str(t["valor"])) == D("0.65") for t in trib
+    )

--- a/tests/test_dte_rounding.py
+++ b/tests/test_dte_rounding.py
@@ -29,10 +29,12 @@ def test_item_and_total_rounding():
     )
 
     assert f"{d2(resumen['totalGravada']):.2f}" == '23.85'
-    assert f"{d2(resumen['totalIva']):.2f}" == '3.10'
+    assert 'totalIva' not in resumen
     assert f"{d2(resumen['totalPagar']):.2f}" == '26.95'
+    trib = resumen['tributos']
+    assert any(t['codigo'] == '20' and f"{d2(t['valor']):.2f}" == '3.10' for t in trib)
 
-    for key in ['totalIva', 'totalPagar']:
+    for key in ['totalPagar']:
         assert decimal_places(resumen[key]) <= 2
     assert decimal_places(resumen['totalGravada']) <= 2
 


### PR DESCRIPTION
## Summary
- avoid setting `totalIva` in DTE summary when the document type is credit-fiscal
- ensure recalculation keeps IVA only in `tributos`
- test that credit-fiscal invoices omit `totalIva`

## Testing
- `pytest` *(fails: 40 errors during collection)*
- `pytest tests/test_dte_rounding.py tests/test_credito_fiscal_total_iva.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6499e65ec8323b585a95bfb8db732