### PR TITLE
Add notes API and debit note generator

### DIFF
--- a/api/notas.py
+++ b/api/notas.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from db import DB
+from dte import enviar_nota_credito, enviar_nota_debito
+from facturas_db.facturas_repo import FacturasRepo
+from models.factura import Factura  # noqa: F401 - reexport for tests
+
+app = FastAPI()
+repo = FacturasRepo()
+db = DB(":memory:")
+
+
+@app.get("/api/facturas/{factura_id}")
+def obtener_factura(factura_id: int):
+    factura = repo.get(factura_id)
+    if not factura:
+        raise HTTPException(status_code=404, detail="Factura no encontrada")
+    return {"factura": factura.to_dict()}
+
+
+@app.post("/api/notas")
+def crear_y_transmitir_nota(payload: dict):
+    tipo = payload.get("tipo")
+    venta_id = payload.get("venta_id")
+    fecha = payload.get("fecha")
+    monto = payload.get("monto", 0)
+    motivo = payload.get("motivo")
+    detalles = payload.get("detalles")
+    try:
+        nota_id = db.agregar_nota(tipo, venta_id, fecha, monto, motivo, detalles)
+    except ValueError as exc:  # pragma: no cover - fastapi handles
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    envio = None
+    if tipo == "credito":
+        envio = enviar_nota_credito(db, nota_id)
+    elif tipo == "debito":
+        envio = enviar_nota_debito(db, nota_id)
+    return {"ok": True, "nota_id": nota_id, "envio": envio}

--- a/db.py
+++ b/db.py
@@ -4,6 +4,7 @@ import json
 import logging
 import threading
 from pathlib import Path
+from decimal import Decimal
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -1900,9 +1901,20 @@ class DB:
             raise ValueError("tipo debe ser 'credito', 'debito' o 'remision'")
 
         if venta_id is not None:
-            self.cursor.execute("SELECT id FROM ventas WHERE id=?", (venta_id,))
-            if self.cursor.fetchone() is None:
+            row = self.cursor.execute("SELECT total FROM ventas WHERE id=?", (venta_id,)).fetchone()
+            if row is None:
                 raise ValueError("La venta indicada no existe")
