### PR TITLE
Preserve 4-decimal precision in ND generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3231,7 +3231,8 @@ def generar_nde_desde_dte(
             total_nosuj += nosuj
             precio = det.get("precio_unitario") or det.get("precioUni")
             if precio is None:
-                precio = float(grav + exenta + nosuj)
+                precio = grav + exenta + nosuj
+            precio = d4(precio)
             cantidad = det.get("cantidad", 1)
             items.append(
                 {
@@ -3245,10 +3246,10 @@ def generar_nde_desde_dte(
                     "cantidad": cantidad,
                     "uniMedida": det.get("uniMedida", 59),
                     "precioUni": precio,
-                    "montoDescu": det.get("montoDescu", 0.0),
-                    "ventaGravada": d2(grav),
-                    "ventaExenta": d2(exenta),
-                    "ventaNoSuj": d2(nosuj),
+                    "montoDescu": d4(det.get("montoDescu", 0.0)),
+                    "ventaGravada": d4(grav),
+                    "ventaExenta": d4(exenta),
+                    "ventaNoSuj": d4(nosuj),
                     "tributos": [TRIBUTO_IVA] if grav > 0 else [],
                     "numeroDocumento": uuid_origen,
                     "codTributo": None,

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -71,3 +71,38 @@ def test_generar_nota_debito_detalles(monkeypatch):
     assert data["resumen"]["totalGravada"] == 2
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
+
+
+def test_generar_nota_debito_precio_4_decimales(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "UUID",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {},
+        "resumen": {
+            "montoTotalOperacion": Decimal("1.23"),
+            "totalGravada": Decimal("0"),
+            "totalExenta": Decimal("1.23"),
+            "totalNoSuj": Decimal("0"),
+        },
+    }
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "ventas_gravadas": 0,
+            "ventas_exentas": Decimal("1.2345"),
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    data = generar_nde_desde_dte(db, dte_origen, detalles, 1.23, "Ajuste")
+    item = data["cuerpoDocumento"][0]
+    assert item["precioUni"] == Decimal("1.2345")
+    assert item["ventaExenta"] == Decimal("1.2345")
+    assert data["resumen"]["montoTotalOperacion"] == Decimal("1.23")
+    assert data["resumen"]["montoTotalOperacion"] == dte_origen["resumen"]["montoTotalOperacion"]


### PR DESCRIPTION
## Summary
- Calculate default item price for debit notes using `Decimal` and quantize to 4 decimals
- Keep unit price and related amounts at 4-decimal precision, matching original invoice
- Add regression test for 4-decimal unit price ensuring note total equals invoice total

## Testing
- `pytest tests/test_nota_detalles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be299a9be88323a8150a2fe73a26a7