### PR TITLE
Normalizar nombre comercial y unidad en notas de remisión

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -39,17 +39,26 @@ def _build_items(
 ) -> list[dict]:
     """Construye items con montos forzados a ``0.00``.
 
-    Si ``numero_documento`` se proporciona se añade a cada ítem.
+    Además normaliza ``uniMedida`` contra el catálogo CAT-014, usando ``59``
+    (Unidad) cuando el detalle no provee una unidad válida.  Si
+    ``numero_documento`` se proporciona se añade a cada ítem.
     """
     items: list[dict] = []
     for num, det in enumerate(detalles, 1):
+        uni = det.get("uniMedida", 59)
+        try:
+            uni = int(uni)
+        except Exception:
+            uni = 59
+        if uni not in catalogos.UNIDADES_MEDIDA_PERMITIDAS:
+            uni = 59
         item = {
             "numItem": num,
             "tipoItem": det.get("tipoItem", 1),
             "codigo": det.get("codigo", f"NR{num:03d}"),
             "descripcion": det.get("descripcion", f"Item {num}"),
             "cantidad": det.get("cantidad", 1),
-            "uniMedida": det.get("uniMedida", 59),
+            "uniMedida": uni,
             "precioUni": 0.0,
             "montoDescu": 0.0,
             "ventaNoSuj": d2(Decimal_0),
@@ -103,6 +112,7 @@ def normalizar_receptor(receptor: dict) -> dict:
         receptor.pop("nrc", None)
     else:
         raise ValueError("tipoDocumento inválido en receptor")
+    receptor.setdefault("nombreComercial", None)
     return receptor
 
 

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -33,8 +33,10 @@ def _build_items(
 ) -> list[dict]:
     """Construye los ítems de la NR forzando todos los montos a ``0.00``.
 
-    Además valida que ``cantidad`` sea mayor que cero y que ``uniMedida`` esté
-    presente.  Si ``numero_documento`` se proporciona se agrega a cada ítem.
+    Además valida que ``cantidad`` sea mayor que cero y normaliza
+    ``uniMedida`` contra el catálogo CAT-014.  Si el ítem no provee una unidad
+    válida se utiliza por defecto ``59`` (Unidad).  Si
+    ``numero_documento`` se proporciona se agrega a cada ítem.
     """
 
     items: list[dict] = []
@@ -42,15 +44,20 @@ def _build_items(
         cantidad = det.get("cantidad", 1)
         if cantidad <= 0:
             raise ValueError("cantidad debe ser mayor que cero")
-        if det.get("uniMedida") is None:
-            raise ValueError("uniMedida requerido en el item")
+        uni = det.get("uniMedida", 59)
+        try:
+            uni = int(uni)
+        except Exception:
+            uni = 59
+        if uni not in catalogos.UNIDADES_MEDIDA_PERMITIDAS:
+            uni = 59
         item = {
             "numItem": num,
             "tipoItem": det.get("tipoItem", 1),
             "codigo": det.get("codigo", f"NR{num:03d}"),
             "descripcion": det.get("descripcion", f"Item {num}"),
             "cantidad": cantidad,
-            "uniMedida": det.get("uniMedida"),
+            "uniMedida": uni,
             "precioUni": 0.0,
             "montoDescu": 0.0,
             "ventaNoSuj": d2(Decimal_0),
@@ -104,6 +111,7 @@ def normalizar_receptor(receptor: dict) -> dict:
         receptor.pop("nrc", None)
     else:
         raise ValueError("tipoDocumento inválido en receptor")
+    receptor.setdefault("nombreComercial", None)
     return receptor
 
 

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -52,6 +52,9 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     assert float(item["ventaGravada"]) == 0.0
     assert "-" not in data["emisor"]["nit"]
     assert " " not in data["receptor"]["numDocumento"]
+    rec = data["receptor"]
+    assert "nombreComercial" in rec
+    assert rec["nombreComercial"] is None
     resumen = data["resumen"]
     assert float(resumen["descuNoSuj"]) == 0.0
     assert float(resumen["descuExenta"]) == 0.0
@@ -82,6 +85,9 @@ def test_nr_desde_factura_extension(monkeypatch):
         db, factura, extension=extension
     )
     assert data["extension"]["nombEntrega"] == "Juan"
+    rec = data["receptor"]
+    assert "nombreComercial" in rec
+    assert rec["nombreComercial"] is None
 
 
 def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
@@ -115,6 +121,7 @@ def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
     assert rec["tipoDocumento"] == "36"
     assert rec["numDocumento"] == "06141407100012"
     assert rec["nrc"] == "1234567"
+    assert "nombreComercial" in rec
     ext = data["extension"]
     assert "tipoDocRecibe" not in ext
     assert "nrcRecibe" not in ext
@@ -148,6 +155,9 @@ def test_nr_independiente_extension(monkeypatch):
     assert ext["docuRecibe"] == "12345678"
     assert "-" not in data["emisor"]["nit"]
     assert " " not in data["receptor"]["numDocumento"]
+    rec = data["receptor"]
+    assert "nombreComercial" in rec
+    assert rec["nombreComercial"] is None
     assert data["cuerpoDocumento"][0]["codTributo"] is None
     res = data["resumen"]
     assert float(res["descuNoSuj"]) == 0.0
@@ -169,15 +179,15 @@ def test_nr_item_validation(monkeypatch):
             detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
             extension=extension,
         )
-    with pytest.raises(ValueError):
-        extension = {"nombEntrega": "X", "docuEntrega": "123", "nombRecibe": "Y", "docuRecibe": "456"}
-        generar_nota_remision_independiente(
-            db,
-            emisor=emisor,
-            receptor=receptor,
-            detalles=[{"descripcion": "Prod", "cantidad": 1}],
-            extension=extension,
-        )
+    extension = {"nombEntrega": "X", "docuEntrega": "123", "nombRecibe": "Y", "docuRecibe": "456"}
+    data = generar_nota_remision_independiente(
+        db,
+        emisor=emisor,
+        receptor=receptor,
+        detalles=[{"descripcion": "Prod", "cantidad": 1, "uniMedida": 1}],
+        extension=extension,
+    )
+    assert data["cuerpoDocumento"][0]["uniMedida"] == 59
 
 
 def test_receptor_dui_sin_nrc(monkeypatch):
@@ -204,6 +214,7 @@ def test_receptor_dui_sin_nrc(monkeypatch):
     assert rec["tipoDocumento"] == "13"
     assert rec["numDocumento"] == "123456789"
     assert "nrc" not in rec
+    assert rec["nombreComercial"] is None
     assert any("Se removió NRC" in str(warn.message) for warn in w)
 
 


### PR DESCRIPTION
## Summary
- always include `receptor.nombreComercial` (null when missing) in generated NR
- normalize item `uniMedida` against CAT-014 and default to 59 when invalid
- update NR tests for new behavior

## Testing
- `pytest tests/test_nota_remision.py tests/test_generar_nota_remision_json.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf81a997c0832383f01f2cdcd6c5d5