### PR TITLE
Ajustar tipoDocumento para notas de débito

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3172,9 +3172,11 @@ def generar_nde_desde_dte(
     }
 
     origen_ident = dte_origen.get("identificacion", {})
+    tipo_origen = origen_ident.get("tipoDte")
+    tipo_rel = "07" if tipo_origen == "07" else "03"
     doc_rel = [
         {
-            "tipoDocumento": origen_ident.get("tipoDte"),
+            "tipoDocumento": tipo_rel,
             "tipoGeneracion": 2,
             "numeroDocumento": origen_ident.get("codigoGeneracion"),
             "fechaEmision": origen_ident.get("fecEmi"),

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -64,7 +64,7 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     assert data["identificacion"]["tipoDte"] == "06"
     assert data["resumen"]["montoTotalOperacion"] > 0
     doc_rel = data["documentoRelacionado"][0]
-    assert doc_rel["tipoDocumento"] == "01"
+    assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["fechaEmision"]
     assert doc_rel["numeroDocumento"] != data["identificacion"].get("numeroControl")

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -69,3 +69,5 @@ def test_generar_nota_debito_detalles(monkeypatch):
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 2
     assert data["resumen"]["totalGravada"] == 2
+    doc_rel = data["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"


### PR DESCRIPTION
## Summary
- Establece `tipoDocumento` de notas de débito en `03` excepto para origen `07`
- Actualiza pruebas de notas de débito para reflejar la nueva lógica

## Testing
- `pytest tests/test_nota_debito_remision.py tests/test_nota_detalles.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bb5504e0a48323b57c783b63a6180a