### PR TITLE
Add commercial name field to ClienteDialog

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -2491,6 +2491,7 @@ class ClienteDialog(QDialog):
 
         self.codigo_edit = QLineEdit()
         self.nombre_edit = QLineEdit()
+        self.nombre_comercial_edit = QLineEdit()
         self.nrc_edit = QLineEdit()
         self.nit_edit = QLineEdit()
         self.dui_edit = QLineEdit()
@@ -2518,6 +2519,7 @@ class ClienteDialog(QDialog):
         form = [
             ("Código:", self.codigo_edit),
             ("Nombre completo:", self.nombre_edit),
+            ("Nombre comercial:", self.nombre_comercial_edit),
             ("NRC:", self.nrc_edit),
             ("NIT:", self.nit_edit),
             ("DUI:", self.dui_edit),
@@ -2552,6 +2554,7 @@ class ClienteDialog(QDialog):
         if cliente:
             self.codigo_edit.setText(cliente.get("codigo", ""))
             self.nombre_edit.setText(cliente.get("nombre", ""))
+            self.nombre_comercial_edit.setText(cliente.get("nombreComercial", ""))
             self.nrc_edit.setText(cliente.get("nrc", ""))
             self.nit_edit.setText(cliente.get("nit", ""))
             self.dui_edit.setText(cliente.get("dui", ""))
@@ -2616,6 +2619,7 @@ class ClienteDialog(QDialog):
         return {
             "codigo": self.codigo_edit.text().strip(),
             "nombre": self.nombre_edit.text().strip(),
+            "nombreComercial": self.nombre_comercial_edit.text().strip(),
             "nrc": self.nrc_edit.text().strip(),
             "nit": self.nit_edit.text().strip(),
             "dui": self.dui_edit.text().strip(),

--- a/tests/test_cliente_dialog.py
+++ b/tests/test_cliente_dialog.py
@@ -49,6 +49,7 @@ def test_invalid_fields(monkeypatch, qt_app, field, value):
     dialog = make_dialog(db)
 
     dialog.nombre_edit.setText('Nombre')
+    dialog.nombre_comercial_edit.setText('Comercial')
     dialog.nrc_edit.setText('1234567')
     dialog.nit_edit.setText('1234-123456-123-1')
     dialog.telefono_edit.setText('1234-5678')
@@ -73,6 +74,7 @@ def test_duplicate_nit(monkeypatch, qt_app):
     dialog = make_dialog(db)
 
     dialog.nombre_edit.setText('Nombre')
+    dialog.nombre_comercial_edit.setText('Comercial')
     dialog.nrc_edit.setText('1234567')
     dialog.nit_edit.setText('1234-123456-123-1')
     dialog.telefono_edit.setText('1234-5678')
@@ -88,3 +90,28 @@ def test_duplicate_nit(monkeypatch, qt_app):
 
     assert warnings.get('called')
     assert not accepted.get('called')
+
+
+def test_nombre_comercial_included(monkeypatch, qt_app):
+    db = DummyDB()
+    dialog = make_dialog(db)
+
+    dialog.nombre_edit.setText('Nombre')
+    dialog.nombre_comercial_edit.setText('Comercial')
+    dialog.nrc_edit.setText('1234567')
+    dialog.nit_edit.setText('1234-123456-123-1')
+    dialog.telefono_edit.setText('1234-5678')
+    dialog.email_edit.setText('test@example.com')
+
+    warnings = {}
+    monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: warnings.setdefault('called', True))
+
+    accepted = {}
+    dialog.accept = lambda: accepted.setdefault('called', True)
+
+    dialog._validar_y_accept()
+
+    assert not warnings.get('called')
+    assert accepted.get('called')
+    data = dialog.get_data()
+    assert data['nombreComercial'] == 'Comercial'


### PR DESCRIPTION
## Summary
- allow entering and editing a client's commercial name
- ensure commercial name is returned from ClienteDialog
- test ClienteDialog handling of the commercial name field

## Testing
- `pytest --no-cov tests/test_cliente_dialog.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf6767f3748323911dceea76d7febf