### PR TITLE
feat: add ajuste and concepto columns

### DIFF
--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -20,9 +20,11 @@
           <th>Valor</th>
           <th>Afectación</th>
           <th>IVA inc.</th>
+          <th>Ajuste (USD)</th>
           <th>Base</th>
           <th>IVA</th>
           <th>Total</th>
+          <th>Concepto</th>
         </tr>
       </thead>
       <tbody>
@@ -84,6 +86,17 @@
             />
           </td>
           <td>
+            <input
+              class="ajuste"
+              type="number"
+              :value="item.ajuste"
+              @focus="onFocus(item, 'ajuste')"
+              @input="update(item, 'ajuste', parseFloat($event.target.value))"
+              @keydown.enter.prevent="$event.target.blur()"
+              @keydown.esc.prevent="onEsc(item, 'ajuste'); $event.target.blur()"
+            />
+          </td>
+          <td>
             <select :value="item.afectacion" @change="update(item, 'afectacion', $event.target.value)">
               <option value="gravada">Gravada</option>
               <option value="exenta">Exenta</option>
@@ -93,6 +106,17 @@
           <td>{{ formatNumber(calcBase(item)) }}</td>
           <td>{{ formatNumber(calcIva(item)) }}</td>
           <td>{{ formatNumber(calcTotal(item)) }}</td>
+          <td>
+            <input
+              type="text"
+              :value="item.concepto"
+              placeholder="Concepto opcional"
+              @focus="onFocus(item, 'concepto')"
+              @input="update(item, 'concepto', $event.target.value)"
+              @keydown.enter.prevent="$event.target.blur()"
+              @keydown.esc.prevent="onEsc(item, 'concepto'); $event.target.blur()"
+            />
+          </td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +126,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, defineProps, defineEmits, defineOptions } from 'vue';
-import { toBaseIva } from '../services/useIvaConversion';
+import { toBaseIva, fromBaseIva } from '../services/useIvaConversion';
 
 interface NotaItem {
   id: number;
@@ -117,11 +141,13 @@ interface NotaItem {
   ivaInc: boolean;
   afectacion: 'gravada' | 'exenta' | 'no_sujeta';
   previas?: number;
+  ajuste?: number;
+  concepto?: string;
 }
 
 defineOptions({ name: 'EditableNotaTable' });
 
-const props = defineProps<{ modelValue: NotaItem[]; topeCredito?: number }>();
+const props = defineProps<{ modelValue: NotaItem[]; topeCredito?: number; ivaIncluido: boolean }>();
 const emit = defineEmits(['update:modelValue']);
 
 const items = ref<NotaItem[]>(props.modelValue ? [...props.modelValue] : []);
@@ -170,6 +196,8 @@ function addItem() {
     ivaInc: false,
     afectacion: 'gravada',
     previas: 0,
+    ajuste: 0,
+    concepto: '',
   });
 }
 
@@ -199,10 +227,16 @@ function resolveValor(item: NotaItem) {
   return item.valor;
 }
 
