### PR TITLE
feat: add global note preview with IVA breakdown

### DIFF
--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -1,0 +1,30 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import NotaForm from '../ventas/NotaForm.vue';
+
+describe('NotaForm', () => {
+  it('cambia input según modo', async () => {
+    const wrapper = mount(NotaForm, {
+      props: { factura: { numero: '1', cliente: 'A', total: 1000 }, tipo: 'credito' }
+    });
+    const radioMonto = wrapper.find('input[value="monto"]');
+    await radioMonto.setValue();
+    const input = wrapper.find('input[type="number"]');
+    expect(input.attributes('title')).toContain('Monto');
+  });
+
+  it('descompone IVA incluido con toBaseIva', async () => {
+    const wrapper = mount(NotaForm, {
+      props: { factura: { numero: '1', cliente: 'A', total: 0 }, tipo: 'credito' }
+    });
+    const radioMonto = wrapper.find('input[value="monto"]');
+    await radioMonto.setValue();
+    const input = wrapper.find('input[type="number"]');
+    await input.setValue('120');
+    await wrapper.vm.$nextTick();
+    const cells = wrapper.findAll('tbody td');
+    expect(cells[1].text()).toBe('100.00');
+    expect(cells[4].text()).toBe('20.00');
+    expect(cells[5].text()).toBe('120.00');
+  });
+});

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -19,7 +19,55 @@
           <button @click="activeTab = 'producto'" :class="{ active: activeTab === 'producto' }">Por producto</button>
         </div>
         <div v-if="activeTab === 'global'">
-          <!-- Detalle global -->
+          <div class="global-options">
+            <label title="Aplica un porcentaje del total">
+              <input type="radio" value="porcentaje" v-model="modoGlobal" />
+              Por porcentaje
+            </label>
+            <label title="Aplica un monto fijo">
+              <input type="radio" value="monto" v-model="modoGlobal" />
+              Por monto
+            </label>
+          </div>
+          <div>
+            <input
+              v-if="modoGlobal === 'porcentaje'"
+              type="number"
+              v-model.number="porcentaje"
+              min="0"
+              max="100"
+              title="Porcentaje del total (0-100)"
+            />
+            <input
+              v-else
+              type="number"
+              v-model.number="monto"
+              min="0"
+              title="Monto total de la nota. Se descompone si IVA incluido"
+            />
+          </div>
+          <table class="preview">
+            <thead>
+              <tr>
+                <th title="Descripción del ajuste">Concepto</th>
+                <th title="Monto sujeto a IVA">Base gravada</th>
+                <th title="Ventas exentas del impuesto">Exenta</th>
+                <th title="Operaciones no sujetas al impuesto">No sujeta</th>
+                <th title="Impuesto calculado al 20%">IVA(20)</th>
+                <th title="Suma de base e IVA">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Global</td>
+                <td>{{ format(preview.base) }}</td>
+                <td>{{ format(0) }}</td>
+                <td>{{ format(0) }}</td>
+                <td>{{ format(preview.iva) }}</td>
+                <td>{{ format(preview.base + preview.iva) }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
         <div v-else>
           <!-- Detalle por producto -->
@@ -33,16 +81,43 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 const props = defineProps<{
-  factura: { numero: string; cliente: string };
+  factura: { numero: string; cliente: string; total?: number };
   tipo: 'credito' | 'debito';
 }>();
 
 const motivo = ref('');
 const ivaIncluido = ref(true);
 const activeTab = ref<'global' | 'producto'>('global');
+
+const modoGlobal = ref<'porcentaje' | 'monto'>('porcentaje');
+const porcentaje = ref(0);
+const monto = ref(0);
+
+function toBaseIva(total: number, tasa = 0.2) {
+  const base = total / (1 + tasa);
+  return { base, iva: total - base };
+}
+
+const globalMonto = computed(() => {
+  return modoGlobal.value === 'porcentaje'
+    ? (props.factura.total ?? 0) * (porcentaje.value || 0) / 100
+    : monto.value || 0;
+});
+
+const preview = computed(() => {
+  const total = globalMonto.value;
+  if (ivaIncluido.value) {
+    return toBaseIva(total);
+  }
+  return { base: total, iva: total * 0.2 };
+});
+
+function format(n: number) {
+  return n.toFixed(2);
+}
 
 const { factura, tipo } = props;
 </script>


### PR DESCRIPTION
## Summary
- add percentage and amount modes with IVA tooltips in NotaForm
- show IVA decomposition in global preview table
- test NotaForm modes and IVA calculations

## Testing
- `npm test`
- `pytest` *(fails: libGL.so.1 missing, fastapi missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be3a5145b08323b4184819ee395600