### PR TITLE
Include commercial name when saving clients

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1329,6 +1329,7 @@ class MainWindow(QMainWindow):
                     data["departamento"],
                     data["municipio"],
                     data["codigo"],
+                    nombreComercial=data["nombreComercial"],
                 )
             except ValueError as e:
                 QMessageBox.warning(dialog, "Cliente", str(e))
@@ -1359,6 +1360,7 @@ class MainWindow(QMainWindow):
                     data["departamento"],
                     data["municipio"],
                     codActividad=data["codActividad"],
+                    nombreComercial=data["nombreComercial"],
                 )
             except ValueError as e:
                 QMessageBox.warning(dialog, "Cliente", str(e))


### PR DESCRIPTION
## Summary
- pass client commercial name to database when adding or updating customers so it can propagate to DTE generation

## Testing
- `pytest tests/test_cliente_nombre_comercial.py tests/test_cliente_dialog.py::test_nombre_comercial_included -q`
- `pytest` *(fails: multiple failing tests, e.g. test_import_trabajador_sales, test_invoice_json_save)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7224a79c8323b10cca61b80b327e