### PR TITLE
Ensure DTE limits and document sanitization

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -28,7 +28,8 @@ from utils.catalogos import (
 import logging
 import warnings
 import xml.etree.ElementTree as ET
-from utils.monto import monto_a_texto_sv
+from utils.monto import monto_a_texto_sv, to_base_iva
+from utils.sanitize import limpiar_documentos, limpiar_doc
 from num2words import num2words
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 from utils.fecha import fecha_emision_hoy_str, TZ_EL_SALVADOR
@@ -154,7 +155,11 @@ def sanitize_dte_payload(data: dict, schema: dict | None = None) -> dict:
     if schema is None:
         schema = FC_SCHEMA
     cleaned = _strip_additional_properties(data, schema)
-    return _remove_nulls(cleaned)
+    limpiar_documentos(cleaned)
+    cleaned = _remove_nulls(cleaned)
+    for key in ("documentoRelacionado", "otrosDocumentos", "ventaTercero", "extension", "apendice"):
+        cleaned.setdefault(key, None)
+    return cleaned
 
 
 def apply_schema_patch(data: dict) -> dict:
@@ -1342,7 +1347,8 @@ def recalcular_totales(
             linea = d4(bruto - monto_descu)
             if linea < 0:
                 linea = d4(0)
-            esperado_iva = money(linea - (linea / D("1.13")))
+            _, iva_calc = to_base_iva(linea)
+            esperado_iva = money(iva_calc)
             iva_raw = item.get("ivaItem")
             actual_iva = money(D(str(iva_raw))) if iva_raw is not None else None
             if iva_raw is not None:
@@ -2070,7 +2076,8 @@ def generar_dte_json(
                 monto_descu = _calc_desc(bruto)
                 line_total = d4(bruto - monto_descu)
                 venta_gravada = line_total if line_total > 0 else D("0")
-                iva_val = d4(venta_gravada - (venta_gravada / D("1.13")))
+                _, iva_val_tmp = to_base_iva(venta_gravada)
+                iva_val = d4(iva_val_tmp)
                 line_total = venta_gravada
                 bruto_total += bruto
                 descuentos_total += monto_descu
@@ -3055,14 +3062,18 @@ def validate_dte_json(
 
     # Validación de longitud de NIT / numDocumento
     emisor_nit = payload.get("emisor", {}).get("nit")
-    if emisor_nit and len(emisor_nit.replace("-", "")) != catalogos.NIT_LENGTH:
-        raise ValueError("NIT inválido en emisor")
+    if emisor_nit:
+        clean_emisor_nit = limpiar_doc(emisor_nit)
+        payload["emisor"]["nit"] = clean_emisor_nit
+        if len(clean_emisor_nit) != catalogos.NIT_LENGTH:
+            raise ValueError("NIT inválido en emisor")
 
     receptor_doc = payload.get("receptor", {}).get("numDocumento")
     if receptor_doc:
-        clean_doc = str(receptor_doc).replace("-", "")
+        clean_doc = limpiar_doc(receptor_doc)
         if len(clean_doc) not in (9, catalogos.NIT_LENGTH):
             raise ValueError("Número de documento inválido en receptor")
+        payload["receptor"]["numDocumento"] = clean_doc
     # Conversión final de Decimals con formatos específicos para el JSON
     def _zero_or(value: D, qfn) -> D:
         """Quantiza ``value`` usando ``qfn`` retornando ``0.0`` si es cero."""

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -98,6 +98,8 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     monto_nc = Decimal(str(nota.get("monto", 0)))
     if total_origen <= Decimal_0:
         raise ValueError("El documento de origen no tiene total válido")
+    if monto_nc > total_origen:
+        raise ValueError("Monto excede total del documento de origen")
     ratio = (monto_nc / total_origen).quantize(Decimal("0.0001"))
 
     return generar_nce_desde_dte(
@@ -176,14 +178,20 @@ def generar_nce_desde_dte(
             total_exenta += exenta
             total_nosuj += nosuj
             precio = det.get("precio_unitario") or det.get("precioUni")
+            codigo = det.get("codigo")
+            numitem = det.get("numItem")
+            orig = None
+            if codigo:
+                orig = next((it for it in orig_items if it.get("codigo") == codigo), None)
+            elif numitem:
+                orig = next((it for it in orig_items if it.get("numItem") == numitem), None)
+            if orig:
+                grav_orig = Decimal(str(orig.get("ventaGravada") or 0)).quantize(Q4)
+                exenta_orig = Decimal(str(orig.get("ventaExenta") or 0)).quantize(Q4)
+                nosuj_orig = Decimal(str(orig.get("ventaNoSuj") or 0)).quantize(Q4)
+                if grav > grav_orig or exenta > exenta_orig or nosuj > nosuj_orig:
+                    raise ValueError("Detalle excede montos de línea original")
             if precio is None:
-                orig = None
-                codigo = det.get("codigo")
-                numitem = det.get("numItem")
-                if codigo:
-                    orig = next((it for it in orig_items if it.get("codigo") == codigo), None)
-                elif numitem:
-                    orig = next((it for it in orig_items if it.get("numItem") == numitem), None)
                 if orig and orig.get("precioUni") is not None:
                     precio = Decimal(str(orig.get("precioUni"))) * ratio_val
                 else:
@@ -215,6 +223,9 @@ def generar_nce_desde_dte(
         total_grav = total_grav.quantize(Q4)
         total_exenta = total_exenta.quantize(Q4)
         total_nosuj = total_nosuj.quantize(Q4)
+        orig_total = Decimal(str(dte_origen.get("resumen", {}).get("montoTotalOperacion", 0)))
+        if total_grav + total_exenta + total_nosuj > orig_total:
+            raise ValueError("Monto de la nota excede total del documento de origen")
     else:
         ratio_val = ratio or Decimal_1
         total_grav = (Decimal(str(orig_resumen.get("totalGravada", 0))) * ratio_val).quantize(Q4)

--- a/tests/test_dte_payload_cleanup.py
+++ b/tests/test_dte_payload_cleanup.py
@@ -43,3 +43,18 @@ def test_sanitize_dte_payload_removes_none_recursively(dte_metadata_factory):
     clean_no_required.get("identificacion", {}).pop("motivoContin", None)
     clean_no_required.get("emisor", {}).pop("nombreComercial", None)
     assert not _has_none(clean_no_required)
+
+
+def test_sanitize_dte_payload_adds_required_fields_and_cleans_docs(dte_metadata_factory):
+    payload = dte_metadata_factory()
+    payload.pop("ventaTercero", None)
+    payload.pop("extension", None)
+    payload.pop("apendice", None)
+    payload["emisor"]["nit"] = "0614-123456-001-1"
+    payload["receptor"]["numDocumento"] = "01234567-8"
+    clean = dte.sanitize_dte_payload(payload)
+    assert clean["ventaTercero"] is None
+    assert clean["extension"] is None
+    assert clean["apendice"] is None
+    assert clean["emisor"]["nit"] == "06141234560011"
+    assert clean["receptor"]["numDocumento"] == "012345678"

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -2,7 +2,8 @@ import fitz
 from decimal import Decimal
 from db import DB
 from dte import generar_dte_json
-from nota_credito_electronica import generar_nce_desde_dte
+from nota_credito_electronica import generar_nce_desde_dte, generar_nce_desde_nota
+import pytest
 from factura_sv import generar_nota_credito_pdf
 
 
@@ -126,6 +127,62 @@ def test_nota_credito_precio_uni(monkeypatch):
     item = data["cuerpoDocumento"][0]
     assert item["precioUni"] == Decimal("7.9600")
     assert data["resumen"]["montoTotalOperacion"] == 9.0
+
+
+def test_generar_nce_rechaza_monto_excedido(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2024-01-02', 15, '')",
+        (venta_id,),
+    ).lastrowid
+    with pytest.raises(ValueError):
+        generar_nce_desde_nota(db, nota_id)
+
+
+def test_generar_nce_detalle_excede(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    codigo = dte_origen["cuerpoDocumento"][0]["codigo"]
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "codigo": codigo,
+            "ventas_gravadas": Decimal("20"),
+        }
+    ]
+    with pytest.raises(ValueError):
+        generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
 
 
 def _sample_data():

--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -18,6 +18,7 @@
           <th>Tipo</th>
           <th>Modo</th>
           <th>Valor</th>
+          <th>Afectación</th>
           <th>IVA inc.</th>
           <th>Base</th>
           <th>IVA</th>
@@ -39,7 +40,11 @@
               @keydown.enter.prevent="$event.target.blur()"
               @keydown.esc.prevent="onEsc(item, 'cantidadAjustar'); $event.target.blur()"
             />
-            <span v-if="item.tipo === 'credito' && item.cantidadAjustar > item.cantidadFacturada" class="error">Excede</span>
+            <span
+              v-if="item.tipo === 'credito' && item.cantidadAjustar > item.cantidadFacturada - (item.previas || 0)"
+              class="error"
+              >Excede</span
+            >
           </td>
           <td>
             <select
@@ -76,6 +81,13 @@
               @change="update(item, 'ivaInc', $event.target.checked)"
             />
           </td>
+          <td>
+            <select :value="item.afectacion" @change="update(item, 'afectacion', $event.target.value)">
+              <option value="gravada">Gravada</option>
+              <option value="exenta">Exenta</option>
+              <option value="no_sujeta">No sujeta</option>
+            </select>
+          </td>
           <td>{{ formatNumber(calcBase(item)) }}</td>
           <td>{{ formatNumber(calcIva(item)) }}</td>
           <td>{{ formatNumber(calcTotal(item)) }}</td>
@@ -88,6 +100,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, defineProps, defineEmits, defineOptions } from 'vue';
+import { toBaseIva } from '../services/useIvaConversion';
 
 interface NotaItem {
   id: number;
@@ -100,6 +113,8 @@ interface NotaItem {
   modo: 'monto' | 'porcentaje';
   valor: number;
   ivaInc: boolean;
+  afectacion: 'gravada' | 'exenta' | 'no_sujeta';
+  previas?: number;
 }
 
 defineOptions({ name: 'EditableNotaTable' });
@@ -151,6 +166,8 @@ function addItem() {
     modo: 'monto',
     valor: 0,
     ivaInc: false,
+    afectacion: 'gravada',
+    previas: 0,
   });
 }
 
@@ -173,12 +190,6 @@ function update(item: NotaItem, field: keyof NotaItem, value: any) {
   }
 }
 
-function toBaseIva(monto: number) {
-  const base = monto / 1.13;
-  const iva = monto - base;
-  return { base, iva };
-}
-
 function resolveValor(item: NotaItem) {
   if (item.modo === 'porcentaje') {
     return (item.cantidadFacturada * item.valor) / 100;
@@ -188,12 +199,18 @@ function resolveValor(item: NotaItem) {
 
 function calcBase(item: NotaItem) {
   const monto = resolveValor(item);
+  if (item.afectacion !== 'gravada') {
+    return monto;
+  }
   if (item.ivaInc) {
     return toBaseIva(monto).base;
   }
   return monto;
 }
 function calcIva(item: NotaItem) {
+  if (item.afectacion !== 'gravada') {
+    return 0;
+  }
   const monto = resolveValor(item);
   if (item.ivaInc) {
     return toBaseIva(monto).iva;

--- a/ui/services/notasApi.ts
+++ b/ui/services/notasApi.ts
@@ -1,8 +1,10 @@
+import { sanitizeDocs } from './sanitize';
+
 export async function previsualizarPdf(data: any) {
   const res = await fetch('/api/notas/previsualizar/pdf', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    body: JSON.stringify(sanitizeDocs(data)),
   });
   if (!res.ok) throw new Error('Error al previsualizar PDF');
   return await res.blob();
@@ -12,7 +14,7 @@ export async function previsualizarJson(data: any) {
   const res = await fetch('/api/notas/previsualizar/json', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    body: JSON.stringify(sanitizeDocs(data)),
   });
   if (!res.ok) throw new Error('Error al previsualizar JSON');
   return await res.json();
@@ -22,7 +24,7 @@ export async function guardarBorrador(data: any) {
   const res = await fetch('/api/notas/borrador', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    body: JSON.stringify(sanitizeDocs(data)),
   });
   if (!res.ok) throw new Error('Error al guardar borrador');
   return await res.json();
@@ -32,7 +34,7 @@ export async function firmarTransmitir(data: any) {
   const res = await fetch('/api/notas/firmar-transmitir', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    body: JSON.stringify(sanitizeDocs(data)),
   });
   if (!res.ok) throw new Error('Error al firmar y transmitir');
   return await res.json();

--- a/ui/services/sanitize.ts
+++ b/ui/services/sanitize.ts
@@ -1,0 +1,22 @@
+export function sanitizeDocs<T>(data: T): T {
+  function walk(obj: any) {
+    if (!obj || typeof obj !== 'object') return;
+    for (const key of Object.keys(obj)) {
+      const val = obj[key];
+      if (val && typeof val === 'object') {
+        walk(val);
+      } else if (typeof val === 'string') {
+        const kl = key.toLowerCase();
+        if (kl === 'nit' || kl === 'dui' || kl === 'numdocumento' || kl.includes('documento')) {
+          obj[key] = val.replace(/[-\s]/g, '');
+        }
+      }
+    }
+  }
+  if (data && typeof data === 'object') {
+    const clone: any = Array.isArray(data) ? [...(data as any)] : { ...(data as any) };
+    walk(clone);
+    return clone;
+  }
+  return data;
+}

--- a/ui/tests/EditableNotaTable.spec.ts
+++ b/ui/tests/EditableNotaTable.spec.ts
@@ -16,12 +16,27 @@ describe('EditableNotaTable', () => {
     const wrapper = mount(EditableNotaTable, {
       props: {
         modelValue: [
-          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false }
+          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 0 }
         ]
       }
     });
     expect(wrapper.findAll('tbody tr')).toHaveLength(1);
     await wrapper.find('input[placeholder="Buscar"]').setValue('no existe');
     expect(wrapper.findAll('tbody tr')).toHaveLength(0);
+  });
+
+  it('marca error si crédito excede saldo por línea', async () => {
+    const wrapper = mount(EditableNotaTable, {
+      props: {
+        modelValue: [
+          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 5, cantidadAjustar: 0, tipo: 'credito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 3 }
+        ],
+        topeCredito: 10
+      }
+    });
+    const input = wrapper.find('tbody tr input[type="number"]');
+    await input.setValue('3');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('span.error').text()).toBe('Excede');
   });
 });

--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -36,8 +36,8 @@ describe('NotaForm', () => {
     await input.setValue('120');
     await wrapper.vm.$nextTick();
     const cells = wrapper.findAll('tbody td');
-    expect(cells[1].text()).toBe('100.00');
-    expect(cells[4].text()).toBe('20.00');
+    expect(cells[1].text()).toBe('106.19');
+    expect(cells[4].text()).toBe('13.81');
     expect(cells[5].text()).toBe('120.00');
   });
 

--- a/ui/tests/sanitize.spec.ts
+++ b/ui/tests/sanitize.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeDocs } from '../services/sanitize';
+
+describe('sanitizeDocs', () => {
+  it('limpia NIT y numDocumento', () => {
+    const data = { nit: '0614-123456-001-1', receptor: { numDocumento: '0123 45678-9' } };
+    const clean = sanitizeDocs(data);
+    expect(clean.nit).toBe('06141234560011');
+    expect(clean.receptor.numDocumento).toBe('0123456789');
+  });
+});

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -53,7 +53,7 @@
                 <th title="Monto sujeto a IVA">Base gravada</th>
                 <th title="Ventas exentas del impuesto">Exenta</th>
                 <th title="Operaciones no sujetas al impuesto">No sujeta</th>
-                <th title="Impuesto calculado al 20%">IVA(20)</th>
+                <th title="Impuesto calculado al 13%">IVA(13)</th>
                 <th title="Suma de base e IVA">Total</th>
               </tr>
             </thead>
@@ -96,6 +96,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { previsualizarPdf, previsualizarJson, guardarBorrador, firmarTransmitir } from '../services/notasApi';
+import { toBaseIva } from '../services/useIvaConversion';
 
 const props = defineProps<{
   factura: { numero: string; cliente: string; total?: number };
@@ -110,11 +111,6 @@ const modoGlobal = ref<'porcentaje' | 'monto'>('porcentaje');
 const porcentaje = ref(0);
 const monto = ref(0);
 
-function toBaseIva(total: number, tasa = 0.2) {
-  const base = total / (1 + tasa);
-  return { base, iva: total - base };
-}
-
 const globalMonto = computed(() => {
   return modoGlobal.value === 'porcentaje'
     ? (props.factura.total ?? 0) * (porcentaje.value || 0) / 100
@@ -126,7 +122,7 @@ const preview = computed(() => {
   if (ivaIncluido.value) {
     return toBaseIva(total);
   }
-  return { base: total, iva: total * 0.2 };
+  return { base: total, iva: total * 0.13 };
 });
 
 const total = computed(() => preview.value.base + preview.value.iva);

--- a/utils/monto.py
+++ b/utils/monto.py
@@ -26,6 +26,20 @@ def iva_item(base_gravada):
     return d8(D(base_gravada) * IVA_TASA)
 
 
+def to_base_iva(total):
+    """Return base and IVA portions for ``total`` with IVA included.
+
+    The calculation mirrors the frontend ``toBaseIva`` helper and ensures
+    consistency when separating a total that already contains IVA.  Results
+    are quantized to 8 decimal places to avoid floating point artifacts.
+    """
+
+    total = D(total)
+    base = d8(total / (D("1") + IVA_TASA))
+    iva = d8(total - base)
+    return base, iva
+
+
 try:
     from num2words import num2words
 except ImportError:  # pragma: no cover - fallback for environments without num2words


### PR DESCRIPTION
## Summary
- Sanitize NIT and document numbers when preparing DTE payloads and API requests
- Validate credit note totals and line items against original documents
- Add tax category handling, IVA logic and per-line limit checks in note editor

## Testing
- `pytest` *(fails: 41 errors during collection)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be42118f0c83238a4b36dad921234a