### PR TITLE
feat: allow adding custom items to debit notes

### DIFF
--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -5,7 +5,13 @@
       <label>
         <input type="checkbox" v-model="applyToSelected" /> Aplicar a todas las líneas seleccionadas
       </label>
-      <button class="add-item" @click="addItem">+ Agregar ítem</button>
+      <button
+        v-if="notaTipo === 'debito'"
+        class="add-item"
+        @click="addItem"
+      >
+        + Agregar ítem
+      </button>
     </div>
     <table>
       <thead>
@@ -143,11 +149,17 @@ interface NotaItem {
   previas?: number;
   ajuste?: number;
   concepto?: string;
+  unidad?: string;
 }
 
 defineOptions({ name: 'EditableNotaTable' });
 
-const props = defineProps<{ modelValue: NotaItem[]; topeCredito?: number; ivaIncluido: boolean }>();
+const props = defineProps<{
+  modelValue: NotaItem[];
+  topeCredito?: number;
+  ivaIncluido: boolean;
+  notaTipo: 'debito' | 'credito';
+}>();
 const emit = defineEmits(['update:modelValue']);
 
 const items = ref<NotaItem[]>(props.modelValue ? [...props.modelValue] : []);
@@ -183,21 +195,33 @@ function toggleAll(val: boolean) {
 
 let nextId = 1;
 function addItem() {
+  const codigo = prompt('Código del ítem');
+  if (codigo === null) return;
+  const descripcion = prompt('Descripción del ítem') || '';
+  const cantidadStr = prompt('Cantidad');
+  if (cantidadStr === null) return;
+  const cantidad = parseFloat(cantidadStr) || 0;
+  const ajusteStr = prompt('Ajuste (USD)');
+  if (ajusteStr === null) return;
+  const ajuste = parseFloat(ajusteStr) || 0;
+  const unidad = prompt('Unidad') || '';
+  const concepto = prompt('Concepto') || '';
   items.value.push({
     id: nextId++,
     selected: false,
-    codigo: '',
-    descripcion: '',
-    cantidadFacturada: 0,
-    cantidadAjustar: 0,
+    codigo,
+    descripcion,
+    cantidadFacturada: cantidad,
+    cantidadAjustar: cantidad,
     tipo: 'debito',
     modo: 'monto',
     valor: 0,
     ivaInc: false,
     afectacion: 'gravada',
     previas: 0,
-    ajuste: 0,
-    concepto: '',
+    ajuste,
+    concepto,
+    unidad,
   });
 }
 

--- a/ui/tests/EditableNotaTable.spec.ts
+++ b/ui/tests/EditableNotaTable.spec.ts
@@ -1,12 +1,23 @@
 import { mount } from '@vue/test-utils';
+import { vi } from 'vitest';
 import EditableNotaTable from '../components/EditableNotaTable.vue';
 
 describe('EditableNotaTable', () => {
   it('agrega item cuando se hace click', async () => {
+    const originalPrompt = global.prompt;
+    global.prompt = vi
+      .fn()
+      .mockReturnValueOnce('A1')
+      .mockReturnValueOnce('Desc')
+      .mockReturnValueOnce('1')
+      .mockReturnValueOnce('10')
+      .mockReturnValueOnce('UND')
+      .mockReturnValueOnce('Concepto');
     const wrapper = mount(EditableNotaTable, {
-      props: { modelValue: [], topeCredito: 10, ivaIncluido: true }
+      props: { modelValue: [], topeCredito: 10, ivaIncluido: true, notaTipo: 'debito' }
     });
     await wrapper.find('button.add-item').trigger('click');
+    global.prompt = originalPrompt;
     const emitted = wrapper.emitted('update:modelValue');
     expect(emitted).toBeTruthy();
     expect(emitted![0][0]).toHaveLength(1);
@@ -18,7 +29,8 @@ describe('EditableNotaTable', () => {
         modelValue: [
           { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 0, ajuste: 0, concepto: '' }
         ],
-        ivaIncluido: true
+        ivaIncluido: true,
+        notaTipo: 'debito'
       }
     });
     expect(wrapper.findAll('tbody tr')).toHaveLength(1);
@@ -33,7 +45,8 @@ describe('EditableNotaTable', () => {
           { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 5, cantidadAjustar: 0, tipo: 'credito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 3, ajuste: 0, concepto: '' }
         ],
         topeCredito: 10,
-        ivaIncluido: true
+        ivaIncluido: true,
+        notaTipo: 'debito'
       }
     });
     const input = wrapper.find('tbody tr input[type="number"]');
@@ -48,7 +61,8 @@ describe('EditableNotaTable', () => {
         modelValue: [
           { id: 1, selected: false, codigo: 'A1', descripcion: 'Test', cantidadFacturada: 1, cantidadAjustar: 0, tipo: 'debito', modo: 'monto', valor: 0, ivaInc: false, afectacion: 'gravada', previas: 0, ajuste: 0, concepto: '' }
         ],
-        ivaIncluido: true
+        ivaIncluido: true,
+        notaTipo: 'debito'
       }
     });
     const ajusteInput = wrapper.find('input.ajuste');

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -77,7 +77,12 @@
           </table>
         </div>
         <div v-else>
-          <EditableNotaTable v-model="items" :topeCredito="saldoDisponible" :ivaIncluido="ivaIncluido" />
+          <EditableNotaTable
+            v-model="items"
+            :topeCredito="saldoDisponible"
+            :ivaIncluido="ivaIncluido"
+            :notaTipo="tipo"
+          />
         </div>
       </div>
       <div class="resumen">
@@ -160,9 +165,21 @@ function resolveValor(item: NotaItem) {
 const itemsPreview = computed(() => {
   return items.value.reduce(
     (acc, item) => {
-      const valor = resolveValor(item);
+      const valor = item.ajuste !== undefined ? item.ajuste : resolveValor(item);
       if (item.afectacion === 'gravada') {
-        if (item.ivaInc) {
+        if (item.ajuste !== undefined) {
+          if (ivaIncluido.value) {
+            const { base, iva } = toBaseIva(valor);
+            acc.base += base;
+            acc.iva += iva;
+            acc.total += valor;
+          } else {
+            const { total, iva } = fromBaseIva(valor);
+            acc.base += valor;
+            acc.iva += iva;
+            acc.total += total;
+          }
+        } else if (item.ivaInc) {
           const { base, iva } = toBaseIva(valor);
           acc.base += base;
           acc.iva += iva;


### PR DESCRIPTION
## Summary
- add "+ Agregar ítem" button for debit notes with prompts to enter item details
- pass note type and handle IVA conversion for custom debit items in summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be5a1f7594832392bf2942bdb2df8b