### PR TITLE
feat: soporte de DTE tipo 04

### DIFF
--- a/app/dte/__init__.py
+++ b/app/dte/__init__.py
@@ -1,14 +1,16 @@
 """Convenience imports for DTE utilities used in tests."""
 
-from .base_envelopes import ND_BASE
-from .identifiers import ND_CONTROL_REGEX, ensure_numero_control
+from .base_envelopes import ND_BASE, NR_BASE
+from .identifiers import ND_CONTROL_REGEX, NR_CONTROL_REGEX, ensure_numero_control
 from .validation import validate_dte
 from .xml_id import build_dte_id_xml
 from .signing import sign_dte, LocalRS256Signer
 
 __all__ = [
     "ND_BASE",
+    "NR_BASE",
     "ND_CONTROL_REGEX",
+    "NR_CONTROL_REGEX",
     "ensure_numero_control",
     "validate_dte",
     "build_dte_id_xml",

--- a/app/dte/base_envelopes.py
+++ b/app/dte/base_envelopes.py
@@ -1,9 +1,9 @@
 """Base envelopes for DTE generation.
 
 This module defines skeleton structures for different DTE documents.
-For the debit note ("Nota de Débito") all fields are initialised to
-``None`` except for ``identificacion.tipoDte`` which is fixed to ``"06"``
-according to the official specification.
+For each supported tipo DTE the corresponding envelope sets
+``identificacion.tipoDte`` to the fixed value dictated by the
+specification while leaving the rest of fields initialised to ``None``.
 """
 
 from __future__ import annotations
@@ -34,4 +34,32 @@ ND_BASE: dict = {
     "apendice": None,
 }
 
-__all__ = ["ND_BASE"]
+
+# Base envelope for Nota de Remisión (NR v3)
+NR_BASE: dict = {
+    "identificacion": {
+        "version": None,
+        "ambiente": None,
+        "tipoDte": "04",
+        "numeroControl": None,
+        "codigoGeneracion": None,
+        "tipoModelo": None,
+        "tipoOperacion": None,
+        "tipoContingencia": None,
+        "motivoContin": None,
+        "fecEmi": None,
+        "horEmi": None,
+        "tipoMoneda": None,
+    },
+    "documentoRelacionado": None,
+    "emisor": None,
+    "receptor": None,
+    "ventaTercero": None,
+    "cuerpoDocumento": None,
+    "resumen": None,
+    "extension": None,
+    "apendice": None,
+}
+
+
+__all__ = ["ND_BASE", "NR_BASE"]

--- a/app/dte/identifiers.py
+++ b/app/dte/identifiers.py
@@ -6,7 +6,13 @@ import re
 import uuid
 from typing import Dict, Any
 
-ND_CONTROL_REGEX = r"^DTE-06-[A-Z0-9]{8}-[0-9]{15}$"
+CONTROL_REGEXES = {
+    "04": r"^DTE-04-[A-Z0-9]{8}-[0-9]{15}$",
+    "06": r"^DTE-06-[A-Z0-9]{8}-[0-9]{15}$",
+}
+
+NR_CONTROL_REGEX = CONTROL_REGEXES["04"]
+ND_CONTROL_REGEX = CONTROL_REGEXES["06"]
 
 
 def ensure_numero_control(
@@ -17,25 +23,35 @@ def ensure_numero_control(
 ) -> str:
     """Ensure ``numeroControl`` and ``codigoGeneracion`` for the envelope.
 
-    ``numeroControl`` follows the official pattern for debit notes::
+    ``numeroControl`` follows the official pattern for the ``tipoDte``
+    present in ``identificacion``.  Currently the supported types are:
 
-        ^DTE-06-[A-Z0-9]{8}-[0-9]{15}$
+    * ``"04"`` - Nota de Remisión
+    * ``"06"`` - Nota de Débito
 
     If ``codigoGeneracion`` is missing a UUIDv4 is generated and stored in
     uppercase format.
     """
 
     ident = envelope.setdefault("identificacion", {})
+    tipo = ident.get("tipoDte")
+    if tipo not in CONTROL_REGEXES:
+        raise ValueError("identificacion.tipoDte inválido o no soportado")
 
     # ``codigoGeneracion`` must be a UUID v4 in uppercase.
     if not ident.get("codigoGeneracion"):
         ident["codigoGeneracion"] = str(uuid.uuid4()).upper()
 
     numero = ident.get("numeroControl")
-    if not (isinstance(numero, str) and re.fullmatch(ND_CONTROL_REGEX, numero)):
+    regex = CONTROL_REGEXES[tipo]
+    if not (isinstance(numero, str) and re.fullmatch(regex, numero)):
         secuencia = f"{correlativo:015d}"
-        ident["numeroControl"] = f"DTE-06-S{sucursal}P{punto}-{secuencia}"
+        ident["numeroControl"] = f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
     return ident["numeroControl"]
 
 
-__all__ = ["ND_CONTROL_REGEX", "ensure_numero_control"]
+__all__ = [
+    "ND_CONTROL_REGEX",
+    "NR_CONTROL_REGEX",
+    "ensure_numero_control",
+]

--- a/app/dte/validation.py
+++ b/app/dte/validation.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from jsonschema import Draft7Validator, validators
 
 SCHEMA_MAP = {
+    "04": "fe-nr-v3.json",
     "06": "fe-nd-v3.json",
 }
 

--- a/tests/test_nr_pipeline.py
+++ b/tests/test_nr_pipeline.py
@@ -1,0 +1,138 @@
+import re
+from copy import deepcopy
+from decimal import Decimal
+
+from app.dte import (
+    NR_BASE,
+    NR_CONTROL_REGEX,
+    ensure_numero_control,
+    validate_dte,
+    build_dte_id_xml,
+    sign_dte,
+)
+
+
+def test_nr_minimum_pipeline():
+    env = deepcopy(NR_BASE)
+    ident = env["identificacion"]
+    ident.update(
+        {
+            "version": 3,
+            "ambiente": "00",
+            "tipoModelo": 1,
+            "tipoOperacion": 1,
+            "fecEmi": "2024-01-01",
+            "horEmi": "00:00:00",
+            "tipoMoneda": "USD",
+            "tipoContingencia": None,
+            "motivoContin": None,
+        }
+    )
+
+    env["emisor"] = {
+        "nit": "06142512891020",
+        "nrc": "1234567",
+        "nombre": "Compañía Demo S.A. de C.V.",
+        "codActividad": "46484",
+        "descActividad": "Venta de productos",
+        "nombreComercial": "Demo Comercial",
+        "tipoEstablecimiento": "01",
+        "telefono": "22222222",
+        "correo": "demo@example.com",
+        "codEstable": "0001",
+        "codEstableMH": "0001",
+        "codPuntoVenta": "0001",
+        "codPuntoVentaMH": "0001",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "01",
+            "complemento": "Calle X",
+        },
+    }
+
+    env["receptor"] = {
+        "nrc": "0000011",
+        "nombre": "Consumidor Final",
+        "nombreComercial": "Cliente Ejemplo",
+        "codActividad": "6201",
+        "descActividad": "Servicios de software",
+        "telefono": "70000001",
+        "correo": "cliente@example.com",
+        "bienTitulo": "01",
+        "numDocumento": "12345678901234",
+        "tipoDocumento": "36",
+        "direccion": {
+            "departamento": "05",
+            "municipio": "01",
+            "complemento": "San Salvador",
+        },
+    }
+
+    env["documentoRelacionado"] = [
+        {
+            "tipoDocumento": "03",
+            "tipoGeneracion": 1,
+            "numeroDocumento": "DTE-03-S001P001-000000000000001",
+            "fechaEmision": "2024-01-01",
+        }
+    ]
+
+    env["ventaTercero"] = None
+
+    env["cuerpoDocumento"] = [
+        {
+            "numItem": 1,
+            "tipoItem": 1,
+            "numeroDocumento": None,
+            "codigo": "SKU001",
+            "codTributo": None,
+            "cantidad": Decimal("2.5"),
+            "precioUni": Decimal("9.54"),
+            "montoDescu": Decimal("0"),
+            "ventaGravada": Decimal("23.85"),
+            "ventaExenta": Decimal("0"),
+            "ventaNoSuj": Decimal("0"),
+            "tributos": ["20"],
+            "descripcion": "Producto de prueba",
+            "uniMedida": 59,
+        }
+    ]
+
+    env["resumen"] = {
+        "subTotal": Decimal("23.85"),
+        "subTotalVentas": Decimal("23.85"),
+        "descuGravada": Decimal("0"),
+        "descuNoSuj": Decimal("0"),
+        "descuExenta": Decimal("0"),
+        "totalDescu": Decimal("0"),
+        "porcentajeDescuento": Decimal("0"),
+        "totalGravada": Decimal("23.85"),
+        "totalNoSuj": Decimal("0"),
+        "totalExenta": Decimal("0"),
+        "tributos": [
+            {
+                "codigo": "20",
+                "descripcion": "Impuesto al Valor Agregado 13%",
+                "valor": Decimal("3.10"),
+            }
+        ],
+        "montoTotalOperacion": Decimal("26.95"),
+        "totalLetras": "VEINTISEIS CON 95/100 USD",
+    }
+
+    env["extension"] = None
+    env["apendice"] = None
+
+    ensure_numero_control(env)
+
+    errors = validate_dte(env, "04")
+    assert errors == []
+
+    xml_id = build_dte_id_xml(env)
+    ident = env["identificacion"]
+    assert ident["codigoGeneracion"] in xml_id
+    assert ident["numeroControl"] in xml_id
+
+    token = sign_dte(env)
+    assert token.count(".") == 2
+    assert re.fullmatch(NR_CONTROL_REGEX, ident["numeroControl"])


### PR DESCRIPTION
## Summary
- agregar plantillas y regex para DTE tipo 04
- exponer esquema oficial para notas de remisión
- probar pipeline mínimo para notas de remisión

## Testing
- `pytest`
- `pytest tests/test_nr_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68be2969dee0832394fa762532b48f17