### PR TITLE
Valida documentos de receptor según CAT-022

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -29,7 +29,7 @@ import logging
 import warnings
 import xml.etree.ElementTree as ET
 from utils.monto import monto_a_texto_sv, to_base_iva
-from utils.sanitize import limpiar_documentos, limpiar_doc
+from utils.sanitize import limpiar_documentos, limpiar_doc, solo_digitos
 from num2words import num2words
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 from utils.fecha import fecha_emision_hoy_str, TZ_EL_SALVADOR
@@ -2662,47 +2662,46 @@ def validate_dte_json(
     nit_field = receptor.get("nit")
     tipo_doc = receptor.get("tipoDocumento")
     if tipo_dte != "03":
-        if tipo_doc is not None:
-            tipo_doc = str(tipo_doc)
         if nit_field is not None:
             receptor["numDocumento"] = _clean_nit(nit_field)
             if tipo_doc is None:
                 tipo_doc = "36"
-        num_doc = receptor.get("numDocumento")
-        if tipo_doc == "36":
-            num_doc = _clean_nit(num_doc)
-            if num_doc and not re.fullmatch(r"[0-9]{14}", num_doc):
-                raise ValueError("NIT inválido en receptor")
-        elif tipo_doc == "13":
-            if num_doc and not re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
-                raise ValueError("DUI inválido en receptor")
-        receptor["tipoDocumento"] = tipo_doc if tipo_doc is not None else None
+        limpiar_documentos(receptor)
+        num_doc = solo_digitos(receptor.get("numDocumento"))
+        nrc_raw = receptor.get("nrc")
+        nrc_digits = solo_digitos(nrc_raw) if nrc_raw is not None else ""
+        if nrc_digits:
+            receptor["nrc"] = nrc_digits
+        else:
+            receptor.pop("nrc", None)
+        if tipo_doc is None:
+            tipo_doc = "36" if receptor.get("nrc") else "13"
+        else:
+            tipo_doc = str(tipo_doc)
+        allowed = {"36", "13", "37", "03", "02"}
+        if tipo_doc not in allowed:
+            raise ValueError("tipoDocumento inválido en receptor")
+        if tipo_doc == "13":
+            if len(num_doc) != 9:
+                raise ValueError("DUI debe tener 9 dígitos (sin guiones)")
+            if nrc_raw:
+                warnings.warn(
+                    "Se removió NRC porque el documento es DUI", UserWarning,
+                )
+            receptor.pop("nrc", None)
+        elif tipo_doc == "36":
+            if len(num_doc) != 14:
+                raise ValueError("NIT debe tener 14 dígitos (sin guiones)")
+            if not receptor.get("nrc") or len(receptor["nrc"]) not in (6, 7):
+                raise ValueError("NRC requerido (6–7 dígitos)")
+        else:
+            receptor.pop("nrc", None)
+        receptor["tipoDocumento"] = tipo_doc
         receptor["numDocumento"] = num_doc
     else:
         receptor["nit"] = _clean_nit(nit_field)
         receptor.pop("tipoDocumento", None)
         receptor.pop("numDocumento", None)
-
-    nrc_schema = (
-        FC_SCHEMA.get("properties", {})
-        .get("receptor", {})
-        .get("properties", {})
-        .get("nrc", {})
-    )
-    # ``nrc`` must always be present: if schema allows null we keep ``None``;
-    # otherwise we strip non-digits and pad with zeros to the minimum length.
-    nrc_types = nrc_schema.get("type", [])
-    if not isinstance(nrc_types, list):
-        nrc_types = [nrc_types]
-    if "null" in nrc_types:
-        nrc_val = _clean_nrc(receptor.get("nrc"))
-        receptor["nrc"] = nrc_val if nrc_val is not None else None
-    else:
-        nrc_val = _clean_nrc(receptor.get("nrc")) or ""
-        if not nrc_val:
-            min_len = nrc_schema.get("minLength", 1)
-            nrc_val = "0" * min_len
-        receptor["nrc"] = nrc_val
 
     receptor.pop("giro", None)
     dir_rec = receptor.get("direccion")

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -48,7 +48,7 @@ from utils.doc_generation import generate_invoice_pdf
 from utils.email_sender import EmailSender
 from utils.jws import sign_and_save
 from utils.stable_json import save_file, stable_stringify
-from utils.sanitize import limpiar_doc
+from utils.sanitize import limpiar_doc, solo_digitos
 from utils import catalogos
 from paths import DATOS_NEGOCIO_PATH
 import tempfile
@@ -152,16 +152,20 @@ class NotaRemisionExtWidget(QWidget):
 
         self.nomb_recibe = QLineEdit()
         self.docu_recibe = QLineEdit()
+        self.nrc_recibe = QLineEdit()
         self.ext_obs = QPlainTextEdit()
         for label, widget in [
             ("Nombre recibe:", self.nomb_recibe),
             ("Documento recibe:", self.docu_recibe),
+            ("NRC:", self.nrc_recibe),
             ("Observaciones:", self.ext_obs),
         ]:
             row = QHBoxLayout()
             row.addWidget(QLabel(label))
             row.addWidget(widget)
             layout.addLayout(row)
+
+        self.tipo_doc_recibe = "13"
 
         # Search handlers and timers
         self.emp_timer = QTimer(self)
@@ -252,8 +256,16 @@ class NotaRemisionExtWidget(QWidget):
         data = item.data(Qt.UserRole) if item else None
         if isinstance(data, dict):
             self.nomb_recibe.setText(data.get("nombre", ""))
-            doc = data.get("dui") or data.get("nit") or data.get("nrc") or ""
-            self.docu_recibe.setText(limpiar_doc(doc))
+            nrc = data.get("nrc") or ""
+            if nrc:
+                self.docu_recibe.setText(limpiar_doc(data.get("nit") or ""))
+                self.nrc_recibe.setText(limpiar_doc(nrc))
+                self.tipo_doc_recibe = "36"
+            else:
+                doc = data.get("dui") or data.get("nit") or ""
+                self.docu_recibe.setText(limpiar_doc(doc))
+                self.nrc_recibe.clear()
+                self.tipo_doc_recibe = "13"
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.KeyPress:
@@ -282,6 +294,8 @@ class NotaRemisionExtWidget(QWidget):
             "docuEntrega": limpiar_doc(self.docu_entrega.text()),
             "nombRecibe": self.nomb_recibe.text(),
             "docuRecibe": limpiar_doc(self.docu_recibe.text()),
+            "nrcRecibe": limpiar_doc(self.nrc_recibe.text()),
+            "tipoDocRecibe": self.tipo_doc_recibe,
             "observaciones": self.ext_obs.toPlainText(),
         }
 