+            if tipo == "credito":
+                total_facturado = Decimal(str(row["total"]))
+                sum_row = self.cursor.execute(
+                    "SELECT COALESCE(SUM(monto),0) AS total FROM notas WHERE venta_id=? AND tipo='credito'",
+                    (venta_id,),
+                ).fetchone()
+                total_creditos = Decimal(str(sum_row["total"]))
+                monto_dec = Decimal(str(monto))
+                saldo = total_facturado - total_creditos
+                if monto_dec > saldo:
+                    raise ValueError("El monto de la nota excede el saldo restante de la venta")
 
         detalles_json = json.dumps(detalles) if detalles is not None else None
         self.cursor.execute(

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -34,8 +34,8 @@ from dte import (
     transmitir_dte,
     enviar_nota_credito,
     enviar_nota_debito,
-    generar_nde_desde_dte,
 )
+from nota_debito_electronica import generar_nde_desde_dte
 from nota_remision import generar_nota_remision_desde_db
 import nota_credito_electronica
 from utils.docs import get_document_paths, get_dte_document_paths

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -1,0 +1,292 @@
+# coding: utf-8
+"""Generación de Nota de Débito Electrónica (NDE).
+
+Este módulo construye la estructura JSON requerida por el Ministerio de
+Hacienda de El Salvador para una Nota de Débito Electrónica (tipoDte ``06``).
+Se genera a partir de un DTE de origen y permite acreditar montos o
+proporciones del documento original.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
+import copy
+import json
+from typing import Optional
+
+from db import DB
+from dte import (
+    DTE_VERSIONES,
+    generar_cabecera_dte_data,
+    generar_dte_json,
+    sanitize_dte_payload,
+    d4,
+)
+from utils import catalogos
+from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
+from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
+from utils.monto import d2, monto_a_texto_sv
+from utils.sanitize import limpiar_documentos
+
+
+def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
+    """Genera una NDE basada en la nota registrada en ``notas``."""
+    row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
+    if not row:
+        raise ValueError("Nota no encontrada")
+    nota = dict(row)
+    if nota.get("tipo") != "debito":
+        raise ValueError("La nota indicada no es de débito")
+
+    venta_id = nota.get("venta_id")
+    venta_row = db.cursor.execute(
+        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,),
+    ).fetchone()
+    tipo_doc = "01"
+    if venta_row:
+        venta = dict(venta_row)
+        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
+            tipo_doc = "03"
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+
+    detalles = None
+    if nota.get("detalles"):
+        try:
+            detalles = json.loads(nota["detalles"])
+        except Exception:
+            detalles = None
+
+    return generar_nde_desde_dte(
+        db,
+        dte_origen,
+        detalles,
+        nota.get("monto"),
+        nota.get("motivo"),
+        ambiente=ambiente,
+    )
+
+
+def generar_nde_desde_dte(
+    db: DB,
+    dte_origen: dict,
+    detalles: list | None,
+    monto: float | None,
+    motivo: str | None = None,
+    *,
+    ambiente: str = "00",
+) -> dict:
+    """Genera la estructura JSON de una NDE."""
+    cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
+    now = datetime.now(TZ_EL_SALVADOR)
+    identificacion = {
+        "version": DTE_VERSIONES["06"],
+        "ambiente": ambiente,
+        "tipoDte": "06",
+        "numeroControl": cabecera["numero_control"],
+        "codigoGeneracion": cabecera["codigo_generacion"],
+        "tipoModelo": cabecera["tipo_modelo"],
+        "tipoOperacion": cabecera["tipo_operacion"],
+        "tipoContingencia": cabecera["tipo_contingencia"],
+        "motivoContin": cabecera["motivo_contin"],
+        "fecEmi": fecha_emision_hoy_str(now),
+        "horEmi": now.strftime("%H:%M:%S"),
+        "tipoMoneda": "USD",
+    }
+
+    origen_ident = dte_origen.get("identificacion", {})
+    tipo_origen = origen_ident.get("tipoDte")
+    tipo_rel = "07" if tipo_origen == "07" else "03"
+    doc_rel = [
+        {
+            "tipoDocumento": tipo_rel,
+            "tipoGeneracion": 2,
+            "numeroDocumento": origen_ident.get("codigoGeneracion"),
+            "fechaEmision": origen_ident.get("fecEmi"),
+        }
+    ]
+
+    emisor = copy.deepcopy(dte_origen.get("emisor", {}))
+    receptor = copy.deepcopy(dte_origen.get("receptor", {}))
+    receptor.setdefault("nombreComercial", None)
+    receptor.setdefault("nit", None)
+    limpiar_documentos(emisor)
+    limpiar_documentos(receptor)
+
+    orig_resumen = dte_origen.get("resumen", {})
+    items: list[dict] = []
+    uuid_origen = origen_ident.get("codigoGeneracion", "")
+    tipo_doc_desc = catalogos.DTE_TIPOS.get(origen_ident.get("tipoDte", ""), "documento")
+    extra_desc = f": {motivo}" if motivo else ""
+
+    if detalles:
+        total_grav = Decimal("0")
+        total_exenta = Decimal("0")
+        total_nosuj = Decimal("0")
+        num = 1
+        for det in detalles:
+            grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
+            exenta = Decimal(str(det.get("ventas_exentas") or det.get("ventaExenta") or 0))
+            nosuj = Decimal(str(det.get("ventas_no_sujetas") or det.get("ventaNoSuj") or 0))
+            total_grav += grav
+            total_exenta += exenta
+            total_nosuj += nosuj
+            precio = det.get("precio_unitario") or det.get("precioUni")
+            if precio is None:
+                precio = grav + exenta + nosuj
+            precio = d4(precio)
+            cantidad = det.get("cantidad", 1)
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": det.get("tipoItem", 1),
+                    "codigo": det.get("codigo", f"ND{uuid_origen[:8]}-{num}"),
+                    "descripcion": det.get(
+                        "descripcion",
+                        f"Nota de débito sobre operaciones del {tipo_doc_desc} relacionado{extra_desc}",
+                    ),
+                    "cantidad": cantidad,
+                    "uniMedida": det.get("uniMedida", 59),
+                    "precioUni": precio,
+                    "montoDescu": d4(det.get("montoDescu", 0.0)),
+                    "ventaGravada": d4(grav),
+                    "ventaExenta": d4(exenta),
+                    "ventaNoSuj": d4(nosuj),
+                    "tributos": [TRIBUTO_IVA] if grav > 0 else [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        total_grav = d2(total_grav)
+        total_exenta = d2(total_exenta)
+        total_nosuj = d2(total_nosuj)
+    else:
+        if monto is None:
+            raise ValueError("Se requiere monto para nota de débito")
+        total_origen = Decimal(
+            str(
+                orig_resumen.get("montoTotalOperacion")
+                or orig_resumen.get("totalPagar")
+                or 0
+            )
+        )
+        if total_origen <= 0:
+            raise ValueError("El documento de origen no tiene total válido")
+        ratio = Decimal(str(monto)) / total_origen
+        pct_text = str((ratio * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+        total_grav = d2(Decimal(str(orig_resumen.get("totalGravada", 0))) * ratio)
+        total_exenta = d2(Decimal(str(orig_resumen.get("totalExenta", 0))) * ratio)
+        total_nosuj = d2(Decimal(str(orig_resumen.get("totalNoSuj", 0))) * ratio)
+        num = 1
+        if total_grav > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"ND{pct_text}-{uuid_origen[:8]}-G",
+                    "descripcion": f"Nota de débito {pct_text}% sobre operaciones gravadas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_grav,
+                    "montoDescu": 0.0,
+                    "ventaGravada": total_grav,
+                    "ventaExenta": 0.0,
+                    "ventaNoSuj": 0.0,
+                    "tributos": [TRIBUTO_IVA],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        if total_exenta > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"ND{pct_text}-{uuid_origen[:8]}-E",
+                    "descripcion": f"Nota de débito {pct_text}% sobre operaciones exentas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_exenta,
+                    "montoDescu": 0.0,
+                    "ventaGravada": 0.0,
+                    "ventaExenta": total_exenta,
+                    "ventaNoSuj": 0.0,
+                    "tributos": [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+            num += 1
+        if total_nosuj > 0:
+            items.append(
+                {
+                    "numItem": num,
+                    "tipoItem": 1,
+                    "codigo": f"ND{pct_text}-{uuid_origen[:8]}-N",
+                    "descripcion": f"Nota de débito {pct_text}% sobre operaciones no sujetas del {tipo_doc_desc} relacionado{extra_desc}",
+                    "cantidad": 1,
+                    "uniMedida": 59,
+                    "precioUni": total_nosuj,
+                    "montoDescu": 0.0,
+                    "ventaGravada": 0.0,
+                    "ventaExenta": 0.0,
+                    "ventaNoSuj": total_nosuj,
+                    "tributos": [],
+                    "numeroDocumento": uuid_origen,
+                    "codTributo": None,
+                }
+            )
+
+    subtotal_ventas = total_grav + total_exenta + total_nosuj
+    orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (
+        ratio if "ratio" in locals() else Decimal("1")
+    )
+    iva_val = d2(orig_total - subtotal_ventas)
+    tributos_resumen = []
+    if iva_val > 0:
+        tributos_resumen.append(
+            {
+                "codigo": TRIBUTO_IVA,
+                "descripcion": TRIBUTOS.get(TRIBUTO_IVA, ""),
+                "valor": iva_val,
+            }
+        )
+    monto_total = d2(orig_total)
+    resumen = {
+        "totalNoSuj": total_nosuj,
+        "totalExenta": total_exenta,
+        "totalGravada": total_grav,
+        "subTotal": subtotal_ventas,
+        "subTotalVentas": subtotal_ventas,
+        "descuNoSuj": 0.0,
+        "descuExenta": 0.0,
+        "descuGravada": 0.0,
+        "totalDescu": 0.0,
+        "ivaPerci1": 0.0,
+        "ivaRete1": 0.0,
+        "reteRenta": 0.0,
+        "condicionOperacion": dte_origen.get("resumen", {}).get("condicionOperacion", 1),
+        "numPagoElectronico": dte_origen.get("resumen", {}).get("numPagoElectronico"),
+        "tributos": tributos_resumen,
+        "montoTotalOperacion": monto_total,
+        "totalLetras": monto_a_texto_sv(monto_total),
+    }
+
+    data = {
+        "identificacion": identificacion,
+        "documentoRelacionado": doc_rel,
+        "emisor": emisor,
+        "receptor": receptor,
+        "cuerpoDocumento": items,
+        "resumen": resumen,
+        "ventaTercero": None,
+        "extension": None,
+        "apendice": None,
+    }
+
+    schema = catalogos.get_dte_schema("06")
+    return sanitize_dte_payload(data, schema)
+
+
+__all__ = ["generar_nde_desde_dte", "generar_nde_desde_nota"]

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,7 +1,8 @@
 import fitz
 from decimal import Decimal
 from db import DB
-from dte import generar_nde_desde_dte, generar_dte_json
+from nota_debito_electronica import generar_nde_desde_dte
+from dte import generar_dte_json
 from nota_remision import generar_nota_remision_desde_db
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
 

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -1,7 +1,8 @@
 from db import DB
 from decimal import Decimal
 from nota_credito_electronica import generar_nce_desde_dte
-from dte import generar_nde_desde_dte, generar_dte_json
+from nota_debito_electronica import generar_nde_desde_dte
+from dte import generar_dte_json
 
 def create_db():
     return DB(":memory:")

--- a/tests/test_notas.py
+++ b/tests/test_notas.py
@@ -39,3 +39,22 @@ def test_agregar_nota_venta_inexistente():
     db = create_db()
     with pytest.raises(ValueError):
         db.agregar_nota("debito", 999, "2024-01-03", 10, "extra")
+
+
+def test_credito_no_supera_total():
+    db = create_db()
+    db.add_cliente("Ana", "", "", "", "", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 50, cliente_id=cliente_id)
+    with pytest.raises(ValueError):
+        db.agregar_nota("credito", venta_id, "2024-01-02", 60, "Dev")
+
+
+def test_credito_no_supera_saldo():
+    db = create_db()
+    db.add_cliente("Ana", "", "", "", "", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 100, cliente_id=cliente_id)
+    db.agregar_nota("credito", venta_id, "2024-01-02", 60, "Parcial")
+    with pytest.raises(ValueError):
+        db.agregar_nota("credito", venta_id, "2024-01-03", 50, "Resto")

--- a/tests/test_notas_api.py
+++ b/tests/test_notas_api.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+import api.notas as notas_api
+from models.factura import Factura
+
+client = TestClient(notas_api.app)
+
+
+def setup_function(_):
+    notas_api.repo._data.clear()
+    notas_api.db.cursor.execute("DELETE FROM notas")
+    notas_api.db.cursor.execute("DELETE FROM ventas")
+    notas_api.db.cursor.execute("DELETE FROM clientes")
+    notas_api.db.conn.commit()
+
+
+def test_crear_nota_credito_transmite(monkeypatch):
+    called = {}
+
+    def fake_envio(db, nota_id):
+        called["id"] = nota_id
+        return {"ok": True}
+
+    monkeypatch.setattr(notas_api, "enviar_nota_credito", fake_envio)
+    notas_api.db.add_cliente("Juan", "", "", "", "", "", "", "", "", "")
+    cliente_id = notas_api.db.cursor.lastrowid
+    venta_id = notas_api.db.add_venta("2024-01-01", 100, cliente_id=cliente_id)
+    resp = client.post(
+        "/api/notas",
+        json={"tipo": "credito", "venta_id": venta_id, "fecha": "2024-01-02", "monto": 10, "motivo": "Dev"},
+    )
+    assert resp.status_code == 200
+    assert called["id"] == 1
+
+
+def test_get_factura():
+    notas_api.repo.add(Factura(id=5))
+    resp = client.get("/api/facturas/5")
+    assert resp.status_code == 200
+    assert resp.json()["factura"]["id"] == 5
+
+
+def test_credito_no_excede_saldo_api(monkeypatch):
+    monkeypatch.setattr(notas_api, "enviar_nota_credito", lambda *a, **k: {"ok": True})
+    notas_api.db.add_cliente("Ana", "", "", "", "", "", "", "", "", "")
+    cliente_id = notas_api.db.cursor.lastrowid
+    venta_id = notas_api.db.add_venta("2024-01-01", 50, cliente_id=cliente_id)
+    resp = client.post(
+        "/api/notas",
+        json={"tipo": "credito", "venta_id": venta_id, "fecha": "2024-01-02", "monto": 60, "motivo": "Dev"},
+    )
+    assert resp.status_code == 400

--- a/tests/test_notas_precio_uni.py
+++ b/tests/test_notas_precio_uni.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from db import DB
 from nota_credito_electronica import generar_nce_desde_dte
-from dte import generar_nde_desde_dte
+from nota_debito_electronica import generar_nde_desde_dte
 
 
 def _datos_negocio():


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to create and transmit notes and to fetch invoices
- introduce nota_debito_electronica module mirroring credit note generator
- validate credit notes against invoice totals and remaining balance

## Testing
- `pytest tests/test_notas.py tests/test_notas_api.py tests/test_nota_detalles.py tests/test_notas_precio_uni.py tests/test_nota_debito_remision.py::test_generar_nota_debito_json_ticket -q`


------
https://chatgpt.com/codex/tasks/task_e_68be420b33608323be52ee1e4c9aa26a