### PR TITLE
Allow remision note creation without sale

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1102,15 +1102,23 @@ class FacturacionTab(QWidget):
             QMessageBox.warning(self, "Nota", "Seleccione una factura")
             return
         venta_id = factura.get("venta_id")
+        json_path = factura.get("json")
+        try:
+            with open(json_path, "r", encoding="utf-8") as fh:
+                factura_json = json.load(fh)
+        except Exception:
+            QMessageBox.warning(self, "Nota", "No se pudo leer la factura")
+            return
         if not venta_id:
             QMessageBox.warning(self, "Nota", "Factura sin venta asociada")
-            return
         dialog = NotaRemisionExtDialog(self)
         if dialog.exec_() != QDialog.Accepted:
             return
         extension = dialog.get_data()
         fecha = QDate.currentDate().toString("yyyy-MM-dd")
         extra = {"extension": extension}
+        if not venta_id:
+            extra["factura"] = factura_json
         nota_id = self.manager.db.agregar_nota(
             "remision", venta_id, fecha, 0, "Remision", detalles=extra
         )

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -212,6 +212,13 @@ def generar_nota_remision_desde_db(
             db, factura=dte_origen, extension=extension, ambiente=ambiente
         )
 
+    factura = extra.get("factura")
+    if factura:
+        extension = extra.get("extension") or {}
+        return generar_nota_remision(
+            db, factura=factura, extension=extension, ambiente=ambiente
+        )
+
     # Nota independiente (sin venta asociada)
     from dte import _load_datos_negocio
 

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -316,3 +316,45 @@ def test_generar_nota_remision_desde_db_independiente(monkeypatch):
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["receptor"]["nombre"] == "Cliente"
     assert "documentoRelacionado" not in data
+
+
+def test_generar_nota_remision_desde_db_factura_sin_venta(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    db = create_db()
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-XYZ-000000000000001",
+        },
+        "emisor": datos,
+        "receptor": {
+            "tipoDocumento": "36",
+            "numDocumento": "1234 567-8",
+            "nombre": "Cliente",
+        },
+        "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    extra = {"extension": extension, "factura": factura}
+    nota_id = db.agregar_nota("remision", None, "2024-01-02", 0, "Envio", detalles=extra)
+    data = generar_nota_remision_desde_db(db, nota_id)
+    doc_rel = data["documentoRelacionado"]
+    assert doc_rel["numeroDocumento"] == "DTE-03-XYZ-000000000000001"
+    assert data["receptor"]["nombre"] == "Cliente"


### PR DESCRIPTION
## Summary
- Allow generating nota de remisión from a factura even when it has no associated sale
- Fall back to stored invoice data when building nota de remisión from DB
- Add regression test for remision notes without sales

## Testing
- `pytest` *(fails: multiple tests failing)*


------
https://chatgpt.com/codex/tasks/task_e_68bef78017d88323a2e221e2d709b04e