### PR TITLE
feat: generate nota remision dte

### DIFF
--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+"""Generación de Nota de Remisión Electrónica (NR).
+
+Este módulo expone utilidades para construir la estructura JSON requerida por
+el Ministerio de Hacienda de El Salvador para una Nota de Remisión (``tipoDte``
+``04``).  Se proveen dos funciones de alto nivel:
+
+* :func:`generar_nota_remision_desde_factura` crea la nota a partir de un DTE de
+  origen reutilizando la información de emisor, receptor y detalles.
+* :func:`generar_nota_remision_independiente` permite crear una nota sin
+  documento relacionado especificando manualmente todos los datos.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Iterable, Optional
+
+from db import DB
+from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
+from utils import catalogos
+from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
+from utils.monto import d2, monto_a_texto_sv
+from utils.sanitize import limpiar_documentos
+
+Decimal_0 = Decimal("0")
+
+
+def _build_items(detalles: Iterable[dict]) -> list[dict]:
+    """Construye los ítems de la NR forzando todos los montos a ``0.00``.
+
+    Además valida que ``cantidad`` sea mayor que cero y que ``uniMedida`` esté
+    presente.
+    """
+
+    items: list[dict] = []
+    for num, det in enumerate(detalles, 1):
+        cantidad = det.get("cantidad", 1)
+        if cantidad <= 0:
+            raise ValueError("cantidad debe ser mayor que cero")
+        if det.get("uniMedida") is None:
+            raise ValueError("uniMedida requerido en el item")
+        items.append(
+            {
+                "numItem": num,
+                "tipoItem": det.get("tipoItem", 1),
+                "codigo": det.get("codigo", f"NR{num:03d}"),
+                "descripcion": det.get("descripcion", f"Item {num}"),
+                "cantidad": cantidad,
+                "uniMedida": det.get("uniMedida"),
+                "precioUni": 0.0,
+                "montoDescu": 0.0,
+                "ventaNoSuj": d2(Decimal_0),
+                "ventaExenta": d2(Decimal_0),
+                "ventaGravada": d2(Decimal_0),
+                "tributos": [],
+                "numeroDocumento": None,
+                "codTributo": None,
+            }
+        )
+    return items
+
+
+def _generar_base(
+    db: DB,
+    *,
+    emisor: dict,
+    receptor: dict,
+    detalles: Iterable[dict],
+    extension: Optional[dict] = None,
+    documento_relacionado: Optional[dict] = None,
+    ambiente: str = "00",
+) -> dict:
+    """Construye la estructura base común de una NR."""
+
+    limpiar_documentos(emisor)
+    limpiar_documentos(receptor)
+
+    cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
+    now = datetime.now(TZ_EL_SALVADOR)
+    identificacion = {
+        "version": DTE_VERSIONES["04"],
+        "ambiente": ambiente,
+        "tipoDte": "04",
+        "numeroControl": cabecera["numero_control"],
+        "codigoGeneracion": cabecera["codigo_generacion"],
+        "tipoModelo": cabecera["tipo_modelo"],
+        "tipoOperacion": cabecera["tipo_operacion"],
+        "tipoContingencia": cabecera["tipo_contingencia"],
+        "motivoContin": cabecera["motivo_contin"],
+        "fecEmi": fecha_emision_hoy_str(now),
+        "horEmi": now.strftime("%H:%M:%S"),
+        "tipoMoneda": "USD",
+    }
+
+    items = _build_items(detalles)
+
+    ext = {
+        "nombEntrega": "N/D",
+        "docuEntrega": "ND",
+        "nombRecibe": "N/D",
+        "docuRecibe": "ND",
+        "observaciones": "N/D",
+    }
+    if extension:
+        ext.update({k: v for k, v in extension.items() if v not in (None, "")})
+    limpiar_documentos(ext)
+
+    resumen = {
+        "totalNoSuj": d2(Decimal_0),
+        "totalExenta": d2(Decimal_0),
+        "totalGravada": d2(Decimal_0),
+        "subTotal": d2(Decimal_0),
+        "subTotalVentas": d2(Decimal_0),
+        "descuNoSuj": 0.0,
+        "descuExenta": 0.0,
+        "descuGravada": 0.0,
+        "totalDescu": 0.0,
+        "ivaPerci1": 0.0,
+        "ivaRete1": 0.0,
+        "reteRenta": 0.0,
+        "montoTotalOperacion": d2(Decimal_0),
+        "totalLetras": monto_a_texto_sv(0.0),
+        "condicionOperacion": 1,
+    }
+
+    data = {
+        "identificacion": identificacion,
+        "documentoRelacionado": documento_relacionado,
+        "emisor": emisor,
+        "receptor": receptor,
+        "cuerpoDocumento": items,
+        "extension": ext,
+        "resumen": resumen,
+        "apendice": None,
+    }
+
+    schema = catalogos.get_dte_schema("04")
+    return sanitize_dte_payload(data, schema)
+
+
+def generar_nota_remision_desde_factura(
+    db: DB,
+    factura: dict,
+    *,
+    detalles: Optional[Iterable[dict]] = None,
+    extension: Optional[dict] = None,
+    ambiente: str = "00",
+) -> dict:
+    """Genera una NR reutilizando los datos de una factura ``factura``."""
+
+    emisor = factura.get("emisor", {})
+    receptor = factura.get("receptor", {})
+    detalles = detalles or factura.get("cuerpoDocumento", [])
+    ident = factura.get("identificacion", {})
+    doc_rel = {
+        "tipoDoc": ident.get("tipoDte"),
+        "numeroDocumento": ident.get("numeroControl"),
+    }
+    return _generar_base(
+        db,
+        emisor=emisor,
+        receptor=receptor,
+        detalles=detalles,
+        extension=extension,
+        documento_relacionado=doc_rel,
+        ambiente=ambiente,
+    )
+
+
+def generar_nota_remision_independiente(
+    db: DB,
+    *,
+    emisor: dict,
+    receptor: dict,
+    detalles: Iterable[dict],
+    extension: Optional[dict] = None,
+    ambiente: str = "00",
+) -> dict:
+    """Genera una NR sin documento relacionado."""
+
+    if not (emisor and receptor and detalles):
+        raise ValueError("emisor, receptor y detalles son obligatorios")
+
+    return _generar_base(
+        db,
+        emisor=emisor,
+        receptor=receptor,
+        detalles=detalles,
+        extension=extension,
+        documento_relacionado=None,
+        ambiente=ambiente,
+    )
+
+
+__all__ = [
+    "generar_nota_remision_desde_factura",
+    "generar_nota_remision_independiente",
+]

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -1,0 +1,94 @@
+import pytest
+
+from db import DB
+from nota_remision_electronica import (
+    generar_nota_remision_desde_factura,
+    generar_nota_remision_independiente,
+)
+import dte
+
+
+def _sample_emisor():
+    return {"nit": "0614-140710-001-2", "nrc": "1234567"}
+
+
+def _sample_receptor():
+    return {"tipoDocumento": "36", "numDocumento": "1234 567-8", "nombre": "Cliente"}
+
+
+def test_nr_desde_factura_documento_relacionado(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-XYZ-000000000000001",
+        },
+        "emisor": _sample_emisor(),
+        "receptor": _sample_receptor(),
+        "cuerpoDocumento": [
+            {"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}
+        ],
+    }
+    data = generar_nota_remision_desde_factura(db, factura)
+    doc_rel = data["documentoRelacionado"]
+    assert doc_rel["tipoDoc"] == "03"
+    assert doc_rel["numeroDocumento"] == "DTE-03-XYZ-000000000000001"
+    item = data["cuerpoDocumento"][0]
+    assert float(item["precioUni"]) == 0.0
+    assert float(item["ventaNoSuj"]) == 0.0
+    assert float(item["ventaExenta"]) == 0.0
+    assert float(item["ventaGravada"]) == 0.0
+    assert "-" not in data["emisor"]["nit"]
+    assert " " not in data["receptor"]["numDocumento"]
+
+
+def test_nr_independiente_extension(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "0614-140710-001-2",
+        "nombRecibe": "Ana",
+        "docuRecibe": "1234 5678",
+        "observaciones": "Obs",
+    }
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    data = generar_nota_remision_independiente(
+        db,
+        emisor=emisor,
+        receptor=receptor,
+        detalles=detalles,
+        extension=extension,
+    )
+    assert data["documentoRelacionado"] is None
+    ext = data["extension"]
+    assert ext["nombEntrega"] == "Juan"
+    assert ext["nombRecibe"] == "Ana"
+    assert ext["docuEntrega"] == "06141407100012"
+    assert ext["docuRecibe"] == "12345678"
+    assert "-" not in data["emisor"]["nit"]
+    assert " " not in data["receptor"]["numDocumento"]
+
+
+def test_nr_item_validation(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
+        )
+    with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=[{"descripcion": "Prod", "cantidad": 1}],
+        )


### PR DESCRIPTION
## Summary
- add generator for nota de remisión DTEs
- cover NR generation and sanitization with unit tests

## Testing
- `pytest tests/test_nota_remision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6c9d81788323bcc18491e2807b72