### PR TITLE
Handle nit and commercial name for credit-fiscal receptor

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1597,14 +1597,12 @@ def generar_dte_json(
         if v not in (None, "", []):
             rec[k] = v
 
-    def _clean_nit(nit):
-        return "".join(c for c in str(nit) if c.isdigit()) if nit else None
-
     tipo_doc = rec.get("tipoDocumento")
     if tipo_doc is not None:
         tipo_doc = str(tipo_doc)
     num_doc = rec.get("numDocumento")
     nit = rec.get("nit")
+    clean_nit = _clean_nit(nit)
     if fiscal:
         tipo_doc = fiscal.get("tipoDocumento") or tipo_doc
         num_doc = fiscal.get("numDocumento") or num_doc
@@ -1625,8 +1623,10 @@ def generar_dte_json(
     receptor = {
         "tipoDocumento": tipo_doc if tipo_doc is not None else None,
         "numDocumento": num_doc,
+        "nit": clean_nit,
         "nrc": (fiscal.get("nrc") if fiscal else None) or rec.get("nrc"),
         "nombre": rec.get("nombre"),
+        "nombreComercial": rec.get("nombreComercial") or rec.get("nombre"),
         "codActividad": None,
         "descActividad": None,
         "telefono": rec.get("telefono"),
@@ -2290,24 +2290,40 @@ def validate_dte_json(
     payload["emisor"] = emisor
 
     receptor = payload.get("receptor", {})
-    nit_field = receptor.pop("nit", None)
+    nit_field = receptor.get("nit")
+    if nit_field is not None:
+        nit_clean = _clean_nit(nit_field)
+        if nit_clean and not re.fullmatch(r"[0-9]{14}|[0-9]{9}", nit_clean):
+            raise ValueError("NIT inválido en receptor")
+        receptor["nit"] = nit_clean
+    else:
+        receptor.pop("nit", None)
+
     tipo_doc = receptor.get("tipoDocumento")
     if tipo_doc is not None:
         tipo_doc = str(tipo_doc)
-    if nit_field is not None:
-        receptor["numDocumento"] = _clean_nit(nit_field)
-        if tipo_doc is None:
+
+    if tipo_dte != "03":
+        if receptor.get("nit") and not receptor.get("numDocumento"):
+            receptor["numDocumento"] = receptor["nit"]
+        if receptor.get("nit") and not tipo_doc:
             tipo_doc = "36"
-    num_doc = receptor.get("numDocumento")
-    if tipo_doc == "36":
-        num_doc = _clean_nit(num_doc)
-        if num_doc and not re.fullmatch(r"[0-9]{14}", num_doc):
-            raise ValueError("NIT inválido en receptor")
-    elif tipo_doc == "13":
-        if num_doc and not re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
-            raise ValueError("DUI inválido en receptor")
-    receptor["tipoDocumento"] = tipo_doc if tipo_doc is not None else None
-    receptor["numDocumento"] = num_doc
+        num_doc = receptor.get("numDocumento")
+        if tipo_doc == "36":
+            num_doc = _clean_nit(num_doc)
+            if num_doc and not re.fullmatch(r"[0-9]{14}", num_doc):
+                raise ValueError("NIT inválido en receptor")
+        elif tipo_doc == "13":
+            if num_doc and not re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
+                raise ValueError("DUI inválido en receptor")
+        receptor["tipoDocumento"] = tipo_doc if tipo_doc is not None else None
+        receptor["numDocumento"] = num_doc
+    else:
+        for key in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+            receptor.pop(key, None)
+
+    if not receptor.get("nombreComercial"):
+        receptor["nombreComercial"] = receptor.get("nombre")
 
     nrc_schema = (
         FC_SCHEMA.get("properties", {})

--- a/tests/test_receptor_credito_fiscal.py
+++ b/tests/test_receptor_credito_fiscal.py
@@ -1,0 +1,63 @@
+import json
+import re
+from db import DB
+import dte
+from svfe.generators import generar_factura_fiscal, strip_extras
+import svfe.config as svfe_config
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_receptor_fields_credito_fiscal(tmp_path):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+
+    db = create_db()
+    payload = strip_extras(generar_factura_fiscal(db))
+    payload["identificacion"]["version"] = 1
+    receptor = payload["receptor"]
+    receptor.pop("nombreComercial")
+    receptor.update({
+        "noRemision": "999",
+        "ordenNo": "888",
+        "numDocumento": "01234567-8",
+        "tipoDocumento": "13",
+    })
+    dte.validate_dte_json(payload, db=db)
+    receptor = payload["receptor"]
+    required = {
+        "nit",
+        "nrc",
+        "nombre",
+        "codActividad",
+        "descActividad",
+        "nombreComercial",
+        "direccion",
+        "telefono",
+        "correo",
+    }
+    assert required <= set(receptor)
+    assert receptor["nombreComercial"] == receptor["nombre"]
+    for key in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+        assert key not in receptor
+    assert re.fullmatch(r"[0-9]{9}|[0-9]{14}", receptor["nit"])


### PR DESCRIPTION
## Summary
- include receptor `nit` and `nombreComercial` with fallback to name
- drop unsupported receptor keys for credit-fiscal DTEs
- add regression test for credit-fiscal receptor schema

## Testing
- `pytest tests/test_receptor_credito_fiscal.py::test_receptor_fields_credito_fiscal -q --no-cov`
- `pytest tests/test_generar_dte_json.py::test_credito_fiscal_incluye_tributo -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b649a689dc8323992d2e20ea5e7516