### PR TITLE
Refactor note generation to use invoice JSON

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3140,45 +3140,58 @@ def generar_nota_credito_json(db: DB, nota_id: int) -> dict:
     return generar_nce_desde_nota(db, nota_id)
 
 
-def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
-    """Genera la estructura JSON para una nota de débito."""
-    row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
-    if not row:
-        raise ValueError("Nota no encontrada")
-    nota = dict(row)
-    if nota.get("tipo") != "debito":
-        raise ValueError("La nota indicada no es de débito")
+def generar_nde_desde_dte(
+    db: DB,
+    dte_origen: dict,
+    detalles: list | None,
+    monto: float | None,
+    motivo: str | None = None,
+    *,
+    ambiente: str = "00",
+) -> dict:
+    """Genera la estructura JSON de una Nota de Débito a partir de un DTE."""
 
-    venta_id = nota.get("venta_id")
-    venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
-    ).fetchone()
-    tipo_doc = "01"
-    if venta_row:
-        venta = dict(venta_row)
-        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-            tipo_doc = "03"
-    data = generar_dte_json(db, venta_id, tipo_dte="06")
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc)
+    cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
+    now = datetime.now(TZ_EL_SALVADOR)
+    identificacion = {
+        "version": DTE_VERSIONES["06"],
+        "ambiente": ambiente,
+        "tipoDte": "06",
+        "numeroControl": cabecera["numero_control"],
+        "codigoGeneracion": cabecera["codigo_generacion"],
+        "tipoModelo": cabecera["tipo_modelo"],
+        "tipoOperacion": cabecera["tipo_operacion"],
+        "tipoContingencia": cabecera["tipo_contingencia"],
+        "motivoContin": cabecera["motivo_contin"],
+        "fecEmi": fecha_emision_hoy_str(now),
+        "horEmi": now.strftime("%H:%M:%S"),
+        "tipoMoneda": "USD",
+    }
+
     origen_ident = dte_origen.get("identificacion", {})
