### PR TITLE
Validar límites de notas y formateo de archivos DTE

### DIFF
--- a/tests/test_get_dte_document_paths.py
+++ b/tests/test_get_dte_document_paths.py
@@ -1,0 +1,11 @@
+from utils.docs import get_dte_document_paths
+
+def test_get_dte_document_paths_pads_number(tmp_path):
+    _, json_path = get_dte_document_paths(
+        "2024-01-02",
+        "Mi Empresa",
+        "DTE-05-ABC-123",
+        "NotaCredito",
+        root=tmp_path,
+    )
+    assert json_path.name == "20240102_Mi_Empresa_DTE-05-ABC-000000000000123_NotaCredito.json"

--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -101,6 +101,11 @@
               @keydown.enter.prevent="$event.target.blur()"
               @keydown.esc.prevent="onEsc(item, 'ajuste'); $event.target.blur()"
             />
+            <span
+              v-if="item.tipo === 'credito' && calcTotal(item) > (item.maxMonto ?? (props.topeCredito ?? 0))"
+              class="error"
+              >Excede</span
+            >
           </td>
           <td>
             <select :value="item.afectacion" @change="update(item, 'afectacion', $event.target.value)">
@@ -150,6 +155,7 @@ interface NotaItem {
   ajuste?: number;
   concepto?: string;
   unidad?: string;
+  maxMonto?: number;
 }
 
 defineOptions({ name: 'EditableNotaTable' });
@@ -203,7 +209,8 @@ function addItem() {
   const cantidad = parseFloat(cantidadStr) || 0;
   const ajusteStr = prompt('Ajuste (USD)');
   if (ajusteStr === null) return;
-  const ajuste = parseFloat(ajusteStr) || 0;
+  let ajuste = parseFloat(ajusteStr) || 0;
+  if (props.notaTipo === 'debito' && ajuste < 0) ajuste = 0;
   const unidad = prompt('Unidad') || '';
   const concepto = prompt('Concepto') || '';
   items.value.push({
@@ -235,6 +242,9 @@ function onEsc(item: NotaItem, field: keyof NotaItem) {
 }
 
 function update(item: NotaItem, field: keyof NotaItem, value: any) {
+  if (field === 'ajuste' && props.notaTipo === 'debito' && value < 0) {
+    value = 0;
+  }
   if (applyToSelected.value) {
     items.value
       .filter((i) => i.selected)

--- a/ui/tests/EditableNotaTable.spec.ts
+++ b/ui/tests/EditableNotaTable.spec.ts
@@ -55,6 +55,71 @@ describe('EditableNotaTable', () => {
     expect(wrapper.find('span.error').text()).toBe('Excede');
   });
 
+  it('marca error si monto de crédito excede disponible', async () => {
+    const wrapper = mount(EditableNotaTable, {
+      props: {
+        modelValue: [
+          {
+            id: 1,
+            selected: false,
+            codigo: 'A1',
+            descripcion: 'Test',
+            cantidadFacturada: 1,
+            cantidadAjustar: 0,
+            tipo: 'credito',
+            modo: 'monto',
+            valor: 0,
+            ivaInc: false,
+            afectacion: 'gravada',
+            previas: 0,
+            ajuste: 0,
+            concepto: '',
+            maxMonto: 5
+          }
+        ],
+        topeCredito: 10,
+        ivaIncluido: true,
+        notaTipo: 'debito'
+      }
+    });
+    const ajuste = wrapper.find('input.ajuste');
+    await ajuste.setValue('6');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('span.error').text()).toBe('Excede');
+  });
+
+  it('rechaza ajuste negativo en notas de débito', async () => {
+    const wrapper = mount(EditableNotaTable, {
+      props: {
+        modelValue: [
+          {
+            id: 1,
+            selected: false,
+            codigo: 'A1',
+            descripcion: 'Test',
+            cantidadFacturada: 1,
+            cantidadAjustar: 0,
+            tipo: 'debito',
+            modo: 'monto',
+            valor: 0,
+            ivaInc: false,
+            afectacion: 'gravada',
+            previas: 0,
+            ajuste: 0,
+            concepto: ''
+          }
+        ],
+        ivaIncluido: true,
+        notaTipo: 'debito'
+      }
+    });
+    const ajuste = wrapper.find('input.ajuste');
+    await ajuste.setValue('-5');
+    await wrapper.vm.$nextTick();
+    // @ts-expect-error accessing internal state for test
+    expect(wrapper.vm.items[0].ajuste).toBe(0);
+  });
+
   it('actualiza base, IVA y total según ivaIncluido', async () => {
     const wrapper = mount(EditableNotaTable, {
       props: {

--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -121,6 +121,43 @@ describe('NotaForm', () => {
     expect(wrapper.find('.badge.rojo').exists()).toBe(true);
   });
 
+  it('muestra badge si créditos por producto exceden saldo', async () => {
+    const wrapper = mount(NotaForm, {
+      props: {
+        factura: {
+          numero: '1',
+          cliente: 'A',
+          total: 50,
+          ventas_gravadas: 50,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'debito'
+      }
+    });
+    const btnProducto = wrapper.findAll('.tabs button')[1];
+    await btnProducto.trigger('click');
+    wrapper.vm.items.push({
+      id: 1,
+      selected: false,
+      codigo: 'A1',
+      descripcion: 'Test',
+      cantidadFacturada: 1,
+      cantidadAjustar: 0,
+      tipo: 'credito',
+      modo: 'monto',
+      valor: 0,
+      ivaInc: false,
+      afectacion: 'gravada',
+      previas: 0,
+      ajuste: 60,
+      concepto: ''
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.badge.rojo').exists()).toBe(true);
+  });
+
   it('llama API tras validación sin motivo', async () => {
     const wrapper = mount(NotaForm, {
       props: {

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -237,8 +237,20 @@ const total = computed(
 
 const totalLetras = computed(() => numeroALetras(total.value));
 
+const totalCredito = computed(() => {
+  if (activeTab.value === 'producto') {
+    return items.value
+      .filter((i) => i.tipo === 'credito')
+      .reduce((acc, i) => {
+        const val = i.ajuste !== undefined ? i.ajuste : resolveValor(i);
+        return acc + val;
+      }, 0);
+  }
+  return tipo === 'credito' ? total.value : 0;
+});
+
 const excedeSaldo = computed(
-  () => tipo === 'credito' && total.value > (props.factura.total ?? 0)
+  () => totalCredito.value > (saldoDisponible.value)
 );
 
 function validar() {

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -74,6 +74,10 @@ def get_dte_document_paths(fecha, empresa, numero_control, doc_type, root=None):
         except Exception:
             d = datetime.now()
     date_str = d.strftime('%Y%m%d')
+    if isinstance(numero_control, str):
+        m = re.match(r"^(DTE-\d{2}-[^-]+-)(\d+)$", numero_control)
+        if m:
+            numero_control = f"{m.group(1)}{int(m.group(2)):015d}"
     base_name = f"{date_str}_{sanitize_filename(empresa)}_{numero_control}_{sanitize_filename(doc_type)}"
     pdf_path = os.path.join(folder, base_name + '.pdf')
     json_path = os.path.join(folder, base_name + '.json')


### PR DESCRIPTION
## Summary
- Verifica que las notas de crédito no excedan el saldo y evita ajustes negativos en notas de débito
- Calcula el crédito total en formularios para impedir superar el saldo disponible
- Asegura que los nombres de archivos DTE usen control numérico con 15 dígitos

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 / ModuleNotFoundError: fastapi)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be5df4b3ec8323949fa32b17143842