### PR TITLE
feat: add nota form actions

### DIFF
--- a/ui/services/notasApi.ts
+++ b/ui/services/notasApi.ts
@@ -1,0 +1,39 @@
+export async function previsualizarPdf(notaId: string) {
+  const res = await fetch(`/api/notas/${notaId}/pdf`);
+  if (!res.ok) {
+    throw new Error('Error al previsualizar PDF');
+  }
+  return await res.blob();
+}
+
+export async function previsualizarJson(notaId: string) {
+  const res = await fetch(`/api/notas/${notaId}/json`);
+  if (!res.ok) {
+    throw new Error('Error al previsualizar JSON');
+  }
+  return await res.json();
+}
+
+export async function guardarBorrador(nota: any) {
+  const res = await fetch('/api/notas/borrador', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(nota),
+  });
+  if (!res.ok) {
+    throw new Error('Error al guardar borrador');
+  }
+  return await res.json();
+}
+
+export async function firmarTransmitir(nota: any) {
+  const res = await fetch('/api/notas/firmar', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(nota),
+  });
+  if (!res.ok) {
+    throw new Error('Error al firmar y transmitir');
+  }
+  return await res.json();
+}

--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NotaForm from '../ventas/NotaForm.vue';
+
+vi.mock('../services/notasApi', () => ({
+  previsualizarPdf: vi.fn().mockResolvedValue({}),
+  previsualizarJson: vi.fn().mockResolvedValue({}),
+  guardarBorrador: vi.fn().mockResolvedValue({}),
+  firmarTransmitir: vi.fn().mockResolvedValue({}),
+}));
+
+const api = await import('../services/notasApi');
+
+const baseNota = {
+  id: '1',
+  baseGravada: 10,
+  exenta: 0,
+  noSujeta: 0,
+  iva: 1.3,
+  total: 11.3,
+  totalLetras: 'once',
+  documentoRelacionado: 'F001',
+  credito: 50,
+};
+
+describe('NotaForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('muestra badge rojo si el crédito excede el saldo', () => {
+    const wrapper = mount(NotaForm, {
+      props: { nota: { ...baseNota, credito: 150 }, saldoDisponible: 100 },
+    });
+    const badge = wrapper.find('.badge');
+    expect(badge.classes()).toContain('red');
+  });
+
+  it('no llama API si la validación falla', async () => {
+    const wrapper = mount(NotaForm, {
+      props: { nota: { ...baseNota, credito: 150 }, saldoDisponible: 100 },
+    });
+    await wrapper.find('button').trigger('click');
+    expect(api.previsualizarPdf).not.toHaveBeenCalled();
+  });
+
+  it('llama previsualizarJson cuando es válido', async () => {
+    const wrapper = mount(NotaForm, {
+      props: { nota: baseNota, saldoDisponible: 100 },
+    });
+    await wrapper.findAll('button')[1].trigger('click');
+    expect(api.previsualizarJson).toHaveBeenCalledWith('1');
+  });
+});

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="nota-form">
+    <div class="right-column">
+      <div>Base gravada: {{ nota.baseGravada }}</div>
+      <div>Base exenta: {{ nota.exenta }}</div>
+      <div>No sujeta: {{ nota.noSujeta }}</div>
+      <div>IVA: {{ nota.iva }}</div>
+      <div>Total: {{ nota.total }}</div>
+      <div>Total en letras: {{ nota.totalLetras }}</div>
+      <div>Documento relacionado: {{ nota.documentoRelacionado }}</div>
+      <div>
+        Crédito: <span class="badge" :class="{ red: excedeSaldo }">{{ nota.credito }}</span>
+      </div>
+    </div>
+    <div class="actions">
+      <button @click="onPreviewPdf">Previsualizar PDF</button>
+      <button @click="onPreviewJson">Previsualizar JSON</button>
+      <button @click="onGuardarBorrador">Guardar borrador</button>
+      <button @click="onFirmarTransmitir">Firmar &amp; Transmitir</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { previsualizarPdf, previsualizarJson, guardarBorrador, firmarTransmitir } from '../services/notasApi';
+
+const props = defineProps<{
+  nota: {
+    id: string;
+    baseGravada: number;
+    exenta: number;
+    noSujeta: number;
+    iva: number;
+    total: number;
+    totalLetras: string;
+    documentoRelacionado: string;
+    credito: number;
+  };
+  saldoDisponible: number;
+}>();
+
+const excedeSaldo = computed(() => props.nota.credito > props.saldoDisponible);
+
+function validar() {
+  return !excedeSaldo.value;
+}
+
+async function onPreviewPdf() {
+  if (validar()) {
+    await previsualizarPdf(props.nota.id);
+  }
+}
+
+async function onPreviewJson() {
+  if (validar()) {
+    await previsualizarJson(props.nota.id);
+  }
+}
+
+async function onGuardarBorrador() {
+  if (validar()) {
+    await guardarBorrador(props.nota);
+  }
+}
+
+async function onFirmarTransmitir() {
+  if (validar()) {
+    await firmarTransmitir(props.nota);
+  }
+}
+</script>
+
+<style scoped>
+.badge {
+  padding: 2px 4px;
+  border-radius: 4px;
+  background-color: #ddd;
+}
+.badge.red {
+  background-color: red;
+  color: white;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add NotaForm Vue component with validation and backend actions
- create notasApi service for previews, drafts, and transmission
- test NotaForm interactions and validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be382dbdcc83239f0325619a199e54