### PR TITLE
Use docs folder for nota remisión files

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1313,14 +1313,11 @@ class FacturacionTab(QWidget):
             )
         cliente = nota_json.get("receptor", {}) or {}
         extension = nota_json.get("extension", {}) or {}
-        out_dir = NOTAS_REMISION_DIR
-        os.makedirs(out_dir, exist_ok=True)
         pdf_path, json_path = get_dte_document_paths(
             nota_json["identificacion"].get("fecEmi"),
             cliente.get("nombre") or cliente.get("nombreComercial") or "",
             nota_json["identificacion"].get("numeroControl"),
             "NotaRemision",
-            out_dir,
         )
         generar_nota_remision_pdf(
             venta_data, detalles_pdf, cliente, extension, archivo=str(pdf_path)
@@ -1546,7 +1543,7 @@ class FacturacionTab(QWidget):
             detalles_pdf,
             cliente or {},
             distribuidor or {},
-            archivo=pdf_path,
+            archivo=str(pdf_path),
         )
 
         # Guardar JSON sin firmar para permitir vista previa

--- a/tests/test_nota_remision_paths.py
+++ b/tests/test_nota_remision_paths.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import facturacion_tab
+from utils import docs
+
+
+def test_guardar_archivos_nota_remision_uses_docs_folder(tmp_path, monkeypatch):
+    folder = tmp_path / "notas_remision"
+    monkeypatch.setitem(docs.FOLDERS, "NotaRemision", str(folder))
+
+    def fake_pdf(venta, detalles, cliente, distribuidor, archivo="nota_remision.pdf", **kwargs):
+        Path(archivo).write_text("PDF")
+
+    monkeypatch.setattr(facturacion_tab, "generar_nota_remision_pdf", fake_pdf)
+
+    nota_json = {
+        "identificacion": {"fecEmi": "2024-05-01", "numeroControl": "DTE-04-ABC-1"},
+        "receptor": {"nombre": "Cliente"},
+        "resumen": {},
+        "cuerpoDocumento": [],
+        "extension": {},
+    }
+
+    facturacion_tab.FacturacionTab._guardar_archivos_nota_remision(object(), nota_json)
+
+    pdf_files = list(folder.glob("*.pdf"))
+    json_files = list(folder.glob("*.json"))
+
+    assert len(pdf_files) == 1
+    assert len(json_files) == 1
+    assert pdf_files[0].parent == folder
+    assert json_files[0].parent == folder
+    assert not (folder / "notas_remision").exists()
+

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 
 from dte import _map_departamento, _map_municipio
 
@@ -60,12 +61,11 @@ def get_document_paths(date, cliente, identifier, doc_type, root=None):
 
 def get_dte_document_paths(fecha, empresa, numero_control, doc_type, root=None):
     """Return paths ensuring MH-required naming for DTE notes."""
-    base = root or BASE_DIR
-    folder = FOLDERS.get(doc_type)
+    base = Path(root or BASE_DIR)
+    folder = Path(FOLDERS.get(doc_type))
     if root:
-        name = os.path.basename(folder)
-        folder = os.path.join(root, name)
-    os.makedirs(folder, exist_ok=True)
+        folder = base / folder.name
+    folder.mkdir(parents=True, exist_ok=True)
     if isinstance(fecha, datetime):
         d = fecha
     else:
@@ -79,8 +79,8 @@ def get_dte_document_paths(fecha, empresa, numero_control, doc_type, root=None):
         if m:
             numero_control = f"{m.group(1)}{int(m.group(2)):015d}"
     base_name = f"{date_str}_{sanitize_filename(empresa)}_{numero_control}_{sanitize_filename(doc_type)}"
-    pdf_path = os.path.join(folder, base_name + '.pdf')
-    json_path = os.path.join(folder, base_name + '.json')
+    pdf_path = folder / (base_name + '.pdf')
+    json_path = folder / (base_name + '.json')
     return pdf_path, json_path
 
 


### PR DESCRIPTION
## Summary
- rely on `get_dte_document_paths` default folder for nota de remisión
- ensure DTE path helper returns `Path` objects
- test that nota remisión files are stored in the common docs folder

## Testing
- `pytest tests/test_nota_remision_paths.py tests/test_get_dte_document_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf36479cac8323afbcf76f022cedec