### PR TITLE
Use Decimal for text amounts

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -248,7 +248,7 @@ def normalize_uuid_v4_upper(value: str) -> str:
 def numero_a_letras(monto):
     """Convierte ``monto`` numérico a su representación en letras."""
     try:
-        texto = monto_a_texto_sv(float(monto))
+        texto = monto_a_texto_sv(monto)
     except Exception:
         return ""
     if " " in texto:
@@ -3368,7 +3368,7 @@ def generar_nde_desde_dte(
         "numPagoElectronico": dte_origen.get("resumen", {}).get("numPagoElectronico"),
         "tributos": tributos_resumen,
         "montoTotalOperacion": monto_total,
-        "totalLetras": monto_a_texto_sv(float(monto_total)),
+        "totalLetras": monto_a_texto_sv(monto_total),
     }
 
     data = {

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -302,7 +302,7 @@ def generar_nce_desde_dte(
         "condicionOperacion": orig_resumen.get("condicionOperacion", 1),
         "tributos": tributos_resumen,
         "montoTotalOperacion": monto_total_operacion,
-    "totalLetras": monto_a_texto_sv(float(monto_total_operacion)),
+    "totalLetras": monto_a_texto_sv(monto_total_operacion),
     }
 
     data = {

--- a/tests/test_monto.py
+++ b/tests/test_monto.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 
 import pytest
+from decimal import Decimal
 
 
 def test_monto_a_texto_sv_import_error(monkeypatch):
@@ -12,3 +13,23 @@ def test_monto_a_texto_sv_import_error(monkeypatch):
     importlib.reload(monto)
     with pytest.raises(ImportError):
         monto.monto_a_texto_sv(10)
+
+
+def test_monto_a_texto_sv_decimal_precision():
+    from utils import monto as monto_mod
+    import importlib as il
+
+    il.reload(monto_mod)
+    monto = Decimal("2.6750")
+    original = Decimal(monto)  # ensure unchanged
+    texto = monto_mod.monto_a_texto_sv(monto)
+    assert texto == "DOS 68/100 DÓLARES"
+    assert monto == original
+
+
+def test_numero_a_letras_decimal_precision():
+    from dte import numero_a_letras
+
+    monto = Decimal("2.6750")
+    texto = numero_a_letras(monto)
+    assert texto == "DOS CON 68/100 DÓLARES"

--- a/utils/monto.py
+++ b/utils/monto.py
@@ -34,9 +34,17 @@ except ImportError:  # pragma: no cover - fallback for environments without num2
 
 
 def monto_a_texto_sv(monto):
-    """Convierte un monto a texto en formato fiscal salvadoreño."""
+    """Convierte un monto a texto en formato fiscal salvadoreño.
+
+    Acepta :class:`Decimal` o cualquier valor numérico convertible a
+    ``Decimal``. El valor se redondea a 2 decimales utilizando ``ROUND_HALF_UP``
+    para que montos con más de dos decimales se conviertan correctamente sin
+    pérdidas de precisión.
+    """
+
+    monto = D(monto).quantize(Q2, rounding=ROUND_HALF_UP)
     entero = int(monto)
-    centavos = int(round((monto - entero) * 100))
+    centavos = int((monto - D(entero)) * 100)
     palabras = num2words(entero, lang="es").upper()
     return f"{palabras} {centavos:02d}/100 DÓLARES"
 


### PR DESCRIPTION
## Summary
- handle Decimal values in `monto_a_texto_sv`
- avoid converting totals to float when generating `totalLetras`
- test 4-decimal amounts convert to text correctly

## Testing
- `pytest tests/test_monto.py::test_monto_a_texto_sv_decimal_precision tests/test_monto.py::test_numero_a_letras_decimal_precision --no-cov -q`
- `pytest tests/test_nota_credito.py::test_generar_nota_credito_json_ticket tests/test_nota_credito.py::test_generar_nota_credito_json_factura --no-cov -q`
- `pytest tests/test_dte_rounding.py::test_item_and_total_rounding --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68be299cb75883239f9bf1ad0ef04cd1