### PR TITLE
Handle IVA-inclusive adjustments for notas

### DIFF
--- a/dialogs/nota_detalle_dialog.py
+++ b/dialogs/nota_detalle_dialog.py
@@ -69,14 +69,20 @@ class NotaDetalleDialog(QDialog):
             desc = d.get("descuento", 0)
             if d.get("descuento_tipo") == "%":
                 desc = price * qty * d.get("descuento", 0) / 100
-            total = price * qty - desc
+
+            has_iva = bool(d.get("ventas_gravadas"))
+            mult = 1.13 if has_iva else 1
+
+            price_iva = price * mult
+            desc_iva = desc * mult
+            total_iva = (price * qty - desc) * mult
 
             items = [
                 QTableWidgetItem(str(prod)),
                 QTableWidgetItem(f"{qty}"),
-                QTableWidgetItem(f"{price:.2f}"),
-                QTableWidgetItem(f"{desc:.2f}"),
-                QTableWidgetItem(f"{total:.2f}"),
+                QTableWidgetItem(f"{price_iva:.2f}"),
+                QTableWidgetItem(f"{desc_iva:.2f}"),
+                QTableWidgetItem(f"{total_iva:.2f}"),
             ]
             for col, item in enumerate(items):
                 item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -838,10 +838,43 @@ class FacturacionTab(QWidget):
                 }
             )
 
+        detalle_map = {d["id"]: d for d in detalles_venta}
+
         dialog = NotaDetalleDialog(detalles_venta, tipo, self)
         if dialog.exec_() != QDialog.Accepted:
             return
         monto, motivo, detalles_nota = dialog.get_data()
+        for det in detalles_nota or []:
+            src = detalle_map.get(det.get("detalle_id"))
+            ajuste_total = abs(det.get("ajuste", 0))
+            if src and src.get("ventas_gravadas"):
+                base = ajuste_total / 1.13
+                iva = ajuste_total - base
+                det.update({
+                    "ventas_gravadas": base,
+                    "iva": iva,
+                    "precio_unitario": base,
+                })
+            elif src and src.get("ventas_exentas"):
+                det.update({
+                    "ventas_exentas": ajuste_total,
+                    "iva": 0.0,
+                    "precio_unitario": ajuste_total,
+                })
+            elif src and src.get("ventas_no_sujetas"):
+                det.update({
+                    "ventas_no_sujetas": ajuste_total,
+                    "iva": 0.0,
+                    "precio_unitario": ajuste_total,
+                })
+            else:
+                base = ajuste_total / 1.13
+                iva = ajuste_total - base
+                det.update({
+                    "ventas_gravadas": base,
+                    "iva": iva,
+                    "precio_unitario": base,
+                })
         if monto == 0:
             QMessageBox.warning(self, "Nota", "El monto total debe ser diferente de cero")
             return
@@ -871,20 +904,18 @@ class FacturacionTab(QWidget):
             tipo, venta_id, fecha, monto, motivo, detalles=detalles_nota
         )
 
-        detalle_map = {d["id"]: d for d in detalles_venta}
         detalles_pdf = []
         for det in detalles_nota or []:
             src = detalle_map.get(det.get("detalle_id"))
             if not src:
                 continue
-            aj = abs(det.get("ajuste", 0))
             detalle = {
                 "cantidad": 1,
                 "descripcion": src.get("descripcion", ""),
-                "precio_unitario": aj,
-                "ventas_gravadas": aj if src.get("ventas_gravadas") else 0,
-                "ventas_exentas": aj if src.get("ventas_exentas") else 0,
-                "ventas_no_sujetas": aj if src.get("ventas_no_sujetas") else 0,
+                "precio_unitario": det.get("precio_unitario", 0),
+                "ventas_gravadas": det.get("ventas_gravadas", 0),
+                "ventas_exentas": det.get("ventas_exentas", 0),
+                "ventas_no_sujetas": det.get("ventas_no_sujetas", 0),
             }
             detalles_pdf.append(detalle)
 


### PR DESCRIPTION
## Summary
- Display IVA-inclusive unit price and total in nota detail dialog
- Convert IVA-inclusive adjustments to base and IVA portions in nota generation

## Testing
- `pytest -q` *(fails: libGL.so.1 missing and FastAPI not installed)*
- `apt-get install -y libgl1`
- `pip install fastapi`
- `pytest --no-cov tests/test_nota_detalles.py::test_generar_nce_detalles -q`


------
https://chatgpt.com/codex/tasks/task_e_68be1c67cd688323b770a75b91cf3e1c