### PR TITLE
Fix IVA rounding for CCF with prices including IVA

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2019,7 +2019,9 @@ def generar_dte_json(
                     precio = d4(money(base_pre / cant))
                     monto_descu = descuento_base
                     venta_gravada = base_final
-                    iva_val = money(bruto_final - base_final)
+                    iva_val_pre = money(base_pre * D("0.13"))
+                    iva_desc = money(descuento_base * D("0.13"))
+                    iva_val = money(iva_val_pre - iva_desc)
                     line_total = money(base_final + iva_val)
                     bruto_total += bruto
                     descuentos_total += descuento_base

--- a/tests/test_ccf_precios_iva_incluido.py
+++ b/tests/test_ccf_precios_iva_incluido.py
@@ -1,4 +1,4 @@
-from decimal import Decimal as D
+from decimal import Decimal as D, ROUND_HALF_UP
 import pytest
 
 from dte import recalcular_totales
@@ -59,6 +59,25 @@ def test_ccf_descuento_linea():
     assert resumen["totalPagar"] == D("10.33")
     assert resumen["pagos"][0]["montoPago"] == D("10.33")
     assert resumen["tributos"][0]["valor"] == D("1.19")
+
+
+def test_ccf_descuento_alto_iva_consistente():
+    """Los tributos deben derivarse de la base gravada con descuentos altos."""
+    items = [
+        {
+            "numItem": 1,
+            "descripcion": "A",
+            "cantidad": D("1"),
+            "precioUni": D("8.85"),
+            "montoDescu": D("0.89"),
+        }
+    ]
+    payload = _build_payload(items)
+    recalcular_totales(payload)
+    resumen = payload["resumen"]
+    total_gravada = resumen["totalGravada"]
+    expected_iva = (total_gravada * D("0.13")).quantize(D("0.01"), rounding=ROUND_HALF_UP)
+    assert resumen["tributos"][0]["valor"] == expected_iva
 
 
 def test_ccf_nit_validation():


### PR DESCRIPTION
## Summary
- derive IVA for consumer invoices from the discounted base instead of the gross total
- add regression test ensuring tributos derive from totalGravada with high discounts

## Testing
- `pytest tests/test_ccf_precios_iva_incluido.py tests/test_resumen_fc.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7bd238e64832386c79fc6e854d679