### PR TITLE
Skip item-level IVA for credit fiscal

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1242,14 +1242,19 @@ def recalcular_totales(
             else:
                 base = linea
                 iva_val = money(base * D("0.13"))
-            if base > 0:
-                item["codTributo"] = TRIBUTO_IVA
-                item["tributos"] = [TRIBUTO_IVA]
-            else:
+            if tipo_dte == "03":
                 item["codTributo"] = None
-                item["tributos"] = []
+                item["tributos"] = [TRIBUTO_IVA] if base > 0 else []
+                item.pop("ivaItem", None)
+            else:
+                if base > 0:
+                    item["codTributo"] = TRIBUTO_IVA
+                    item["tributos"] = [TRIBUTO_IVA]
+                else:
+                    item["codTributo"] = None
+                    item["tributos"] = []
+                item["ivaItem"] = iva_val
             item["ventaGravada"] = base
-            item["ivaItem"] = iva_val
             item["ventaExenta"] = money(0)
             item["ventaNoSuj"] = money(0)
             item["noGravado"] = money(0)
@@ -1845,7 +1850,11 @@ def generar_dte_json(
         }
         if trib_code:
             item_data["codTributo"] = trib_code
-        if tipo_dte == "01":
+        if tipo_dte == "03":
+            item_data.pop("ivaItem", None)
+            item_data["codTributo"] = None
+            item_data["tributos"] = [TRIBUTO_IVA] if D(str(item_data.get("ventaGravada") or 0)) > 0 else []
+        elif tipo_dte == "01":
             item_data["codTributo"] = None
             item_data["tributos"] = None
         else:
@@ -2373,6 +2382,8 @@ def validate_dte_json(
         }
     precio_key = "precioUni"
     iva_key = "ivaItem" if "ivaItem" in allowed_item_keys else None
+    if tipo_dte == "03":
+        iva_key = None
 
     for item in cuerpo:
         # --- Normalización de nombres ---
@@ -2431,6 +2442,8 @@ def validate_dte_json(
             item.setdefault("tributos", [])
         if iva_key:
             item.setdefault(iva_key, cero)
+        if tipo_dte == "03":
+            item.pop("ivaItem", None)
 
         # --- Cálculo de base ---
         cantidad = d1(D(str(item.get("cantidad") or 0)))
@@ -2480,6 +2493,9 @@ def validate_dte_json(
         if tipo_dte == "01":
             item["codTributo"] = None
             item["tributos"] = None
+        elif tipo_dte == "03":
+            item["codTributo"] = None
+            item["tributos"] = [TRIBUTO_IVA] if venta_gravada_val > 0 else []
         else:
             invalid = [
                 t
@@ -2555,6 +2571,14 @@ def validate_dte_json(
             )
             iva_chk = money(linea * D("0.13") / D("1.13"))
             assert i.get("ventaGravada") == linea and i.get("ivaItem") == iva_chk
+    elif ident.get("tipoDte") == "03":
+        for i in payload.get("cuerpoDocumento", []):
+            i["codTributo"] = None
+            i.pop("ivaItem", None)
+            if D(str(i.get("ventaGravada") or 0)) > 0:
+                i["tributos"] = [TRIBUTO_IVA]
+            else:
+                i["tributos"] = []
 
     resumen["pagos"] = normalizar_pagos(
         resumen.get("pagos"),

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -211,6 +211,17 @@ def test_clamp_uni_medida(dte_metadata_factory, db_fixture):
     assert dte["cuerpoDocumento"][0]["uniMedida"] == 59
 
 
+def test_tipo03_remueve_iva_item_y_cod_tributo(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoDte"] = "03"
+    validate_dte_json(dte, db=db_fixture)
+    item = dte["cuerpoDocumento"][0]
+    assert "ivaItem" not in item
+    assert item["codTributo"] is None
+    if item["ventaGravada"] > 0:
+        assert item["tributos"] == [TRIBUTO_IVA]
+
+
 def test_numero_control_regex(dte_metadata_factory, tmp_path, monkeypatch, db_fixture):
     _patch_datos_negocio(tmp_path, monkeypatch)
     dte = dte_metadata_factory()

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -278,11 +278,11 @@ def test_generar_dte_json_tipo_fiscal(tmp_path):
     assert D(str(items[0]["ventaExenta"])) == D("10")
     assert D(str(items[0]["ventaNoSuj"])) == D("0")
     assert D(str(items[0]["ventaGravada"])) == D("0")
-    assert D(str(items[0]["ivaItem"])) == D("0")
+    assert "ivaItem" not in items[0]
     assert D(str(items[1]["ventaNoSuj"])) == D("20")
     assert D(str(items[1]["ventaExenta"])) == D("0")
     assert D(str(items[1]["ventaGravada"])) == D("0")
-    assert D(str(items[1]["ivaItem"])) == D("0")
+    assert "ivaItem" not in items[1]
     assert D(str(res["totalExenta"])) == D("10")
     assert D(str(res["totalNoSuj"])) == D("20")
     assert D(str(res["totalGravada"])) == D("0")
@@ -1449,10 +1449,11 @@ def test_credito_fiscal_incluye_tributo(tmp_path):
     data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
     item = data["cuerpoDocumento"][0]
     resumen = data["resumen"]
-    assert item["codTributo"] == TRIBUTO_IVA
+    assert item["codTributo"] is None
     assert item["tributos"] == [TRIBUTO_IVA]
     assert resumen["tributos"][0]["codigo"] == TRIBUTO_IVA
-    assert D(str(resumen["totalIva"])) == D(str(item["ivaItem"]))
+    assert "ivaItem" not in item
+    assert Decimal(str(resumen["totalIva"])) == Decimal("1.30")
 
 
 def test_resumen_tributo_codigo_str(tmp_path):


### PR DESCRIPTION
## Summary
- avoid setting `ivaItem` and `codTributo` on items when `tipoDte` is `03`
- keep `tributos` on credit fiscal items when gravadas
- update validations and generator tests for credit fiscal documents

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_tipo_fiscal tests/test_generar_dte_json.py::test_credito_fiscal_incluye_tributo tests/test_dte_validation.py::test_tipo03_remueve_iva_item_y_cod_tributo`

------
https://chatgpt.com/codex/tasks/task_e_68b64993fa0c8323880cecf06aa50c49