### PR TITLE
feat(ui): add reusable editable nota table component

### DIFF
--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -1,0 +1,250 @@
+<template>
+  <div class="editable-nota-table">
+    <div class="controls">
+      <input v-model="search" placeholder="Buscar" />
+      <label>
+        <input type="checkbox" v-model="applyToSelected" /> Aplicar a todas las líneas seleccionadas
+      </label>
+      <button class="add-item" @click="addItem">+ Agregar ítem</button>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th><input type="checkbox" :checked="allSelected" @change="toggleAll($event.target.checked)" /></th>
+          <th>Código</th>
+          <th>Descripción</th>
+          <th>Cant. facturada</th>
+          <th>Cant. a ajustar</th>
+          <th>Tipo</th>
+          <th>Modo</th>
+          <th>Valor</th>
+          <th>IVA inc.</th>
+          <th>Base</th>
+          <th>IVA</th>
+          <th>Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="item in filteredItems" :key="item.id">
+          <td><input type="checkbox" v-model="item.selected" /></td>
+          <td>{{ item.codigo }}</td>
+          <td>{{ item.descripcion }}</td>
+          <td>{{ item.cantidadFacturada }}</td>
+          <td>
+            <input
+              type="number"
+              :value="item.cantidadAjustar"
+              @focus="onFocus(item, 'cantidadAjustar')"
+              @input="update(item, 'cantidadAjustar', parseFloat($event.target.value))"
+              @keydown.enter.prevent="$event.target.blur()"
+              @keydown.esc.prevent="onEsc(item, 'cantidadAjustar'); $event.target.blur()"
+            />
+            <span v-if="item.tipo === 'credito' && item.cantidadAjustar > item.cantidadFacturada" class="error">Excede</span>
+          </td>
+          <td>
+            <select
+              :value="item.tipo"
+              @change="update(item, 'tipo', $event.target.value)"
+            >
+              <option value="debito">Débito</option>
+              <option value="credito">Crédito</option>
+            </select>
+          </td>
+          <td>
+            <select
+              :value="item.modo"
+              @change="update(item, 'modo', $event.target.value)"
+            >
+              <option value="monto">Monto</option>
+              <option value="porcentaje">%</option>
+            </select>
+          </td>
+          <td>
+            <input
+              type="number"
+              :value="item.valor"
+              @focus="onFocus(item, 'valor')"
+              @input="update(item, 'valor', parseFloat($event.target.value))"
+              @keydown.enter.prevent="$event.target.blur()"
+              @keydown.esc.prevent="onEsc(item, 'valor'); $event.target.blur()"
+            />
+          </td>
+          <td>
+            <input
+              type="checkbox"
+              :checked="item.ivaInc"
+              @change="update(item, 'ivaInc', $event.target.checked)"
+            />
+          </td>
+          <td>{{ formatNumber(calcBase(item)) }}</td>
+          <td>{{ formatNumber(calcIva(item)) }}</td>
+          <td>{{ formatNumber(calcTotal(item)) }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-if="creditoExcede" class="error">Tope global de crédito excedido</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, defineProps, defineEmits, defineOptions } from 'vue';
+
+interface NotaItem {
+  id: number;
+  selected: boolean;
+  codigo: string;
+  descripcion: string;
+  cantidadFacturada: number;
+  cantidadAjustar: number;
+  tipo: 'debito' | 'credito';
+  modo: 'monto' | 'porcentaje';
+  valor: number;
+  ivaInc: boolean;
+}
+
+defineOptions({ name: 'EditableNotaTable' });
+
+const props = defineProps<{ modelValue: NotaItem[]; topeCredito?: number }>();
+const emit = defineEmits(['update:modelValue']);
+
+const items = ref<NotaItem[]>(props.modelValue ? [...props.modelValue] : []);
+watch(
+  () => props.modelValue,
+  (val) => {
+    items.value = val ? [...val] : [];
+  }
+);
+watch(
+  items,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+const search = ref('');
+const applyToSelected = ref(false);
+
+const filteredItems = computed(() => {
+  if (!search.value) return items.value;
+  return items.value.filter(
+    (i) =>
+      i.codigo.toLowerCase().includes(search.value.toLowerCase()) ||
+      i.descripcion.toLowerCase().includes(search.value.toLowerCase())
+  );
+});
+
+const allSelected = computed(() => filteredItems.value.length > 0 && filteredItems.value.every((i) => i.selected));
+
+function toggleAll(val: boolean) {
+  filteredItems.value.forEach((i) => (i.selected = val));
+}
+
+let nextId = 1;
+function addItem() {
+  items.value.push({
+    id: nextId++,
+    selected: false,
+    codigo: '',
+    descripcion: '',
+    cantidadFacturada: 0,
+    cantidadAjustar: 0,
+    tipo: 'debito',
+    modo: 'monto',
+    valor: 0,
+    ivaInc: false,
+  });
+}
+
+const cache = new Map<string, any>();
+function onFocus(item: NotaItem, field: keyof NotaItem) {
+  cache.set(item.id + field, (item as any)[field]);
+}
+function onEsc(item: NotaItem, field: keyof NotaItem) {
+  const key = item.id + field;
+  (item as any)[field] = cache.get(key);
+}
+
+function update(item: NotaItem, field: keyof NotaItem, value: any) {
+  if (applyToSelected.value) {
+    items.value
+      .filter((i) => i.selected)
+      .forEach((i) => ((i as any)[field] = value));
+  } else {
+    (item as any)[field] = value;
+  }
+}
+
+function toBaseIva(monto: number) {
+  const base = monto / 1.13;
+  const iva = monto - base;
+  return { base, iva };
+}
+
+function resolveValor(item: NotaItem) {
+  if (item.modo === 'porcentaje') {
+    return (item.cantidadFacturada * item.valor) / 100;
+  }
+  return item.valor;
+}
+
+function calcBase(item: NotaItem) {
+  const monto = resolveValor(item);
+  if (item.ivaInc) {
+    return toBaseIva(monto).base;
+  }
+  return monto;
+}
+function calcIva(item: NotaItem) {
+  const monto = resolveValor(item);
+  if (item.ivaInc) {
+    return toBaseIva(monto).iva;
+  }
+  return monto * 0.13;
+}
+function calcTotal(item: NotaItem) {
+  if (item.ivaInc) {
+    return resolveValor(item);
+  }
+  return calcBase(item) + calcIva(item);
+}
+
+function formatNumber(n: number) {
+  return isNaN(n) ? '' : n.toFixed(2);
+}
+
+const totalCredito = computed(() =>
+  items.value
+    .filter((i) => i.tipo === 'credito')
+    .reduce((acc, cur) => acc + cur.cantidadAjustar, 0)
+);
+
+const creditoExcede = computed(() =>
+  props.topeCredito !== undefined && totalCredito.value > props.topeCredito
+);
+</script>
+
+<style scoped>
+.editable-nota-table {
+  overflow-x: auto;
+}
+.controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th,
+ td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  text-align: left;
+}
+.error {
+  color: red;
+  font-size: 0.8rem;
+}
+</style>
+

--- a/ui/tests/EditableNotaTable.spec.ts
+++ b/ui/tests/EditableNotaTable.spec.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import EditableNotaTable from '../components/EditableNotaTable.vue';
+
+describe('EditableNotaTable', () => {
+  it('agrega item cuando se hace click', async () => {
+    const wrapper = mount(EditableNotaTable, {
+      props: { modelValue: [], topeCredito: 10 }
+    });
+    await wrapper.find('button.add-item').trigger('click');
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toHaveLength(1);
+  });
+
+  it('filtra por código o descripción', async () => {
+    const wrapper = mount(EditableNotaTable, {
+      props: {
+        modelValue: [
+          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false }
+        ]
+      }
+    });
+    expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+    await wrapper.find('input[placeholder="Buscar"]').setValue('no existe');
+    expect(wrapper.findAll('tbody tr')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add EditableNotaTable.vue with search, selection and IVA handling
- support keyboard shortcuts and global credit validation
- cover table behaviour with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be382cf8b88323a0aa6680abdfcf4d