### PR TITLE
Skip otrosDocumentos for credit and debit notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -157,8 +157,17 @@ def sanitize_dte_payload(data: dict, schema: dict | None = None) -> dict:
     cleaned = _strip_additional_properties(data, schema)
     limpiar_documentos(cleaned)
     cleaned = _remove_nulls(cleaned)
-    for key in ("documentoRelacionado", "otrosDocumentos", "ventaTercero", "extension", "apendice"):
-        cleaned.setdefault(key, None)
+
+    schema_props = set(schema.get("properties", {}))
+    for key in (
+        "documentoRelacionado",
+        "otrosDocumentos",
+        "ventaTercero",
+        "extension",
+        "apendice",
+    ):
+        if key in schema_props:
+            cleaned.setdefault(key, None)
     return cleaned
 
 

--- a/tests/test_dte_payload_cleanup.py
+++ b/tests/test_dte_payload_cleanup.py
@@ -1,4 +1,5 @@
 import dte
+from utils import catalogos
 
 
 def _has_none(data):
@@ -58,3 +59,18 @@ def test_sanitize_dte_payload_adds_required_fields_and_cleans_docs(dte_metadata_
     assert clean["apendice"] is None
     assert clean["emisor"]["nit"] == "06141234560011"
     assert clean["receptor"]["numDocumento"] == "012345678"
+
+
+def test_sanitize_skips_otros_documentos_for_notas():
+    payload = {
+        "identificacion": {},
+        "emisor": {},
+        "receptor": {},
+        "cuerpoDocumento": [],
+        "resumen": {},
+    }
+
+    for tipo in ("05", "06"):
+        schema = catalogos.get_dte_schema(tipo)
+        clean = dte.sanitize_dte_payload(payload, schema)
+        assert "otrosDocumentos" not in clean


### PR DESCRIPTION
## Summary
- Avoid adding `otrosDocumentos` when schema does not allow it
- Add regression test ensuring credit and debit notes omit `otrosDocumentos`

## Testing
- `pytest` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf049cbe4c8323bbea9a65d879d7a7