### PR TITLE
Procesar extension en nota remision

### DIFF
--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -218,12 +218,23 @@ def generar_nota_remision_desde_factura(
             "fechaEmision": ident.get("fecEmi"),
         }
     ]
+    ext = extension.copy() if extension else None
+    if ext:
+        tipo_doc = ext.pop("tipoDocRecibe", None)
+        nrc_recibe = ext.pop("nrcRecibe", None)
+        if tipo_doc:
+            receptor["tipoDocumento"] = tipo_doc
+            doc_recibe = ext.get("docuRecibe")
+            if doc_recibe:
+                receptor["numDocumento"] = doc_recibe
+        if nrc_recibe:
+            receptor["nrc"] = nrc_recibe
     return _generar_base(
         db,
         emisor=emisor,
         receptor=receptor,
         detalles=detalles,
-        extension=extension,
+        extension=ext,
         documento_relacionado=doc_rel,
         ambiente=ambiente,
     )

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -84,6 +84,42 @@ def test_nr_desde_factura_extension(monkeypatch):
     assert data["extension"]["nombEntrega"] == "Juan"
 
 
+def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": _sample_emisor(),
+        "receptor": {
+            "tipoDocumento": "13",
+            "numDocumento": "12345678-9",
+            "nombre": "Cliente",
+            "bienTitulo": "01",
+        },
+        "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "0614-140710-001-2",
+        "tipoDocRecibe": "36",
+        "nrcRecibe": "1234567",
+    }
+    data = generar_nota_remision_desde_factura(db, factura, extension=extension)
+    rec = data["receptor"]
+    assert rec["tipoDocumento"] == "36"
+    assert rec["numDocumento"] == "06141407100012"
+    assert rec["nrc"] == "1234567"
+    ext = data["extension"]
+    assert "tipoDocRecibe" not in ext
+    assert "nrcRecibe" not in ext
+
+
 def test_nr_independiente_extension(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")


### PR DESCRIPTION
## Summary
- Update note generation from invoice to sanitize and apply extension receiver info
- Add regression test for receiver update via extension

## Testing
- `pytest tests/test_nota_remision.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1; ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68bf79ca51988323a24ce15db04cee4e