### PR TITLE
Manejar errores al importar JSON

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -321,7 +321,12 @@ class InventoryManager:
 
     def importar_inventario_json(self, filename):
         with open(filename, "r", encoding="utf-8") as f:
-            data = json.load(f)
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                raise InventoryManagerError(
+                    f"No se pudo importar inventario desde {filename}: JSON malformado en línea {e.lineno}, columna {e.colno}"
+                ) from e
         # Limpia tablas hijas primero para evitar violaciones de clave foránea
         self.db.conn.execute("BEGIN")
         try:

--- a/tests/test_import_malformed_json.py
+++ b/tests/test_import_malformed_json.py
@@ -1,0 +1,22 @@
+import inventory_manager as im
+import pytest
+
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+def test_importar_json_malformado(tmp_path, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    manager = im.InventoryManager()
+    bad_file = tmp_path / "malformado.json"
+    bad_file.write_text("{", encoding="utf-8")
+
+    with pytest.raises(im.InventoryManagerError) as excinfo:
+        manager.importar_inventario_json(str(bad_file))
+
+    msg = str(excinfo.value)
+    assert str(bad_file) in msg
+    assert ("línea" in msg or "linea" in msg)
+    assert "columna" in msg


### PR DESCRIPTION
## Resumen
- Maneja `json.JSONDecodeError` en `importar_inventario_json` y relanza `InventoryManagerError` con detalle de ubicación.
- Agrega prueba que verifica el manejo de JSON malformado.

## Testing
- `pytest tests/test_import_malformed_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be156032ac8323bfed39f925d09f72