### PR TITLE
Agregar campo nombreComercial a clientes

### DIFF
--- a/db.py
+++ b/db.py
@@ -336,6 +336,7 @@ class DB:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 codigo TEXT UNIQUE,
                 nombre TEXT,
+                nombreComercial TEXT,
                 nrc TEXT,
                 nit TEXT,
                 dui TEXT,
@@ -354,6 +355,7 @@ class DB:
 
         )
         self.ensure_column("clientes", "codActividad", "TEXT")
+        self.ensure_column("clientes", "nombreComercial", "TEXT")
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS pagos (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1285,6 +1287,7 @@ class DB:
         municipio,
         codigo=None,
         codActividad=None,
+        nombreComercial=None,
         commit: bool = True,
     ):
         if codigo is None:
@@ -1295,12 +1298,13 @@ class DB:
             raise ValueError("El NIT ya existe")
         self.cursor.execute(
             """
-            INSERT INTO clientes (codigo, nombre, nrc, nit, dui, giro, codActividad, telefono, email, direccion, departamento, municipio)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO clientes (codigo, nombre, nombreComercial, nrc, nit, dui, giro, codActividad, telefono, email, direccion, departamento, municipio)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 codigo,
                 nombre,
+                nombreComercial,
                 nrc,
                 nit,
                 dui,
@@ -1346,6 +1350,7 @@ class DB:
         departamento,
         municipio,
         codActividad=None,
+        nombreComercial=None,
     ):
         nit = nit.strip() if isinstance(nit, str) else nit
         nit = nit or None
@@ -1353,11 +1358,12 @@ class DB:
             raise ValueError("El NIT ya existe")
         self.cursor.execute(
             """
-            UPDATE clientes SET codigo=?, nombre=?, nrc=?, nit=?, dui=?, giro=?, codActividad=?, telefono=?, email=?, direccion=?, departamento=?, municipio=? WHERE id=?
+            UPDATE clientes SET codigo=?, nombre=?, nombreComercial=?, nrc=?, nit=?, dui=?, giro=?, codActividad=?, telefono=?, email=?, direccion=?, departamento=?, municipio=? WHERE id=?
             """,
             (
                 codigo,
                 nombre,
+                nombreComercial,
                 nrc,
                 nit,
                 dui,
@@ -1388,17 +1394,17 @@ class DB:
 
     def get_clientes(self, search=""):
         query = (
-            "SELECT id, codigo, nombre, nrc, nit, dui, giro, codActividad, telefono, email, direccion, departamento, municipio, otros "
+            "SELECT id, codigo, nombre, nombreComercial, nrc, nit, dui, giro, codActividad, telefono, email, direccion, departamento, municipio, otros "
             "FROM clientes"
         )
         params = []
         if search:
             like = f"%{search}%"
             query += (
-                " WHERE nombre LIKE ? OR codigo LIKE ? OR nit LIKE ? OR nrc LIKE ? "
+                " WHERE nombre LIKE ? OR nombreComercial LIKE ? OR codigo LIKE ? OR nit LIKE ? OR nrc LIKE ? "
                 "OR dui LIKE ? OR telefono LIKE ? OR email LIKE ?"
             )
-            params = [like, like, like, like, like, like, like]
+            params = [like, like, like, like, like, like, like, like]
         self.cursor.execute(query, params)
         return [dict(row) for row in self.cursor.fetchall()]
 

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -521,6 +521,7 @@ class InventoryManager:
                     c.get("municipio", ""),
                     c.get("codigo"),
                     codActividad=c.get("codActividad"),
+                    nombreComercial=c.get("nombreComercial"),
                     commit=False,
                 )
                 self.db.cursor.execute(
@@ -832,6 +833,7 @@ class InventoryManager:
         departamento,
         municipio,
         codigo=None,
+        nombreComercial=None,
     ):
         """Add a new client and refresh the cached lists."""
 
@@ -848,6 +850,7 @@ class InventoryManager:
             municipio,
             codigo=codigo,
             codActividad=codActividad,
+            nombreComercial=nombreComercial,
         )
         self.refresh_data()
 
@@ -866,6 +869,7 @@ class InventoryManager:
         departamento,
         municipio,
         codActividad=None,
+        nombreComercial=None,
     ):
         """Update an existing client and refresh the cached lists."""
 
@@ -883,6 +887,7 @@ class InventoryManager:
             departamento,
             municipio,
             codActividad=codActividad,
+            nombreComercial=nombreComercial,
         )
         self.refresh_data()
 

--- a/schema_patches/add_nombreComercial_clientes.sql
+++ b/schema_patches/add_nombreComercial_clientes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE clientes ADD COLUMN nombreComercial TEXT;

--- a/tests/test_cliente_nombre_comercial.py
+++ b/tests/test_cliente_nombre_comercial.py
@@ -1,0 +1,54 @@
+import json
+from db import DB
+import dte as dte_module
+
+
+def test_cliente_nombre_comercial_en_dte(tmp_path):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+        nombreComercial="Comercial XYZ",
+    )
+    cid = db.cursor.lastrowid
+    cliente = db.get_cliente(cid)
+    assert cliente["nombreComercial"] == "Comercial XYZ"
+
+    venta_id = db.add_venta(
+        "2024-01-01", 10, cliente_id=cid, extra={"precios_incluyen_iva": False}
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    assert data["receptor"]["nombreComercial"] == "Comercial XYZ"


### PR DESCRIPTION
## Summary
- Add nombreComercial column and migration
- Include nombreComercial in client CRUD and import/export
- Test that DTE receptor uses client nombreComercial

## Testing
- `pytest tests/test_cliente_nombre_comercial.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf675fa9948323a6cf962ae77e2e50