### PR TITLE
Adjust DTE summary totals to match sale exactly

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1088,6 +1088,23 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
             (total_descu * D("100") / base_desc) if base_desc else D("0")
         )
 
+    venta_total = None
+    if isinstance(venta, dict):
+        venta_total_raw = venta.get("total")
+        if venta_total_raw is not None:
+            venta_total = money(venta_total_raw)
+    elif venta is not None:
+        try:
+            venta_total = money(venta)
+        except Exception:
+            venta_total = None
+    if venta_total is not None:
+        diff = money(venta_total - total_pagar)
+        if diff != 0:
+            total_iva = money(total_iva + diff)
+            monto_total_operacion = money(monto_total_operacion + diff)
+            total_pagar = money(total_pagar + diff)
+
     resumen = RESUMEN_DEFAULTS.get(tipo_dte, {}).copy()
     resumen.update(
         {

--- a/tests/test_dte_rounding.py
+++ b/tests/test_dte_rounding.py
@@ -47,3 +47,12 @@ def test_pagos_rounding_adjusts_last_payment():
     suma = sum(p["montoPago"] for p in norm)
     assert suma == total
     assert norm[-1]["montoPago"] == D("5.00")
+
+
+def test_resumen_matches_sale_total():
+    items_total = D('40.51')
+    fiscal = {'iva': D('5.27')}
+    venta = {'total': D('45.77')}
+    resumen = calcular_resumen(items_total, venta, fiscal=fiscal, tipo_dte='03')
+    assert resumen['totalPagar'] == D('45.77')
+    assert resumen['tributos'][0]['valor'] == D('5.26')


### PR DESCRIPTION
## Summary
- adjust resumen totals to match original sale's total by shifting IVA
- add test ensuring calculated resumen uses sale total

## Testing
- `pytest -q` *(fails: libGL.so.1 missing, fastapi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b92bc1d6948323afde18ca108f203f