-    data["documentoRelacionado"] = [
+    doc_rel = [
         {
-            "tipoDocumento": tipo_doc,
+            "tipoDocumento": origen_ident.get("tipoDte"),
             "tipoGeneracion": 2,
             "numeroDocumento": origen_ident.get("codigoGeneracion"),
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]
 
-    detalles = None
-    if nota.get("detalles"):
-        try:
-            detalles = json.loads(nota["detalles"])
-        except Exception:
-            detalles = None
+    emisor = dte_origen.get("emisor")
+    receptor = dte_origen.get("receptor")
+    from utils.sanitize import limpiar_documentos
+
+    limpiar_documentos(emisor)
+    limpiar_documentos(receptor)
+
+    orig_resumen = dte_origen.get("resumen", {})
+    items: list[dict] = []
+    uuid_origen = origen_ident.get("codigoGeneracion", "")
+    tipo_doc_desc = catalogos.DTE_TIPOS.get(origen_ident.get("tipoDte", ""), "documento")
+    extra_desc = f": {motivo}" if motivo else ""
 
     if detalles:
-        items = []
         total_grav = Decimal("0")
         total_exenta = Decimal("0")
         total_nosuj = Decimal("0")
@@ -3198,8 +3211,11 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
                 {
                     "numItem": num,
                     "tipoItem": det.get("tipoItem", 1),
-                    "codigo": det.get("codigo", f"ND{origen_ident.get('codigoGeneracion','')[:8]}-{num}"),
-                    "descripcion": det.get("descripcion", "Nota de débito"),
+                    "codigo": det.get("codigo", f"ND{uuid_origen[:8]}-{num}"),
+                    "descripcion": det.get(
+                        "descripcion",
+                        f"Nota de débito sobre operaciones del {tipo_doc_desc} relacionado{extra_desc}",
+                    ),
                     "cantidad": cantidad,
                     "uniMedida": det.get("uniMedida", 59),
                     "precioUni": precio,
@@ -3208,46 +3224,161 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
                     "ventaExenta": d2(exenta),
                     "ventaNoSuj": d2(nosuj),
                     "tributos": [TRIBUTO_IVA] if grav > 0 else [],
-                    "numeroDocumento": origen_ident.get("codigoGeneracion"),
+                    "numeroDocumento": uuid_origen,
                     "codTributo": None,
                 }
             )
             num += 1
-        subtotal = total_grav + total_exenta + total_nosuj
-        iva_val = d2(Decimal(str(total_grav)) * Decimal("0.13"))
-        tributos_resumen = []
-        if iva_val > 0:
-            tributos_resumen.append(
+        total_grav = d2(total_grav)
+        total_exenta = d2(total_exenta)
+        total_nosuj = d2(total_nosuj)
+    else:
+        if monto is None:
+            raise ValueError("Se requiere monto para nota de débito")
+        total_origen = Decimal(
+            str(
+                orig_resumen.get("montoTotalOperacion")
+                or orig_resumen.get("totalPagar")
+                or 0
+            )
+        )
+        if total_origen <= 0:
+            raise ValueError("El documento de origen no tiene total válido")
+        ratio = Decimal(str(monto)) / total_origen
+        pct_text = str((ratio * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+        total_grav = d2(Decimal(str(orig_resumen.get("totalGravada", 0))) * ratio)
+        total_exenta = d2(Decimal(str(orig_resumen.get("totalExenta", 0))) * ratio)
+        total_nosuj = d2(Decimal(str(orig_resumen.get("totalNoSuj", 0))) * ratio)
+        num = 1
+        if total_grav > 0:
+            items.append(
                 {
-                    "codigo": TRIBUTO_IVA,
-                    "descripcion": TRIBUTOS.get(TRIBUTO_IVA, ""),
-                    "valor": iva_val,
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"ND{pct_text}-{uuid_origen[:8]}-G",
+                    "descripcion": f"Nota de débito {pct_text}% sobre operaciones gravadas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_grav,
+                    "montoDescu": 0.0,
+                    "ventaGravada": total_grav,
+                    "ventaExenta": 0.0,
+                    "ventaNoSuj": 0.0,
+                    "tributos": [TRIBUTO_IVA],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
                 }
             )
-        monto_total = d2(Decimal(str(subtotal)) + Decimal(str(iva_val)))
-        data["cuerpoDocumento"] = items
-        data["resumen"] = {
-            "totalNoSuj": d2(total_nosuj),
-            "totalExenta": d2(total_exenta),
-            "totalGravada": d2(total_grav),
-            "subTotal": d2(subtotal),
-            "subTotalVentas": d2(subtotal),
-            "descuNoSuj": 0.0,
-            "descuExenta": 0.0,
-            "descuGravada": 0.0,
-            "totalDescu": 0.0,
-            "tributos": tributos_resumen,
-            "montoTotalOperacion": monto_total,
-            "totalLetras": monto_a_texto_sv(float(monto_total)),
-        }
+            num += 1
+        if total_exenta > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"ND{pct_text}-{uuid_origen[:8]}-E",
+                    "descripcion": f"Nota de débito {pct_text}% sobre operaciones exentas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_exenta,
+                    "montoDescu": 0.0,
+                    "ventaGravada": 0.0,
+                    "ventaExenta": total_exenta,
+                    "ventaNoSuj": 0.0,
+                    "tributos": [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        if total_nosuj > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"ND{pct_text}-{uuid_origen[:8]}-N",
+                    "descripcion": f"Nota de débito {pct_text}% sobre operaciones no sujetas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_nosuj,
+                    "montoDescu": 0.0,
+                    "ventaGravada": 0.0,
+                    "ventaExenta": 0.0,
+                    "ventaNoSuj": total_nosuj,
+                    "tributos": [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
 
-    from utils.sanitize import limpiar_documentos
-    limpiar_documentos(data.get("emisor"))
-    limpiar_documentos(data.get("receptor"))
-    limpiar_documentos(data.get("extension"))
-    from utils import catalogos as _catalogos
-    schema = _catalogos.get_dte_schema("06")
+    subtotal_ventas = total_grav + total_exenta + total_nosuj
+    iva_val = d2(Decimal(str(total_grav)) * Decimal("0.13"))
+    tributos_resumen = []
+    if iva_val > 0:
+        tributos_resumen.append(
+            {
+                "codigo": TRIBUTO_IVA,
+                "descripcion": TRIBUTOS.get(TRIBUTO_IVA, ""),
+                "valor": iva_val,
+            }
+        )
+    monto_total = d2(Decimal(str(subtotal_ventas)) + Decimal(str(iva_val)))
+    resumen = {
+        "totalNoSuj": total_nosuj,
+        "totalExenta": total_exenta,
+        "totalGravada": total_grav,
+        "subTotal": subtotal_ventas,
+        "subTotalVentas": subtotal_ventas,
+        "descuNoSuj": 0.0,
+        "descuExenta": 0.0,
+        "descuGravada": 0.0,
+        "totalDescu": 0.0,
+        "tributos": tributos_resumen,
+        "montoTotalOperacion": monto_total,
+        "totalLetras": monto_a_texto_sv(float(monto_total)),
+    }
+
+    data = {
+        "identificacion": identificacion,
+        "documentoRelacionado": doc_rel,
+        "emisor": emisor,
+        "receptor": receptor,
+        "cuerpoDocumento": items,
+        "resumen": resumen,
+        "ventaTercero": None,
+        "extension": None,
+        "apendice": None,
+    }
+
+    schema = catalogos.get_dte_schema("06")
     return sanitize_dte_payload(data, schema)
+
+
+def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
+    """Genera la estructura JSON para una nota de débito."""
+    row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
+    if not row:
+        raise ValueError("Nota no encontrada")
+    nota = dict(row)
+    if nota.get("tipo") != "debito":
+        raise ValueError("La nota indicada no es de débito")
+
+    venta_id = nota.get("venta_id")
+    venta_row = db.cursor.execute(
+        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+    ).fetchone()
+    tipo_doc = "01"
+    if venta_row:
+        venta = dict(venta_row)
+        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
+            tipo_doc = "03"
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc)
+    detalles = None
+    if nota.get("detalles"):
+        try:
+            detalles = json.loads(nota["detalles"])
+        except Exception:
+            detalles = None
+    return generar_nde_desde_dte(db, dte_origen, detalles, nota.get("monto"), nota.get("motivo"))
 
 
 def generar_nota_remision_json(db: DB, nota_id: int) -> dict:

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -30,14 +30,13 @@ from factura_sv import (
     generar_nota_remision_pdf,
 )
 from dte import (
-    generar_nota_credito_json,
-    generar_nota_debito_json,
     generar_nota_remision_json,
     transmitir_dte,
     enviar_nota_credito,
     enviar_nota_debito,
+    generar_nde_desde_dte,
 )
-from utils.monto import monto_a_texto_sv
+import nota_credito_electronica
 from utils.docs import get_document_paths, get_dte_document_paths
 from utils.doc_generation import generate_invoice_pdf
 from utils.email_sender import EmailSender
@@ -47,6 +46,7 @@ import subprocess
 import shutil
 import dte
 from dialogs.nota_detalle_dialog import NotaDetalleDialog
+from decimal import Decimal
 
 # Directory where debit notes will be stored
 NOTAS_DEBITO_DIR = os.path.join(os.path.dirname(__file__), "notas_debito")
@@ -827,19 +827,16 @@ class FacturacionTab(QWidget):
                     "id": d.get("numItem"),
                     "producto_id": d.get("codigo"),
                     "descripcion": d.get("descripcion", ""),
-                    "cantidad": d.get("cantidad", 0),
-                    "precio_unitario": d.get("precioUni", 0),
-                    "descuento": d.get("montoDescu", 0),
+                    "cantidad": float(d.get("cantidad", 0)),
+                    "precio_unitario": float(d.get("precioUni", 0)),
+                    "descuento": float(d.get("montoDescu", 0)),
                     "descuento_tipo": "$",
+                    "ventas_gravadas": float(d.get("ventaGravada", 0)),
+                    "ventas_exentas": float(d.get("ventaExenta", 0)),
+                    "ventas_no_sujetas": float(d.get("ventaNoSuj", 0)),
                 }
             )
 
-        venta = None
-        if venta_id is not None:
-            venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
-            if venta is None:
-                QMessageBox.warning(self, "Nota", "Venta asociada no encontrada")
-                return
         dialog = NotaDetalleDialog(detalles_venta, tipo, self)
         if dialog.exec_() != QDialog.Accepted:
             return
@@ -848,12 +845,11 @@ class FacturacionTab(QWidget):
             QMessageBox.warning(self, "Nota", "El monto total debe ser diferente de cero")
             return
         fecha = QDate.currentDate().toString("yyyy-MM-dd")
-
         resumen_factura = data.get("resumen", {}) or {}
         total_original = float(
             resumen_factura.get("totalPagar")
             or resumen_factura.get("montoTotalOperacion")
-            or (venta.get("total") if venta else 0)
+            or 0
         )
         if tipo == "debito":
             total_ajustado = total_original + monto
@@ -870,106 +866,90 @@ class FacturacionTab(QWidget):
         if QMessageBox.question(self, "Confirmar", resumen, QMessageBox.Yes | QMessageBox.No) != QMessageBox.Yes:
             return
 
-        if venta_id is None:
-            confirm = QMessageBox.question(
-                self,
-                "Nota",
-                "La factura no está asociada a una venta. Esto podría causar algún conflicto. ¿Desea continuar?",
-                QMessageBox.Yes | QMessageBox.No,
-            )
-            if confirm != QMessageBox.Yes:
-                return
-
         nota_id = self.manager.db.agregar_nota(
             tipo, venta_id, fecha, monto, motivo, detalles=detalles_nota
         )
 
-        if venta_id is None:
-            QMessageBox.warning(
-                self,
-                "Nota",
-                "La nota no está asociada a una venta; no se puede generar DTE.",
-            )
-            return
-
-        credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
-        venta_data = dict(venta)
-        if credito_info:
-            venta_data.update(credito_info)
-
-        if venta_data.get("vendedor_id"):
-            trabajador = self.manager.db.get_trabajador(venta_data["vendedor_id"])
-            if trabajador:
-                venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
-
-        sumas = descuentos = 0
-        ventas_exentas = ventas_no_sujetas = iva = 0
-        for d in detalles_venta:
-            base_total = d.get("precio_unitario", 0) * d.get("cantidad", 0)
-            desc = d.get("descuento", 0)
-            if d.get("descuento_tipo") == "%":
-                desc = base_total * d.get("descuento", 0) / 100
-            base = base_total - desc
-            iva_item = d.get("iva", 0)
-            tipo_fiscal = d.get("tipo_fiscal", "").lower()
-            if tipo_fiscal == "venta exenta":
-                d["ventas_exentas"] = base
-                ventas_exentas += base
-            elif tipo_fiscal == "venta no sujeta":
-                d["ventas_no_sujetas"] = base
-                ventas_no_sujetas += base
-            else:
-                d["ventas_gravadas"] = base
-                sumas += base_total
-                descuentos += desc
-                iva += iva_item
-
-        subtotal = (sumas - descuentos) + iva
-        total = subtotal + ventas_exentas + ventas_no_sujetas
-        venta_data.update(
-            {
-                "sumas": sumas,
-                "descuentos": descuentos,
-                "iva": iva,
-                "ventas_exentas": ventas_exentas,
-                "ventas_no_sujetas": ventas_no_sujetas,
-                "subtotal": subtotal,
-                "total": total,
+        detalle_map = {d["id"]: d for d in detalles_venta}
+        detalles_pdf = []
+        for det in detalles_nota or []:
+            src = detalle_map.get(det.get("detalle_id"))
+            if not src:
+                continue
+            aj = abs(det.get("ajuste", 0))
+            detalle = {
+                "cantidad": 1,
+                "descripcion": src.get("descripcion", ""),
+                "precio_unitario": aj,
+                "ventas_gravadas": aj if src.get("ventas_gravadas") else 0,
+                "ventas_exentas": aj if src.get("ventas_exentas") else 0,
+                "ventas_no_sujetas": aj if src.get("ventas_no_sujetas") else 0,
             }
-        )
-        if not venta_data.get("total_letras"):
-            try:
-                venta_data["total_letras"] = monto_a_texto_sv(total)
-            except Exception:
-                venta_data["total_letras"] = ""
+            detalles_pdf.append(detalle)
 
-        cliente = None
-        if venta.get("cliente_id"):
-            cliente = next((c for c in self.manager._clientes if c["id"] == venta["cliente_id"]), None)
-        distribuidor = None
-        if venta.get("Distribuidor_id"):
-            distribuidor = next(
-                (d for d in self.manager._Distribuidores if d["id"] == venta["Distribuidor_id"]),
-                None,
+        if tipo == "credito":
+            ratio = None
+            if not detalles_pdf:
+                ratio = Decimal(str(monto / total_original))
+            nota_json = nota_credito_electronica.generar_nce_desde_dte(
+                self.manager.db,
+                data,
+                ratio,
+                detalles=detalles_pdf or None,
+                motivo=motivo,
             )
+        elif tipo == "debito":
+            nota_json = generar_nde_desde_dte(
+                self.manager.db, data, detalles_pdf or None, monto, motivo
+            )
+        else:
+            nota_json = generar_nota_remision_json(self.manager.db, nota_id)
+
+        resumen_nota = nota_json.get("resumen", {})
+        tributos = {t.get("codigo"): t.get("valor", 0) for t in resumen_nota.get("tributos", []) or []}
+        venta_data = {
+            "sumas": float(resumen_nota.get("subTotalVentas", 0)),
+            "descuentos": float(resumen_nota.get("totalDescu", 0)),
+            "iva": float(tributos.get("20", 0)),
+            "ventas_exentas": float(resumen_nota.get("totalExenta", 0)),
+            "ventas_no_sujetas": float(resumen_nota.get("totalNoSuj", 0)),
+            "subtotal": float(resumen_nota.get("subTotal", 0)),
+            "total": float(resumen_nota.get("montoTotalOperacion", 0)),
+            "total_letras": resumen_nota.get("totalLetras", ""),
+        }
+        if not detalles_pdf:
+            detalles_pdf = []
+            for d in nota_json.get("cuerpoDocumento", []) or []:
+                detalles_pdf.append(
+                    {
+                        "cantidad": float(d.get("cantidad", 1)),
+                        "descripcion": d.get("descripcion", ""),
+                        "precio_unitario": float(d.get("precioUni", 0)),
+                        "ventas_gravadas": float(d.get("ventaGravada", 0)),
+                        "ventas_exentas": float(d.get("ventaExenta", 0)),
+                        "ventas_no_sujetas": float(d.get("ventaNoSuj", 0)),
+                    }
+                )
+
+        cliente = data.get("receptor", {}) or {}
+        distribuidor = {}
 
         conf = {
-            "debito": (NOTAS_DEBITO_DIR, "NotaDebito", generar_nota_debito_pdf, generar_nota_debito_json),
-            "credito": (NOTAS_CREDITO_DIR, "NotaCredito", generar_nota_credito_pdf, generar_nota_credito_json),
-            "remision": (NOTAS_REMISION_DIR, "NotaRemision", generar_nota_remision_pdf, generar_nota_remision_json),
+            "debito": (NOTAS_DEBITO_DIR, "NotaDebito", generar_nota_debito_pdf),
+            "credito": (NOTAS_CREDITO_DIR, "NotaCredito", generar_nota_credito_pdf),
+            "remision": (NOTAS_REMISION_DIR, "NotaRemision", generar_nota_remision_pdf),
         }
-        out_dir, doc_type, pdf_func, json_func = conf.get(tipo)
+        out_dir, doc_type, pdf_func = conf.get(tipo)
         os.makedirs(out_dir, exist_ok=True)
-        nota_json = json_func(self.manager.db, nota_id)
         pdf_path, json_path = get_dte_document_paths(
             nota_json["identificacion"].get("fecEmi"),
-            cliente.get("nombre") if cliente else "",
+            cliente.get("nombre") or cliente.get("nombreComercial") or "",
             nota_json["identificacion"].get("numeroControl"),
             doc_type,
         )
         pdf_func(
             venta_data,
-            detalles_venta,
+            detalles_pdf,
             cliente or {},
             distribuidor or {},
             archivo=pdf_path,

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -1,6 +1,8 @@
 import fitz
+from decimal import Decimal
 from db import DB
-from nota_credito_electronica import generar_nce_desde_nota
+from dte import generar_dte_json
+from nota_credito_electronica import generar_nce_desde_dte
 from factura_sv import generar_nota_credito_pdf
 
 
@@ -25,14 +27,8 @@ def test_generar_nota_credito_json_ticket(tmp_path, monkeypatch):
     pid = db.cursor.lastrowid
     venta_id = db.add_venta("2024-01-01", 10)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
-    db.cursor.execute(
-        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
-        (venta_id, "credito", "2024-01-02", 10, "Dev"),
-    )
-    nota_id = db.cursor.lastrowid
-    db.conn.commit()
-
-    data = generar_nce_desde_nota(db, nota_id)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), motivo="Dev")
     assert data["identificacion"]["tipoDte"] == "05"
     assert data.get("documentoRelacionado")
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "03"
@@ -64,14 +60,8 @@ def test_generar_nota_credito_json_factura(tmp_path, monkeypatch):
         cliente_id, "2024-01-01", 10, "123", "06141407100012", "giro", descuentos=0
     )
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
-    db.cursor.execute(
-        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
-        (venta_id, "credito", "2024-01-02", 10, "Dev"),
-    )
-    nota_id = db.cursor.lastrowid
-    db.conn.commit()
-
-    data = generar_nce_desde_nota(db, nota_id)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="01")
+    data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), motivo="Dev")
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert "-" not in data["receptor"].get("nit", "")
 

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,6 +1,6 @@
 import fitz
 from db import DB
