### PR TITLE
Remove editable total in letters field from note dialog

### DIFF
--- a/dialogs/nota_detalle_dialog.py
+++ b/dialogs/nota_detalle_dialog.py
@@ -69,12 +69,6 @@ class NotaDetalleDialog(QDialog):
         motivo_layout.addWidget(self.motivo_edit)
         layout.addLayout(motivo_layout)
 
-        letras_layout = QHBoxLayout()
-        letras_layout.addWidget(QLabel("Total en letras:"))
-        self.total_letras_edit = QLineEdit()
-        letras_layout.addWidget(self.total_letras_edit)
-        layout.addLayout(letras_layout)
-
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)


### PR DESCRIPTION
## Summary
- remove the "Total en letras" input from note detail dialog so total in letters isn't editable

## Testing
- `pytest -q` *(fails: numerous tests failing and run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bef9e3fb248323a7a639ae6051aa0c