### PR TITLE
Reuse saved JWS for notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3953,8 +3953,13 @@ def _parse_error_response(respuesta: dict) -> str:
     return mensaje
 
 
-def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> dict:
-    """Firma y envía ``data`` a la API de Hacienda registrando el envío."""
+def _enviar_documento(
+    db: DB, doc_id: int, data: dict, modo: str = "normal", jws_token: str | None = None
+) -> dict:
+    """Firma y envía ``data`` registrando el envío.
+
+    Si ``jws_token`` se proporciona, se reutiliza en lugar de firmar nuevamente.
+    """
     config = _load_dte_api_config()
     if modo == "contingencia":
         db.registrar_envio_dte(doc_id, modo, "Pendiente", "")
@@ -3996,7 +4001,7 @@ def _enviar_documento(db: DB, doc_id: int, data: dict, modo: str = "normal") -> 
         logger.error("ERROR: DTE inválido: %s", exc)
         raise ValueError(f"DTE inválido: {exc}") from exc
 
-    signed = jws.sign_json(data)
+    signed = jws_token or jws.sign_json(data)
 
     # Verify that metadata matches the signed payload and update it
     payload = _decode_jws_payload(signed)
@@ -4074,7 +4079,25 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     #     json_path = save_dte_json(data)
     #     errors = _format_validation_errors(exc)
     #     raise DTEValidationError(errors, json_path) from exc
-    return _enviar_documento(db, nota_id, data, modo)
+    from utils.docs import get_dte_document_paths
+
+    ident = data.get("identificacion", {})
+    receptor = data.get("receptor", {}) or {}
+    _, json_path = get_dte_document_paths(
+        ident.get("fecEmi"),
+        receptor.get("nombre") or receptor.get("nombreComercial") or "",
+        ident.get("numeroControl"),
+        "NotaCredito",
+    )
+    jws_path = os.path.splitext(json_path)[0] + ".jws"
+    jws_token = None
+    if os.path.exists(jws_path):
+        try:
+            with open(jws_path, "r", encoding="utf-8") as fh:
+                jws_token = fh.read()
+        except Exception:
+            jws_token = None
+    return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
 
 
 def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
@@ -4089,7 +4112,25 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     #     json_path = save_dte_json(data)
     #     errors = _format_validation_errors(exc)
     #     raise DTEValidationError(errors, json_path) from exc
-    return _enviar_documento(db, nota_id, data, modo)
+    from utils.docs import get_dte_document_paths
+
+    ident = data.get("identificacion", {})
+    receptor = data.get("receptor", {}) or {}
+    _, json_path = get_dte_document_paths(
+        ident.get("fecEmi"),
+        receptor.get("nombre") or receptor.get("nombreComercial") or "",
+        ident.get("numeroControl"),
+        "NotaDebito",
+    )
+    jws_path = os.path.splitext(json_path)[0] + ".jws"
+    jws_token = None
+    if os.path.exists(jws_path):
+        try:
+            with open(jws_path, "r", encoding="utf-8") as fh:
+                jws_token = fh.read()
+        except Exception:
+            jws_token = None
+    return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
 
 
 def enviar_nota_remision(db: DB, nota_id: int, modo: str = "normal") -> dict:

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -40,6 +40,7 @@ import nota_credito_electronica
 from utils.docs import get_document_paths, get_dte_document_paths
 from utils.doc_generation import generate_invoice_pdf
 from utils.email_sender import EmailSender
+from utils.jws import sign_and_save
 from paths import DATOS_NEGOCIO_PATH
 import tempfile
 import subprocess
@@ -954,8 +955,7 @@ class FacturacionTab(QWidget):
             distribuidor or {},
             archivo=pdf_path,
         )
-        with open(json_path, "w", encoding="utf-8") as fh:
-            json.dump(nota_json, fh, ensure_ascii=False, indent=2)
+        sign_and_save(nota_json, json_path)
 
         try:
             if tipo == "debito":

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import pytest
 
 from pathlib import Path
