### PR TITLE
feat: add IVA conversion helpers

### DIFF
--- a/ui/services/useIvaConversion.ts
+++ b/ui/services/useIvaConversion.ts
@@ -1,0 +1,32 @@
+/**
+ * Utilidades para convertir montos con IVA del 13%.
+ *
+ * - Cuando un precio tiene `ivaIncluido = true`, usa `toBaseIva` para separar
+ *   el total en base imponible e impuesto.
+ * - Cuando `ivaIncluido = false`, parte de la base con `fromBaseIva` para
+ *   obtener el total con IVA.
+ */
+const IVA_FACTOR = 1.13;
+
+function roundHalfUp(value: number, decimals = 2): number {
+  const factor = Math.pow(10, decimals);
+  return (Math.sign(value) * Math.round(Math.abs(value) * factor + Number.EPSILON)) / factor;
+}
+
+/**
+ * Convierte un monto con `ivaIncluido = true` en base imponible e IVA.
+ */
+export function toBaseIva(total: number): { base: number; iva: number } {
+  const base = roundHalfUp(total / IVA_FACTOR, 2);
+  const iva = roundHalfUp(total - base, 2);
+  return { base, iva };
+}
+
+/**
+ * Convierte una base imponible con `ivaIncluido = false` al total con IVA.
+ */
+export function fromBaseIva(base: number): { total: number; iva: number } {
+  const total = roundHalfUp(base * IVA_FACTOR, 2);
+  const iva = roundHalfUp(total - base, 2);
+  return { total, iva };
+}

--- a/ui/tests/useIvaConversion.spec.ts
+++ b/ui/tests/useIvaConversion.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { toBaseIva, fromBaseIva } from '../services/useIvaConversion';
+
+describe('useIvaConversion', () => {
+  it('convierte total a base e iva', () => {
+    const { base, iva } = toBaseIva(113);
+    expect(base).toBe(100);
+    expect(iva).toBe(13);
+  });
+
+  it('convierte base a total e iva', () => {
+    const { total, iva } = fromBaseIva(100);
+    expect(total).toBe(113);
+    expect(iva).toBe(13);
+  });
+});


### PR DESCRIPTION
## Summary
- add IVA conversion utilities with ROUND_HALF_UP logic
- test IVA conversion helpers

## Testing
- `npm test`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68be382df6ac8323b63d356e4708a774