### PR TITLE
feat: add factura-based remision note flow

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -231,6 +231,65 @@ class NotaRemisionDialog(QDialog):
         }
         return detalles, extension, receptor
 
+
+class NotaRemisionExtDialog(QDialog):
+    """Diálogo para capturar los campos de extensión de la NR."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Datos de entrega")
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        self.nomb_entrega = QLineEdit()
+        self.docu_entrega = QLineEdit()
+        self.nomb_recibe = QLineEdit()
+        self.docu_recibe = QLineEdit()
+        self.ext_obs = QLineEdit()
+        for label, widget in [
+            ("Nombre entrega:", self.nomb_entrega),
+            ("Documento entrega:", self.docu_entrega),
+            ("Nombre recibe:", self.nomb_recibe),
+            ("Documento recibe:", self.docu_recibe),
+            ("Observaciones:", self.ext_obs),
+        ]:
+            row = QHBoxLayout()
+            row.addWidget(QLabel(label))
+            row.addWidget(widget)
+            layout.addLayout(row)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_data(self):
+        return {
+            "nombEntrega": self.nomb_entrega.text(),
+            "docuEntrega": self.docu_entrega.text(),
+            "nombRecibe": self.nomb_recibe.text(),
+            "docuRecibe": self.docu_recibe.text(),
+            "observaciones": self.ext_obs.text(),
+        }
+
+    def accept(self):
+        for w in [
+            self.nomb_entrega,
+            self.docu_entrega,
+            self.nomb_recibe,
+            self.docu_recibe,
+            self.ext_obs,
+        ]:
+            if not w.text().strip():
+                QMessageBox.warning(
+                    self,
+                    "Nota",
+                    "Todos los campos de entrega/recepción son obligatorios",
+                )
+                return
+        super().accept()
+
 class FacturacionTab(QWidget):
     """Tab para gestionar facturas y notas."""
 
@@ -308,7 +367,7 @@ class FacturacionTab(QWidget):
         self.btn_nota = QPushButton("Nota crédito / débito")
         self.btn_nota.clicked.connect(self.abrir_dialogo_tipo_nota)
         self.btn_remision = QPushButton("Nota remisión")
-        self.btn_remision.clicked.connect(self.crear_nota_remision)
+        self.btn_remision.clicked.connect(self.abrir_dialogo_nota_remision)
         self.btn_enviar = QPushButton("Enviar")
         self.btn_enviar.setEnabled(False)
         self.btn_abrir_pdf = QPushButton("Abrir PDF")
@@ -960,22 +1019,36 @@ class FacturacionTab(QWidget):
             tipo = "credito" if radio_credito.isChecked() else "debito"
             self.create_nota(tipo, factura)
 
-    def crear_nota_remision(self):
-        dialog = NotaRemisionDialog(self.manager._products, self)
-        if dialog.exec_() != QDialog.Accepted:
-            return
-        detalles, extension, receptor = dialog.get_data()
-        fecha = QDate.currentDate().toString("yyyy-MM-dd")
-        extra = {"items": detalles, "receptor": receptor, "extension": extension}
-        nota_id = self.manager.db.agregar_nota(
-            "remision", None, fecha, 0, "Remision", detalles=extra
-        )
-        nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
+    def abrir_dialogo_nota_remision(self):
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Nota de remisión")
+        layout = QVBoxLayout(dialog)
+
+        radio_factura = QRadioButton("Desde factura", dialog)
+        radio_productos = QRadioButton("Desde productos", dialog)
+        radio_factura.setChecked(True)
+        layout.addWidget(radio_factura)
+        layout.addWidget(radio_productos)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.button(QDialogButtonBox.Ok).setText("Continuar")
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        layout.addWidget(buttons)
+
+        if dialog.exec_() == QDialog.Accepted:
+            if radio_factura.isChecked():
+                self.crear_nota_remision_desde_factura()
+            else:
+                self.crear_nota_remision_desde_productos()
+
+    def _guardar_archivos_nota_remision(self, nota_json):
         resumen_nota = nota_json.get("resumen", {})
+        tributos = {t.get("codigo"): t.get("valor", 0) for t in resumen_nota.get("tributos", []) or []}
         venta_data = {
             "sumas": float(resumen_nota.get("subTotalVentas", 0)),
             "descuentos": float(resumen_nota.get("totalDescu", 0)),
-            "iva": 0.0,
+            "iva": float(tributos.get("20", 0)),
             "ventas_exentas": float(resumen_nota.get("totalExenta", 0)),
             "ventas_no_sujetas": float(resumen_nota.get("totalNoSuj", 0)),
             "subtotal": float(resumen_nota.get("subTotal", 0)),
@@ -994,13 +1067,13 @@ class FacturacionTab(QWidget):
                     "ventas_no_sujetas": float(d.get("ventaNoSuj", 0)),
                 }
             )
-
-        cliente = receptor
+        cliente = nota_json.get("receptor", {}) or {}
+        extension = nota_json.get("extension", {}) or {}
         out_dir = NOTAS_REMISION_DIR
         os.makedirs(out_dir, exist_ok=True)
         pdf_path, json_path = get_dte_document_paths(
             nota_json["identificacion"].get("fecEmi"),
-            cliente.get("nombre") or "",
+            cliente.get("nombre") or cliente.get("nombreComercial") or "",
             nota_json["identificacion"].get("numeroControl"),
             "NotaRemision",
             out_dir,
@@ -1009,6 +1082,40 @@ class FacturacionTab(QWidget):
             venta_data, detalles_pdf, cliente, extension, archivo=str(pdf_path)
         )
         save_file(json_path, stable_stringify(nota_json))
+
+    def crear_nota_remision_desde_productos(self):
+        dialog = NotaRemisionDialog(self.manager._products, self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        detalles, extension, receptor = dialog.get_data()
+        fecha = QDate.currentDate().toString("yyyy-MM-dd")
+        extra = {"items": detalles, "receptor": receptor, "extension": extension}
+        nota_id = self.manager.db.agregar_nota(
+            "remision", None, fecha, 0, "Remision", detalles=extra
+        )
+        nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
+        self._guardar_archivos_nota_remision(nota_json)
+
+    def crear_nota_remision_desde_factura(self):
+        factura = self._selected_factura()
+        if not factura:
+            QMessageBox.warning(self, "Nota", "Seleccione una factura")
+            return
+        venta_id = factura.get("venta_id")
+        if not venta_id:
+            QMessageBox.warning(self, "Nota", "Factura sin venta asociada")
+            return
+        dialog = NotaRemisionExtDialog(self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        extension = dialog.get_data()
+        fecha = QDate.currentDate().toString("yyyy-MM-dd")
+        extra = {"extension": extension}
+        nota_id = self.manager.db.agregar_nota(
+            "remision", venta_id, fecha, 0, "Remision", detalles=extra
+        )
+        nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
+        self._guardar_archivos_nota_remision(nota_json)
 
     def create_nota(self, tipo, factura=None):
         factura = factura or self._selected_factura()

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -185,6 +185,14 @@ def generar_nota_remision_desde_db(
     if nota.get("tipo") != "remision":
         raise ValueError("La nota indicada no es de remisión")
 
+    import json
+
+    detalles_raw = nota.get("detalles") or "{}"
+    try:
+        extra = json.loads(detalles_raw)
+    except Exception:
+        extra = {}
+
     venta_id = nota.get("venta_id")
     if venta_id:
         venta_row = db.cursor.execute(
@@ -199,17 +207,14 @@ def generar_nota_remision_desde_db(
         from dte import generar_dte_json
 
         dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
-        return generar_nota_remision(db, factura=dte_origen, ambiente=ambiente)
+        extension = extra.get("extension") or {}
+        return generar_nota_remision(
+            db, factura=dte_origen, extension=extension, ambiente=ambiente
+        )
 
     # Nota independiente (sin venta asociada)
-    import json
     from dte import _load_datos_negocio
 
-    detalles_raw = nota.get("detalles") or "{}"
-    try:
-        extra = json.loads(detalles_raw)
-    except Exception:
-        extra = {}
     detalles = extra.get("items") or []
     receptor = extra.get("receptor") or {}
     extension = extra.get("extension") or {}

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -195,16 +195,22 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
-    db.cursor.execute(
-        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?,?,?,?,?)",
-        (venta_id, "remision", "2024-01-02", 0, "Envio"),
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    extra = {"extension": extension}
+    nota_id = db.agregar_nota(
+        "remision", venta_id, "2024-01-02", 0, "Envio", detalles=extra
     )
-    nota_id = db.cursor.lastrowid
-    db.conn.commit()
 
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "04"
     assert data["documentoRelacionado"]["tipoDoc"] == "01"
+    assert data["extension"]["nombEntrega"] == "Juan"
 
 
 def test_nota_debito_pdf(tmp_path):

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -43,6 +43,31 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     assert " " not in data["receptor"]["numDocumento"]
 
 
+def test_nr_desde_factura_extension(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-XYZ-000000000000001",
+        },
+        "emisor": _sample_emisor(),
+        "receptor": _sample_receptor(),
+        "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    data = generar_nota_remision_desde_factura(
+        db, factura, extension=extension
+    )
+    assert data["extension"]["nombEntrega"] == "Juan"
+
+
 def test_nr_independiente_extension(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")


### PR DESCRIPTION
## Summary
- add dialog for Nota de Remisión with options "Desde factura" and "Desde productos"
- implement crear_nota_remision_desde_factura and reuse helper to store JSON/PDF
- ensure nota_remision.generar_nota_remision_desde_db preserves extension when linked to a sale
- add tests for factura and product based remisión notes

## Testing
- `pytest tests/test_nota_debito_remision.py tests/test_nota_remision.py -q | tail -n 20`
- `pytest tests/test_nota_debito_remision.py::test_generar_nota_remision_factura tests/test_nota_remision.py::test_nr_desde_factura_extension -q | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68beefb7700483239ecb2494c5986f71