### PR TITLE
feat: add original invoice summary to nota form

### DIFF
--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -98,6 +98,38 @@ describe('NotaForm', () => {
     expect(cells[5].text()).toBe('12.00');
   });
 
+  it('muestra bloques de factura y nota y solo nota cambia', async () => {
+    const wrapper = mount(NotaForm, {
+      props: {
+        factura: {
+          tipo: '01',
+          numero: '1',
+          fecha: '2024-01-01',
+          uuid: 'abc',
+          cliente: 'A',
+          total: 1000,
+          ventas_gravadas: 1000,
+          ventas_exentas: 0,
+          ventas_no_sujetas: 0,
+          iva: 0
+        },
+        tipo: 'debito'
+      }
+    });
+    const facturaTexto = wrapper.find('.factura-resumen').text();
+    expect(facturaTexto).toContain('Base gravada: 1000.00');
+    const radioMonto = wrapper.find('input[value="monto"]');
+    await radioMonto.setValue();
+    const chk = wrapper.find('.nota-header input[type="checkbox"]');
+    await chk.setValue(false);
+    const input = wrapper.find('input[type="number"]');
+    await input.setValue('10');
+    await wrapper.vm.$nextTick();
+    const notaTexto = wrapper.find('.nota-resumen').text();
+    expect(notaTexto).toContain('Base gravada: 10.00');
+    expect(wrapper.find('.factura-resumen').text()).toBe(facturaTexto);
+  });
+
   it('muestra badge rojo si excede saldo', async () => {
     const wrapper = mount(NotaForm, {
       props: {

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -86,11 +86,22 @@
         </div>
       </div>
       <div class="resumen">
-        <div>Base gravada: {{ format(preview.base) }}</div>
-        <div>Exenta: {{ format(preview.exenta) }}</div>
-        <div>No sujeta: {{ format(preview.noSujeta) }}</div>
-        <div>IVA: {{ format(preview.iva) }}</div>
-        <div>Total: {{ format(total) }}</div>
+        <section class="factura-resumen">
+          <h3>Factura original</h3>
+          <div>Base gravada: {{ format(facturaResumen.base) }}</div>
+          <div>Exenta: {{ format(facturaResumen.exenta) }}</div>
+          <div>No sujeta: {{ format(facturaResumen.noSujeta) }}</div>
+          <div>IVA: {{ format(facturaResumen.iva) }}</div>
+          <div>Total: {{ format(facturaResumen.total) }}</div>
+        </section>
+        <section class="nota-resumen">
+          <h3>Nota</h3>
+          <div>Base gravada: {{ format(preview.base) }}</div>
+          <div>Exenta: {{ format(preview.exenta) }}</div>
+          <div>No sujeta: {{ format(preview.noSujeta) }}</div>
+          <div>IVA: {{ format(preview.iva) }}</div>
+          <div>Total: {{ format(total) }}</div>
+        </section>
         <div>Documento relacionado: {{ factura.numero }}</div>
         <span v-if="excedeSaldo" class="badge rojo">Crédito excede saldo</span>
         <div class="acciones">
@@ -153,6 +164,14 @@ interface NotaItem {
 const items = ref<NotaItem[]>([]);
 
 const saldoDisponible = computed(() => props.factura.total ?? 0);
+
+const facturaResumen = computed(() => ({
+  base: props.factura.ventas_gravadas ?? 0,
+  exenta: props.factura.ventas_exentas ?? 0,
+  noSujeta: props.factura.ventas_no_sujetas ?? 0,
+  iva: props.factura.iva ?? 0,
+  total: props.factura.total ?? 0,
+}));
 
 function resolveValor(item: NotaItem) {
   if (item.modo === 'porcentaje') {
@@ -300,6 +319,12 @@ const { factura, tipo } = props;
 }
 .resumen {
   width: 30%;
+}
+.resumen section {
+  margin-bottom: 1rem;
+}
+.resumen h3 {
+  margin: 0 0 0.5rem 0;
 }
 .nota-header {
   display: flex;


### PR DESCRIPTION
## Summary
- show original invoice totals alongside dynamic note totals in NotaForm
- document behavior with tests ensuring invoice section stays static

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be74ead32483238b80b903d259354d