### PR TITLE
Handle missing receiver NIT when generating debit notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3185,13 +3185,12 @@ def generar_nde_desde_dte(
         }
     ]
 
-    emisor = dte_origen.get("emisor")
+    emisor = copy.deepcopy(dte_origen.get("emisor", {}))
     receptor = copy.deepcopy(dte_origen.get("receptor", {}))
     from utils.sanitize import limpiar_documentos
 
     receptor.setdefault("nombreComercial", None)
-    if not receptor.get("nit"):
-        raise ValueError("receptor.nit es obligatorio para notas de débito")
+    receptor.setdefault("nit", None)
 
     limpiar_documentos(emisor)
     limpiar_documentos(receptor)

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -71,6 +71,66 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     assert "-" not in data["emisor"].get("nit", "")
 
 
+def test_generar_nde_consumidor_final_sin_nit(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    db = create_db()
+    dte_origen = {
+        "identificacion": {"tipoDte": "01", "codigoGeneracion": "UUID", "fecEmi": "2024-01-01"},
+        "emisor": {},
+        "receptor": {"nombre": "Consumidor Final"},
+        "resumen": {
+            "montoTotalOperacion": 10,
+            "totalGravada": 10,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+        },
+    }
+    data = generar_nde_desde_dte(db, dte_origen, None, 10, "Ajuste")
+    assert data["identificacion"]["tipoDte"] == "06"
+
+
+def test_generar_nde_ticket_minimo(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    db = create_db()
+    dte_origen = {
+        "identificacion": {"tipoDte": "03", "codigoGeneracion": "UUID", "fecEmi": "2024-01-01"},
+        "emisor": {},
+        "receptor": {},
+        "resumen": {
+            "montoTotalOperacion": 5,
+            "totalGravada": 5,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+        },
+    }
+    data = generar_nde_desde_dte(db, dte_origen, None, 5, "Ajuste")
+    assert data["identificacion"]["tipoDte"] == "06"
+
+
 def test_generar_nota_remision_json_factura(tmp_path, monkeypatch):
     datos = {
         "nit": "0614-140710-001-2",


### PR DESCRIPTION
## Summary
- allow `generar_nde_desde_dte` to accept DTEs without receptor NIT
- add regression tests for NDE generation on consumer invoices and tickets with minimal receiver info

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts="" tests/test_nota_debito_remision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf475b56c832383db46a77afb5ecd