### PR TITLE
Fix receptor fields for consumer final DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1711,21 +1711,37 @@ def generar_dte_json(
         receptor["correo"] = "no-reply@example.com"
 
     # Campos obligatorios y limpieza de campos no permitidos
-    required_rec_fields = [
-        "nit",
-        "nrc",
-        "nombre",
-        "nombreComercial",
-        "codActividad",
-        "descActividad",
-        "telefono",
-        "correo",
-        "direccion",
-    ]
+    if tipo_dte == "01":
+        required_rec_fields = [
+            "nrc",
+            "nombre",
+            "codActividad",
+            "descActividad",
+            "telefono",
+            "correo",
+            "direccion",
+            "tipoDocumento",
+            "numDocumento",
+        ]
+        for f in ("nit", "nombreComercial"):
+            receptor.pop(f, None)
+    else:
+        required_rec_fields = [
+            "nit",
+            "nrc",
+            "nombre",
+            "nombreComercial",
+            "codActividad",
+            "descActividad",
+            "telefono",
+            "correo",
+            "direccion",
+        ]
+        for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+            receptor.pop(f, None)
+
     for f in required_rec_fields:
         receptor.setdefault(f, None)
-    for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
-        receptor.pop(f, None)
 
     cuerpo = []
     items_total = D("0")

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -1473,6 +1473,59 @@ def test_credito_fiscal_incluye_tributo(tmp_path):
         assert f not in receptor
 
 
+def test_generar_dte_json_receptor_consumidor_final(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01", 10, cliente_id=cid, extra={"precios_incluyen_iva": False}
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = dte_module.generar_dte_json(db, venta_id)
+    receptor = data["receptor"]
+    assert receptor["tipoDocumento"] == "36"
+    assert receptor["numDocumento"] == "06141990011019"
+    assert "nit" not in receptor
+    assert "nombreComercial" not in receptor
+
+
 def test_resumen_tributo_codigo_str(tmp_path):
     import dte as dte_module
 


### PR DESCRIPTION
## Summary
- ensure DTE generator keeps `tipoDocumento` and `numDocumento` only for consumer final documents and drops unsupported `nit`/`nombreComercial`
- add regression test verifying consumer final receptor fields

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_receptor_consumidor_final -q`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b6683bbeb08323b9f2c26cf8f97984