+function getMonto(item: NotaItem) {
+  return item.ajuste !== undefined ? item.ajuste : resolveValor(item);
+}
 function calcBase(item: NotaItem) {
-  const monto = resolveValor(item);
+  const monto = getMonto(item);
   if (item.afectacion !== 'gravada') {
     return monto;
+  }
+  if (item.ajuste !== undefined) {
+    return props.ivaIncluido ? toBaseIva(monto).base : monto;
   }
   if (item.ivaInc) {
     return toBaseIva(monto).base;
@@ -213,15 +247,25 @@ function calcIva(item: NotaItem) {
   if (item.afectacion !== 'gravada') {
     return 0;
   }
-  const monto = resolveValor(item);
+  const monto = getMonto(item);
+  if (item.ajuste !== undefined) {
+    return props.ivaIncluido ? toBaseIva(monto).iva : fromBaseIva(monto).iva;
+  }
   if (item.ivaInc) {
     return toBaseIva(monto).iva;
   }
   return monto * 0.13;
 }
 function calcTotal(item: NotaItem) {
+  const monto = getMonto(item);
+  if (item.afectacion !== 'gravada') {
+    return monto;
+  }
+  if (item.ajuste !== undefined) {
+    return props.ivaIncluido ? monto : fromBaseIva(monto).total;
+  }
   if (item.ivaInc) {
-    return resolveValor(item);
+    return monto;
   }
   return calcBase(item) + calcIva(item);
 }

--- a/ui/tests/EditableNotaTable.spec.ts
+++ b/ui/tests/EditableNotaTable.spec.ts
@@ -4,7 +4,7 @@ import EditableNotaTable from '../components/EditableNotaTable.vue';
 describe('EditableNotaTable', () => {
   it('agrega item cuando se hace click', async () => {
     const wrapper = mount(EditableNotaTable, {
-      props: { modelValue: [], topeCredito: 10 }
+      props: { modelValue: [], topeCredito: 10, ivaIncluido: true }
     });
     await wrapper.find('button.add-item').trigger('click');
     const emitted = wrapper.emitted('update:modelValue');
@@ -16,8 +16,9 @@ describe('EditableNotaTable', () => {
     const wrapper = mount(EditableNotaTable, {
       props: {
         modelValue: [
-          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 0 }
-        ]
+          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 0, ajuste: 0, concepto: '' }
+        ],
+        ivaIncluido: true
       }
     });
     expect(wrapper.findAll('tbody tr')).toHaveLength(1);
@@ -29,14 +30,40 @@ describe('EditableNotaTable', () => {
     const wrapper = mount(EditableNotaTable, {
       props: {
         modelValue: [
-          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 5, cantidadAjustar: 0, tipo: 'credito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 3 }
+          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 5, cantidadAjustar: 0, tipo: 'credito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 3, ajuste: 0, concepto: '' }
         ],
-        topeCredito: 10
+        topeCredito: 10,
+        ivaIncluido: true
       }
     });
     const input = wrapper.find('tbody tr input[type="number"]');
     await input.setValue('3');
     await wrapper.vm.$nextTick();
     expect(wrapper.find('span.error').text()).toBe('Excede');
+  });
+
+  it('actualiza base, IVA y total según ivaIncluido', async () => {
+    const wrapper = mount(EditableNotaTable, {
+      props: {
+        modelValue: [
+          { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 0, ajuste: 0, concepto: '' }
+        ],
+        ivaIncluido: true
+      }
+    });
+    const ajusteInput = wrapper.find('input.ajuste');
+    await ajusteInput.setValue('113');
+    await wrapper.vm.$nextTick();
+    let cells = wrapper.findAll('tbody td');
+    expect(cells[11].text()).toBe('100.00');
+    expect(cells[12].text()).toBe('13.00');
+    expect(cells[13].text()).toBe('113.00');
+    await wrapper.setProps({ ivaIncluido: false });
+    await ajusteInput.setValue('100');
+    await wrapper.vm.$nextTick();
+    cells = wrapper.findAll('tbody td');
+    expect(cells[11].text()).toBe('100.00');
+    expect(cells[12].text()).toBe('13.00');
+    expect(cells[13].text()).toBe('113.00');
   });
 });

--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -151,6 +151,7 @@ describe('NotaForm', () => {
     });
     const btnProducto = wrapper.findAll('.tabs button')[1];
     await btnProducto.trigger('click');
+    wrapper.vm.ivaIncluido = false;
     wrapper.vm.items.push({
       id: 1,
       selected: false,
@@ -163,7 +164,9 @@ describe('NotaForm', () => {
       valor: 100,
       ivaInc: false,
       afectacion: 'gravada',
-      previas: 0
+      previas: 0,
+      ajuste: 100,
+      concepto: ''
     });
     await wrapper.vm.$nextTick();
     const resumen = wrapper.find('.resumen').text();

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -70,7 +70,7 @@
           </table>
         </div>
         <div v-else>
-          <EditableNotaTable v-model="items" :topeCredito="saldoDisponible" />
+          <EditableNotaTable v-model="items" :topeCredito="saldoDisponible" :ivaIncluido="ivaIncluido" />
         </div>
       </div>
       <div class="resumen">


### PR DESCRIPTION
## Summary
- allow entering per-line adjustment and concept in detail table
- recalc base, IVA and total based on global ivaIncluido
- pass ivaIncluido flag from note form to table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be58a3d8108323b8075a46b6f7dfd8