### PR TITLE
feat: add global proration helper

### DIFF
--- a/ui/services/prorrateo.ts
+++ b/ui/services/prorrateo.ts
@@ -1,0 +1,50 @@
+export interface FacturaResumen {
+  ventas_gravadas?: number;
+  ventas_exentas?: number;
+  ventas_no_sujetas?: number;
+  iva?: number;
+}
+
+export interface ProrrateoResultado {
+  ventas_gravadas: number;
+  ventas_exentas: number;
+  ventas_no_sujetas: number;
+  iva: number;
+  total: number;
+}
+
+export function prorratearGlobal(
+  factura: FacturaResumen,
+  ajuste: { monto?: number; porcentaje?: number }
+): ProrrateoResultado {
+  const gravada = factura.ventas_gravadas ?? 0;
+  const exenta = factura.ventas_exentas ?? 0;
+  const noSujeta = factura.ventas_no_sujetas ?? 0;
+  const iva = factura.iva ?? 0;
+  const totalFactura = gravada + exenta + noSujeta + iva;
+
+  let ratio: number | undefined;
+  if (ajuste.porcentaje != null) {
+    ratio = ajuste.porcentaje / 100;
+  } else if (ajuste.monto != null) {
+    ratio = totalFactura > 0 ? ajuste.monto / totalFactura : 0;
+  }
+  if (ratio == null || ratio < 0) {
+    throw new Error('Debe especificar un monto o porcentaje válido');
+  }
+
+  const gravadaRes = gravada * ratio;
+  const exentaRes = exenta * ratio;
+  const noSujetaRes = noSujeta * ratio;
+  const ivaRes = iva * ratio;
+  const totalRes = gravadaRes + exentaRes + noSujetaRes + ivaRes;
+
+  return {
+    ventas_gravadas: gravadaRes,
+    ventas_exentas: exentaRes,
+    ventas_no_sujetas: noSujetaRes,
+    iva: ivaRes,
+    total: totalRes,
+  };
+}
+

--- a/ui/tests/prorrateo.spec.ts
+++ b/ui/tests/prorrateo.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { prorratearGlobal } from '../services/prorrateo';
+
+describe('prorratearGlobal', () => {
+  const factura = {
+    ventas_gravadas: 100,
+    ventas_exentas: 50,
+    ventas_no_sujetas: 25,
+    iva: 13,
+  };
+
+  it('prorratea según porcentaje', () => {
+    const res = prorratearGlobal(factura, { porcentaje: 10 });
+    expect(res.ventas_gravadas).toBeCloseTo(10);
+    expect(res.ventas_exentas).toBeCloseTo(5);
+    expect(res.ventas_no_sujetas).toBeCloseTo(2.5);
+    expect(res.iva).toBeCloseTo(1.3);
+    expect(res.total).toBeCloseTo(18.8);
+  });
+
+  it('prorratea según monto', () => {
+    const res = prorratearGlobal(factura, { monto: 18.8 });
+    expect(res.ventas_gravadas).toBeCloseTo(10);
+    expect(res.iva).toBeCloseTo(1.3);
+    expect(res.total).toBeCloseTo(18.8);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `prorratearGlobal` service to distribute a global adjustment across invoice bases
- test prorrateo for percentage and absolute amount cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be382e84208323bb0dd940a248ea16