### PR TITLE
Add note API limit fixtures and IVA prorrateo tests

### DIFF
--- a/tests/fixtures/factura_ejemplo.json
+++ b/tests/fixtures/factura_ejemplo.json
@@ -1,0 +1,5 @@
+{
+  "fecha": "2024-01-01",
+  "total": 100,
+  "cliente": {"nombre": "Ana"}
+}

--- a/tests/fixtures/notas_previas.json
+++ b/tests/fixtures/notas_previas.json
@@ -1,0 +1,4 @@
+[
+  {"tipo": "credito", "fecha": "2024-01-02", "monto": 40, "motivo": "Ajuste"},
+  {"tipo": "credito", "fecha": "2024-01-03", "monto": 30, "motivo": "Ajuste2"}
+]

--- a/tests/test_iva_conversion_prorrateo.py
+++ b/tests/test_iva_conversion_prorrateo.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+from utils.monto import to_base_iva, d8
+from nota_credito_electronica import generar_nce_desde_dte
+from db import DB
+from dte import generar_dte_json
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_to_base_iva_splits_total():
+    base, iva = to_base_iva(113)
+    assert base == d8("100")
+    assert iva == d8("13")
+
+
+def test_prorrateo_porcentaje(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 100)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 100)
+    db.add_detalle_venta(venta_id, pid, 1, 100, vendedor_id=vid)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    data = generar_nce_desde_dte(db, dte_origen, Decimal("0.1"))
+    assert data["resumen"]["montoTotalOperacion"] == 10.0
+

--- a/tests/test_notas_api.py
+++ b/tests/test_notas_api.py
@@ -1,4 +1,6 @@
 from fastapi.testclient import TestClient
+import json
+from pathlib import Path
 import api.notas as notas_api
 from models.factura import Factura
 
@@ -49,3 +51,52 @@ def test_credito_no_excede_saldo_api(monkeypatch):
         json={"tipo": "credito", "venta_id": venta_id, "fecha": "2024-01-02", "monto": 60, "motivo": "Dev"},
     )
     assert resp.status_code == 400
+
+
+def _cargar_fixtures():
+    fixtures = Path(__file__).parent / "fixtures"
+    factura = json.loads((fixtures / "factura_ejemplo.json").read_text())
+    notas_previas = json.loads((fixtures / "notas_previas.json").read_text())
+    return factura, notas_previas
+
+
+def test_credito_respetar_limite_con_notas_previas(monkeypatch):
+    monkeypatch.setattr(notas_api, "enviar_nota_credito", lambda *a, **k: {"ok": True})
+    factura, notas_previas = _cargar_fixtures()
+    notas_api.db.add_cliente(factura["cliente"]["nombre"], "", "", "", "", "", "", "", "", "")
+    cliente_id = notas_api.db.cursor.lastrowid
+    venta_id = notas_api.db.add_venta(factura["fecha"], factura["total"], cliente_id=cliente_id)
+    for nota in notas_previas:
+        notas_api.db.agregar_nota(nota["tipo"], venta_id, nota["fecha"], nota["monto"], nota["motivo"])
+    resp = client.post(
+        "/api/notas",
+        json={
+            "tipo": "credito",
+            "venta_id": venta_id,
+            "fecha": "2024-01-04",
+            "monto": 40,
+            "motivo": "Dev3",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_credito_acepta_monto_restante(monkeypatch):
+    monkeypatch.setattr(notas_api, "enviar_nota_credito", lambda *a, **k: {"ok": True})
+    factura, notas_previas = _cargar_fixtures()
+    notas_api.db.add_cliente(factura["cliente"]["nombre"], "", "", "", "", "", "", "", "", "")
+    cliente_id = notas_api.db.cursor.lastrowid
+    venta_id = notas_api.db.add_venta(factura["fecha"], factura["total"], cliente_id=cliente_id)
+    for nota in notas_previas:
+        notas_api.db.agregar_nota(nota["tipo"], venta_id, nota["fecha"], nota["monto"], nota["motivo"])
+    resp = client.post(
+        "/api/notas",
+        json={
+            "tipo": "credito",
+            "venta_id": venta_id,
+            "fecha": "2024-01-04",
+            "monto": 30,
+            "motivo": "Dev3",
+        },
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add IVA base conversion and prorrateo tests
- verify /api/notas limit handling with fixture-backed cases
- include sample factura and prior notes fixtures

## Testing
- `pytest tests/test_iva_conversion_prorrateo.py tests/test_notas_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be45987b008323847c5ab24d50942c