### PR TITLE
Align update_cliente order with DB signature

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -860,12 +860,12 @@ class InventoryManager:
         nit,
         dui,
         giro,
-        codActividad,
         telefono,
         email,
         direccion,
         departamento,
         municipio,
+        codActividad=None,
     ):
         """Update an existing client and refresh the cached lists."""
 
@@ -877,12 +877,12 @@ class InventoryManager:
             nit,
             dui,
             giro,
-            codActividad,
             telefono,
             email,
             direccion,
             departamento,
             municipio,
+            codActividad=codActividad,
         )
         self.refresh_data()
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1353,12 +1353,12 @@ class MainWindow(QMainWindow):
                     data["nit"],
                     data["dui"],
                     data["giro"],
-                    data["codActividad"],
                     data["telefono"],
                     data["email"],
                     data["direccion"],
                     data["departamento"],
                     data["municipio"],
+                    codActividad=data["codActividad"],
                 )
             except ValueError as e:
                 QMessageBox.warning(dialog, "Cliente", str(e))


### PR DESCRIPTION
## Summary
- match InventoryManager.update_cliente signature and call order with DB.update_cliente
- update UI client edit to use new argument order

## Testing
- `pytest tests/test_cliente_dialog.py tests/test_cliente_dui.py tests/test_cliente_nit_unique.py tests/test_estado_cuenta_cliente.py tests/test_estado_cuenta_clientes.py tests/test_estado_cuenta_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf632fc2d08323a19e34f18222f46e