### PR TITLE
Corrige cálculo de IVA en facturas de crédito fiscal

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1022,7 +1022,9 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         )
         sub_total_ventas = money(total_no_suj + total_exenta + total_gravada)
         sub_total = money(sub_total_ventas - total_descu)
-        monto_total_operacion = money(sub_total + total_no_gravado + total_iva)
+        monto_total_operacion = money(
+            sub_total + total_no_gravado + (D("0") if tipo_dte == "03" else total_iva)
+        )
         total_pagar = money(monto_total_operacion)
         base_desc = sub_total_ventas + total_descu
         porcentaje_desc = money(
@@ -1037,7 +1039,9 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         total_iva = money(fiscal.get("iva", 0)) if total_gravada > D("0") else money(0)
         sub_total_ventas = money(total_no_suj + total_exenta + total_gravada)
         sub_total = money(sub_total_ventas - total_descu)
-        monto_total_operacion = money(sub_total + total_no_gravado + total_iva)
+        monto_total_operacion = money(
+            sub_total + total_no_gravado + (D("0") if tipo_dte == "03" else total_iva)
+        )
         total_pagar = money(monto_total_operacion)
         base_desc = sub_total_ventas + total_descu
         porcentaje_desc = money(
@@ -1304,7 +1308,10 @@ def recalcular_totales(
         _set_resumen("subTotal", money(venta_gravada_sum))
         _set_resumen("totalNoGravado", money(0))
         _set_resumen("totalIva", total_iva_sum)
-        monto_total_operacion = money(money(venta_gravada_sum) + total_iva_sum)
+        if tipo_dte == "03":
+            monto_total_operacion = money(money(venta_gravada_sum))
+        else:
+            monto_total_operacion = money(money(venta_gravada_sum) + total_iva_sum)
         _set_resumen("montoTotalOperacion", monto_total_operacion)
         _set_resumen("totalPagar", monto_total_operacion)
     trib_raw = resumen.get("tributos")

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -273,7 +273,10 @@ def _resumen(tipo: str) -> Dict[str, Any]:
         precio = Decimal("9.54")
         venta = d2(cantidad * precio)
         iva = d2(venta * Decimal("0.13"))
-        total = d2(venta + iva)
+        if tipo == "ccf":
+            total = d2(venta)
+        else:
+            total = d2(venta + iva)
     data = {
         "totalNoSuj": d2(Decimal("0")),
         "totalExenta": d2(Decimal("0")),
@@ -290,7 +293,13 @@ def _resumen(tipo: str) -> Dict[str, Any]:
         "montoTotalOperacion": d2(total),
         "totalNoGravado": d2(Decimal("0")),
         "totalPagar": d2(total),
-        "totalLetras": "Veintiseis Dolares con noventa y cinco centavos" if tipo == "fc" else "VEINTISEIS CON 95/100 USD",
+        "totalLetras": (
+            "Veintiseis Dolares con noventa y cinco centavos"
+            if tipo == "fc"
+            else (
+                "VEINTITRÉS CON 85/100 USD" if tipo == "ccf" else "VEINTISEIS CON 95/100 USD"
+            )
+        ),
         "saldoFavor": d2(Decimal("0")),
         "condicionOperacion": 1,
         "pagos": [
@@ -308,6 +317,7 @@ def _resumen(tipo: str) -> Dict[str, Any]:
         data["totalIva"] = iva
         data["tributos"] = None
     else:
+        data["totalIva"] = iva
         data["ivaPerci1"] = d2(Decimal("0"))
         if venta > D("0"):
             data["tributos"] = [

--- a/tests/goldens/ccf.json
+++ b/tests/goldens/ccf.json
@@ -2,21 +2,23 @@
   "apendice": null,
   "cuerpoDocumento": [
     {
-      "cantidad": "2.5000",
+      "numItem": 1,
+      "tipoItem": 1,
+      "numeroDocumento": null,
       "codigo": "SKU001",
       "descripcion": "Producto de prueba",
-      "montoDescu": "0.0000",
-      "noGravado": "0.0000",
-      "numItem": 1,
-      "numeroDocumento": null,
-      "precioUni": "9.5400",
-      "psv": "0.0000",
-      "tipoItem": 1,
-      "tributos": [],
+      "cantidad": "2.5000",
       "uniMedida": 59,
+      "precioUni": "9.5400",
+      "montoDescu": "0.0000",
+      "ventaNoSuj": "0.0000",
       "ventaExenta": "0.0000",
       "ventaGravada": "23.8500",
-      "ventaNoSuj": "0.0000"
+      "psv": "0.0000",
+      "noGravado": "0.0000",
+      "ivaItem": "3.1005",
+      "codTributo": "20",
+      "tributos": ["20"]
     }
   ],
   "documentoRelacionado": null,
@@ -29,9 +31,9 @@
     "correo": "demo@example.com",
     "descActividad": "Venta de productos",
     "direccion": {
-      "complemento": "Calle X #123",
-      "departamento": "06",
-      "municipio": "23"
+      "complemento": "Local.3 #4-6 B, Paseo Concepcion",
+      "departamento": "05",
+      "municipio": "25"
     },
     "nit": "06142512891020",
     "nombre": "Compañía Demo S.A. de C.V.",
@@ -63,7 +65,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "05",
-      "municipio": "23"
+      "municipio": "13"
     },
     "nit": "06141990011019",
     "nombre": "Consumidor Final",
@@ -78,12 +80,12 @@
     "descuNoSuj": "0.00",
     "ivaPerci1": "0.00",
     "ivaRete1": "0.00",
-    "montoTotalOperacion": "26.95",
+    "montoTotalOperacion": "23.85",
     "numPagoElectronico": null,
     "pagos": [
       {
         "codigo": "01",
-        "montoPago": "26.95",
+        "montoPago": "23.85",
         "periodo": null,
         "plazo": null,
         "referencia": null
@@ -97,10 +99,11 @@
     "totalDescu": "0.00",
     "totalExenta": "0.00",
     "totalGravada": "23.85",
-    "totalLetras": "VEINTISEIS CON 95/100 USD",
+    "totalIva": "3.10",
+    "totalLetras": "VEINTITRÉS CON 85/100 USD",
     "totalNoGravado": "0.00",
     "totalNoSuj": "0.00",
-    "totalPagar": "26.95",
+    "totalPagar": "23.85",
     "tributos": [
       {
         "codigo": "20",

--- a/tests/test_all_dtes.py
+++ b/tests/test_all_dtes.py
@@ -95,6 +95,17 @@ def _assert_base(data: dict, tipo: str) -> None:
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
         assert str(total) == "26.95"
         assert str(_q2(resumen["totalIva"])) == "3.10"
+    elif tipo == "ccf":
+        assert str(item["ventaGravada"]) == "23.8500"
+        iva = _q4(item["ventaGravada"] * Decimal("0.13"))
+        assert str(iva) == "3.1005"
+        assert str(resumen["totalGravada"]) == "23.85"
+        total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
+        assert str(total) == "23.85"
+        total_iva = resumen.get("totalIva")
+        if total_iva is None:
+            total_iva = resumen["montoTotalOperacion"] - resumen["totalGravada"]
+        assert str(_q2(total_iva)) == "3.10"
     else:
         assert str(item["ventaGravada"]) == "23.8500"
         iva = _q4(item["ventaGravada"] * Decimal("0.13"))

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -37,7 +37,7 @@ def _assert_base(data):
             assert str(item["ivaItem"]) == str(iva)
         assert str(resumen["totalGravada"]) == "23.85"
         total = resumen.get("totalPagar", resumen["montoTotalOperacion"])
-        assert str(total) == "26.95"
+        assert str(total) == "23.85"
         total_iva = resumen.get("totalIva")
         if total_iva is None:
             total_iva = resumen["montoTotalOperacion"] - resumen["totalGravada"]

--- a/tests/test_resumen_fc.py
+++ b/tests/test_resumen_fc.py
@@ -19,6 +19,15 @@ def test_resumen_formulas_fc():
     assert D(str(resumen['totalIva'])) == D('1.50')
 
 
+def test_resumen_credito_fiscal_no_suma_iva():
+    items_total = D('15.00')
+    fiscal = {'iva': D('1.95'), 'sumas': D('15.00')}
+    resumen = calcular_resumen(items_total, {}, fiscal=fiscal, tipo_dte='03')
+    assert D(str(resumen['subTotal'])) == D('15.00')
+    assert D(str(resumen['totalIva'])) == D('1.95')
+    assert D(str(resumen['totalPagar'])) == D('15.00')
+
+
 def test_resumen_sin_gravada_sin_tributos():
     items_total = D('0')
     fiscal = {'sumas': D('0'), 'ventas_exentas': D('5'), 'iva': D('0')}


### PR DESCRIPTION
## Summary
- evita sumar el IVA al total en facturas de crédito fiscal
- actualiza generadores y pruebas para reflejar el IVA informativo

## Testing
- `pytest tests/test_generators.py::test_generar_factura_fiscal -q`
- `pytest tests/test_all_dtes.py::test_all_dtes[ccf] -q`
- `pytest tests/test_resumen_fc.py::test_resumen_credito_fiscal_no_suma_iva -q`


------
https://chatgpt.com/codex/tasks/task_e_68b651d3d94c83239a491c5934d1abb3