### PR TITLE
Fix precioUni net amount for Credito Fiscal DTE

### DIFF
--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -231,16 +231,19 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
         venta = d4(cantidad * precio)
         iva_item = d2(venta - (venta / Decimal("1.13")))
         base = venta
+        precio_uni = d4(precio)
     elif tipo == "ccf":
-        precio = Decimal("10.78")
+        precio = Decimal("10.78")  # precio con IVA incluido
         base_unit = d2(precio / Decimal("1.13"))
         base = d4(base_unit * cantidad)
         venta = d4(cantidad * precio)
+        precio_uni = d4(base_unit)
     else:
         precio = Decimal("9.54")
         venta = d4(cantidad * precio)
         iva_item = d4(venta * Decimal("0.13"))
         base = venta
+        precio_uni = d4(precio)
     numero_documento = None
     tipo_item = 4 if tipo == "fc" else 1
     uni_medida = 99 if tipo == "fc" else 59
@@ -252,7 +255,7 @@ def _cuerpo_documento(tipo: str) -> List[Dict[str, Any]]:
         "descripcion": "Producto de prueba",
         "cantidad": d4(cantidad),
         "uniMedida": uni_medida,
-        "precioUni": d4(precio),
+        "precioUni": precio_uni,
         "montoDescu": d4(Decimal("0")),
         "ventaNoSuj": d4(Decimal("0")),
         "ventaExenta": d4(Decimal("0")),

--- a/tests/goldens/ccf.json
+++ b/tests/goldens/ccf.json
@@ -11,7 +11,7 @@
       "noGravado": "0.0",
       "numItem": 1,
       "numeroDocumento": null,
-      "precioUni": "10.7800",
+      "precioUni": "9.5400",
       "psv": "0.0",
       "tipoItem": 1,
       "tributos": ["20"],


### PR DESCRIPTION
## Summary
- ensure `precioUni` is recorded without IVA in Credit Fiscal DTE generator
- update CCF golden file to expect net unit price

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6890e156883238af1d341c226bc9c