-from dte import generar_nota_debito_json, generar_nota_remision_json, generar_dte_json
+from dte import generar_nde_desde_dte, generar_nota_remision_json, generar_dte_json
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
 
 
@@ -59,14 +59,8 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "1234567", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
-    db.cursor.execute(
-        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
-        (venta_id, "debito", "2024-01-02", 10, "Ajuste"),
-    )
-    nota_id = db.cursor.lastrowid
-    db.conn.commit()
-
-    data = generar_nota_debito_json(db, nota_id)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="01")
+    data = generar_nde_desde_dte(db, dte_origen, None, 10, "Ajuste")
     assert data["identificacion"]["tipoDte"] == "06"
     assert data["resumen"]["montoTotalOperacion"] > 0
     doc_rel = data["documentoRelacionado"][0]
@@ -77,15 +71,32 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     assert "-" not in data["emisor"].get("nit", "")
 
 
-def test_generar_nota_remision_json_factura(tmp_path):
+def test_generar_nota_remision_json_factura(tmp_path, monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
     db = create_db()
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", None,  vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "nit1", "", "giro", "", "", "", "", "")
+    db.add_cliente("Cliente", "123", "06141407100012", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "nit1", "giro", descuentos=0)
+    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
     db.cursor.execute(
         "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -1,7 +1,7 @@
-import json
 from db import DB
-from nota_credito_electronica import generar_nce_desde_nota
-from dte import generar_nota_debito_json
+from decimal import Decimal
+from nota_credito_electronica import generar_nce_desde_dte
+from dte import generar_nde_desde_dte, generar_dte_json
 
 def create_db():
     return DB(":memory:")
@@ -38,13 +38,8 @@ def test_generar_nce_detalles(monkeypatch):
             "ventas_no_sujetas": 0,
         }
     ]
