### PR TITLE
Reubicar botones de nota de remisión

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -334,16 +334,19 @@ class NotaRemisionDialog(QDialog):
         )
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         left.addWidget(self.table)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        left.addWidget(buttons, alignment=Qt.AlignLeft)
+
         main_layout.addLayout(left, 1)
 
         # Right column: datos de entrega
         self.ext_widget = NotaRemisionExtWidget(self.db, self)
         main_layout.addWidget(self.ext_widget, 1)
 
-        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
-        main_layout.addWidget(buttons)
+
 
         # Search debounce
         self.prod_timer = QTimer(self)


### PR DESCRIPTION
## Summary
- Mover los botones del cuadro de diálogo de nota de remisión bajo la tabla de productos.

## Testing
- `pytest` *(falla: múltiples pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_68bf47e0b49883238b275a1c9779a48f