### PR TITLE
Calcular IVA de notas de crédito a partir del total original

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -273,7 +273,8 @@ def generar_nce_desde_dte(
             )
 
     subtotal_ventas = total_grav + total_exenta + total_nosuj
-    iva_val = d2(Decimal(str(total_grav)) * IVA)
+    orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (ratio or Decimal("1"))
+    iva_val = d2(orig_total - Decimal(str(subtotal_ventas)))
     tributos_resumen = []
     if iva_val > 0:
         tributos_resumen.append(
@@ -283,7 +284,7 @@ def generar_nce_desde_dte(
                 "valor": iva_val,
             }
         )
-    monto_total_operacion = d2(Decimal(str(subtotal_ventas)) + Decimal(str(iva_val)))
+    monto_total_operacion = d2(orig_total)
     resumen = {
         "totalNoSuj": total_nosuj,
         "totalExenta": total_exenta,

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -70,6 +70,29 @@ def test_generar_nota_credito_json_factura(tmp_path, monkeypatch):
     assert "-" not in data["receptor"].get("nit", "")
 
 
+def test_nota_credito_total_nueve(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 9)
+    db.add_detalle_venta(venta_id, pid, 1, 7.96, vendedor_id=vid)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    assert dte_origen["resumen"]["montoTotalOperacion"] == Decimal("9.00")
+    data = generar_nce_desde_dte(db, dte_origen, Decimal("1"))
+    assert data["resumen"]["montoTotalOperacion"] == 9.0
+
+
 def _sample_data():
     venta = {
         "sumas": 10,


### PR DESCRIPTION
## Summary
- Corrige cálculo de IVA en notas de crédito usando el monto original del documento.
- Actualiza el total de la operación basado en el monto original.
- Añade prueba que garantiza que una nota generada desde una factura de $9.00 conserve ese total.

## Testing
- `pytest tests/test_nota_credito.py tests/test_notas.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be24c647d08323b37fec033a0db5a2