### PR TITLE
Corregir generación de Nota de Remisión DTE-04

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3500,29 +3500,29 @@ def generar_nota_remision_json(
 
     emisor = copy.deepcopy(factura.get("emisor") or {})
     receptor = copy.deepcopy(factura.get("receptor") or {})
+    receptor.setdefault("bienTitulo", "01")
     limpiar_documentos(receptor)
 
+    numero_doc = documento_relacionado[0]["numeroDocumento"]
     items: list[dict] = []
     for num, det in enumerate(factura.get("cuerpoDocumento", []), 1):
         cantidad = cantidades.get(num, det.get("cantidad", 1))
-        items.append(
-            {
-                "numItem": num,
-                "tipoItem": det.get("tipoItem", 1),
-                "codigo": det.get("codigo", f"NR{num:03d}"),
-                "descripcion": det.get("descripcion", f"Item {num}"),
-                "cantidad": cantidad,
-                "uniMedida": det.get("uniMedida", 59),
-                "precioUni": 0.0,
-                "montoDescu": 0.0,
-                "ventaNoSuj": d2(D(0)),
-                "ventaExenta": d2(D(0)),
-                "ventaGravada": d2(D(0)),
-                "tributos": [],
-                "numeroDocumento": None,
-                "codTributo": None,
-            }
-        )
+        item = {
+            "numItem": num,
+            "tipoItem": det.get("tipoItem", 1),
+            "codigo": det.get("codigo", f"NR{num:03d}"),
+            "descripcion": det.get("descripcion", f"Item {num}"),
+            "cantidad": cantidad,
+            "uniMedida": det.get("uniMedida", 59),
+            "precioUni": 0.0,
+            "montoDescu": 0.0,
+            "ventaNoSuj": d2(D(0)),
+            "ventaExenta": d2(D(0)),
+            "ventaGravada": d2(D(0)),
+            "tributos": None,
+            "numeroDocumento": numero_doc,
+        }
+        items.append(item)
 
     ext = {
         "nombEntrega": "N/D",
@@ -3541,16 +3541,11 @@ def generar_nota_remision_json(
         "totalGravada": d2(D(0)),
         "subTotal": d2(D(0)),
         "subTotalVentas": d2(D(0)),
-        "descuNoSuj": 0.0,
-        "descuExenta": 0.0,
-        "descuGravada": 0.0,
-        "totalDescu": 0.0,
-        "ivaPerci1": 0.0,
-        "ivaRete1": 0.0,
-        "reteRenta": 0.0,
+        "porcentajeDescuento": d2(D(0)),
+        "totalDescu": d2(D(0)),
+        "tributos": None,
         "montoTotalOperacion": d2(D(0)),
         "totalLetras": monto_a_texto_sv(0.0),
-        "condicionOperacion": 1,
     }
 
     data = {

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -291,7 +291,6 @@ class NotaRemisionExtWidget(QWidget):
             limpiar_doc(self.docu_entrega.text()),
             self.nomb_recibe.text().strip(),
             limpiar_doc(self.docu_recibe.text()),
-            self.ext_obs.toPlainText().strip(),
         ]
         if not all(checks):
             QMessageBox.warning(
@@ -444,6 +443,7 @@ class NotaRemisionDialog(QDialog):
             "nombre": extension.get("nombRecibe"),
             "tipoDocumento": "13",
             "numDocumento": extension.get("docuRecibe"),
+            "bienTitulo": "01",
             "direccion": {"departamento": "05", "municipio": "24", "complemento": ""},
         }
         return detalles, extension, receptor

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -32,28 +32,32 @@ from utils.sanitize import limpiar_documentos
 Decimal_0 = Decimal("0")
 
 
-def _build_items(detalles: Iterable[dict]) -> list[dict]:
-    """Construye items con montos forzados a ``0.00``."""
+def _build_items(
+    detalles: Iterable[dict], numero_documento: Optional[str] = None
+) -> list[dict]:
+    """Construye items con montos forzados a ``0.00``.
+
+    Si ``numero_documento`` se proporciona se añade a cada ítem.
+    """
     items: list[dict] = []
     for num, det in enumerate(detalles, 1):
-        items.append(
-            {
-                "numItem": num,
-                "tipoItem": det.get("tipoItem", 1),
-                "codigo": det.get("codigo", f"NR{num:03d}"),
-                "descripcion": det.get("descripcion", f"Item {num}"),
-                "cantidad": det.get("cantidad", 1),
-                "uniMedida": det.get("uniMedida", 59),
-                "precioUni": 0.0,
-                "montoDescu": 0.0,
-                "ventaNoSuj": d2(Decimal_0),
-                "ventaExenta": d2(Decimal_0),
-                "ventaGravada": d2(Decimal_0),
-                "tributos": [],
-                "numeroDocumento": None,
-                "codTributo": None,
-            }
-        )
+        item = {
+            "numItem": num,
+            "tipoItem": det.get("tipoItem", 1),
+            "codigo": det.get("codigo", f"NR{num:03d}"),
+            "descripcion": det.get("descripcion", f"Item {num}"),
+            "cantidad": det.get("cantidad", 1),
+            "uniMedida": det.get("uniMedida", 59),
+            "precioUni": 0.0,
+            "montoDescu": 0.0,
+            "ventaNoSuj": d2(Decimal_0),
+            "ventaExenta": d2(Decimal_0),
+            "ventaGravada": d2(Decimal_0),
+            "tributos": None,
+        }
+        if numero_documento:
+            item["numeroDocumento"] = numero_documento
+        items.append(item)
     return items
 
 
@@ -62,7 +66,7 @@ def generar_nota_remision(
     factura: Optional[dict] = None,
     *,
     detalles: Optional[Iterable[dict]] = None,
-    documento_relacionado: Optional[dict] = None,
+    documento_relacionado: Optional[list[dict]] = None,
     emisor: Optional[dict] = None,
     receptor: Optional[dict] = None,
     extension: Optional[dict] = None,
@@ -71,14 +75,18 @@ def generar_nota_remision(
     """Genera la estructura JSON de una Nota de Remisión."""
     if factura:
         emisor = factura.get("emisor")
-        receptor = factura.get("receptor")
+        receptor = factura.get("receptor") or {}
         detalles = detalles or factura.get("cuerpoDocumento", [])
         if documento_relacionado is None:
             ident = factura.get("identificacion", {})
-            documento_relacionado = {
-                "tipoDoc": ident.get("tipoDte"),
-                "numeroDocumento": ident.get("numeroControl"),
-            }
+            documento_relacionado = [
+                {
+                    "tipoDocumento": ident.get("tipoDte"),
+                    "tipoGeneracion": 2,
+                    "numeroDocumento": ident.get("codigoGeneracion"),
+                    "fechaEmision": ident.get("fecEmi"),
+                }
+            ]
         # Para notas derivadas de factura la extensión puede omitirse
         ext = {
             "nombEntrega": "N/D",
@@ -89,6 +97,10 @@ def generar_nota_remision(
         }
         if extension:
             ext.update({k: v for k, v in extension.items() if v not in (None, "")})
+            receptor.setdefault("nombre", extension.get("nombRecibe"))
+            receptor.setdefault("tipoDocumento", "13")
+            receptor.setdefault("numDocumento", extension.get("docuRecibe"))
+        receptor.setdefault("bienTitulo", "01")
     else:
         if not (emisor and receptor and detalles):
             raise ValueError("emisor, receptor y detalles son obligatorios")
@@ -101,7 +113,6 @@ def generar_nota_remision(
             "docuEntrega",
             "nombRecibe",
             "docuRecibe",
-            "observaciones",
         ]
         missing = [k for k in required_ext if not extension.get(k)]
         if missing:
@@ -109,8 +120,13 @@ def generar_nota_remision(
                 "Faltan campos obligatorios en extension: " + ", ".join(missing)
             )
         ext = {k: extension.get(k) for k in required_ext}
+        if extension.get("observaciones"):
+            ext["observaciones"] = extension.get("observaciones")
 
     limpiar_documentos(emisor)
+    receptor.setdefault("bienTitulo", "01")
+    if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
+        raise ValueError("receptor requiere tipoDocumento y numDocumento")
     limpiar_documentos(receptor)
     limpiar_documentos(ext)
 
@@ -131,7 +147,10 @@ def generar_nota_remision(
         "tipoMoneda": "USD",
     }
 
-    items = _build_items(detalles)
+    numero_doc = None
+    if documento_relacionado:
+        numero_doc = documento_relacionado[0].get("numeroDocumento")
+    items = _build_items(detalles, numero_doc)
 
     resumen = {
         "totalNoSuj": d2(Decimal_0),
@@ -139,16 +158,11 @@ def generar_nota_remision(
         "totalGravada": d2(Decimal_0),
         "subTotal": d2(Decimal_0),
         "subTotalVentas": d2(Decimal_0),
-        "descuNoSuj": 0.0,
-        "descuExenta": 0.0,
-        "descuGravada": 0.0,
-        "totalDescu": 0.0,
-        "ivaPerci1": 0.0,
-        "ivaRete1": 0.0,
-        "reteRenta": 0.0,
+        "porcentajeDescuento": d2(Decimal_0),
+        "totalDescu": d2(Decimal_0),
+        "tributos": None,
         "montoTotalOperacion": d2(Decimal_0),
         "totalLetras": monto_a_texto_sv(0.0),
-        "condicionOperacion": 1,
     }
 
     data = {

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -26,11 +26,13 @@ from utils.sanitize import limpiar_documentos
 Decimal_0 = Decimal("0")
 
 
-def _build_items(detalles: Iterable[dict]) -> list[dict]:
+def _build_items(
+    detalles: Iterable[dict], numero_documento: Optional[str] = None
+) -> list[dict]:
     """Construye los ítems de la NR forzando todos los montos a ``0.00``.
 
     Además valida que ``cantidad`` sea mayor que cero y que ``uniMedida`` esté
-    presente.
+    presente.  Si ``numero_documento`` se proporciona se agrega a cada ítem.
     """
 
     items: list[dict] = []
@@ -40,24 +42,23 @@ def _build_items(detalles: Iterable[dict]) -> list[dict]:
             raise ValueError("cantidad debe ser mayor que cero")
         if det.get("uniMedida") is None:
             raise ValueError("uniMedida requerido en el item")
-        items.append(
-            {
-                "numItem": num,
-                "tipoItem": det.get("tipoItem", 1),
-                "codigo": det.get("codigo", f"NR{num:03d}"),
-                "descripcion": det.get("descripcion", f"Item {num}"),
-                "cantidad": cantidad,
-                "uniMedida": det.get("uniMedida"),
-                "precioUni": 0.0,
-                "montoDescu": 0.0,
-                "ventaNoSuj": d2(Decimal_0),
-                "ventaExenta": d2(Decimal_0),
-                "ventaGravada": d2(Decimal_0),
-                "tributos": [],
-                "numeroDocumento": None,
-                "codTributo": None,
-            }
-        )
+        item = {
+            "numItem": num,
+            "tipoItem": det.get("tipoItem", 1),
+            "codigo": det.get("codigo", f"NR{num:03d}"),
+            "descripcion": det.get("descripcion", f"Item {num}"),
+            "cantidad": cantidad,
+            "uniMedida": det.get("uniMedida"),
+            "precioUni": 0.0,
+            "montoDescu": 0.0,
+            "ventaNoSuj": d2(Decimal_0),
+            "ventaExenta": d2(Decimal_0),
+            "ventaGravada": d2(Decimal_0),
+            "tributos": None,
+        }
+        if numero_documento:
+            item["numeroDocumento"] = numero_documento
+        items.append(item)
     return items
 
 
@@ -68,12 +69,15 @@ def _generar_base(
     receptor: dict,
     detalles: Iterable[dict],
     extension: Optional[dict] = None,
-    documento_relacionado: Optional[dict] = None,
+    documento_relacionado: Optional[list[dict]] = None,
     ambiente: str = "00",
 ) -> dict:
     """Construye la estructura base común de una NR."""
 
     limpiar_documentos(emisor)
+    receptor.setdefault("bienTitulo", "01")
+    if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
+        raise ValueError("receptor requiere tipoDocumento y numDocumento")
     limpiar_documentos(receptor)
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
@@ -93,7 +97,10 @@ def _generar_base(
         "tipoMoneda": "USD",
     }
 
-    items = _build_items(detalles)
+    numero_doc = None
+    if documento_relacionado:
+        numero_doc = documento_relacionado[0].get("numeroDocumento")
+    items = _build_items(detalles, numero_doc)
 
     ext = {
         "nombEntrega": "N/D",
@@ -112,21 +119,15 @@ def _generar_base(
         "totalGravada": d2(Decimal_0),
         "subTotal": d2(Decimal_0),
         "subTotalVentas": d2(Decimal_0),
-        "descuNoSuj": 0.0,
-        "descuExenta": 0.0,
-        "descuGravada": 0.0,
-        "totalDescu": 0.0,
-        "ivaPerci1": 0.0,
-        "ivaRete1": 0.0,
-        "reteRenta": 0.0,
+        "porcentajeDescuento": d2(Decimal_0),
+        "totalDescu": d2(Decimal_0),
+        "tributos": None,
         "montoTotalOperacion": d2(Decimal_0),
         "totalLetras": monto_a_texto_sv(0.0),
-        "condicionOperacion": 1,
     }
 
     data = {
         "identificacion": identificacion,
-        "documentoRelacionado": documento_relacionado,
         "emisor": emisor,
         "receptor": receptor,
         "cuerpoDocumento": items,
@@ -134,9 +135,14 @@ def _generar_base(
         "resumen": resumen,
         "apendice": None,
     }
+    if documento_relacionado:
+        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
-    return sanitize_dte_payload(data, schema)
+    result = sanitize_dte_payload(data, schema)
+    if not documento_relacionado:
+        result.pop("documentoRelacionado", None)
+    return result
 
 
 def generar_nota_remision_desde_factura(
@@ -151,12 +157,17 @@ def generar_nota_remision_desde_factura(
 
     emisor = factura.get("emisor", {})
     receptor = factura.get("receptor", {})
+    receptor.setdefault("bienTitulo", "01")
     detalles = detalles or factura.get("cuerpoDocumento", [])
     ident = factura.get("identificacion", {})
-    doc_rel = {
-        "tipoDoc": ident.get("tipoDte"),
-        "numeroDocumento": ident.get("numeroControl"),
-    }
+    doc_rel = [
+        {
+            "tipoDocumento": ident.get("tipoDte"),
+            "tipoGeneracion": 2,
+            "numeroDocumento": ident.get("codigoGeneracion"),
+            "fechaEmision": ident.get("fecEmi"),
+        }
+    ]
     return _generar_base(
         db,
         emisor=emisor,

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -13,7 +13,12 @@ def _sample_emisor():
 
 
 def _sample_receptor():
-    return {"tipoDocumento": "36", "numDocumento": "1234 567-8", "nombre": "Cliente"}
+    return {
+        "tipoDocumento": "36",
+        "numDocumento": "1234 567-8",
+        "nombre": "Cliente",
+        "bienTitulo": "01",
+    }
 
 
 def test_nr_desde_factura_documento_relacionado(monkeypatch):
@@ -22,7 +27,8 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     factura = {
         "identificacion": {
             "tipoDte": "03",
-            "numeroControl": "DTE-03-XYZ-000000000000001",
+            "codigoGeneracion": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fecEmi": "2024-01-01",
         },
         "emisor": _sample_emisor(),
         "receptor": _sample_receptor(),
@@ -31,10 +37,11 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
         ],
     }
     data = generar_nota_remision_desde_factura(db, factura)
-    doc_rel = data["documentoRelacionado"]
-    assert doc_rel["tipoDoc"] == "03"
-    assert doc_rel["numeroDocumento"] == "DTE-03-XYZ-000000000000001"
+    doc_rel = data["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"
+    assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
     item = data["cuerpoDocumento"][0]
+    assert item["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
     assert float(item["precioUni"]) == 0.0
     assert float(item["ventaNoSuj"]) == 0.0
     assert float(item["ventaExenta"]) == 0.0
@@ -49,7 +56,8 @@ def test_nr_desde_factura_extension(monkeypatch):
     factura = {
         "identificacion": {
             "tipoDte": "03",
-            "numeroControl": "DTE-03-XYZ-000000000000001",
+            "codigoGeneracion": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fecEmi": "2024-01-01",
         },
         "emisor": _sample_emisor(),
         "receptor": _sample_receptor(),
@@ -88,7 +96,7 @@ def test_nr_independiente_extension(monkeypatch):
         detalles=detalles,
         extension=extension,
     )
-    assert data["documentoRelacionado"] is None
+    assert "documentoRelacionado" not in data
     ext = data["extension"]
     assert ext["nombEntrega"] == "Juan"
     assert ext["nombRecibe"] == "Ana"


### PR DESCRIPTION
## Resumen
- Ajuste de generación de Nota de Remisión para cumplir con campos obligatorios de receptor y resumen.
- Inclusión de `documentoRelacionado` como arreglo y propagación del UUID a cada ítem.
- Interfaz de notas de remisión actualiza validaciones y añade `bienTitulo` al receptor.

## Testing
- `pytest tests/test_nota_remision.py tests/test_generar_nota_remision_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf3f26a4108323ac177a8b257a6d96