### PR TITLE
Handle ventaGravada mismatch without assertion

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2736,7 +2736,14 @@ def validate_dte_json(
                 - D(str(i.get("montoDescu") or 0))
             )
             iva_chk = money(linea * D("0.13") / D("1.13"))
-            assert i.get("ventaGravada") == linea and i.get("ivaItem") == iva_chk
+            if i.get("ventaGravada") != linea or i.get("ivaItem") != iva_chk:
+                logger.warning(
+                    "ventaGravada/ivaItem incoherente: %s/%s esperado %s/%s",
+                    i.get("ventaGravada"),
+                    i.get("ivaItem"),
+                    linea,
+                    iva_chk,
+                )
 
     resumen["pagos"] = normalizar_pagos(
         resumen.get("pagos"),


### PR DESCRIPTION
## Summary
- warn instead of asserting when ventaGravada or ivaItem do not match calculated values

## Testing
- `pytest`
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_basic -q`
- `python - <<'PY'
from dte import generar_dte_json
from db import DB
import dte
import svfe.config as svfe_config
import json

# Setup business data
datos = {
    "nit": "06141990011019",
    "nrc": "12345678",
    "nombre": "Mi Negocio",
    "nombreComercial": "Mi Negocio",
    "cod_giro": "123456",
    "descActividad": "Comercio",
    "telefono": "22222222",
    "correo": "test@example.com",
    "direccion": {
        "departamento": "06",
        "municipio": "10",
        "complemento": "Calle 1",
    },
}
svfe_config.load_datos_negocio = lambda: datos
dte._load_datos_negocio = lambda: datos

from decimal import Decimal

db = DB(":memory:")
db.add_vendedor("V1")
vend_id = db.cursor.lastrowid
db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
prod_id = db.cursor.lastrowid
db.add_cliente("Cliente", "123", "06141990011019", "", "giro", "70000001", "", "C", "06", "01")
cliente_id = db.cursor.lastrowid
venta_id = db.add_venta("2024-01-01", 11.3, cliente_id=cliente_id, extra={"precios_incluyen_iva": False})
db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)

payload = generar_dte_json(db, venta_id, tipo_dte="03")
print(payload["identificacion"]["tipoDte"])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b692878a988323803627b90f602f73