### PR TITLE
fix: include receptor document fields in DTE01

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2443,10 +2443,13 @@ def validate_dte_json(
     ident["tipoDte"] = tipo_dte_val
     if tipo_dte_val not in catalogos.DTE_TIPOS:
         raise ValueError("tipoDte inválido")
-    if tipo_dte_val in {"01", "03"}:
+    if tipo_dte_val == "03":
         precios_flag = True
         extra_conf["precios_incluyen_iva"] = True
         payload["extra"] = extra_conf
+    elif tipo_dte_val == "01":
+        precios_flag = True
+        extra_conf["precios_incluyen_iva"] = True
 
     # Normalización de operación y contingencia
     try:
@@ -2660,21 +2663,40 @@ def validate_dte_json(
         raise ValueError("Correo de receptor inválido")
     if receptor.get("telefono") and not PHONE_RE.fullmatch(receptor["telefono"]):
         raise ValueError("Teléfono de receptor inválido")
-    required_rec_fields = [
-        "nit",
-        "nrc",
-        "nombre",
-        "nombreComercial",
-        "codActividad",
-        "descActividad",
-        "telefono",
-        "correo",
-        "direccion",
-    ]
-    for f in required_rec_fields:
-        receptor.setdefault(f, None)
-    for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
-        receptor.pop(f, None)
+    if tipo_dte == "01":
+        required_rec_fields = [
+            "nrc",
+            "nombre",
+            "codActividad",
+            "descActividad",
+            "telefono",
+            "correo",
+            "direccion",
+            "tipoDocumento",
+            "numDocumento",
+        ]
+        for f in ("nit", "nombreComercial"):
+            receptor.pop(f, None)
+        for f in required_rec_fields:
+            receptor.setdefault(f, None)
+        for f in ("noRemision", "ordenNo"):
+            receptor.pop(f, None)
+    else:
+        required_rec_fields = [
+            "nit",
+            "nrc",
+            "nombre",
+            "nombreComercial",
+            "codActividad",
+            "descActividad",
+            "telefono",
+            "correo",
+            "direccion",
+        ]
+        for f in required_rec_fields:
+            receptor.setdefault(f, None)
+        for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+            receptor.pop(f, None)
     payload["receptor"] = receptor
 
     cuerpo = payload.get("cuerpoDocumento", [])
@@ -3056,6 +3078,8 @@ def validate_dte_json(
         for p in resumen["pagos"]:
             p["montoPago"] = _zero_or(p["montoPago"], money)
 
+    if payload.get("identificacion", {}).get("tipoDte") == "01":
+        payload.pop("extra", None)
     payload["resumen"] = resumen
 
 


### PR DESCRIPTION
## Summary
- keep receptor document fields for DTE 01 and drop nit/nombreComercial
- avoid attaching `extra` to DTE 01 payloads

## Testing
- `pytest tests/test_validaciones_basicas.py::test_receptor_documentos tests/test_generar_dte_json.py::test_generar_dte_json_receptor_consumidor_final -q`
- `pytest` *(fails: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b9253f00ac8323a1e08b7751b3425f