### PR TITLE
Skip NIT validation for ticket DTEs

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1269,9 +1269,17 @@ def recalcular_totales(
         precios_flag = True
         extra_conf["precios_incluyen_iva"] = True
         data["extra"] = extra_conf
-        nit = str(data.get("receptor", {}).get("nit") or "")
-        if not (len(nit) == 14 and nit.isdigit()):
-            raise ValueError("receptor.nit debe tener 14 dígitos sin guiones")
+        # ``03`` se usa tanto para comprobantes de crédito fiscal como para
+        # tickets.  Solo los primeros requieren un NIT receptor válido; los
+        # tickets pueden omitirlo.  Se omite la validación si no hay receptor
+        # o si ``extra['es_ticket']`` está definido y es verdadero.
+        receptor = data.get("receptor") or {}
+        if receptor and not extra_conf.get("es_ticket"):
+            nit = str(receptor.get("nit") or "")
+            if not (len(nit) == 14 and nit.isdigit()):
+                raise ValueError(
+                    "receptor.nit debe tener 14 dígitos sin guiones"
+                )
     else:
         precios_flag = _precios_incluyen_iva_from(extra_conf, precios_incluyen_iva)
 
@@ -3117,11 +3125,16 @@ def generar_ticket_json(
     motivo_contin: str | None = None,
     **kwargs,
 ) -> dict:
-    """Genera la estructura JSON para un Ticket Electrónico."""
+    """Genera la estructura JSON para un Ticket Electrónico.
+
+    El resultado se marca con ``extra['es_ticket']`` para indicar que se trata
+    de un ticket y no de un comprobante de crédito fiscal completo.
+    """
     if ambiente not in ("00", "01"):
         ambiente_cfg = str(ambiente).lower()
         ambiente = "01" if ambiente_cfg.startswith("produc") else "00"
-    return generar_dte_json(
+
+    data = generar_dte_json(
         db,
         venta_id,
         tipo_dte="03",
@@ -3131,6 +3144,9 @@ def generar_ticket_json(
         motivo_contin=motivo_contin,
         **kwargs,
     )
+
+    data.setdefault("extra", {})["es_ticket"] = True
+    return data
 
 
 def generar_nota_credito_json(db: DB, nota_id: int) -> dict:

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -1,0 +1,46 @@
+from decimal import Decimal
+from db import DB
+from dte import generar_ticket_json, recalcular_totales
+from nota_credito_electronica import generar_nce_desde_dte
+
+
+def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
+    # Mock dependencies for business data and validation
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "",  # NIT vacío para simular ticket sin NIT
+        "",
+        "giro",
+        "",
+        "",
+        "",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cliente_id)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = generar_ticket_json(db, venta_id)
+    # No debe lanzar error al recalcular totales aunque no haya NIT
+    recalcular_totales(data)
+
+    nce = generar_nce_desde_dte(db, data, Decimal("1"), motivo="Dev")
+    assert nce["identificacion"]["tipoDte"] == "05"
+    assert nce["documentoRelacionado"][0]["tipoDocumento"] == "03"


### PR DESCRIPTION
## Summary
- allow tipoDte 03 tickets without NIT by marking tickets and skipping NIT validation
- document ticket flag usage and add regression test for ticket note generation

## Testing
- `pytest tests/test_ticket_nitless.py::test_recalcular_ticket_sin_nit_generar_nota -q`
- `pytest tests/test_generar_dte_json.py::test_generar_ticket_json_tipo -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdf475dcec832384c9983a8c4a61d0