@@ -299,6 +313,25 @@ class NotaRemisionExtWidget(QWidget):
                 "Todos los campos de entrega/recepción son obligatorios",
             )
             return False
+        doc = solo_digitos(self.docu_recibe.text())
+        if self.tipo_doc_recibe == "36":
+            if len(doc) != 14:
+                QMessageBox.warning(
+                    self, "Nota", "NIT debe tener 14 dígitos (sin guiones)"
+                )
+                return False
+            nrc = solo_digitos(self.nrc_recibe.text())
+            if len(nrc) not in (6, 7):
+                QMessageBox.warning(
+                    self, "Nota", "NRC requerido (6–7 dígitos)"
+                )
+                return False
+        else:
+            if len(doc) != 9:
+                QMessageBox.warning(
+                    self, "Nota", "DUI debe tener 9 dígitos (sin guiones)"
+                )
+                return False
         return True
 
 
@@ -442,13 +475,17 @@ class NotaRemisionDialog(QDialog):
                 }
             )
         extension = self.ext_widget.get_data()
+        tipo_doc = extension.pop("tipoDocRecibe")
+        nrc = extension.pop("nrcRecibe", "")
         receptor = {
             "nombre": extension.get("nombRecibe"),
-            "tipoDocumento": "13",
+            "tipoDocumento": tipo_doc,
             "numDocumento": extension.get("docuRecibe"),
             "bienTitulo": "01",
             "direccion": {"departamento": "05", "municipio": "24", "complemento": ""},
         }
+        if tipo_doc == "36" and nrc:
+            receptor["nrc"] = nrc
         return detalles, extension, receptor
 
 

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -27,6 +27,8 @@ from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import monto_a_texto_sv, d2
+import warnings
+
 from utils.sanitize import limpiar_documentos, solo_digitos
 
 Decimal_0 = Decimal("0")
@@ -86,6 +88,10 @@ def normalizar_receptor(receptor: dict) -> dict:
     if tipo == "13":
         if len(num) != 9:
             raise ValueError("DUI debe tener 9 dígitos (sin guiones)")
+        if nrc_raw:
+            warnings.warn(
+                "Se removió NRC porque el documento es DUI", UserWarning
+            )
         receptor.pop("nrc", None)
     elif tipo == "36":
         if len(num) != 14:
@@ -93,6 +99,8 @@ def normalizar_receptor(receptor: dict) -> dict:
         nrc = receptor.get("nrc")
         if not nrc or len(nrc) not in (6, 7):
             raise ValueError("NRC requerido (6–7 dígitos)")
+    elif tipo in {"37", "03", "02"}:
+        receptor.pop("nrc", None)
     else:
         raise ValueError("tipoDocumento inválido en receptor")
     return receptor

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -21,6 +21,8 @@ from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
+import warnings
+
 from utils.sanitize import limpiar_documentos, solo_digitos
 
 Decimal_0 = Decimal("0")
@@ -87,6 +89,10 @@ def normalizar_receptor(receptor: dict) -> dict:
     if tipo == "13":
         if len(num) != 9:
             raise ValueError("DUI debe tener 9 dígitos (sin guiones)")
+        if nrc_raw:
+            warnings.warn(
+                "Se removió NRC porque el documento es DUI", UserWarning
+            )
         receptor.pop("nrc", None)
     elif tipo == "36":
         if len(num) != 14:
@@ -94,6 +100,8 @@ def normalizar_receptor(receptor: dict) -> dict:
         nrc = receptor.get("nrc")
         if not nrc or len(nrc) not in (6, 7):
             raise ValueError("NRC requerido (6–7 dígitos)")