-    db.cursor.execute(
-        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?,?,?,?,?,?)",
-        (venta_id, "credito", "2024-01-02", 10, "Dev", json.dumps(detalles)),
-    )
-    nota_id = db.cursor.lastrowid
-    db.conn.commit()
-    data = generar_nce_desde_nota(db, nota_id)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles, motivo="Dev")
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 10
     assert data["resumen"]["totalGravada"] == 10
@@ -69,13 +64,8 @@ def test_generar_nota_debito_detalles(monkeypatch):
             "ventas_no_sujetas": 0,
         }
     ]
-    db.cursor.execute(
-        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?,?,?,?,?,?)",
-        (venta_id, "debito", "2024-01-02", 2, "Ajuste", json.dumps(detalles)),
-    )
-    nota_id = db.cursor.lastrowid
-    db.conn.commit()
-    data = generar_nota_debito_json(db, nota_id)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    data = generar_nde_desde_dte(db, dte_origen, detalles, 2, "Ajuste")
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 2
     assert data["resumen"]["totalGravada"] == 2


### PR DESCRIPTION
## Summary
- Generate debit and credit notes from invoice JSON, eliminating venta_id checks
- Add `generar_nde_desde_dte` helper for building debit notes directly from DTE data
- Use receptor details and JSON-derived totals when creating note PDFs

## Testing
- `pytest tests/test_nota_credito.py tests/test_nota_debito_remision.py tests/test_nota_detalles.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb40b4ea648323814068f24d886a24