### PR TITLE
Validate NR receptor documents and add required fields

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3501,7 +3501,23 @@ def generar_nota_remision_json(
     emisor = copy.deepcopy(factura.get("emisor") or {})
     receptor = copy.deepcopy(factura.get("receptor") or {})
     receptor.setdefault("bienTitulo", "01")
+    if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
+        raise ValueError("receptor requiere tipoDocumento y numDocumento")
     limpiar_documentos(receptor)
+    tipo_doc = receptor.get("tipoDocumento")
+    num_doc = receptor.get("numDocumento")
+    nrc = receptor.get("nrc")
+    if tipo_doc == "13":
+        if not re.fullmatch(r"\d{9}", num_doc or ""):
+            raise ValueError("DUI inválido en receptor")
+        receptor.pop("nrc", None)
+    elif tipo_doc == "36":
+        if not re.fullmatch(r"\d{14}", num_doc or ""):
+            raise ValueError("NIT inválido en receptor")
+        if not nrc or not re.fullmatch(r"\d{1,8}", nrc):
+            raise ValueError("NRC inválido en receptor")
+    else:
+        raise ValueError("tipoDocumento inválido en receptor")
 
     numero_doc = documento_relacionado[0]["numeroDocumento"]
     items: list[dict] = []
@@ -3520,6 +3536,7 @@ def generar_nota_remision_json(
             "ventaExenta": d2(D(0)),
             "ventaGravada": d2(D(0)),
             "tributos": None,
+            "codTributo": None,
             "numeroDocumento": numero_doc,
         }
         items.append(item)
@@ -3543,6 +3560,9 @@ def generar_nota_remision_json(
         "subTotalVentas": d2(D(0)),
         "porcentajeDescuento": d2(D(0)),
         "totalDescu": d2(D(0)),
+        "descuNoSuj": d2(D(0)),
+        "descuExenta": d2(D(0)),
+        "descuGravada": d2(D(0)),
         "tributos": None,
         "montoTotalOperacion": d2(D(0)),
         "totalLetras": monto_a_texto_sv(0.0),

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+import re
 from typing import Iterable, Optional
 
 from db import DB
@@ -54,6 +55,7 @@ def _build_items(
             "ventaExenta": d2(Decimal_0),
             "ventaGravada": d2(Decimal_0),
             "tributos": None,
+            "codTributo": None,
         }
         if numero_documento:
             item["numeroDocumento"] = numero_documento
@@ -128,6 +130,20 @@ def generar_nota_remision(
     if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
         raise ValueError("receptor requiere tipoDocumento y numDocumento")
     limpiar_documentos(receptor)
+    tipo_doc = receptor.get("tipoDocumento")
+    num_doc = receptor.get("numDocumento")
+    nrc = receptor.get("nrc")
+    if tipo_doc == "13":
+        if not re.fullmatch(r"\d{9}", num_doc or ""):
+            raise ValueError("DUI inválido en receptor")
+        receptor.pop("nrc", None)
+    elif tipo_doc == "36":
+        if not re.fullmatch(r"\d{14}", num_doc or ""):
+            raise ValueError("NIT inválido en receptor")
+        if not nrc or not re.fullmatch(r"\d{1,8}", nrc):
+            raise ValueError("NRC inválido en receptor")
+    else:
+        raise ValueError("tipoDocumento inválido en receptor")
     limpiar_documentos(ext)
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
@@ -160,6 +176,9 @@ def generar_nota_remision(
         "subTotalVentas": d2(Decimal_0),
         "porcentajeDescuento": d2(Decimal_0),
         "totalDescu": d2(Decimal_0),
+        "descuNoSuj": d2(Decimal_0),
+        "descuExenta": d2(Decimal_0),
+        "descuGravada": d2(Decimal_0),
         "tributos": None,
         "montoTotalOperacion": d2(Decimal_0),
         "totalLetras": monto_a_texto_sv(0.0),

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+import re
 from typing import Iterable, Optional
 
 from db import DB
@@ -55,6 +56,7 @@ def _build_items(
             "ventaExenta": d2(Decimal_0),
             "ventaGravada": d2(Decimal_0),
             "tributos": None,
+            "codTributo": None,
         }
         if numero_documento:
             item["numeroDocumento"] = numero_documento
@@ -79,6 +81,20 @@ def _generar_base(
     if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
         raise ValueError("receptor requiere tipoDocumento y numDocumento")
     limpiar_documentos(receptor)
+    tipo_doc = receptor.get("tipoDocumento")
+    num_doc = receptor.get("numDocumento")
+    nrc = receptor.get("nrc")
+    if tipo_doc == "13":
+        if not re.fullmatch(r"\d{9}", num_doc or ""):
+            raise ValueError("DUI inválido en receptor")
+        receptor.pop("nrc", None)
+    elif tipo_doc == "36":
+        if not re.fullmatch(r"\d{14}", num_doc or ""):
+            raise ValueError("NIT inválido en receptor")
+        if not nrc or not re.fullmatch(r"\d{1,8}", nrc):
+            raise ValueError("NRC inválido en receptor")
+    else:
+        raise ValueError("tipoDocumento inválido en receptor")
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
@@ -121,6 +137,9 @@ def _generar_base(
         "subTotalVentas": d2(Decimal_0),
         "porcentajeDescuento": d2(Decimal_0),
         "totalDescu": d2(Decimal_0),
+        "descuNoSuj": d2(Decimal_0),
+        "descuExenta": d2(Decimal_0),
+        "descuGravada": d2(Decimal_0),
         "tributos": None,
         "montoTotalOperacion": d2(Decimal_0),
         "totalLetras": monto_a_texto_sv(0.0),

--- a/tests/goldens/nr.json
+++ b/tests/goldens/nr.json
@@ -11,6 +11,7 @@
       "precioUni": "9.5400",
       "tipoItem": 1,
       "tributos": [],
+      "codTributo": null,
       "uniMedida": 59,
       "ventaExenta": "0.0000",
       "ventaGravada": "23.8500",

--- a/tests/test_generar_nota_remision_json.py
+++ b/tests/test_generar_nota_remision_json.py
@@ -13,7 +13,12 @@ def test_generar_nota_remision_json_from_dte(db_conn):
             "fecEmi": "2024-01-01",
         },
         "emisor": {"nombre": "Emisor"},
-        "receptor": {"numDocumento": "0614-123456-102-3", "nombre": "Cliente"},
+        "receptor": {
+            "numDocumento": "0614-123456-102-3",
+            "tipoDocumento": "36",
+            "nrc": "1234567",
+            "nombre": "Cliente",
+        },
         "cuerpoDocumento": [
             {
                 "numItem": 1,
@@ -47,8 +52,12 @@ def test_generar_nota_remision_json_from_dte(db_conn):
     item = nr["cuerpoDocumento"][0]
     assert item["precioUni"] == 0.0
     assert item["cantidad"] == 2
+    assert item["codTributo"] is None
 
     resumen = nr["resumen"]
     assert resumen["montoTotalOperacion"] == Decimal("0.00")
     assert resumen["totalNoSuj"] == Decimal("0.00")
     assert resumen["totalGravada"] == Decimal("0.00")
+    assert resumen["descuNoSuj"] == Decimal("0.00")
+    assert resumen["descuExenta"] == Decimal("0.00")
+    assert resumen["descuGravada"] == Decimal("0.00")

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -15,7 +15,8 @@ def _sample_emisor():
 def _sample_receptor():
     return {
         "tipoDocumento": "36",
-        "numDocumento": "1234 567-8",
+        "numDocumento": "0614-140710-001-2",
+        "nrc": "1234567",
         "nombre": "Cliente",
         "bienTitulo": "01",
     }
@@ -42,12 +43,17 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
     item = data["cuerpoDocumento"][0]
     assert item["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
+    assert item["codTributo"] is None
     assert float(item["precioUni"]) == 0.0
     assert float(item["ventaNoSuj"]) == 0.0
     assert float(item["ventaExenta"]) == 0.0
     assert float(item["ventaGravada"]) == 0.0
     assert "-" not in data["emisor"]["nit"]
     assert " " not in data["receptor"]["numDocumento"]
+    resumen = data["resumen"]
+    assert float(resumen["descuNoSuj"]) == 0.0
+    assert float(resumen["descuExenta"]) == 0.0
+    assert float(resumen["descuGravada"]) == 0.0
 
 
 def test_nr_desde_factura_extension(monkeypatch):
@@ -104,6 +110,11 @@ def test_nr_independiente_extension(monkeypatch):
     assert ext["docuRecibe"] == "12345678"
     assert "-" not in data["emisor"]["nit"]
     assert " " not in data["receptor"]["numDocumento"]
+    assert data["cuerpoDocumento"][0]["codTributo"] is None
+    res = data["resumen"]
+    assert float(res["descuNoSuj"]) == 0.0
+    assert float(res["descuExenta"]) == 0.0
+    assert float(res["descuGravada"]) == 0.0
 
 
 def test_nr_item_validation(monkeypatch):
@@ -124,4 +135,55 @@ def test_nr_item_validation(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=[{"descripcion": "Prod", "cantidad": 1}],
+        )
+
+
+def test_receptor_dui_sin_nrc(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = {
+        "tipoDocumento": "13",
+        "numDocumento": "12345678-9",
+        "nrc": "1234567",
+        "nombre": "Cliente",
+        "bienTitulo": "01",
+    }
+    factura = {
+        "identificacion": {"tipoDte": "03", "codigoGeneracion": "1", "fecEmi": "2024-01-01"},
+        "emisor": emisor,
+        "receptor": receptor,
+        "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
+    }
+    data = generar_nota_remision_desde_factura(db, factura)
+    rec = data["receptor"]
+    assert rec["tipoDocumento"] == "13"
+    assert rec["numDocumento"] == "123456789"
+    assert "nrc" not in rec
+
+
+def test_receptor_nit_sin_nrc_error(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = {
+        "tipoDocumento": "36",
+        "numDocumento": "0614-140710-001-2",
+        "nombre": "Cliente",
+        "bienTitulo": "01",
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "0614-140710-001-2",
+        "nombRecibe": "Ana",
+        "docuRecibe": "1234 5678",
+    }
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
         )


### PR DESCRIPTION
## Summary
- enforce strict validation of receptor document types and NRC handling in nota de remisión generators
- include mandatory discount fields in NR summaries and add `codTributo` placeholders for each item
- expand tests to cover receptor document consistency and new fields

## Testing
- `pytest` *(fails: libGL.so.1 and fastapi missing)*
- `pytest tests/test_nota_remision.py tests/test_generar_nota_remision_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf4da274888323b8411d62916ba14d