### PR TITLE
feat: sanitize and normalize NR receptor

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-import re
 from typing import Iterable, Optional
 
 from db import DB
@@ -28,7 +27,7 @@ from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import monto_a_texto_sv, d2
-from utils.sanitize import limpiar_documentos
+from utils.sanitize import limpiar_documentos, solo_digitos
 
 Decimal_0 = Decimal("0")
 
@@ -61,6 +60,44 @@ def _build_items(
             item["numeroDocumento"] = numero_documento
         items.append(item)
     return items
+
+
+def normalizar_receptor(receptor: dict) -> dict:
+    """Sanitize and validate ``receptor`` according to tipoDocumento."""
+
+    if not receptor or not receptor.get("tipoDocumento"):
+        raise ValueError("receptor requiere tipoDocumento y numDocumento")
+
+    limpiar_documentos(receptor)
+    tipo = receptor.get("tipoDocumento")
+    num = solo_digitos(receptor.get("numDocumento"))
+    if not num:
+        raise ValueError("receptor requiere numDocumento")
+    receptor["numDocumento"] = num
+
+    nrc_raw = receptor.get("nrc")
+    if nrc_raw is not None:
+        nrc = solo_digitos(nrc_raw)
+        if nrc:
+            receptor["nrc"] = nrc
+        else:
+            receptor.pop("nrc", None)
+
+    if tipo == "13":
+        if len(num) != 9:
+            raise ValueError("DUI debe tener 9 dígitos (sin guiones)")
+        receptor.pop("nrc", None)
+        receptor.pop("codActividad", None)
+        receptor.pop("descActividad", None)
+    elif tipo == "36":
+        if len(num) != 14:
+            raise ValueError("NIT debe tener 14 dígitos (sin guiones)")
+        nrc = receptor.get("nrc")
+        if not nrc or len(nrc) not in (6, 7):
+            raise ValueError("NRC requerido (6–7 dígitos)")
+    else:
+        raise ValueError("tipoDocumento inválido en receptor")
+    return receptor
 
 
 def generar_nota_remision(
@@ -127,23 +164,11 @@ def generar_nota_remision(
 
     limpiar_documentos(emisor)
     receptor.setdefault("bienTitulo", "01")
-    if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
-        raise ValueError("receptor requiere tipoDocumento y numDocumento")
-    limpiar_documentos(receptor)
-    tipo_doc = receptor.get("tipoDocumento")
-    num_doc = receptor.get("numDocumento")
-    nrc = receptor.get("nrc")
-    if tipo_doc == "13":
-        if not re.fullmatch(r"\d{9}", num_doc or ""):
-            raise ValueError("DUI inválido en receptor")
-        receptor.pop("nrc", None)
-    elif tipo_doc == "36":
-        if not re.fullmatch(r"\d{14}", num_doc or ""):
-            raise ValueError("NIT inválido en receptor")
-        if not nrc or not re.fullmatch(r"\d{1,8}", nrc):
-            raise ValueError("NRC inválido en receptor")
-    else:
-        raise ValueError("tipoDocumento inválido en receptor")
+    receptor = normalizar_receptor(receptor)
+    for key in ("docuEntrega", "docuRecibe"):
+        ext[key] = solo_digitos(ext.get(key))
+        if not ext[key]:
+            raise ValueError(f"{key} requerido")
     limpiar_documentos(ext)
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-import re
 from typing import Iterable, Optional
 
 from db import DB
@@ -22,7 +21,7 @@ from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
-from utils.sanitize import limpiar_documentos
+from utils.sanitize import limpiar_documentos, solo_digitos
 
 Decimal_0 = Decimal("0")
 
@@ -64,6 +63,44 @@ def _build_items(
     return items
 
 
+def normalizar_receptor(receptor: dict) -> dict:
+    """Sanitize and validate ``receptor`` fields according to its document type."""
+
+    if not receptor or not receptor.get("tipoDocumento"):
+        raise ValueError("receptor requiere tipoDocumento y numDocumento")
+
+    limpiar_documentos(receptor)
+    tipo = receptor.get("tipoDocumento")
+    num = solo_digitos(receptor.get("numDocumento"))
+    if not num:
+        raise ValueError("receptor requiere numDocumento")
+    receptor["numDocumento"] = num
+
+    nrc_raw = receptor.get("nrc")
+    if nrc_raw is not None:
+        nrc = solo_digitos(nrc_raw)
+        if nrc:
+            receptor["nrc"] = nrc
+        else:
+            receptor.pop("nrc", None)
+
+    if tipo == "13":
+        if len(num) != 9:
+            raise ValueError("DUI debe tener 9 dígitos (sin guiones)")
+        receptor.pop("nrc", None)
+        receptor.pop("codActividad", None)
+        receptor.pop("descActividad", None)
+    elif tipo == "36":
+        if len(num) != 14:
+            raise ValueError("NIT debe tener 14 dígitos (sin guiones)")
+        nrc = receptor.get("nrc")
+        if not nrc or len(nrc) not in (6, 7):
+            raise ValueError("NRC requerido (6–7 dígitos)")
+    else:
+        raise ValueError("tipoDocumento inválido en receptor")
+    return receptor
+
+
 def _generar_base(
     db: DB,
     *,
@@ -78,23 +115,7 @@ def _generar_base(
 
     limpiar_documentos(emisor)
     receptor.setdefault("bienTitulo", "01")
-    if not receptor.get("tipoDocumento") or not receptor.get("numDocumento"):
-        raise ValueError("receptor requiere tipoDocumento y numDocumento")
-    limpiar_documentos(receptor)
-    tipo_doc = receptor.get("tipoDocumento")
-    num_doc = receptor.get("numDocumento")
-    nrc = receptor.get("nrc")
-    if tipo_doc == "13":
-        if not re.fullmatch(r"\d{9}", num_doc or ""):
-            raise ValueError("DUI inválido en receptor")
-        receptor.pop("nrc", None)
-    elif tipo_doc == "36":
-        if not re.fullmatch(r"\d{14}", num_doc or ""):
-            raise ValueError("NIT inválido en receptor")
-        if not nrc or not re.fullmatch(r"\d{1,8}", nrc):
-            raise ValueError("NRC inválido en receptor")
-    else:
-        raise ValueError("tipoDocumento inválido en receptor")
+    receptor = normalizar_receptor(receptor)
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
@@ -127,6 +148,10 @@ def _generar_base(
     }
     if extension:
         ext.update({k: v for k, v in extension.items() if v not in (None, "")})
+    for key in ("docuEntrega", "docuRecibe"):
+        ext[key] = solo_digitos(ext.get(key))
+        if not ext[key]:
+            raise ValueError(f"{key} requerido")
     limpiar_documentos(ext)
 
     resumen = {

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -191,9 +191,9 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", None,  vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "123", "06141407100012", "", "giro", "", "", "", "", "")
+    db.add_cliente("Cliente", "1234567", "06141407100012", "", "giro", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
-    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "123", "06141407100012", "giro", descuentos=0)
+    venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "1234567", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
     extension = {
         "nombEntrega": "Juan",
@@ -209,7 +209,7 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
 
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "04"
-    assert data["documentoRelacionado"]["tipoDoc"] == "01"
+    assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert data["extension"]["nombEntrega"] == "Juan"
 
 
@@ -335,12 +335,14 @@ def test_generar_nota_remision_desde_db_factura_sin_venta(monkeypatch):
     factura = {
         "identificacion": {
             "tipoDte": "03",
-            "numeroControl": "DTE-03-XYZ-000000000000001",
+            "codigoGeneracion": "DTE-03-XYZ-000000000000001",
+            "fecEmi": "2024-01-01",
         },
         "emisor": datos,
         "receptor": {
             "tipoDocumento": "36",
-            "numDocumento": "1234 567-8",
+            "numDocumento": "0614-140710-001-2",
+            "nrc": "1234567",
             "nombre": "Cliente",
         },
         "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
@@ -355,6 +357,6 @@ def test_generar_nota_remision_desde_db_factura_sin_venta(monkeypatch):
     extra = {"extension": extension, "factura": factura}
     nota_id = db.agregar_nota("remision", None, "2024-01-02", 0, "Envio", detalles=extra)
     data = generar_nota_remision_desde_db(db, nota_id)
-    doc_rel = data["documentoRelacionado"]
+    doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["numeroDocumento"] == "DTE-03-XYZ-000000000000001"
     assert data["receptor"]["nombre"] == "Cliente"

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -37,7 +37,8 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
             {"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}
         ],
     }
-    data = generar_nota_remision_desde_factura(db, factura)
+    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
@@ -123,18 +124,22 @@ def test_nr_item_validation(monkeypatch):
     emisor = _sample_emisor()
     receptor = _sample_receptor()
     with pytest.raises(ValueError):
+        extension = {"nombEntrega": "X", "docuEntrega": "123", "nombRecibe": "Y", "docuRecibe": "456"}
         generar_nota_remision_independiente(
             db,
             emisor=emisor,
             receptor=receptor,
             detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
+            extension=extension,
         )
     with pytest.raises(ValueError):
+        extension = {"nombEntrega": "X", "docuEntrega": "123", "nombRecibe": "Y", "docuRecibe": "456"}
         generar_nota_remision_independiente(
             db,
             emisor=emisor,
             receptor=receptor,
             detalles=[{"descripcion": "Prod", "cantidad": 1}],
+            extension=extension,
         )
 
 
@@ -155,7 +160,8 @@ def test_receptor_dui_sin_nrc(monkeypatch):
         "receptor": receptor,
         "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
     }
-    data = generar_nota_remision_desde_factura(db, factura)
+    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     rec = data["receptor"]
     assert rec["tipoDocumento"] == "13"
     assert rec["numDocumento"] == "123456789"

--- a/utils/sanitize.py
+++ b/utils/sanitize.py
@@ -16,6 +16,19 @@ def limpiar_doc(s: str | None) -> str:
     return "".join(ch for ch in str(s) if ch.isalnum())
 
 
+def solo_digitos(s: str | None) -> str:
+    """Return only the digit characters from ``s``.
+
+    Parameters
+    ----------
+    s: str | None
+        Input value possibly containing non-digit characters.
+    """
+    if not s:
+        return ""
+    return "".join(ch for ch in str(s) if ch.isdigit())
+
+
 def limpiar_documentos(data: dict | None) -> None:
     """Sanitize document numbers inside ``data`` in-place."""
     if not isinstance(data, dict):


### PR DESCRIPTION
## Summary
- enforce digit-only sanitization for NR receptor and extension documents
- add receptor normalization with rules for DUI, NIT and NRC
- update tests for new validation logic

## Testing
- `pytest tests/test_nota_remision.py tests/test_generar_nota_remision_json.py tests/test_nota_debito_remision.py::test_generar_nota_remision_factura tests/test_nota_debito_remision.py::test_generar_nota_remision_sin_documento_relacionado tests/test_nota_debito_remision.py::test_generar_nota_remision_desde_db_independiente tests/test_nota_debito_remision.py::test_generar_nota_remision_desde_db_factura_sin_venta`
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf53076c748323b95fa9c346cbe25d