### PR TITLE
Propagar errores de Hacienda en respuestas y UI

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4064,6 +4064,8 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
     res = {"estado": estado, "sello": sello}
     if detalle:
         res["detalle"] = detalle
+    if respuesta.get("errores"):
+        res["errores"] = respuesta["errores"]
     return res
 
 
@@ -4204,6 +4206,8 @@ def _enviar_documento(
     res = {"estado": estado, "sello": sello}
     if detalle:
         res["detalle"] = detalle
+    if respuesta.get("errores"):
+        res["errores"] = respuesta["errores"]
     return res
 
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1012,9 +1012,11 @@ class FacturacionTab(QWidget):
                 json_path = factura.get("json")
                 try:
                     resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
-                    if resp.get("estado") == "Error":
+                    if resp.get("estado") not in {"Transmitido", "Recibido", "PROCESADO"}:
                         QMessageBox.critical(
-                            self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                            self,
+                            "Enviar a Hacienda",
+                            resp.get("errores") or resp.get("detalle") or "Error",
                         )
                     else:
                         QMessageBox.information(
@@ -1030,9 +1032,11 @@ class FacturacionTab(QWidget):
                 tipo = "03" if rtype == "ticket" else "01"
                 try:
                     resp = transmitir_dte(self.manager.db, entry.get("id"), tipo_dte=tipo)
-                    if resp.get("estado") == "Error":
+                    if resp.get("estado") not in {"Transmitido", "Recibido", "PROCESADO"}:
                         QMessageBox.critical(
-                            self, "Enviar a Hacienda", resp.get("detalle", "Error")
+                            self,
+                            "Enviar a Hacienda",
+                            resp.get("errores") or resp.get("detalle") or "Error",
                         )
                     else:
                         QMessageBox.information(


### PR DESCRIPTION
## Summary
- Include Hacienda rejection details in `_enviar_documento` and `transmitir_dte_orphan` responses
- Show backend rejection details in the UI and treat non-success states as errors

## Testing
- `python -m py_compile dte.py facturacion_tab.py`
- `pytest -q` *(fails: libGL.so.1 missing, fastapi missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf393d09f08323ab404805e892c044