### PR TITLE
Ensure debit notes honor explicit totals

### DIFF
--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -122,7 +122,6 @@ def generar_nde_desde_dte(
         total_grav = Decimal("0")
         total_exenta = Decimal("0")
         total_nosuj = Decimal("0")
-        iva_val = Decimal("0")
         num = 1
         for det in detalles:
             grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
@@ -131,9 +130,6 @@ def generar_nde_desde_dte(
             total_grav += grav
             total_exenta += exenta
             total_nosuj += nosuj
-            iva_val += (grav * Decimal("0.13")).quantize(
-                Decimal("0.01"), rounding=ROUND_HALF_UP
-            )
             precio = det.get("precio_unitario") or det.get("precioUni")
             if precio is None:
                 precio = grav + exenta + nosuj
@@ -161,12 +157,24 @@ def generar_nde_desde_dte(
                 }
             )
             num += 1
+
+        total_grav = d4(total_grav)
+        total_exenta = d4(total_exenta)
+        total_nosuj = d4(total_nosuj)
+        subtotal_ventas = total_grav + total_exenta + total_nosuj
+
+        user_total = Decimal(str(monto)) if monto is not None else None
+        if user_total is not None and user_total >= subtotal_ventas:
+            iva_val = d2(user_total - subtotal_ventas)
+            monto_total = d2(user_total)
+        else:
+            iva_val = d2(total_grav * Decimal("0.13"))
+            monto_total = d2(subtotal_ventas + iva_val)
+
         total_grav = d2(total_grav)
         total_exenta = d2(total_exenta)
         total_nosuj = d2(total_nosuj)
-        iva_val = d2(iva_val)
-        subtotal_ventas = total_grav + total_exenta + total_nosuj
-        monto_total = d2(subtotal_ventas + iva_val)
+        subtotal_ventas = d2(subtotal_ventas)
     else:
         if monto is None:
             raise ValueError("Se requiere monto para nota de débito")

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -66,7 +66,7 @@ def test_generar_nota_debito_detalles(monkeypatch):
         }
     ]
     dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
-    data = generar_nde_desde_dte(db, dte_origen, detalles, 2, "Ajuste")
+    data = generar_nde_desde_dte(db, dte_origen, detalles, Decimal("2.26"), "Ajuste")
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 2
     assert data["resumen"]["totalGravada"] == 2
@@ -75,6 +75,33 @@ def test_generar_nota_debito_detalles(monkeypatch):
     assert data["resumen"]["montoTotalOperacion"] == Decimal("2") + expected_iva
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
+
+
+def test_generar_nde_respeta_total(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 9)
+    db.add_detalle_venta(venta_id, pid, 1, 7.96, vendedor_id=vid)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "precio_unitario": Decimal("7.96"),
+            "ventas_gravadas": Decimal("7.96"),
+            "ventas_exentas": 0,
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    data = generar_nde_desde_dte(db, dte_origen, detalles, Decimal("9"), "Ajuste")
+    resumen = data["resumen"]
+    assert resumen["montoTotalOperacion"] == Decimal("9.00")
+    assert resumen["totalGravada"] == Decimal("7.96")
+    assert resumen["tributos"][0]["valor"] == Decimal("1.04")
 
 
 def test_generar_nota_debito_precio_4_decimales(monkeypatch):


### PR DESCRIPTION
## Summary
- make debit notes compute VAT from the user-provided total
- adjust existing debit-note test and add coverage for preserving totals

## Testing
- `pytest tests/test_nota_detalles.py tests/test_nota_debito_remision.py tests/test_notas_precio_uni.py`
- `pytest` *(fails: ModuleNotFoundError/Qt-related errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf18788d248323812dc724801239b3