### PR TITLE
feat: prorrateo global en vista previa de notas

### DIFF
--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -18,7 +18,18 @@ describe('NotaForm', () => {
 
   it('cambia input según modo', async () => {
     const wrapper = mount(NotaForm, {
-      props: { factura: { numero: '1', cliente: 'A', total: 1000 }, tipo: 'credito' }
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 1000,
+          ventas_gravadas: 1000,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'credito'
+      }
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
@@ -26,24 +37,48 @@ describe('NotaForm', () => {
     expect(input.attributes('title')).toContain('Monto');
   });
 
-  it('descompone IVA incluido con toBaseIva', async () => {
+  it('prorratea monto global con prorratearGlobal', async () => {
     const wrapper = mount(NotaForm, {
-      props: { factura: { numero: '1', cliente: 'A', total: 0 }, tipo: 'credito' }
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 188,
+          ventas_gravadas: 100,
+          ventas_exentas: 50,
+          ventas_no_sujetas: 25,
+          iva: 13
+        },
+        tipo: 'credito'
+      }
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
     const input = wrapper.find('input[type="number"]');
-    await input.setValue('120');
+    await input.setValue('18.8');
     await wrapper.vm.$nextTick();
     const cells = wrapper.findAll('tbody td');
-    expect(cells[1].text()).toBe('106.19');
-    expect(cells[4].text()).toBe('13.81');
-    expect(cells[5].text()).toBe('120.00');
+    expect(cells[1].text()).toBe('10.00');
+    expect(cells[2].text()).toBe('5.00');
+    expect(cells[3].text()).toBe('2.50');
+    expect(cells[4].text()).toBe('1.30');
+    expect(cells[5].text()).toBe('18.80');
   });
 
   it('muestra badge rojo si excede saldo', async () => {
     const wrapper = mount(NotaForm, {
-      props: { factura: { numero: '1', cliente: 'A', total: 100 }, tipo: 'credito' }
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 100,
+          ventas_gravadas: 100,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'credito'
+      }
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
@@ -55,7 +90,18 @@ describe('NotaForm', () => {
 
   it('llama API tras validación sin motivo', async () => {
     const wrapper = mount(NotaForm, {
-      props: { factura: { numero: '1', cliente: 'A', total: 1000 }, tipo: 'debito' }
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 1000,
+          ventas_gravadas: 1000,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'debito'
+      }
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
@@ -69,7 +115,18 @@ describe('NotaForm', () => {
 
   it('no llama API si total es cero', async () => {
     const wrapper = mount(NotaForm, {
-      props: { factura: { numero: '1', cliente: 'A', total: 1000 }, tipo: 'debito' }
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 1000,
+          ventas_gravadas: 1000,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'debito'
+      }
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
@@ -79,7 +136,18 @@ describe('NotaForm', () => {
 
   it('calcula totales para ítems en pestaña producto', async () => {
     const wrapper = mount(NotaForm, {
-      props: { factura: { numero: '1', cliente: 'A', total: 1000 }, tipo: 'debito' }
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 1000,
+          ventas_gravadas: 1000,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'debito'
+      }
     });
     const btnProducto = wrapper.findAll('.tabs button')[1];
     await btnProducto.trigger('click');

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -54,17 +54,17 @@
                 <th title="Ventas exentas del impuesto">Exenta</th>
                 <th title="Operaciones no sujetas al impuesto">No sujeta</th>
                 <th title="Impuesto calculado al 13%">IVA(13)</th>
-                <th title="Suma de base e IVA">Total</th>
+                <th title="Suma de base, exenta, no sujeta e IVA">Total</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>Global</td>
                 <td>{{ format(preview.base) }}</td>
-                <td>{{ format(0) }}</td>
-                <td>{{ format(0) }}</td>
+                <td>{{ format(preview.exenta) }}</td>
+                <td>{{ format(preview.noSujeta) }}</td>
                 <td>{{ format(preview.iva) }}</td>
-                <td>{{ format(preview.base + preview.iva) }}</td>
+                <td>{{ format(preview.base + preview.exenta + preview.noSujeta + preview.iva) }}</td>
               </tr>
             </tbody>
           </table>
@@ -98,9 +98,18 @@ import { ref, computed } from 'vue';
 import { previsualizarPdf, previsualizarJson, guardarBorrador, firmarTransmitir } from '../services/notasApi';
 import { toBaseIva } from '../services/useIvaConversion';
 import EditableNotaTable from '../components/EditableNotaTable.vue';
+import { prorratearGlobal } from '../services/prorrateo';
 
 const props = defineProps<{
-  factura: { numero: string; cliente: string; total?: number };
+  factura: {
+    numero: string;
+    cliente: string;
+    total?: number;
+    ventas_gravadas?: number;
+    ventas_exentas?: number;
+    ventas_no_sujetas?: number;
+    iva?: number;
+  };
   tipo: 'credito' | 'debito';
 }>();
 
@@ -130,12 +139,6 @@ interface NotaItem {
 const items = ref<NotaItem[]>([]);
 
 const saldoDisponible = computed(() => props.factura.total ?? 0);
-
-const globalMonto = computed(() => {
-  return modoGlobal.value === 'porcentaje'
-    ? (props.factura.total ?? 0) * (porcentaje.value || 0) / 100
-    : monto.value || 0;
-});
 
 function resolveValor(item: NotaItem) {
   if (item.modo === 'porcentaje') {
@@ -175,12 +178,21 @@ const itemsPreview = computed(() => {
 
 const preview = computed(() => {
   if (activeTab.value === 'global') {
-    const total = globalMonto.value;
-    if (ivaIncluido.value) {
-      const { base, iva } = toBaseIva(total);
-      return { base, exenta: 0, noSujeta: 0, iva };
-    }
-    return { base: total, exenta: 0, noSujeta: 0, iva: total * 0.13 };
+    const ajuste =
+      modoGlobal.value === 'porcentaje'
+        ? { porcentaje: porcentaje.value || 0 }
+        : {
+            monto: ivaIncluido.value
+              ? monto.value || 0
+              : (monto.value || 0) * 1.13,
+          };
+    const res = prorratearGlobal(props.factura, ajuste);
+    return {
+      base: res.ventas_gravadas,
+      exenta: res.ventas_exentas,
+      noSujeta: res.ventas_no_sujetas,
+      iva: res.iva,
+    };
   }
   return itemsPreview.value;
 });


### PR DESCRIPTION
## Summary
- muestra en la tabla todas las columnas de la nota
- prorratea el ajuste global con `prorratearGlobal`
- amplía la interfaz de factura usada en NotaForm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be4d18a0588323b7eea774eddb8e42