### PR TITLE
Ajustar manejo de IVA por ítem en recalcular_totales

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1348,18 +1348,19 @@ def recalcular_totales(
             if linea < 0:
                 linea = d4(0)
             _, iva_calc = to_base_iva(linea)
-            esperado_iva = money(iva_calc)
+            esperado_iva = d4(iva_calc)
             iva_raw = item.get("ivaItem")
             actual_iva = money(D(str(iva_raw))) if iva_raw is not None else None
-            if iva_raw is not None:
-                if linea > D("0") and actual_iva != esperado_iva:
-                    raise ValueError(
-                        "IVA por ítem incoherente con modelo de precios con IVA incluido"
-                    )
-                if linea == D("0") and actual_iva != D("0"):
-                    raise ValueError("ivaItem debe ser 0 cuando ventaGravada es 0")
+            if iva_raw is not None and linea > D("0") and actual_iva != esperado_iva:
+                logger.warning(
+                    "IVA por ítem incoherente (%s); se corrige a %s",
+                    actual_iva,
+                    esperado_iva,
+                )
             item["ventaGravada"] = linea
             item["ivaItem"] = esperado_iva
+            if iva_raw is not None and linea == D("0") and actual_iva != D("0"):
+                raise ValueError("ivaItem debe ser 0 cuando ventaGravada es 0")
             item["ventaExenta"] = d4(0)
             item["ventaNoSuj"] = d4(0)
             item["noGravado"] = d4(0)
@@ -1472,7 +1473,7 @@ def recalcular_totales(
                 descu_gravada_sum = money(0)
 
     venta_gravada_sum = venta_gravada_sum
-    total_iva_sum = money(iva_total)
+    total_iva_sum = d4(iva_total)
 
     modificados: list[str] = []
 
@@ -2203,7 +2204,7 @@ def generar_dte_json(
     total_exenta_sum = _zero_or_d4(total_exenta_sum)
     total_gravada_sum = _zero_or_d2(total_gravada_sum)
     total_no_gravado_sum = money(total_no_gravado_sum)
-    total_iva_sum = money(iva_total)
+    total_iva_sum = d4(iva_total)
     sub_total_ventas = money(sub_total_ventas)
     descu_gravada_sum = money(descu_gravada_sum)
 

--- a/tests/test_iva_por_item.py
+++ b/tests/test_iva_por_item.py
@@ -30,7 +30,7 @@ def test_calculo_iva_item():
     resumen = payload["resumen"]
     assert D(str(item["ventaGravada"])) == D("13.00")
     assert D(str(item["ivaItem"])) == D("1.4956")
-    assert D(str(resumen["totalIva"])) == D("1.50")
+    assert D(str(resumen["totalIva"])) == D("1.4956")
 
 
 def test_serializacion_sin_tributos():
@@ -53,14 +53,14 @@ def test_fc_precio_incluye_iva_default():
     assert D(str(item["ventaGravada"])) == D("13.00")
     assert D(str(item["ivaItem"])) == D("1.4956")
     assert D(str(resumen["totalGravada"])) == D("13.00")
-    assert D(str(resumen["totalIva"])) == D("1.50")
+    assert D(str(resumen["totalIva"])) == D("1.4956")
     assert D(str(resumen["totalPagar"])) == D("13.00")
     assert item.get("codTributo") is None
     assert item.get("tributos") is None
     assert resumen.get("tributos") is None
 
 
-def test_valida_iva_incorrecto_error():
+def test_valida_iva_incorrecto_warning(caplog):
     payload = {
         "identificacion": {"tipoDte": "01"},
         "cuerpoDocumento": [
@@ -75,5 +75,8 @@ def test_valida_iva_incorrecto_error():
         ],
         "resumen": {},
     }
-    with pytest.raises(ValueError):
+    with caplog.at_level("WARNING"):
         recalcular_totales(payload)
+    assert "IVA por ítem incoherente" in caplog.text
+    item = payload["cuerpoDocumento"][0]
+    assert D(str(item["ivaItem"])) == D("1.4956")


### PR DESCRIPTION
## Summary
- Reemplaza la excepción por un aviso cuando el IVA declarado no coincide y lo corrige automáticamente
- Se garantiza que el IVA del ítem se reasigne siempre y que los totales usen precisión de cuatro decimales
- Actualiza las pruebas para reflejar el nuevo comportamiento y verificar el aviso

## Testing
- `pytest tests/test_iva_por_item.py tests/test_ccf_precios_iva_incluido.py tests/test_ticket_nitless.py tests/test_notas_iva_incluido.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf0216f7c883238df7b382ff68d23c