### PR TITLE
Ensure note totals and enforce debit/credit adjustment rules

### DIFF
--- a/dialogs/nota_detalle_dialog.py
+++ b/dialogs/nota_detalle_dialog.py
@@ -17,9 +17,10 @@ from PyQt5.QtCore import Qt
 class NotaDetalleDialog(QDialog):
     """Dialogo para ajustar montos de una venta por partida."""
 
-    def __init__(self, detalles: List[Dict], parent=None):
+    def __init__(self, detalles: List[Dict], tipo: str, parent=None):
         super().__init__(parent)
         self.detalles = detalles
+        self.tipo = tipo
         self.setWindowTitle("Detalle de Nota")
         self._build_ui()
         self._populate_table()
@@ -83,7 +84,10 @@ class NotaDetalleDialog(QDialog):
 
             spin = QDoubleSpinBox()
             spin.setDecimals(2)
-            spin.setRange(-1_000_000, 1_000_000)
+            if self.tipo == "credito":
+                spin.setRange(-1_000_000, 0)
+            else:
+                spin.setRange(0, 1_000_000)
             spin.setValue(0)
             spin.valueChanged.connect(self._update_total)
             self.table.setCellWidget(row, 5, spin)
@@ -93,7 +97,7 @@ class NotaDetalleDialog(QDialog):
         for row in range(self.table.rowCount()):
             spin = self.table.cellWidget(row, 5)
             if isinstance(spin, QDoubleSpinBox):
-                total += spin.value()
+                total += abs(spin.value())
         self.total_label.setText(f"Total: {total:.2f}")
 
     def get_data(self) -> Tuple[float, str, List[Dict]]:
@@ -111,5 +115,5 @@ class NotaDetalleDialog(QDialog):
                             "ajuste": val,
                         }
                     )
-                    total += val
+                    total += abs(val)
         return total, self.motivo_edit.text(), detalles

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -837,7 +837,7 @@ class FacturacionTab(QWidget):
         venta = None
         if venta_id is not None:
             venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
-        dialog = NotaDetalleDialog(detalles_venta, self)
+        dialog = NotaDetalleDialog(detalles_venta, tipo, self)
         if dialog.exec_() != QDialog.Accepted:
             return
         monto, motivo, detalles_nota = dialog.get_data()
@@ -846,7 +846,12 @@ class FacturacionTab(QWidget):
             return
         fecha = QDate.currentDate().toString("yyyy-MM-dd")
 
-        total_original = float(venta.get("total", 0)) if venta else 0
+        resumen_factura = data.get("resumen", {}) or {}
+        total_original = float(
+            resumen_factura.get("totalPagar")
+            or resumen_factura.get("montoTotalOperacion")
+            or (venta.get("total") if venta else 0)
+        )
         if tipo == "debito":
             total_ajustado = total_original + monto
         elif tipo == "credito":


### PR DESCRIPTION
## Summary
- Calculate original invoice total from JSON when creating notes
- Limit credit notes to negative adjustments and debit notes to positive

## Testing
- `pytest tests/test_all_dtes.py::test_all_dtes[ccf] -q` *(fails: ValueError datos_negocio.json inválido)*

------
https://chatgpt.com/codex/tasks/task_e_68bb25da69e48323bdf003bed10dfb87