### PR TITLE
Usar totales precalculados para notas de venta

### DIFF
--- a/dialogs/nota_detalle_dialog.py
+++ b/dialogs/nota_detalle_dialog.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Tuple
+from decimal import Decimal
 from PyQt5.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -79,17 +80,9 @@ class NotaDetalleDialog(QDialog):
         for row, d in enumerate(self.detalles):
             prod = d.get("descripcion", "")
             qty = d.get("cantidad", 0)
-            price = d.get("precio_unitario", 0)
-            desc = d.get("descuento", 0)
-            if d.get("descuento_tipo") == "%":
-                desc = price * qty * d.get("descuento", 0) / 100
-
-            has_iva = bool(d.get("ventas_gravadas"))
-            mult = 1.13 if has_iva else 1
-
-            price_iva = price * mult
-            desc_iva = desc * mult
-            total_iva = (price * qty - desc) * mult
+            price_iva = d.get("precio_unitario_iva", Decimal("0"))
+            desc_iva = d.get("descuento_iva", Decimal("0"))
+            total_iva = d.get("total_linea", Decimal("0"))
 
             items = [
                 QTableWidgetItem(str(prod)),

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1432,6 +1432,9 @@ class FacturacionTab(QWidget):
                     "ventas_gravadas": float(d.get("ventaGravada", 0)),
                     "ventas_exentas": float(d.get("ventaExenta", 0)),
                     "ventas_no_sujetas": float(d.get("ventaNoSuj", 0)),
+                    "precio_unitario_iva": Decimal(str(d.get("ivaItem", 0))),
+                    "descuento_iva": Decimal(str(d.get("montoDescu", 0))),
+                    "total_linea": Decimal(str(d.get("ventaGravada", 0))),
                 }
             )
 


### PR DESCRIPTION
## Summary
- Incluir en `detalles_venta` los montos calculados del JSON como Decimals
- Mostrar precios, descuentos y totales precalculados en `NotaDetalleDialog`

## Testing
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3f405d208323b3f91f75e640b696