### PR TITLE
Colapsar descuentos en DTE 03 y ajustar redondeos

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1256,6 +1256,7 @@ def recalcular_totales(
     cuerpo = data.get("cuerpoDocumento", [])
     resumen = data.get("resumen", {})
 
+    colapso_desc = False
     if tipo_dte == "03":
         bruto_desc = D("0")
         desc_sum = D("0")
@@ -1265,19 +1266,22 @@ def recalcular_totales(
             _descu = D(str(_it.get("montoDescu") or 0))
             bruto_desc += _cant * _precio
             desc_sum += _descu
-        porcentaje = (
-            d2(desc_sum * D("100") / bruto_desc) if bruto_desc else D("0")
-        )
+        porcentaje = d2(desc_sum * D("100") / bruto_desc) if bruto_desc else D("0")
         if porcentaje != D("1"):
+            colapso_desc = True
             for _it in cuerpo:
                 _cant = D(str(_it.get("cantidad") or 0))
                 _precio = D(str(_it.get("precioUni") or 0))
                 _descu = D(str(_it.get("montoDescu") or 0))
                 if _descu:
-                    total_final = (_cant * _precio) - _descu
+                    total_final_base = (_cant * _precio) - _descu
                     if _cant:
-                        _it["precioUni"] = money(total_final / _cant)
-                    _it["montoDescu"] = money(0)
+                        base_unit = d4(total_final_base / _cant)
+                    else:
+                        base_unit = d4(0)
+                    _it["precioUni"] = base_unit
+                    _it["montoDescu"] = d4(0)
+                    _it["ventaGravada"] = d4(base_unit * _cant)
             resumen["descuNoSuj"] = resumen["descuExenta"] = resumen["descuGravada"] = resumen["totalDescu"] = money(0)
             resumen["porcentajeDescuento"] = money(0)
 
@@ -1329,10 +1333,10 @@ def recalcular_totales(
             iva_total += esperado_iva
             venta_gravada_sum += linea
         elif tipo_dte == "03":
-            base_pre = money(cant * precio)
-            base = money(base_pre - monto_descu)
+            base_pre = d4(cant * precio)
+            base = d4(base_pre - monto_descu)
             if base < 0:
-                base = money(0)
+                base = d4(0)
             bruto_desc = money_round_up(base * D("1.13"))
             iva_val = money(bruto_desc - base)
             bruto_linea = money_round_up(base_pre * D("1.13"))
@@ -1344,9 +1348,9 @@ def recalcular_totales(
             descu_sum += money(monto_descu)
             cantidades.append(cant)
             item.pop("ivaItem", None)
-            item["ventaExenta"] = money(0)
-            item["ventaNoSuj"] = money(0)
-            item["noGravado"] = money(0)
+            item["ventaExenta"] = d4(0)
+            item["ventaNoSuj"] = d4(0)
+            item["noGravado"] = d4(0)
         else:
             bruto_linea = money(cant * precio)
             bruto_linea_sum += bruto_linea
@@ -1381,18 +1385,18 @@ def recalcular_totales(
             base_res = base_total - sum(bases)
             iva_res = iva_total_calc - sum(ivas)
             if base_res or iva_res:
-                bases[0] = money(bases[0] + base_res)
+                bases[0] = d4(bases[0] + base_res)
                 ivas[0] = money(ivas[0] + iva_res)
             for idx, item in enumerate(cuerpo):
                 if idx < len(bases):
-                    base_val = bases[idx]
+                    base_val = d4(bases[idx])
                     cant = cantidades[idx]
                     iva_val = ivas[idx]
                     item["ventaGravada"] = base_val
                     if cant > 0:
-                        item["precioUni"] = money(base_val / cant)
+                        item["precioUni"] = d4(base_val / cant)
                     else:
-                        item["precioUni"] = money(0)
+                        item["precioUni"] = d4(0)
                     trib_list: list[str] = []
                     tipo_item = int(item.get("tipoItem", 1))
                     if base_val > 0:
@@ -1413,10 +1417,14 @@ def recalcular_totales(
             iva_total = D("0")
 
         if tipo_dte == "03":
-            sub_total_ventas = money(sum(bases_pre))
-            descu_gravada_sum = money(
-                sum(bp - b for bp, b in zip(bases_pre, bases))
-            )
+            if colapso_desc:
+                sub_total_ventas = money(sum(bases))
+                descu_gravada_sum = money(0)
+            else:
+                sub_total_ventas = money(sum(bases_pre))
+                descu_gravada_sum = money(
+                    sum(bp - b for bp, b in zip(bases_pre, bases))
+                )
         else:
             if precios_flag:
                 sub_total_ventas = money(sum(bases_pre))

--- a/tests/test_ccf_precios_iva_incluido.py
+++ b/tests/test_ccf_precios_iva_incluido.py
@@ -22,9 +22,9 @@ def test_ccf_totals_with_inclusive_prices():
     recalcular_totales(payload)
     item1, item2 = payload["cuerpoDocumento"]
     resumen = payload["resumen"]
-    assert item1["ventaGravada"] == D("0.05")
-    assert item2["ventaGravada"] == D("0.04")
-    assert resumen["totalGravada"] == D("0.09")
+    assert item1["ventaGravada"] == D("0.0460")
+    assert item2["ventaGravada"] == D("0.0440")
+    assert resumen["totalGravada"] == D("0.0900")
     assert resumen["montoTotalOperacion"] == D("0.10")
     assert resumen["totalPagar"] == D("0.10")
     assert resumen["tributos"][0]["codigo"] == "20"
@@ -47,6 +47,9 @@ def test_ccf_descuento_no_permitido():
     resumen = payload["resumen"]
     assert item["precioUni"] == D("8.00")
     assert item["montoDescu"] == D("0")
+    assert item["ventaGravada"] == D("8.00")
+    assert resumen["subTotalVentas"] == D("8.00")
+    assert resumen["subTotal"] == D("8.00")
     assert resumen["totalDescu"] == D("0")
     assert resumen["porcentajeDescuento"] == D("0")
     assert resumen["totalGravada"] == D("8.00")
@@ -74,6 +77,32 @@ def test_ccf_descuento_un_por_ciento():
     assert resumen["porcentajeDescuento"] == D("1.00")
     assert resumen["tributos"][0]["valor"] == D("12.87")
     assert resumen["totalPagar"] == D("111.87")
+
+
+def test_ccf_descuento_colapsado_consistente():
+    items = [
+        {
+            "numItem": 1,
+            "descripcion": "A",
+            "cantidad": D("1"),
+            "precioUni": D("15.04"),
+            "montoDescu": D("0.75"),
+        }
+    ]
+    payload = _build_payload(items)
+    recalcular_totales(payload)
+    item = payload["cuerpoDocumento"][0]
+    resumen = payload["resumen"]
+    assert item["precioUni"] == D("14.29")
+    assert item["montoDescu"] == D("0")
+    assert item["ventaGravada"] == D("14.29")
+    assert resumen["subTotalVentas"] == D("14.29")
+    assert resumen["subTotal"] == D("14.29")
+    assert resumen["totalGravada"] == D("14.29")
+    assert resumen["totalDescu"] == D("0")
+    assert resumen["porcentajeDescuento"] == D("0")
+    assert resumen["montoTotalOperacion"] == D("16.15")
+    assert resumen["pagos"][0]["montoPago"] == D("16.15")
 
 
 def test_ccf_precio_7_96_iva_redondeo():


### PR DESCRIPTION
## Summary
- Normaliza DTE 03: colapsa descuentos distintos de 1 %, recalcula precio base y limpieza de descuentos
- Ajusta cálculo de totales y redondeos a 4/2 decimales según corresponda
- Añade pruebas para validar colapso y coherencia de totales

## Testing
- `pytest`
- `pytest tests/test_ccf_precios_iva_incluido.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90b639a208323a8687c0786096b73