+    elif tipo in {"37", "03", "02"}:
+        receptor.pop("nrc", None)
     else:
         raise ValueError("tipoDocumento inválido en receptor")
     return receptor

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from db import DB
 from nota_remision_electronica import (
@@ -161,11 +162,13 @@ def test_receptor_dui_sin_nrc(monkeypatch):
         "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
     }
     extension = {"docuEntrega": "123", "docuRecibe": "456"}
-    data = generar_nota_remision_desde_factura(db, factura, extension=extension)
+    with warnings.catch_warnings(record=True) as w:
+        data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     rec = data["receptor"]
     assert rec["tipoDocumento"] == "13"
     assert rec["numDocumento"] == "123456789"
     assert "nrc" not in rec
+    assert any("Se removió NRC" in str(warn.message) for warn in w)
 
 
 def test_receptor_nit_sin_nrc_error(monkeypatch):

--- a/tests/test_nr_ext_dialog.py
+++ b/tests/test_nr_ext_dialog.py
@@ -14,12 +14,15 @@ def test_nr_ext_dialog_autofill_and_sanitize(db_conn, qt_app):
     assert dialog.docu_entrega.text() == "061234567"
 
     cli_item = QListWidgetItem("Cli")
-    cli_item.setData(Qt.UserRole, {"nombre": "Ana", "nit": "0612 34567"})
+    cli_item.setData(Qt.UserRole, {"nombre": "Ana", "dui": "0612 34567"})
     dialog._seleccionar_cliente(cli_item)
     assert dialog.nomb_recibe.text() == "Ana"
     assert dialog.docu_recibe.text() == "061234567"
+    assert dialog.nrc_recibe.text() == ""
 
     dialog.ext_obs.setPlainText("Obs")
     data = dialog.get_data()
     assert data["docuEntrega"] == "061234567"
     assert data["docuRecibe"] == "061234567"
+    assert data["nrcRecibe"] == ""
+    assert data["tipoDocRecibe"] == "13"

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -98,9 +98,9 @@ def test_receptor_documentos(monkeypatch, db_fixture):
 
     data = _load_fc()
     data["receptor"]["tipoDocumento"] = 13
-    data["receptor"]["numDocumento"] = "12345678-9"
-    validate_dte_json(data, db=db_fixture)
     data["receptor"]["numDocumento"] = "123456789"
+    validate_dte_json(data, db=db_fixture)
+    data["receptor"]["numDocumento"] = "12345678"
     with pytest.raises(ValueError):
         validate_dte_json(data, db=db_fixture)
 

--- a/ui/services/sanitize.ts
+++ b/ui/services/sanitize.ts
@@ -7,8 +7,8 @@ export function sanitizeDocs<T>(data: T): T {
         walk(val);
       } else if (typeof val === 'string') {
         const kl = key.toLowerCase();
-        if (kl === 'nit' || kl === 'dui' || kl === 'numdocumento' || kl.includes('documento')) {
-          obj[key] = val.replace(/[-\s]/g, '');
+        if (kl === 'nit' || kl === 'dui' || kl === 'nrc' || kl === 'numdocumento' || kl.includes('documento')) {
+          obj[key] = val.replace(/\D+/g, '');
         }
       }
     }

--- a/ui/tests/sanitize.spec.ts
+++ b/ui/tests/sanitize.spec.ts
@@ -2,10 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { sanitizeDocs } from '../services/sanitize';
 
 describe('sanitizeDocs', () => {
-  it('limpia NIT y numDocumento', () => {
-    const data = { nit: '0614-123456-001-1', receptor: { numDocumento: '0123 45678-9' } };
+  it('limpia NIT, numDocumento y NRC', () => {
+    const data = {
+      nit: '0614-123456-001-1',
+      receptor: { numDocumento: '0123 45678-9', nrc: '123-456' },
+    };
     const clean = sanitizeDocs(data);
     expect(clean.nit).toBe('06141234560011');
     expect(clean.receptor.numDocumento).toBe('0123456789');
+    expect(clean.receptor.nrc).toBe('123456');
   });
 });

--- a/utils/sanitize.py
+++ b/utils/sanitize.py
@@ -40,4 +40,7 @@ def limpiar_documentos(data: dict | None) -> None:
             kl = key.lower()
             if kl in {"nit", "nrc", "numdocumento", "dui", "pasaporte"} or "doc" in kl:
                 if kl not in {"numerocontrol", "codigogeneracion"} and key != "numeroDocumento":
-                    data[key] = limpiar_doc(value)
+                    if kl in {"nrc", "numdocumento"}:
+                        data[key] = solo_digitos(value)
+                    else:
+                        data[key] = limpiar_doc(value)


### PR DESCRIPTION
## Summary
- Sanitiza `numDocumento` y `nrc` dejando solo dígitos
- Valida `tipoDocumento` según CAT-022 y exige NRC para NIT
- Ajusta UI de nota de remisión para capturar NRC y tipo de documento

## Testing
- `npm test`
- `QT_QPA_PLATFORM=offscreen pytest` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6e01a1a48323b8e92aa6e72bd0b2