### PR TITLE
Enhance debit note generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 import base64
+import copy
 import platform
 import sys
 import re
@@ -122,6 +123,7 @@ def sanitize_dte_payload(data: dict, schema: dict | None = None) -> dict:
         "tipoContingencia",
         "motivoContin",
         "nombreComercial",
+        "numPagoElectronico",
     }
 
     def _remove_nulls(value, parent_key=None):
@@ -3182,8 +3184,12 @@ def generar_nde_desde_dte(
     ]
 
     emisor = dte_origen.get("emisor")
-    receptor = dte_origen.get("receptor")
+    receptor = copy.deepcopy(dte_origen.get("receptor", {}))
     from utils.sanitize import limpiar_documentos
+
+    receptor.setdefault("nombreComercial", None)
+    if not receptor.get("nit"):
+        raise ValueError("receptor.nit es obligatorio para notas de débito")
 
     limpiar_documentos(emisor)
     limpiar_documentos(receptor)
@@ -3335,6 +3341,11 @@ def generar_nde_desde_dte(
         "descuExenta": 0.0,
         "descuGravada": 0.0,
         "totalDescu": 0.0,
+        "ivaPerci1": 0.0,
+        "ivaRete1": 0.0,
+        "reteRenta": 0.0,
+        "condicionOperacion": dte_origen.get("resumen", {}).get("condicionOperacion", 1),
+        "numPagoElectronico": dte_origen.get("resumen", {}).get("numPagoElectronico"),
         "tributos": tributos_resumen,
         "montoTotalOperacion": monto_total,
         "totalLetras": monto_a_texto_sv(float(monto_total)),


### PR DESCRIPTION
## Summary
- Validate and copy debtor data when generating debit notes
- Include additional resumen fields and preserve numPagoElectronico

## Testing
- `pytest` *(fails: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5504f0c08323941d74aeeefc9cb4