### PR TITLE
Sanitize receptor NIT and include tributo descriptions

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1120,7 +1120,15 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     tributos_list = [{"codigo": c, "valor": v} for c, v in suma_por_codigo.items()]
     if tipo_dte == "03":
         resumen["tributos"] = (
-            [{"codigo": TRIBUTO_IVA, "valor": total_iva}] if total_gravada > D("0") else None
+            [
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": catalogos.TRIBUTOS.get(TRIBUTO_IVA),
+                    "valor": money(total_iva),
+                }
+            ]
+            if total_gravada > D("0")
+            else None
         )
     else:
         if tipo_dte != "01" and total_gravada > D("0"):
@@ -1348,7 +1356,13 @@ def recalcular_totales(
     else:
         if tipo_dte == "03":
             trib = (
-                [{"codigo": TRIBUTO_IVA, "valor": total_iva_sum}]
+                [
+                    {
+                        "codigo": TRIBUTO_IVA,
+                        "descripcion": catalogos.TRIBUTOS.get(TRIBUTO_IVA),
+                        "valor": money(total_iva_sum),
+                    }
+                ]
                 if venta_gravada_sum > D("0")
                 else None
             )
@@ -1636,11 +1650,11 @@ def generar_dte_json(
     if tipo_doc is not None:
         tipo_doc = str(tipo_doc)
     num_doc = rec.get("numDocumento")
-    nit = rec.get("nit")
+    nit = _clean_nit(rec.get("nit"))
     if fiscal:
         tipo_doc = fiscal.get("tipoDocumento") or tipo_doc
         num_doc = fiscal.get("numDocumento") or num_doc
-        nit = fiscal.get("nit") or nit
+        nit = _clean_nit(fiscal.get("nit") or nit)
     if nit and not num_doc:
         num_doc = nit
     if nit and not tipo_doc:
@@ -2679,7 +2693,13 @@ def validate_dte_json(
         iva_val = D(str(resumen.get("totalIva") or 0))
         resumen.pop("totalIva", None)
         if total_grav > 0:
-            resumen["tributos"] = [{"codigo": TRIBUTO_IVA, "valor": iva_val}]
+            resumen["tributos"] = [
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": catalogos.TRIBUTOS.get(TRIBUTO_IVA),
+                    "valor": money(iva_val),
+                }
+            ]
         else:
             resumen.pop("tributos", None)
             iva_val = D("0")

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 from uuid import uuid4
 from db import DB
 from zoneinfo import ZoneInfo
-from utils.catalogos import TRIBUTO_IVA
+from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 
 from .config import get_emisor_direccion
 
@@ -320,7 +320,13 @@ def _resumen(tipo: str) -> Dict[str, Any]:
         data["totalIva"] = iva
         data["ivaPerci1"] = d2(Decimal("0"))
         if venta > D("0"):
-            data["tributos"] = [{"codigo": TRIBUTO_IVA, "valor": iva}]
+            data["tributos"] = [
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": TRIBUTOS.get(TRIBUTO_IVA),
+                    "valor": iva,
+                }
+            ]
         else:
             data["tributos"] = None
     return data

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -1375,7 +1375,7 @@ def test_item_no_tributo_when_exento(tmp_path):
 
 def test_credito_fiscal_incluye_tributo(tmp_path):
     import dte as dte_module
-    from utils.catalogos import TRIBUTO_IVA
+    from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 
     datos = {
         "nit": "06141990011019",
@@ -1453,8 +1453,10 @@ def test_credito_fiscal_incluye_tributo(tmp_path):
     assert item["tributos"] == [TRIBUTO_IVA]
     assert "ivaItem" not in item
     assert "totalIva" not in resumen
-    assert resumen["tributos"] == [{"codigo": TRIBUTO_IVA, "valor": Decimal("1.30")}]
-    assert "descripcion" not in resumen["tributos"][0]
+    assert resumen["tributos"][0]["codigo"] == TRIBUTO_IVA
+    assert resumen["tributos"][0]["descripcion"] == TRIBUTOS[TRIBUTO_IVA]
+    assert resumen["tributos"][0]["valor"] == Decimal("1.30")
+    assert receptor["nit"] == "06140000001025"
     for f in (
         "nit",
         "nrc",


### PR DESCRIPTION
## Summary
- Clean receptor NIT values to remove non-digit characters
- Populate credit-fiscal resumen tributos with code, description and two-decimal value
- Update generators and tests for tributo descriptions

## Testing
- `pytest tests/test_generar_dte_json.py::test_credito_fiscal_incluye_tributo -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file; ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b661fec86483238343b91a9b2466ba