### PR TITLE
Corregir redondeo de IVA en DTE tipo 03

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1303,9 +1303,9 @@ def recalcular_totales(
             base = money(base_pre - monto_descu)
             if base < 0:
                 base = money(0)
-            iva_val = money(base * D("0.13"))
-            bruto_desc = money(base + iva_val)
-            bruto_linea = money(base_pre * D("1.13"))
+            bruto_desc = money((base * D("1.13")).quantize(D("0.001"), rounding=ROUND_HALF_UP))
+            iva_val = money(bruto_desc - base)
+            bruto_linea = money((base_pre * D("1.13")).quantize(D("0.001"), rounding=ROUND_HALF_UP))
             bases_pre.append(base_pre)
             bases.append(base)
             ivas.append(iva_val)

--- a/tests/test_ccf_precios_iva_incluido.py
+++ b/tests/test_ccf_precios_iva_incluido.py
@@ -1,7 +1,7 @@
 from decimal import Decimal as D, ROUND_HALF_UP
 import pytest
 
-from dte import recalcular_totales
+from dte import recalcular_totales, money
 
 
 def _build_payload(items, nit="06141990011019"):
@@ -76,8 +76,26 @@ def test_ccf_descuento_alto_iva_consistente():
     recalcular_totales(payload)
     resumen = payload["resumen"]
     total_gravada = resumen["totalGravada"]
-    expected_iva = (total_gravada * D("0.13")).quantize(D("0.01"), rounding=ROUND_HALF_UP)
+    bruto = money((total_gravada * D("1.13")).quantize(D("0.001"), rounding=ROUND_HALF_UP))
+    expected_iva = money(bruto - total_gravada)
     assert resumen["tributos"][0]["valor"] == expected_iva
+
+
+def test_ccf_precio_7_96_iva_redondeo():
+    items = [
+        {
+            "numItem": 1,
+            "descripcion": "A",
+            "cantidad": D("1"),
+            "precioUni": D("7.96"),
+            "montoDescu": D("0"),
+        }
+    ]
+    payload = _build_payload(items)
+    recalcular_totales(payload)
+    resumen = payload["resumen"]
+    assert resumen["tributos"][0]["valor"] == D("1.04")
+    assert resumen["montoTotalOperacion"] == D("9.00")
 
 
 def test_ccf_nit_validation():


### PR DESCRIPTION
## Summary
- Corrige el cálculo de bruto e IVA para DTE tipo 03 utilizando un redondeo intermedio a milésimas
- Añade prueba que verifica que un precio unitario de 7.96 genera IVA 1.04 y total 9.00

## Testing
- `pytest tests/test_ccf_precios_iva_incluido.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7cda20980832384f8d56c5c49cfce