### PR TITLE
Include IVA in credit invoice total

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1029,16 +1029,24 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
                 total_gravada = money(fiscal["sumas"])
                 total_iva = money(fiscal.get("iva", 0))
                 sub_total_ventas = total_gravada
-                sub_total = total_gravada
-                monto_total_operacion = total_gravada
+                sub_total = (
+                    money(total_gravada - total_descu)
+                    if total_descu
+                    else total_gravada
+                )
+                monto_total_operacion = money(total_gravada + total_iva)
             else:
                 total_gravada = money(items_total)
                 total_iva = money(
                     fiscal.get("iva", items_total * D("0.13"))
                 )
                 sub_total_ventas = total_gravada
-                sub_total = total_gravada
-                monto_total_operacion = money(total_gravada + total_iva)
+                sub_total = (
+                    money(total_gravada - total_descu)
+                    if total_descu
+                    else total_gravada
+                )
+                monto_total_operacion = money(sub_total + total_iva)
             total_pagar = monto_total_operacion
             porcentaje_desc = money(
                 (total_descu * D("100") / sub_total_ventas)

--- a/tests/test_resumen_fc.py
+++ b/tests/test_resumen_fc.py
@@ -19,13 +19,14 @@ def test_resumen_formulas_fc():
     assert D(str(resumen['totalIva'])) == D('1.50')
 
 
-def test_resumen_credito_fiscal_no_suma_iva():
+def test_resumen_credito_fiscal_suma_iva():
     items_total = D('15.00')
     fiscal = {'iva': D('1.95'), 'sumas': D('15.00')}
     resumen = calcular_resumen(items_total, {}, fiscal=fiscal, tipo_dte='03')
     assert D(str(resumen['subTotal'])) == D('15.00')
     assert D(str(resumen['totalIva'])) == D('1.95')
-    assert D(str(resumen['totalPagar'])) == D('15.00')
+    assert D(str(resumen['montoTotalOperacion'])) == D('16.95')
+    assert D(str(resumen['totalPagar'])) == D('16.95')
 
 
 def test_resumen_credito_fiscal_sin_sumas():
@@ -34,10 +35,10 @@ def test_resumen_credito_fiscal_sin_sumas():
     resumen = calcular_resumen(items_total, {}, fiscal=fiscal, tipo_dte='03')
     assert D(str(resumen['totalGravada'])) == D('100.00')
     assert D(str(resumen['subTotalVentas'])) == D('100.00')
-    assert D(str(resumen['subTotal'])) == D('100.00')
+    assert D(str(resumen['subTotal'])) == D('90.00')
     assert D(str(resumen['totalIva'])) == D('13.00')
-    assert D(str(resumen['montoTotalOperacion'])) == D('113.00')
-    assert D(str(resumen['totalPagar'])) == D('113.00')
+    assert D(str(resumen['montoTotalOperacion'])) == D('103.00')
+    assert D(str(resumen['totalPagar'])) == D('103.00')
     assert D(str(resumen['totalDescu'])) == D('10.00')
     assert D(str(resumen['porcentajeDescuento'])) == D('10.00')
 


### PR DESCRIPTION
## Summary
- Include IVA in `montoTotalOperacion` when credit fiscal uses manual sums
- Ensure subtotal accounts for discounts and add corresponding tests

## Testing
- `pytest tests/test_resumen_fc.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7888651088323b1c06a749b0507a7