### PR TITLE
feat: add invoice detail dialog

### DIFF
--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -1,0 +1,75 @@
+from typing import List, Dict
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QTableWidget,
+    QTableWidgetItem,
+    QLabel,
+    QDialogButtonBox,
+    QHeaderView,
+    QAbstractItemView,
+)
+from PyQt5.QtCore import Qt
+
+
+class InvoiceDetailDialog(QDialog):
+    """Simple read-only dialog showing invoice items and totals."""
+
+    def __init__(self, items: List[Dict], resumen: Dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Detalle de factura")
+        layout = QVBoxLayout(self)
+
+        self.table = QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels([
+            "Descripción",
+            "Cantidad",
+            "P. Unitario",
+            "Total",
+        ])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        layout.addWidget(self.table)
+
+        for it in items:
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            desc = it.get("descripcion", "")
+            qty = it.get("cantidad", 0)
+            price = it.get("precioUni", 0)
+            try:
+                price = float(price)
+            except Exception:
+                price = 0.0
+            total = (
+                float(it.get("ventaGravada", 0))
+                + float(it.get("ventaExenta", 0))
+                + float(it.get("ventaNoSuj", 0))
+                + float(it.get("noGravado", 0))
+            )
+            self.table.setItem(row, 0, QTableWidgetItem(str(desc)))
+            self.table.setItem(row, 1, QTableWidgetItem(f"{qty}"))
+            self.table.setItem(row, 2, QTableWidgetItem(f"{price:.2f}"))
+            self.table.setItem(row, 3, QTableWidgetItem(f"{total:.2f}"))
+
+        totals_layout = QVBoxLayout()
+        total_gravada = float(resumen.get("totalGravada", 0))
+        total_exenta = float(resumen.get("totalExenta", 0))
+        total_no_suj = float(resumen.get("totalNoSuj", 0))
+        total_iva = float(resumen.get("totalIva", 0))
+        total = float(resumen.get("totalPagar", resumen.get("montoTotalOperacion", 0)))
+        for text in [
+            f"Gravada: {total_gravada:.2f}",
+            f"Exenta: {total_exenta:.2f}",
+            f"No sujeta: {total_no_suj:.2f}",
+            f"IVA: {total_iva:.2f}",
+            f"Total: {total:.2f}",
+        ]:
+            totals_layout.addWidget(QLabel(text))
+        totals_layout.addStretch()
+        layout.addLayout(totals_layout)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok)
+        buttons.button(QDialogButtonBox.Ok).setText("Cerrar")
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons)

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -53,6 +53,7 @@ import subprocess
 import shutil
 import dte
 from dialogs.nota_detalle_dialog import NotaDetalleDialog
+from dialogs.invoice_detail_dialog import InvoiceDetailDialog
 from decimal import Decimal
 
 # Directory where debit notes will be stored
@@ -554,6 +555,7 @@ class FacturacionTab(QWidget):
         self.date_to.dateChanged.connect(self.load_invoices)
         self.table.itemSelectionChanged.connect(self.show_invoice)
         self.table.itemSelectionChanged.connect(self._update_send_btn)
+        self.table.itemDoubleClicked.connect(self.mostrar_detalle_factura)
 
         self.btn_enviar.clicked.connect(self.send_selected_invoice)
         self.btn_abrir_pdf.clicked.connect(self.open_pdf)
@@ -997,6 +999,26 @@ class FacturacionTab(QWidget):
             QDesktopServices.openUrl(QUrl.fromLocalFile(pdf_path))
         else:
             QMessageBox.warning(self, "Abrir PDF", "No se encontró el archivo PDF.")
+
+    def mostrar_detalle_factura(self, item=None):
+        factura = self._selected_factura()
+        if not factura:
+            QMessageBox.warning(self, "Detalle", "Seleccione una factura válida")
+            return
+        json_path = factura.get("json")
+        if not json_path or not os.path.exists(json_path):
+            QMessageBox.warning(self, "Detalle", "No se encontró el archivo JSON")
+            return
+        try:
+            with open(json_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            QMessageBox.warning(self, "Detalle", "Error al leer el archivo JSON")
+            return
+        items = data.get("cuerpoDocumento") or []
+        resumen = data.get("resumen") or {}
+        dlg = InvoiceDetailDialog(items, resumen, self)
+        dlg.exec_()
 
     def _send_invoice_email(self, venta_id):
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)


### PR DESCRIPTION
## Summary
- open invoice detail by double clicking a row in the billing table
- show invoice items and totals in new read-only InvoiceDetailDialog

## Testing
- `pytest` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2c3d24948323a54c177c1cce2b08