### PR TITLE
Permitir nota de remisión sin documento relacionado

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -18,6 +18,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QCheckBox,
     QRadioButton,
+    QSpinBox,
 )
 from PyQt5.QtCore import QDate, Qt, QUrl
 from PyQt5.QtGui import QPixmap, QDesktopServices
@@ -90,6 +91,145 @@ class SendOptionsDialog(QDialog):
         layout.addWidget(buttons)
 
 
+
+class NotaRemisionDialog(QDialog):
+    """Diálogo simple para construir una Nota de Remisión."""
+
+    def __init__(self, productos, parent=None):
+        super().__init__(parent)
+        self.productos = productos or []
+        self.setWindowTitle("Nota de Remisión")
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        add_layout = QHBoxLayout()
+        self.prod_cb = QComboBox()
+        for p in self.productos:
+            self.prod_cb.addItem(p.get("nombre", ""), p.get("id"))
+        add_layout.addWidget(self.prod_cb)
+        self.qty_spin = QSpinBox()
+        self.qty_spin.setMinimum(1)
+        add_layout.addWidget(self.qty_spin)
+        self.obs_edit = QLineEdit()
+        self.obs_edit.setPlaceholderText("Observación")
+        add_layout.addWidget(self.obs_edit)
+        self.add_btn = QPushButton("Agregar")
+        add_layout.addWidget(self.add_btn)
+        layout.addLayout(add_layout)
+
+        self.table = QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Producto", "Cantidad", "Observación"])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        layout.addWidget(self.table)
+
+        # Campos de extensión obligatorios
+        form_layout = QVBoxLayout()
+        self.nomb_entrega = QLineEdit()
+        self.docu_entrega = QLineEdit()
+        self.nomb_recibe = QLineEdit()
+        self.docu_recibe = QLineEdit()
+        self.ext_obs = QLineEdit()
+        for label, widget in [
+            ("Nombre entrega:", self.nomb_entrega),
+            ("Documento entrega:", self.docu_entrega),
+            ("Nombre recibe:", self.nomb_recibe),
+            ("Documento recibe:", self.docu_recibe),
+            ("Observaciones:", self.ext_obs),
+        ]:
+            row = QHBoxLayout()
+            row.addWidget(QLabel(label))
+            row.addWidget(widget)
+            form_layout.addLayout(row)
+        layout.addLayout(form_layout)
+
+        # Datos básicos del receptor
+        rec_layout = QHBoxLayout()
+        rec_layout.addWidget(QLabel("Receptor:"))
+        self.receptor_nombre = QLineEdit()
+        rec_layout.addWidget(self.receptor_nombre)
+        rec_layout.addWidget(QLabel("Documento:"))
+        self.receptor_doc = QLineEdit()
+        rec_layout.addWidget(self.receptor_doc)
+        layout.addLayout(rec_layout)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.add_btn.clicked.connect(self._add_item)
+
+    def _add_item(self):
+        idx = self.prod_cb.currentIndex()
+        nombre = self.prod_cb.currentText()
+        pid = self.prod_cb.itemData(idx)
+        qty = self.qty_spin.value()
+        obs = self.obs_edit.text()
+        if qty <= 0:
+            return
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        item = QTableWidgetItem(nombre)
+        item.setData(Qt.UserRole, pid)
+        self.table.setItem(row, 0, item)
+        self.table.setItem(row, 1, QTableWidgetItem(str(qty)))
+        self.table.setItem(row, 2, QTableWidgetItem(obs))
+        self.qty_spin.setValue(1)
+        self.obs_edit.clear()
+
+    def accept(self):
+        if self.table.rowCount() == 0:
+            QMessageBox.warning(self, "Nota", "Agregue al menos un producto")
+            return
+        for w in [
+            self.nomb_entrega,
+            self.docu_entrega,
+            self.nomb_recibe,
+            self.docu_recibe,
+            self.ext_obs,
+            self.receptor_nombre,
+            self.receptor_doc,
+        ]:
+            if not w.text().strip():
+                QMessageBox.warning(
+                    self, "Nota", "Todos los campos de entrega/recepción son obligatorios"
+                )
+                return
+        super().accept()
+
+    def get_data(self):
+        detalles = []
+        for row in range(self.table.rowCount()):
+            prod_item = self.table.item(row, 0)
+            qty_item = self.table.item(row, 1)
+            obs_item = self.table.item(row, 2)
+            desc = prod_item.text()
+            obs = obs_item.text()
+            if obs:
+                desc = f"{desc} - {obs}"
+            detalles.append(
+                {
+                    "codigo": prod_item.data(Qt.UserRole),
+                    "descripcion": desc,
+                    "cantidad": int(qty_item.text()),
+                }
+            )
+        extension = {
+            "nombEntrega": self.nomb_entrega.text(),
+            "docuEntrega": self.docu_entrega.text(),
+            "nombRecibe": self.nomb_recibe.text(),
+            "docuRecibe": self.docu_recibe.text(),
+            "observaciones": self.ext_obs.text(),
+        }
+        receptor = {
+            "nombre": self.receptor_nombre.text(),
+            "tipoDocumento": "13",
+            "numDocumento": self.receptor_doc.text(),
+            "direccion": {"departamento": "05", "municipio": "24", "complemento": ""},
+        }
+        return detalles, extension, receptor
 
 class FacturacionTab(QWidget):
     """Tab para gestionar facturas y notas."""
