### PR TITLE
Confirm continuation when factura lacks venta

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -868,8 +868,14 @@ class FacturacionTab(QWidget):
             return
 
         if venta_id is None:
-            QMessageBox.warning(self, "Nota", "La factura no está asociada a una venta")
-            return
+            confirm = QMessageBox.question(
+                self,
+                "Nota",
+                "La factura no está asociada a una venta. Esto podría causar algún conflicto. ¿Desea continuar?",
+                QMessageBox.Yes | QMessageBox.No,
+            )
+            if confirm != QMessageBox.Yes:
+                return
 
         nota_id = self.manager.db.agregar_nota(
             tipo, venta_id, fecha, monto, motivo, detalles=detalles_nota


### PR DESCRIPTION
## Summary
- ask for confirmation when a factura is not linked to a venta before creating a nota

## Testing
- `pytest` *(fails: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a42e29c83238a82847a1034ba07