### PR TITLE
Ajuste de IVA y monto total en notas de débito

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3337,7 +3337,10 @@ def generar_nde_desde_dte(
             )
 
     subtotal_ventas = total_grav + total_exenta + total_nosuj
-    iva_val = d2(Decimal(str(total_grav)) * Decimal("0.13"))
+    orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (
+        ratio if "ratio" in locals() else Decimal("1")
+    )
+    iva_val = d2(orig_total - subtotal_ventas)
     tributos_resumen = []
     if iva_val > 0:
         tributos_resumen.append(
@@ -3347,7 +3350,7 @@ def generar_nde_desde_dte(
                 "valor": iva_val,
             }
         )
-    monto_total = d2(Decimal(str(subtotal_ventas)) + Decimal(str(iva_val)))
+    monto_total = d2(orig_total)
     resumen = {
         "totalNoSuj": total_nosuj,
         "totalExenta": total_exenta,

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,4 +1,5 @@
 import fitz
+from decimal import Decimal
 from db import DB
 from dte import generar_nde_desde_dte, generar_nota_remision_json, generar_dte_json
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
@@ -129,6 +130,40 @@ def test_generar_nde_ticket_minimo(monkeypatch):
     }
     data = generar_nde_desde_dte(db, dte_origen, None, 5, "Ajuste")
     assert data["identificacion"]["tipoDte"] == "06"
+
+
+def test_generar_nde_conserva_total(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "UUID",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {"nombre": "Consumidor Final"},
+        "resumen": {
+            "montoTotalOperacion": 11.3,
+            "totalGravada": 10,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+        },
+    }
+    data = generar_nde_desde_dte(db, dte_origen, None, 1, "Ajuste")
+    assert data["resumen"]["montoTotalOperacion"] == Decimal("1.00")
 
 
 def test_generar_nota_remision_json_factura(tmp_path, monkeypatch):


### PR DESCRIPTION
## Resumen
- Corrige cálculo de IVA en `generar_nde_desde_dte` para basarse en el total original del DTE
- Ajusta monto total utilizando el valor original del documento
- Añade prueba que verifica la conservación del total original en notas de débito

## Testing
- `python -m pytest tests/test_nota_debito_remision.py -q`
- `python -m pytest -q -c /dev/null tests/test_nota_debito_remision.py::test_generar_nde_conserva_total`


------
https://chatgpt.com/codex/tasks/task_e_68be24c6e47883239184ecc10d8788c0