### PR TITLE
Refactor remission note generation to dedicated module

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3416,27 +3416,18 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
 
 
 def generar_nota_remision_json(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
-    """Genera la estructura JSON para una nota de remisión."""
-    row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
-    if not row:
-        raise ValueError("Nota no encontrada")
-    nota = dict(row)
-    if nota.get("tipo") != "remision":
-        raise ValueError("La nota indicada no es de remisión")
+    """[DEPRECADO] Use ``nota_remision.generar_nota_remision_desde_db``."""
+    import warnings
 
-    venta_id = nota.get("venta_id")
-    venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
-    ).fetchone()
-    tipo_doc = "01"
-    if venta_row:
-        venta = dict(venta_row)
-        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-            tipo_doc = "03"
+    warnings.warn(
+        "generar_nota_remision_json está deprecado; utiliza "
+        "nota_remision.generar_nota_remision_desde_db",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from nota_remision import generar_nota_remision_desde_db
 
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
-    from nota_remision import generar_nota_remision
-    return generar_nota_remision(db, factura=dte_origen, ambiente=ambiente)
+    return generar_nota_remision_desde_db(db, nota_id, ambiente=ambiente)
 
 def _normalize_recepcion_url(raw: str) -> str:
     """Normaliza y valida ``raw`` como URL de recepción de Hacienda.
@@ -4166,7 +4157,9 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
 
 def enviar_nota_remision(db: DB, nota_id: int, modo: str = "normal") -> dict:
     """Genera y transmite una nota de remisión."""
-    data = generar_nota_remision_json(db, nota_id)
+    from nota_remision import generar_nota_remision_desde_db
+
+    data = generar_nota_remision_desde_db(db, nota_id)
     data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema("04")
     # Validación omitida.

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -30,12 +30,12 @@ from factura_sv import (
     generar_nota_remision_pdf,
 )
 from dte import (
-    generar_nota_remision_json,
     transmitir_dte,
     enviar_nota_credito,
     enviar_nota_debito,
     generar_nde_desde_dte,
 )
+from nota_remision import generar_nota_remision_desde_db
 import nota_credito_electronica
 from utils.docs import get_document_paths, get_dte_document_paths
 from utils.doc_generation import generate_invoice_pdf
@@ -935,7 +935,7 @@ class FacturacionTab(QWidget):
                 self.manager.db, data, detalles_pdf or None, monto, motivo
             )
         else:
-            nota_json = generar_nota_remision_json(self.manager.db, nota_id)
+            nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
 
         resumen_nota = nota_json.get("resumen", {})
         tributos = {t.get("codigo"): t.get("valor", 0) for t in resumen_nota.get("tributos", []) or []}

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -153,4 +153,35 @@ def generar_nota_remision(
     return sanitize_dte_payload(data, schema)
 
 
-__all__ = ["generar_nota_remision"]
+def generar_nota_remision_desde_db(
+    db: DB, nota_id: int, *, ambiente: str = "00"
+) -> dict:
+    """Genera la estructura JSON para una Nota de Remisión desde la BD.
+
+    Obtiene los datos de la nota y la venta asociada para construir la
+    estructura base y delega la construcción final a :func:`generar_nota_remision`.
+    """
+    row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
+    if not row:
+        raise ValueError("Nota no encontrada")
+    nota = dict(row)
+    if nota.get("tipo") != "remision":
+        raise ValueError("La nota indicada no es de remisión")
+
+    venta_id = nota.get("venta_id")
+    venta_row = db.cursor.execute(
+        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+    ).fetchone()
+    tipo_doc = "01"
+    if venta_row:
+        venta = dict(venta_row)
+        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
+            tipo_doc = "03"
+
+    from dte import generar_dte_json
+
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+    return generar_nota_remision(db, factura=dte_origen, ambiente=ambiente)
+
+
+__all__ = ["generar_nota_remision", "generar_nota_remision_desde_db"]

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,7 +1,8 @@
 import fitz
 from decimal import Decimal
 from db import DB
-from dte import generar_nde_desde_dte, generar_nota_remision_json, generar_dte_json
+from dte import generar_nde_desde_dte, generar_dte_json
+from nota_remision import generar_nota_remision_desde_db
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
 
 
@@ -166,7 +167,7 @@ def test_generar_nde_conserva_total(monkeypatch):
     assert data["resumen"]["montoTotalOperacion"] == Decimal("1.00")
 
 
-def test_generar_nota_remision_json_factura(tmp_path, monkeypatch):
+def test_generar_nota_remision_factura(tmp_path, monkeypatch):
     datos = {
         "nit": "0614-140710-001-2",
         "nrc": "1234567",
@@ -200,7 +201,7 @@ def test_generar_nota_remision_json_factura(tmp_path, monkeypatch):
     nota_id = db.cursor.lastrowid
     db.conn.commit()
 
-    data = generar_nota_remision_json(db, nota_id)
+    data = generar_nota_remision_desde_db(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "04"
     assert data["documentoRelacionado"]["tipoDoc"] == "01"
 


### PR DESCRIPTION
## Summary
- add `generar_nota_remision_desde_db` helper in `nota_remision` and export it
- update UI, tests and dte helpers to call the new function
- deprecate old `generar_nota_remision_json` wrapper

## Testing
- `pytest tests/test_nota_debito_remision.py -q`
- `pytest tests/test_generators.py::test_generar_nota_remision -q`


------
https://chatgpt.com/codex/tasks/task_e_68be2969e7188323b1447008ba71ad3f