### PR TITLE
Fix IVA calculation in debit notes generated from DTE details

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3242,6 +3242,7 @@ def generar_nde_desde_dte(
         total_grav = Decimal("0")
         total_exenta = Decimal("0")
         total_nosuj = Decimal("0")
+        iva_val = Decimal("0")
         num = 1
         for det in detalles:
             grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
@@ -3250,6 +3251,9 @@ def generar_nde_desde_dte(
             total_grav += grav
             total_exenta += exenta
             total_nosuj += nosuj
+            iva_val += (grav * Decimal("0.13")).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
             precio = det.get("precio_unitario") or det.get("precioUni")
             if precio is None:
                 precio = grav + exenta + nosuj
@@ -3280,6 +3284,9 @@ def generar_nde_desde_dte(
         total_grav = d2(total_grav)
         total_exenta = d2(total_exenta)
         total_nosuj = d2(total_nosuj)
+        iva_val = d2(iva_val)
+        subtotal_ventas = total_grav + total_exenta + total_nosuj
+        monto_total = d2(subtotal_ventas + iva_val)
     else:
         if monto is None:
             raise ValueError("Se requiere monto para nota de débito")
@@ -3357,13 +3364,14 @@ def generar_nde_desde_dte(
                     "codTributo": None,
                 }
             )
+        subtotal_ventas = total_grav + total_exenta + total_nosuj
+        orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (
+            ratio if "ratio" in locals() else Decimal("1")
+        )
+        iva_val = d2(orig_total - subtotal_ventas)
+        monto_total = d2(orig_total)
 
-    subtotal_ventas = total_grav + total_exenta + total_nosuj
-    orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (
-        ratio if "ratio" in locals() else Decimal("1")
-    )
-    iva_val = d2(orig_total - subtotal_ventas)
-    tributos_resumen = []
+    tributos_resumen: list[dict] = []
     if iva_val > 0:
         tributos_resumen.append(
             {
@@ -3372,7 +3380,6 @@ def generar_nde_desde_dte(
                 "valor": iva_val,
             }
         )
-    monto_total = d2(orig_total)
     resumen = {
         "totalNoSuj": total_nosuj,
         "totalExenta": total_exenta,

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -122,6 +122,7 @@ def generar_nde_desde_dte(
         total_grav = Decimal("0")
         total_exenta = Decimal("0")
         total_nosuj = Decimal("0")
+        iva_val = Decimal("0")
         num = 1
         for det in detalles:
             grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
@@ -130,6 +131,9 @@ def generar_nde_desde_dte(
             total_grav += grav
             total_exenta += exenta
             total_nosuj += nosuj
+            iva_val += (grav * Decimal("0.13")).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
             precio = det.get("precio_unitario") or det.get("precioUni")
             if precio is None:
                 precio = grav + exenta + nosuj
@@ -160,6 +164,9 @@ def generar_nde_desde_dte(
         total_grav = d2(total_grav)
         total_exenta = d2(total_exenta)
         total_nosuj = d2(total_nosuj)
+        iva_val = d2(iva_val)
+        subtotal_ventas = total_grav + total_exenta + total_nosuj
+        monto_total = d2(subtotal_ventas + iva_val)
     else:
         if monto is None:
             raise ValueError("Se requiere monto para nota de débito")
@@ -238,12 +245,14 @@ def generar_nde_desde_dte(
                 }
             )
 
-    subtotal_ventas = total_grav + total_exenta + total_nosuj
-    orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (
-        ratio if "ratio" in locals() else Decimal("1")
-    )
-    iva_val = d2(orig_total - subtotal_ventas)
-    tributos_resumen = []
+        subtotal_ventas = total_grav + total_exenta + total_nosuj
+        orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (
+            ratio if "ratio" in locals() else Decimal("1")
+        )
+        iva_val = d2(orig_total - subtotal_ventas)
+        monto_total = d2(orig_total)
+
+    tributos_resumen: list[dict] = []
     if iva_val > 0:
         tributos_resumen.append(
             {
@@ -252,7 +261,6 @@ def generar_nde_desde_dte(
                 "valor": iva_val,
             }
         )
-    monto_total = d2(orig_total)
     resumen = {
         "totalNoSuj": total_nosuj,
         "totalExenta": total_exenta,

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -1,5 +1,5 @@
 from db import DB
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from nota_credito_electronica import generar_nce_desde_dte
 from nota_debito_electronica import generar_nde_desde_dte
 from dte import generar_dte_json
@@ -70,6 +70,9 @@ def test_generar_nota_debito_detalles(monkeypatch):
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 2
     assert data["resumen"]["totalGravada"] == 2
+    expected_iva = Decimal("2") * Decimal("0.13")
+    assert data["resumen"]["tributos"][0]["valor"] == expected_iva
+    assert data["resumen"]["montoTotalOperacion"] == Decimal("2") + expected_iva
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
 
@@ -105,5 +108,42 @@ def test_generar_nota_debito_precio_4_decimales(monkeypatch):
     item = data["cuerpoDocumento"][0]
     assert item["precioUni"] == Decimal("1.2345")
     assert item["ventaExenta"] == Decimal("1.2345")
-    assert data["resumen"]["montoTotalOperacion"] == Decimal("1.23")
-    assert data["resumen"]["montoTotalOperacion"] == dte_origen["resumen"]["montoTotalOperacion"]
+    subtotal = Decimal("1.2345")
+    expected_total = subtotal.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    assert data["resumen"]["montoTotalOperacion"] == expected_total
+
+
+def test_iva_no_excesivo_en_nota(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "UUID",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {},
+        "resumen": {
+            "montoTotalOperacion": Decimal("104.92"),
+            "totalGravada": Decimal("92.85"),
+            "totalExenta": Decimal("0"),
+            "totalNoSuj": Decimal("0"),
+        },
+    }
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "precio_unitario": Decimal("4.42"),
+            "ventas_gravadas": Decimal("4.42"),
+            "ventas_exentas": 0,
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    nde = generar_nde_desde_dte(db, dte_origen, detalles, None, "Ajuste")
+    iva = Decimal("4.42") * Decimal("0.13")
+    iva = iva.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    assert nde["resumen"]["tributos"][0]["valor"] == iva
+    assert nde["resumen"]["montoTotalOperacion"] == Decimal("4.42") + iva
+    assert nde["resumen"]["tributos"][0]["valor"] != Decimal("12.07")

--- a/tests/test_notas_precio_uni.py
+++ b/tests/test_notas_precio_uni.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 
 from db import DB
 from nota_credito_electronica import generar_nce_desde_dte
@@ -76,12 +76,22 @@ def test_notas_precio_uni_cuatro_decimales(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     nde = generar_nde_desde_dte(db, dte_origen, detalles, None, "Ajuste")
 
-    total_original = Decimal(str(dte_origen["resumen"]["montoTotalOperacion"]))
+    expected_subtotal = sum(
+        Decimal(str(d.get("ventaGravada", 0)))
+        + Decimal(str(d.get("ventaExenta", 0)))
+        + Decimal(str(d.get("ventaNoSuj", 0)))
+        for d in detalles
+    )
+    expected_iva = sum(
+        (Decimal(str(d.get("ventaGravada", 0))) * Decimal("0.13")).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+        for d in detalles
+    )
+    expected_total = expected_subtotal + expected_iva
     for nota in (nce, nde):
         for det, esperado in zip(nota["cuerpoDocumento"], precios):
             dec = Decimal(str(det["precioUni"]))
             assert dec == esperado
             assert dec.as_tuple().exponent == -4
-        assert (
-            Decimal(str(nota["resumen"]["montoTotalOperacion"])) == total_original
-        )
+        assert Decimal(str(nota["resumen"]["montoTotalOperacion"])) == expected_total


### PR DESCRIPTION
## Summary
- compute debit note totals from provided item details
- avoid pulling IVA and totals from original DTE when details are given
- add regression tests for per-item IVA and reported issue

## Testing
- `pytest tests/test_nota_detalles.py::test_generar_nota_debito_detalles tests/test_nota_detalles.py::test_generar_nota_debito_precio_4_decimales tests/test_nota_detalles.py::test_iva_no_excesivo_en_nota tests/test_notas_precio_uni.py::test_notas_precio_uni_cuatro_decimales -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0bb9eecc8323afa96c8f62ff3db0