### PR TITLE
Simplify type 03 total calculation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1303,9 +1303,9 @@ def recalcular_totales(
             base = money(base_pre - monto_descu)
             if base < 0:
                 base = money(0)
-            bruto_desc = money((base * D("1.13")).quantize(D("0.001"), rounding=ROUND_HALF_UP))
+            bruto_desc = money(base * D("1.13"))
             iva_val = money(bruto_desc - base)
-            bruto_linea = money((base_pre * D("1.13")).quantize(D("0.001"), rounding=ROUND_HALF_UP))
+            bruto_linea = money(base_pre * D("1.13"))
             bases_pre.append(base_pre)
             bases.append(base)
             ivas.append(iva_val)


### PR DESCRIPTION
## Summary
- compute DTE type 03 totals using a direct 1.13 multiplier and derive IVA from the result

## Testing
- `pytest` (fails: 40 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b7d57a23e08323826d308c0b739ed8