### PR TITLE
fix: include line totals in credit sum

### DIFF
--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -231,7 +231,7 @@ function formatNumber(n: number) {
 const totalCredito = computed(() =>
   items.value
     .filter((i) => i.tipo === 'credito')
-    .reduce((acc, cur) => acc + cur.cantidadAjustar, 0)
+    .reduce((acc, i) => acc + calcTotal(i), 0)
 );
 
 const creditoExcede = computed(() =>


### PR DESCRIPTION
## Summary
- sum credit totals using `calcTotal` for each credit item
- keep global credit limit validation against summed totals

## Testing
- `npm test`
- `pytest` *(fails: ImportError: libGL.so.1, ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68be528d7fe083238169f6129fd8bb72