### PR TITLE
Map client email to DTE correo field

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1874,6 +1874,7 @@ def generar_dte_json(
         raise ValueError("Teléfono de emisor inválido")
 
     rec = dict(cliente or {})
+    rec.setdefault("correo", rec.get("email"))
     rec_extra = extra.get("receptor") or {}
     for k, v in rec_extra.items():
         if v not in (None, "", []):

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -311,6 +311,10 @@ def test_generar_dte_json_precios_incluyen_iva_default(tmp_path):
     tmp_file = tmp_path / "datos_negocio.json"
     tmp_file.write_text(json.dumps(datos))
     dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: datos
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
 
     db = create_db()
     db.add_vendedor("V1")
@@ -1744,3 +1748,59 @@ def test_generar_dte_json_dte03_descuento_colapsado(tmp_path):
     assert D(str(res["subTotalVentas"])) == D("14.29")
     assert D(str(res["subTotal"])) == D("14.29")
     assert D(str(res["totalGravada"])) == D("14.29")
+
+
+def test_cliente_email_alias(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: datos
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "Cliente Giro",
+        "70000001",
+        "cliente@example.com",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01",
+        11.3,
+        cliente_id=cliente_id,
+        extra={"precios_incluyen_iva": False},
+    )
+    db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
+
+    data = dte_module.generar_dte_json(db, venta_id)
+    assert data["receptor"]["correo"] == "cliente@example.com"


### PR DESCRIPTION
## Summary
- map `email` from cliente to receptor `correo` when generating DTEs
- add integration test ensuring client email is included in generated DTE JSON

## Testing
- `pytest tests/test_generar_dte_json.py::test_cliente_email_alias -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bf633a029483238702b8d618220f25