### PR TITLE
Reestructura formulario de notas de débito/crédito

### DIFF
--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -53,7 +53,7 @@ describe('NotaForm', () => {
         tipo: 'credito'
       }
     });
-    const inputs = wrapper.findAll('.nota-header input[readonly]');
+    const inputs = wrapper.findAll('.factura-data input[readonly]');
     expect(inputs[0].element.value).toBe('01');
     expect(inputs[1].element.value).toBe('A-1');
     expect(inputs[2].element.value).toBe('2024-01-01');
@@ -87,7 +87,7 @@ describe('NotaForm', () => {
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
-    const chk = wrapper.find('.nota-header input[type="checkbox"]');
+    const chk = wrapper.find('.nota-controls input[type="checkbox"]');
     await chk.setValue(false);
     const input = wrapper.find('input[type="number"]');
     await input.setValue('10');
@@ -120,7 +120,7 @@ describe('NotaForm', () => {
     expect(facturaTexto).toContain('Base gravada: 1000.00');
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
-    const chk = wrapper.find('.nota-header input[type="checkbox"]');
+    const chk = wrapper.find('.nota-controls input[type="checkbox"]');
     await chk.setValue(false);
     const input = wrapper.find('input[type="number"]');
     await input.setValue('10');
@@ -210,7 +210,7 @@ describe('NotaForm', () => {
     const input = wrapper.find('input[type="number"]');
     await input.setValue('10');
     await wrapper.vm.$nextTick();
-    const btn = wrapper.find('.resumen .acciones button');
+    const btn = wrapper.find('.nota-resumen .acciones button');
     await btn.trigger('click');
     expect(api.previsualizarPdf).toHaveBeenCalled();
   });
@@ -232,7 +232,7 @@ describe('NotaForm', () => {
     });
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
-    await wrapper.find('.resumen .acciones button').trigger('click');
+    await wrapper.find('.nota-resumen .acciones button').trigger('click');
     expect(api.previsualizarPdf).not.toHaveBeenCalled();
   });
 
@@ -271,7 +271,7 @@ describe('NotaForm', () => {
       concepto: ''
     });
     await wrapper.vm.$nextTick();
-    const resumen = wrapper.find('.resumen').text();
+    const resumen = wrapper.find('.nota-resumen').text();
     expect(resumen).toContain('Base gravada: 100.00');
     expect(resumen).toContain('IVA: 20.00');
     expect(resumen).toContain('Total: 120.00');

--- a/ui/ventas/NotaForm.vue
+++ b/ui/ventas/NotaForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="nota-form">
-    <header class="nota-header">
+    <section class="factura-resumen">
       <div class="factura-data">
         <input readonly :value="factura.tipo" title="Tipo de documento (01/03)" />
         <input readonly :value="factura.numero" title="Serie-correlativo" />
@@ -12,106 +12,105 @@
         />
         <div>{{ factura.cliente }}</div>
       </div>
-      <span class="badge">{{ tipo === 'credito' ? 'Crédito' : 'Débito' }}</span>
-      <input v-model="motivo" placeholder="Motivo" maxlength="50" />
-      <label>
-        IVA Incluido
-        <input type="checkbox" v-model="ivaIncluido" />
-      </label>
-    </header>
-    <div class="contenido">
-      <div class="detalle">
-        <div class="tabs">
-          <button @click="activeTab = 'global'" :class="{ active: activeTab === 'global' }">Global</button>
-          <button @click="activeTab = 'producto'" :class="{ active: activeTab === 'producto' }">Por producto</button>
+      <div class="factura-totales">
+        <div>Base gravada: {{ format(facturaResumen.base) }}</div>
+        <div>Exenta: {{ format(facturaResumen.exenta) }}</div>
+        <div>No sujeta: {{ format(facturaResumen.noSujeta) }}</div>
+        <div>IVA: {{ format(facturaResumen.iva) }}</div>
+        <div>Total: {{ format(facturaResumen.total) }}</div>
+      </div>
+    </section>
+
+    <section class="detalle">
+      <div class="nota-controls">
+        <span class="badge">{{ tipo === 'credito' ? 'Crédito' : 'Débito' }}</span>
+        <input v-model="motivo" placeholder="Motivo" maxlength="50" />
+        <label>
+          IVA Incluido
+          <input type="checkbox" v-model="ivaIncluido" />
+        </label>
+      </div>
+      <div class="tabs">
+        <button @click="activeTab = 'global'" :class="{ active: activeTab === 'global' }">Global</button>
+        <button @click="activeTab = 'producto'" :class="{ active: activeTab === 'producto' }">Por producto</button>
+      </div>
+      <div v-if="activeTab === 'global'">
+        <div class="global-options">
+          <label title="Aplica un porcentaje del total">
+            <input type="radio" value="porcentaje" v-model="modoGlobal" />
+            Por porcentaje
+          </label>
+          <label title="Aplica un monto fijo">
+            <input type="radio" value="monto" v-model="modoGlobal" />
+            Por monto
+          </label>
         </div>
-        <div v-if="activeTab === 'global'">
-          <div class="global-options">
-            <label title="Aplica un porcentaje del total">
-              <input type="radio" value="porcentaje" v-model="modoGlobal" />
-              Por porcentaje
-            </label>
-            <label title="Aplica un monto fijo">
-              <input type="radio" value="monto" v-model="modoGlobal" />
-              Por monto
-            </label>
-          </div>
-          <div>
-            <input
-              v-if="modoGlobal === 'porcentaje'"
-              type="number"
-              v-model.number="porcentaje"
-              min="0"
-              max="100"
-              title="Porcentaje del total (0-100)"
-            />
-            <input
-              v-else
-              type="number"
-              v-model.number="monto"
-              min="0"
-              title="Monto total de la nota. Se descompone si IVA incluido"
-            />
-          </div>
-          <table class="preview">
-            <thead>
-              <tr>
-                <th title="Descripción del ajuste">Concepto</th>
-                <th title="Monto sujeto a IVA">Base gravada</th>
-                <th title="Ventas exentas del impuesto">Exenta</th>
-                <th title="Operaciones no sujetas al impuesto">No sujeta</th>
-                <th title="Impuesto calculado al 20%">IVA(20)</th>
-                <th title="Suma de base, exenta, no sujeta e IVA">Total</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Global</td>
-                <td>{{ format(preview.base) }}</td>
-                <td>{{ format(preview.exenta) }}</td>
-                <td>{{ format(preview.noSujeta) }}</td>
-                <td>{{ format(preview.iva) }}</td>
-                <td>{{ format(preview.base + preview.exenta + preview.noSujeta + preview.iva) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div v-else>
-          <EditableNotaTable
-            v-model="items"
-            :topeCredito="saldoDisponible"
-            :ivaIncluido="ivaIncluido"
-            :notaTipo="tipo"
+        <div>
+          <input
+            v-if="modoGlobal === 'porcentaje'"
+            type="number"
+            v-model.number="porcentaje"
+            min="0"
+            max="100"
+            title="Porcentaje del total (0-100)"
+          />
+          <input
+            v-else
+            type="number"
+            v-model.number="monto"
+            min="0"
+            title="Monto total de la nota. Se descompone si IVA incluido"
           />
         </div>
+        <table class="preview">
+          <thead>
+            <tr>
+              <th title="Descripción del ajuste">Concepto</th>
+              <th title="Monto sujeto a IVA">Base gravada</th>
+              <th title="Ventas exentas del impuesto">Exenta</th>
+              <th title="Operaciones no sujetas al impuesto">No sujeta</th>
+              <th title="Impuesto calculado al 20%">IVA(20)</th>
+              <th title="Suma de base, exenta, no sujeta e IVA">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Global</td>
+              <td>{{ format(preview.base) }}</td>
+              <td>{{ format(preview.exenta) }}</td>
+              <td>{{ format(preview.noSujeta) }}</td>
+              <td>{{ format(preview.iva) }}</td>
+              <td>{{ format(preview.base + preview.exenta + preview.noSujeta + preview.iva) }}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-      <div class="resumen">
-        <section class="factura-resumen">
-          <h3>Factura original</h3>
-          <div>Base gravada: {{ format(facturaResumen.base) }}</div>
-          <div>Exenta: {{ format(facturaResumen.exenta) }}</div>
-          <div>No sujeta: {{ format(facturaResumen.noSujeta) }}</div>
-          <div>IVA: {{ format(facturaResumen.iva) }}</div>
-          <div>Total: {{ format(facturaResumen.total) }}</div>
-        </section>
-        <section class="nota-resumen">
-          <h3>Nota</h3>
-          <div>Base gravada: {{ format(preview.base) }}</div>
-          <div>Exenta: {{ format(preview.exenta) }}</div>
-          <div>No sujeta: {{ format(preview.noSujeta) }}</div>
-          <div>IVA: {{ format(preview.iva) }}</div>
-          <div>Total: {{ format(total) }}</div>
-        </section>
-        <div>Documento relacionado: {{ factura.numero }}</div>
-        <span v-if="excedeSaldo" class="badge rojo">Crédito excede saldo</span>
-        <div class="acciones">
-          <button @click="onPreviewPdf">Previsualizar PDF</button>
-          <button @click="onPreviewJson">Previsualizar JSON</button>
-          <button @click="onGuardarBorrador">Guardar borrador</button>
-          <button @click="onFirmarTransmitir">Firmar &amp; Transmitir</button>
-        </div>
+      <div v-else>
+        <EditableNotaTable
+          v-model="items"
+          :topeCredito="saldoDisponible"
+          :ivaIncluido="ivaIncluido"
+          :notaTipo="tipo"
+        />
       </div>
-    </div>
+    </section>
+
+    <section class="nota-resumen">
+      <h3>Nota</h3>
+      <div>Base gravada: {{ format(preview.base) }}</div>
+      <div>Exenta: {{ format(preview.exenta) }}</div>
+      <div>No sujeta: {{ format(preview.noSujeta) }}</div>
+      <div>IVA: {{ format(preview.iva) }}</div>
+      <div>Total: {{ format(total) }}</div>
+      <div>Documento relacionado: {{ factura.numero }}</div>
+      <span v-if="excedeSaldo" class="badge rojo">Crédito excede saldo</span>
+      <div class="acciones">
+        <button @click="onPreviewPdf">Previsualizar PDF</button>
+        <button @click="onPreviewJson">Previsualizar JSON</button>
+        <button @click="onGuardarBorrador">Guardar borrador</button>
+        <button @click="onFirmarTransmitir">Firmar &amp; Transmitir</button>
+      </div>
+    </section>
   </div>
 </template>
 
@@ -311,25 +310,27 @@ const { factura, tipo } = props;
 </script>
 
 <style scoped>
-.contenido {
+.nota-form {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
-.detalle {
-  width: 70%;
+.factura-data {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
 }
-.resumen {
-  width: 30%;
+.factura-totales {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
-.resumen section {
-  margin-bottom: 1rem;
-}
-.resumen h3 {
-  margin: 0 0 0.5rem 0;
-}
-.nota-header {
+.nota-controls {
   display: flex;
   gap: 1rem;
   align-items: center;
+  margin-bottom: 1rem;
 }
 .badge {
   background-color: #eee;
@@ -348,6 +349,12 @@ const { factura, tipo } = props;
 }
 .tabs button.active {
   font-weight: bold;
+}
+.nota-resumen {
+  margin-top: 1rem;
+}
+.nota-resumen h3 {
+  margin: 0 0 0.5rem 0;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- Reorganize note creation view to show DTE summary at the top, editable item menu in the middle and real-time note totals at the bottom
- Update tests to reflect the new structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beee43cb2c83239f5ec6c5e36f97cc