@@ -167,6 +307,8 @@ class FacturacionTab(QWidget):
         # Botón para crear notas asociadas a la factura seleccionada
         self.btn_nota = QPushButton("Nota crédito / débito")
         self.btn_nota.clicked.connect(self.abrir_dialogo_tipo_nota)
+        self.btn_remision = QPushButton("Nota remisión")
+        self.btn_remision.clicked.connect(self.crear_nota_remision)
         self.btn_enviar = QPushButton("Enviar")
         self.btn_enviar.setEnabled(False)
         self.btn_abrir_pdf = QPushButton("Abrir PDF")
@@ -175,6 +317,7 @@ class FacturacionTab(QWidget):
             "background-color: #b71c1c; color: #fff; border-radius: 6px;",
         )
         btns.addWidget(self.btn_nota)
+        btns.addWidget(self.btn_remision)
         btns.addWidget(self.btn_enviar)
         btns.addWidget(self.btn_abrir_pdf)
         btns.addWidget(self.btn_eliminar)
@@ -816,6 +959,56 @@ class FacturacionTab(QWidget):
         if dialog.exec_() == QDialog.Accepted:
             tipo = "credito" if radio_credito.isChecked() else "debito"
             self.create_nota(tipo, factura)
+
+    def crear_nota_remision(self):
+        dialog = NotaRemisionDialog(self.manager._products, self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        detalles, extension, receptor = dialog.get_data()
+        fecha = QDate.currentDate().toString("yyyy-MM-dd")
+        extra = {"items": detalles, "receptor": receptor, "extension": extension}
+        nota_id = self.manager.db.agregar_nota(
+            "remision", None, fecha, 0, "Remision", detalles=extra
+        )
+        nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
+        resumen_nota = nota_json.get("resumen", {})
+        venta_data = {
+            "sumas": float(resumen_nota.get("subTotalVentas", 0)),
+            "descuentos": float(resumen_nota.get("totalDescu", 0)),
+            "iva": 0.0,
+            "ventas_exentas": float(resumen_nota.get("totalExenta", 0)),
+            "ventas_no_sujetas": float(resumen_nota.get("totalNoSuj", 0)),
+            "subtotal": float(resumen_nota.get("subTotal", 0)),
+            "total": float(resumen_nota.get("montoTotalOperacion", 0)),
+            "total_letras": resumen_nota.get("totalLetras", ""),
+        }
+        detalles_pdf = []
+        for d in nota_json.get("cuerpoDocumento", []) or []:
+            detalles_pdf.append(
+                {
+                    "cantidad": float(d.get("cantidad", 1)),
+                    "descripcion": d.get("descripcion", ""),
+                    "precio_unitario": float(d.get("precioUni", 0)),
+                    "ventas_gravadas": float(d.get("ventaGravada", 0)),
+                    "ventas_exentas": float(d.get("ventaExenta", 0)),
+                    "ventas_no_sujetas": float(d.get("ventaNoSuj", 0)),
+                }
+            )
+
+        cliente = receptor
+        out_dir = NOTAS_REMISION_DIR
+        os.makedirs(out_dir, exist_ok=True)
+        pdf_path, json_path = get_dte_document_paths(
+            nota_json["identificacion"].get("fecEmi"),
+            cliente.get("nombre") or "",
+            nota_json["identificacion"].get("numeroControl"),
+            "NotaRemision",
+            out_dir,
+        )
+        generar_nota_remision_pdf(
+            venta_data, detalles_pdf, cliente, extension, archivo=str(pdf_path)
+        )
+        save_file(json_path, stable_stringify(nota_json))
 
     def create_nota(self, tipo, factura=None):
         factura = factura or self._selected_factura()

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -79,16 +79,40 @@ def generar_nota_remision(
                 "tipoDoc": ident.get("tipoDte"),
                 "numeroDocumento": ident.get("numeroControl"),
             }
+        # Para notas derivadas de factura la extensión puede omitirse
+        ext = {
+            "nombEntrega": "N/D",
+            "docuEntrega": "ND",
+            "nombRecibe": "N/D",
+            "docuRecibe": "ND",
+            "observaciones": "N/D",
+        }
+        if extension:
+            ext.update({k: v for k, v in extension.items() if v not in (None, "")})
     else:
         if not (emisor and receptor and detalles):
             raise ValueError("emisor, receptor y detalles son obligatorios")
-        if documento_relacionado is None:
+        if not detalles:
+            raise ValueError("Se requiere al menos un detalle")
+        if not extension:
+            raise ValueError("extension es obligatoria")
+        required_ext = [
+            "nombEntrega",
+            "docuEntrega",
+            "nombRecibe",
+            "docuRecibe",
+            "observaciones",
+        ]
+        missing = [k for k in required_ext if not extension.get(k)]
+        if missing:
             raise ValueError(
-                "documento_relacionado requerido cuando no hay factura"
+                "Faltan campos obligatorios en extension: " + ", ".join(missing)
             )
+        ext = {k: extension.get(k) for k in required_ext}
 
     limpiar_documentos(emisor)
     limpiar_documentos(receptor)
+    limpiar_documentos(ext)
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
@@ -108,17 +132,6 @@ def generar_nota_remision(
     }
 
     items = _build_items(detalles)
-
-    ext = {
-        "nombEntrega": "N/D",
-        "docuEntrega": "ND",
-        "nombRecibe": "N/D",
-        "docuRecibe": "ND",
-        "observaciones": "N/D",
-    }
-    if extension:
-        ext.update({k: v for k, v in extension.items() if v not in (None, "")})
-    limpiar_documentos(ext)
 
     resumen = {
         "totalNoSuj": d2(Decimal_0),
@@ -140,7 +153,6 @@ def generar_nota_remision(
 
     data = {
         "identificacion": identificacion,
-        "documentoRelacionado": documento_relacionado,
         "emisor": emisor,
         "receptor": receptor,
         "cuerpoDocumento": items,
@@ -148,9 +160,14 @@ def generar_nota_remision(
         "resumen": resumen,
         "apendice": None,
     }
+    if documento_relacionado:
+        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
-    return sanitize_dte_payload(data, schema)
+    result = sanitize_dte_payload(data, schema)
+    if not documento_relacionado:
+        result.pop("documentoRelacionado", None)
+    return result
 
 
 def generar_nota_remision_desde_db(
@@ -169,19 +186,43 @@ def generar_nota_remision_desde_db(
         raise ValueError("La nota indicada no es de remisión")
 
     venta_id = nota.get("venta_id")
-    venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
-    ).fetchone()
-    tipo_doc = "01"
-    if venta_row:
-        venta = dict(venta_row)
-        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-            tipo_doc = "03"
+    if venta_id:
+        venta_row = db.cursor.execute(
+            "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+        ).fetchone()
+        tipo_doc = "01"
+        if venta_row:
+            venta = dict(venta_row)
+            if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
+                tipo_doc = "03"
 
-    from dte import generar_dte_json
+        from dte import generar_dte_json
 
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
-    return generar_nota_remision(db, factura=dte_origen, ambiente=ambiente)
+        dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+        return generar_nota_remision(db, factura=dte_origen, ambiente=ambiente)
+
+    # Nota independiente (sin venta asociada)
+    import json
+    from dte import _load_datos_negocio
+
+    detalles_raw = nota.get("detalles") or "{}"
+    try:
+        extra = json.loads(detalles_raw)
+    except Exception:
+        extra = {}
+    detalles = extra.get("items") or []
+    receptor = extra.get("receptor") or {}
+    extension = extra.get("extension") or {}
+
+    emisor = _load_datos_negocio()
+    return generar_nota_remision(
+        db,
+        emisor=emisor,
+        receptor=receptor,
+        detalles=detalles,
+        extension=extension,
+        ambiente=ambiente,
+    )
 
 
 __all__ = ["generar_nota_remision", "generar_nota_remision_desde_db"]

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from db import DB
 from nota_debito_electronica import generar_nde_desde_dte
 from dte import generar_dte_json
-from nota_remision import generar_nota_remision_desde_db
+from nota_remision import generar_nota_remision_desde_db, generar_nota_remision
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
 
 
@@ -232,3 +232,81 @@ def test_nota_remision_pdf(tmp_path):
     with fitz.open(out) as doc:
         text = "".join(p.get_text() for p in doc)
     assert "NOTA DE REMISI" in text
+
+
+def test_generar_nota_remision_sin_documento_relacionado(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    db = create_db()
+    receptor = {
+        "nombre": "Cliente",
+        "tipoDocumento": "13",
+        "numDocumento": "12345678-9",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    detalles = [
+        {"codigo": "P1", "descripcion": "Prod", "cantidad": 1},
+    ]
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    data = generar_nota_remision(
+        db,
+        emisor=datos,
+        receptor=receptor,
+        detalles=detalles,
+        extension=extension,
+    )
+    assert "documentoRelacionado" not in data
+    assert str(data["resumen"]["montoTotalOperacion"]) == "0.00"
+
+
+def test_generar_nota_remision_desde_db_independiente(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    db = create_db()
+    receptor = {
+        "nombre": "Cliente",
+        "tipoDocumento": "13",
+        "numDocumento": "12345678-9",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    detalles = [
+        {"codigo": "P1", "descripcion": "Prod", "cantidad": 1},
+    ]
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    extra = {"items": detalles, "receptor": receptor, "extension": extension}
+    nota_id = db.agregar_nota("remision", None, "2024-01-01", 0, "Envio", detalles=extra)
+    data = generar_nota_remision_desde_db(db, nota_id)
+    assert data["receptor"]["nombre"] == "Cliente"
+    assert "documentoRelacionado" not in data


### PR DESCRIPTION
## Summary
- Soporte para generar notas de remisión sin documentoRelacionado con campos de extensión obligatorios
- Interfaz en facturacion_tab para seleccionar productos y construir nota de remisión independiente
- Pruebas para nueva funcionalidad de notas de remisión

## Testing
- `pytest tests/test_nota_debito_remision.py::test_generar_nota_remision_sin_documento_relacionado -q`
- `pytest tests/test_nota_debito_remision.py::test_generar_nota_remision_desde_db_independiente -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68be6c896110832390306a89f24ca6d8