### PR TITLE
Handle detailed amounts in credit/debit notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -19,6 +19,7 @@ from jsonschema import ValidationError, RefResolver
 from utils import catalogos
 from utils.catalogos import (
     TRIBUTO_IVA,
+    TRIBUTOS,
     TRIBUTOS_PERMITIDOS_ITEM,
     TRIBUTOS_PERMITIDOS_RESUMEN,
     UNIDADES_MEDIDA_PERMITIDAS,
@@ -3168,6 +3169,78 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]
+
+    detalles = None
+    if nota.get("detalles"):
+        try:
+            detalles = json.loads(nota["detalles"])
+        except Exception:
+            detalles = None
+
+    if detalles:
+        items = []
+        total_grav = Decimal("0")
+        total_exenta = Decimal("0")
+        total_nosuj = Decimal("0")
+        num = 1
+        for det in detalles:
+            grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
+            exenta = Decimal(str(det.get("ventas_exentas") or det.get("ventaExenta") or 0))
+            nosuj = Decimal(str(det.get("ventas_no_sujetas") or det.get("ventaNoSuj") or 0))
+            total_grav += grav
+            total_exenta += exenta
+            total_nosuj += nosuj
+            precio = det.get("precio_unitario") or det.get("precioUni")
+            if precio is None:
+                precio = float(grav + exenta + nosuj)
+            cantidad = det.get("cantidad", 1)
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": det.get("tipoItem", 1),
+                    "codigo": det.get("codigo", f"ND{origen_ident.get('codigoGeneracion','')[:8]}-{num}"),
+                    "descripcion": det.get("descripcion", "Nota de débito"),
+                    "cantidad": cantidad,
+                    "uniMedida": det.get("uniMedida", 59),
+                    "precioUni": precio,
+                    "montoDescu": det.get("montoDescu", 0.0),
+                    "ventaGravada": d2(grav),
+                    "ventaExenta": d2(exenta),
+                    "ventaNoSuj": d2(nosuj),
+                    "tributos": [TRIBUTO_IVA] if grav > 0 else [],
+                    "numeroDocumento": origen_ident.get("codigoGeneracion"),
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        subtotal = total_grav + total_exenta + total_nosuj
+        iva_val = d2(Decimal(str(total_grav)) * Decimal("0.13"))
+        tributos_resumen = []
+        if iva_val > 0:
+            tributos_resumen.append(
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": TRIBUTOS.get(TRIBUTO_IVA, ""),
+                    "valor": iva_val,
+                }
+            )
+        monto_total = d2(Decimal(str(subtotal)) + Decimal(str(iva_val)))
+        data["cuerpoDocumento"] = items
+        data["resumen"] = {
+            "totalNoSuj": d2(total_nosuj),
+            "totalExenta": d2(total_exenta),
+            "totalGravada": d2(total_grav),
+            "subTotal": d2(subtotal),
+            "subTotalVentas": d2(subtotal),
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "tributos": tributos_resumen,
+            "montoTotalOperacion": monto_total,
+            "totalLetras": monto_a_texto_sv(float(monto_total)),
+        }
+
     from utils.sanitize import limpiar_documentos
     limpiar_documentos(data.get("emisor"))
     limpiar_documentos(data.get("receptor"))

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -471,8 +471,9 @@ def generar_nota_credito_pdf(
     det_neg = []
     for d in detalles:
         dn = d.copy()
-        if "cantidad" in dn and isinstance(dn["cantidad"], (int, float)):
-            dn["cantidad"] = -abs(dn["cantidad"])
+        for key in ("cantidad", "precio_unitario", "ventas_gravadas", "ventas_exentas", "ventas_no_sujetas"):
+            if key in dn and isinstance(dn[key], (int, float)):
+                dn[key] = -abs(dn[key])
         det_neg.append(dn)
 
     generar_factura_electronica_pdf(

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
+import json
 from typing import Optional
 
 from db import DB
@@ -74,6 +75,24 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         tipo_doc = "03"
 
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+
+    detalles = None
+    if nota.get("detalles"):
+        try:
+            detalles = json.loads(nota["detalles"])
+        except Exception:
+            detalles = None
+
+    if detalles:
+        return generar_nce_desde_dte(
+            db,
+            dte_origen,
+            None,
+            detalles=detalles,
+            ambiente=ambiente,
+            motivo=nota.get("motivo"),
+        )
+
     total_origen = Decimal(str(dte_origen.get("resumen", {}).get("montoTotalOperacion", 0)))
     monto_nc = Decimal(str(nota.get("monto", 0)))
     if total_origen <= Decimal_0:
@@ -92,28 +111,16 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
 def generar_nce_desde_dte(
     db: DB,
     dte_origen: dict,
-    ratio: Decimal,
+    ratio: Decimal | None,
     *,
+    detalles: Optional[list] = None,
     ambiente: str = "00",
     motivo: Optional[str] = None,
 ) -> dict:
-    """Genera la estructura JSON de una NCE.
-
-    Parameters
-    ----------
-    db:
-        Conexión a la base de datos (usada para numeración).
-    dte_origen:
-        DTE original desde el cual se prorrateará la nota.
-    ratio:
-        Fracción del documento original que se acreditará (``0`` a ``1``).
-    ambiente:
-        Código de ambiente MH.
-    motivo:
-        Texto opcional para incluir en la descripción del ítem.
-    """
-    if ratio <= Decimal_0:
-        raise ValueError("El porcentaje a acreditar debe ser mayor que cero")
+    """Genera la estructura JSON de una NCE."""
+    if detalles is None:
+        if ratio is None or ratio <= Decimal_0:
+            raise ValueError("El porcentaje a acreditar debe ser mayor que cero")
 
     cabecera = generar_cabecera_dte_data(1, 1, "05", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
@@ -148,79 +155,122 @@ def generar_nce_desde_dte(
     limpiar_documentos(receptor)
 
     orig_resumen = dte_origen.get("resumen", {})
-    total_grav = Decimal(str(orig_resumen.get("totalGravada", 0))) * ratio
-    total_exenta = Decimal(str(orig_resumen.get("totalExenta", 0))) * ratio
-    total_nosuj = Decimal(str(orig_resumen.get("totalNoSuj", 0))) * ratio
-
-    total_grav = d2(total_grav)
-    total_exenta = d2(total_exenta)
-    total_nosuj = d2(total_nosuj)
-
-    items = []
-    num = 1
+    items: list[dict] = []
     uuid_origen = origen_ident.get("codigoGeneracion", "")
-    pct_text = _pct_label(ratio)
     tipo_doc_desc = catalogos.DTE_TIPOS.get(origen_ident.get("tipoDte", ""), "documento")
     extra_desc = f": {motivo}" if motivo else ""
-    if total_grav > 0:
-        items.append(
-            {
-                "numItem": num,
-                "tipoItem": 1,
-                "codigo": f"NC{pct_text}-{uuid_origen[:8]}-G",
-                "descripcion": f"Nota de crédito {pct_text}% sobre operaciones gravadas del {tipo_doc_desc} relacionado{extra_desc}",
-                "cantidad": 1,
-                "uniMedida": 59,
-                "precioUni": total_grav,
-                "montoDescu": 0.0,
-                "ventaGravada": total_grav,
-                "ventaExenta": 0.0,
-                "ventaNoSuj": 0.0,
-                "tributos": [TRIBUTO_IVA],
-                "numeroDocumento": uuid_origen,
-                "codTributo": None,
-            }
-        )
-        num += 1
-    if total_exenta > 0:
-        items.append(
-            {
-                "numItem": num,
-                "tipoItem": 1,
-                "codigo": f"NC{pct_text}-{uuid_origen[:8]}-E",
-                "descripcion": f"Nota de crédito {pct_text}% sobre operaciones exentas del {tipo_doc_desc} relacionado{extra_desc}",
-                "cantidad": 1,
-                "uniMedida": 59,
-                "precioUni": total_exenta,
-                "montoDescu": 0.0,
-                "ventaGravada": 0.0,
-                "ventaExenta": total_exenta,
-                "ventaNoSuj": 0.0,
-                "tributos": [],
-                "numeroDocumento": uuid_origen,
-                "codTributo": None,
-            }
-        )
-        num += 1
-    if total_nosuj > 0:
-        items.append(
-            {
-                "numItem": num,
-                "tipoItem": 1,
-                "codigo": f"NC{pct_text}-{uuid_origen[:8]}-N",
-                "descripcion": f"Nota de crédito {pct_text}% sobre operaciones no sujetas del {tipo_doc_desc} relacionado{extra_desc}",
-                "cantidad": 1,
-                "uniMedida": 59,
-                "precioUni": total_nosuj,
-                "montoDescu": 0.0,
-                "ventaGravada": 0.0,
-                "ventaExenta": 0.0,
-                "ventaNoSuj": total_nosuj,
-                "tributos": [],
-                "numeroDocumento": uuid_origen,
-                "codTributo": None,
-            }
-        )
+
+    if detalles:
+        total_grav = Decimal_0
+        total_exenta = Decimal_0
+        total_nosuj = Decimal_0
+        num = 1
+        for det in detalles:
+            grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
+            exenta = Decimal(str(det.get("ventas_exentas") or det.get("ventaExenta") or 0))
+            nosuj = Decimal(str(det.get("ventas_no_sujetas") or det.get("ventaNoSuj") or 0))
+            total_grav += grav
+            total_exenta += exenta
+            total_nosuj += nosuj
+            precio = det.get("precio_unitario") or det.get("precioUni")
+            if precio is None:
+                precio = float(grav + exenta + nosuj)
+            cantidad = det.get("cantidad", 1)
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": det.get("tipoItem", 1),
+                    "codigo": det.get("codigo", f"NC{uuid_origen[:8]}-{num}"),
+                    "descripcion": det.get(
+                        "descripcion",
+                        f"Nota de crédito sobre operaciones del {tipo_doc_desc} relacionado{extra_desc}",
+                    ),
+                    "cantidad": cantidad,
+                    "uniMedida": det.get("uniMedida", 59),
+                    "precioUni": precio,
+                    "montoDescu": det.get("montoDescu", 0.0),
+                    "ventaGravada": d2(grav),
+                    "ventaExenta": d2(exenta),
+                    "ventaNoSuj": d2(nosuj),
+                    "tributos": [TRIBUTO_IVA] if grav > 0 else [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        total_grav = d2(total_grav)
+        total_exenta = d2(total_exenta)
+        total_nosuj = d2(total_nosuj)
+    else:
+        total_grav = Decimal(str(orig_resumen.get("totalGravada", 0))) * ratio
+        total_exenta = Decimal(str(orig_resumen.get("totalExenta", 0))) * ratio
+        total_nosuj = Decimal(str(orig_resumen.get("totalNoSuj", 0))) * ratio
+
+        total_grav = d2(total_grav)
+        total_exenta = d2(total_exenta)
+        total_nosuj = d2(total_nosuj)
+
+        num = 1
+        pct_text = _pct_label(ratio)
+        if total_grav > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"NC{pct_text}-{uuid_origen[:8]}-G",
+                    "descripcion": f"Nota de crédito {pct_text}% sobre operaciones gravadas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_grav,
+                    "montoDescu": 0.0,
+                    "ventaGravada": total_grav,
+                    "ventaExenta": 0.0,
+                    "ventaNoSuj": 0.0,
+                    "tributos": [TRIBUTO_IVA],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        if total_exenta > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"NC{pct_text}-{uuid_origen[:8]}-E",
+                    "descripcion": f"Nota de crédito {pct_text}% sobre operaciones exentas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_exenta,
+                    "montoDescu": 0.0,
+                    "ventaGravada": 0.0,
+                    "ventaExenta": total_exenta,
+                    "ventaNoSuj": 0.0,
+                    "tributos": [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        if total_nosuj > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"NC{pct_text}-{uuid_origen[:8]}-N",
+                    "descripcion": f"Nota de crédito {pct_text}% sobre operaciones no sujetas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_nosuj,
+                    "montoDescu": 0.0,
+                    "ventaGravada": 0.0,
+                    "ventaExenta": 0.0,
+                    "ventaNoSuj": total_nosuj,
+                    "tributos": [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
 
     subtotal_ventas = total_grav + total_exenta + total_nosuj
     iva_val = d2(Decimal(str(total_grav)) * IVA)

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -1,0 +1,81 @@
+import json
+from db import DB
+from nota_credito_electronica import generar_nce_desde_nota
+from dte import generar_nota_debito_json
+
+def create_db():
+    return DB(":memory:")
+
+
+def _prep(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+
+def test_generar_nce_detalles(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "precio_unitario": 10,
+            "ventas_gravadas": 10,
+            "ventas_exentas": 0,
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?,?,?,?,?,?)",
+        (venta_id, "credito", "2024-01-02", 10, "Dev", json.dumps(detalles)),
+    )
+    nota_id = db.cursor.lastrowid
+    db.conn.commit()
+    data = generar_nce_desde_nota(db, nota_id)
+    item = data["cuerpoDocumento"][0]
+    assert item["ventaGravada"] == 10
+    assert data["resumen"]["totalGravada"] == 10
+
+
+def test_generar_nota_debito_detalles(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Ajuste",
+            "precio_unitario": 2,
+            "ventas_gravadas": 2,
+            "ventas_exentas": 0,
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?,?,?,?,?,?)",
+        (venta_id, "debito", "2024-01-02", 2, "Ajuste", json.dumps(detalles)),
+    )
+    nota_id = db.cursor.lastrowid
+    db.conn.commit()
+    data = generar_nota_debito_json(db, nota_id)
+    item = data["cuerpoDocumento"][0]
+    assert item["ventaGravada"] == 2
+    assert data["resumen"]["totalGravada"] == 2


### PR DESCRIPTION
## Summary
- use nota[`detalles`] to build credit note items and resumenes
- adjust debit note JSON generation to reflect detailed amounts
- show adjusted lines in note PDF generation and add tests

## Testing
- `pytest tests/test_nota_credito.py tests/test_nota_detalles.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba77a5e8448323be9ed9695e9abbe9