### PR TITLE
Evitar aviso de guardado sin cambios pendientes

### DIFF
--- a/tests/test_close_event_prompt.py
+++ b/tests/test_close_event_prompt.py
@@ -1,0 +1,68 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+import pytest
+
+import inventory_manager as im
+import ui_mainwindow
+from PyQt5.QtWidgets import QApplication, QMessageBox
+
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_close_without_changes_does_not_prompt(qt_app, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    window = ui_mainwindow.MainWindow()
+    called = False
+
+    def fake_question(*a, **k):
+        nonlocal called
+        called = True
+        return QMessageBox.Yes
+
+    monkeypatch.setattr(ui_mainwindow.QMessageBox, "question", fake_question)
+    window.close()
+    assert not called
+
+
+def test_close_with_changes_prompts(qt_app, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    window = ui_mainwindow.MainWindow()
+    window.manager.db.add_producto("P1", "C1", None, None, None, 1, 2, 3, 5)
+    called = False
+
+    def fake_question(*a, **k):
+        nonlocal called
+        called = True
+        return QMessageBox.No
+
+    monkeypatch.setattr(ui_mainwindow.QMessageBox, "question", fake_question)
+    window.close()
+    assert called
+
+
+def test_close_after_save_does_not_prompt(qt_app, monkeypatch):
+    monkeypatch.setattr(im, "DB", MemoryDB)
+    window = ui_mainwindow.MainWindow()
+    window.manager.db.add_producto("P1", "C1", None, None, None, 1, 2, 3, 5)
+    window._mark_saved()
+    called = False
+
+    def fake_question(*a, **k):
+        nonlocal called
+        called = True
+        return QMessageBox.Yes
+
+    monkeypatch.setattr(ui_mainwindow.QMessageBox, "question", fake_question)
+    window.close()
+    assert not called
+

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -77,6 +77,8 @@ class MainWindow(QMainWindow):
         self.resize(1200, 700)
         self.manager = InventoryManager()
         self.ultimo_archivo_json = None  # Guarda la ruta del último archivo .json usado
+        # Contador de cambios en la base de datos para detectar si hay datos sin guardar
+        self._mark_saved()
         self._setup_ui()
         self._apply_styles()
 
@@ -893,6 +895,7 @@ class MainWindow(QMainWindow):
                 self.ultimo_archivo_json = filename
                 with open(LAST_INVENTORY_PATH, "w", encoding="utf-8") as f:
                     json.dump({"ultimo": filename}, f)
+                self._mark_saved()
                 QMessageBox.information(self, "Guardar como", "Inventario guardado correctamente.")
 
             thread.finished.connect(on_finished)
@@ -923,7 +926,7 @@ class MainWindow(QMainWindow):
                 self._actualizar_inventario_actual()
                 self._actualizar_historial()
                 self._cargar_personas_estado()
-
+                self._mark_saved()
                 QMessageBox.information(self, "Cargar inventario", "Inventario cargado correctamente.")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"No se pudo cargar el inventario:\n{e}")
@@ -974,6 +977,7 @@ class MainWindow(QMainWindow):
             )
 
             def on_finished():
+                self._mark_saved()
                 QMessageBox.information(
                     self,
                     "Guardar rápido",
@@ -1003,6 +1007,7 @@ class MainWindow(QMainWindow):
                 self.filter_products()
                 self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA
                 self._mostrar_historial_general()
+                self._mark_saved()
                 QMessageBox.information(self, "Cargar rápido", f"Inventario cargado de:\n{self.ultimo_archivo_json}")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"No se pudo cargar el inventario:\n{e}")
@@ -1810,7 +1815,19 @@ class MainWindow(QMainWindow):
                 return i
         return -1
 
+    def _mark_saved(self):
+        """Registra el estado actual de la base de datos como guardado.
+
+        Se almacena el número total de cambios realizados en la conexión de
+        SQLite para poder detectar posteriormente si el inventario ha sido
+        modificado sin guardar.
+        """
+        self._db_change_counter = self.manager.db.conn.total_changes
+
     def closeEvent(self, event):
+        if self.manager.db.conn.total_changes == self._db_change_counter:
+            event.accept()
+            return
         reply = QMessageBox.question(
             self,
             "Salir",


### PR DESCRIPTION
## Summary
- Track database change count to detect pending inventory edits
- Only prompt to save on close when there are unsaved changes
- Add tests covering close behavior with and without modifications

## Testing
- `pytest` *(fails: tests/test_import_trabajador_sales.py::test_import_trabajador_sales ... tests/test_close_event_prompt.py::test_close_after_save_does_not_prompt)`

------
https://chatgpt.com/codex/tasks/task_e_68bf2cd6d338832396d21950f741ff7c