### PR TITLE
Remove extra field from DTE payload after validation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2393,6 +2393,7 @@ def generar_dte_json(
     }
 
     validate_dte_json(result, db=db, precios_incluyen_iva=False)
+    result.pop("extra", None)
     return json.loads(stable_stringify(result), parse_float=Decimal)
 
 


### PR DESCRIPTION
## Summary
- drop `extra` data from generated DTE JSON, preserving required `null` fields

## Testing
- `pytest` *(fails: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b91dc14ed48323a1dc6a8435cf2338