@@ -15,6 +16,7 @@ from dte import (
 import dte
 import auth
 from tests.conftest import make_jws
+from utils import docs
 
 
 def create_sale(db):
@@ -267,6 +269,116 @@ def test_enviar_nota_credito(monkeypatch, tmp_path):
     assert headers["Content-Type"] == "application/json"
     assert headers["Accept"] == "application/json"
     assert headers["User-Agent"] == "Vertex-DTE/1.0"
+
+
+def test_enviar_nota_credito_reuses_jws(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+    nota_id = db.add_nota(venta, "credito", "2024-01-02", 10, "motivo")
+
+    data = {
+        "receptor": {"nombre": "Cliente"},
+        "cuerpoDocumento": [{"cantidad": 1, "precioUni": 10}],
+        "resumen": {
+            "totalNoSuj": 0,
+            "totalExenta": 0,
+            "totalGravada": 10,
+            "subTotalVentas": 10,
+            "descuNoSuj": 0,
+            "descuExenta": 0,
+            "descuGravada": 0,
+            "porcentajeDescuento": 0,
+            "totalDescu": 0,
+            "tributos": [],
+            "subTotal": 10,
+            "ivaRete1": 0,
+            "reteRenta": 0,
+            "montoTotalOperacion": 10,
+            "totalNoGravado": 0,
+            "totalPagar": 10,
+            "totalLetras": "DIEZ",
+            "totalIva": 0,
+            "saldoFavor": 0,
+            "condicionOperacion": 1,
+            "pagos": None,
+            "numPagoElectronico": None,
+        },
+        "identificacion": {
+            "tipoDte": "01",
+            "version": 2,
+            "ambiente": "00",
+            "codigoGeneracion": "NC1",
+            "numeroControl": "1",
+            "fecEmi": "2024-01-02",
+        },
+    }
+
+    monkeypatch.setattr(
+        "dte.generar_nota_credito_json",
+        lambda db_obj, nid: data,
+    )
+
+    sign_calls = {"count": 0}
+
+    def fake_sign(payload):
+        sign_calls["count"] += 1
+        return "SIGNED"
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
+
+    orig_paths = docs.get_dte_document_paths
+
+    def fake_paths(fecha, empresa, numero_control, doc_type, root=None):
+        return orig_paths(fecha, empresa, numero_control, doc_type, root=tmp_path)
+
+    monkeypatch.setattr(docs, "get_dte_document_paths", fake_paths)
+
+    _, json_path = fake_paths(
+        data["identificacion"]["fecEmi"],
+        data["receptor"]["nombre"],
+        data["identificacion"]["numeroControl"],
+        "NotaCredito",
+    )
+    jws_path = os.path.splitext(json_path)[0] + ".jws"
+    token = make_jws(data)
+    with open(jws_path, "w", encoding="utf-8") as fh:
+        fh.write(token)
+
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=20):
+        captured["token"] = json["documento"]
+
+        class R:
+            status_code = 200
+
+            def json(self):
+                return {"estado": "Transmitido", "sello": "XYZ"}
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: "apitest.dtes.mh.gob.sv")
+
+    orig_load = dte._load_datos_negocio
+
+    def fake_load():
+        cfg = orig_load()
+        cfg.setdefault("dte_api", {})["url"] = dte.DEFAULT_RECEPCION_URL
+        cfg["dte_api"]["ambiente"] = "pruebas"
+        return cfg
+
+    monkeypatch.setattr(dte, "_load_datos_negocio", fake_load)
+
+    res = enviar_nota_credito(db, nota_id)
+    assert res["estado"] == "Transmitido"
+    assert captured["token"] == token
+    assert sign_calls["count"] == 0
 
 
 def test_post_dte_packs_jws_in_json_body(monkeypatch):


### PR DESCRIPTION
## Summary
- Use `sign_and_save` when generating credit/debit/remision notes so JSON and JWS are produced together
- Reuse existing JWS in `enviar_nota_credito` and `enviar_nota_debito` to avoid re-signing
- Add regression test covering JWS reuse for credit notes

## Testing
- `pytest tests/test_envio_documentos.py::test_enviar_nota_credito -q`
- `pytest tests/test_envio_documentos.py::test_enviar_nota_credito_reuses_jws -q`
- `pytest -q` *(fails: libGL.so.1 missing; No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68bb490ef85c8323b53a7dc3288550ae