### PR TITLE
Enforce receptor contact fields for notas de remisión

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -112,6 +112,15 @@ def normalizar_receptor(receptor: dict) -> dict:
         receptor.pop("nrc", None)
     else:
         raise ValueError("tipoDocumento inválido en receptor")
+    # Campos adicionales requeridos para receptores
+    for campo in ("codActividad", "descActividad", "telefono", "correo"):
+        if not receptor.get(campo):
+            raise ValueError(f"receptor requiere {campo}")
+
+    direccion = receptor.get("direccion") or {}
+    if not direccion.get("complemento"):
+        raise ValueError("receptor requiere direccion.complemento")
+
     receptor.setdefault("nombreComercial", None)
     return receptor
 

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -111,6 +111,15 @@ def normalizar_receptor(receptor: dict) -> dict:
         receptor.pop("nrc", None)
     else:
         raise ValueError("tipoDocumento inválido en receptor")
+    # Campos adicionales requeridos para receptores
+    for campo in ("codActividad", "descActividad", "telefono", "correo"):
+        if not receptor.get(campo):
+            raise ValueError(f"receptor requiere {campo}")
+
+    direccion = receptor.get("direccion") or {}
+    if not direccion.get("complemento"):
+        raise ValueError("receptor requiere direccion.complemento")
+
     receptor.setdefault("nombreComercial", None)
     return receptor
 

--- a/tests/test_generar_nota_remision_json.py
+++ b/tests/test_generar_nota_remision_json.py
@@ -18,6 +18,15 @@ def test_generar_nota_remision_json_from_dte(db_conn):
             "tipoDocumento": "36",
             "nrc": "1234567",
             "nombre": "Cliente",
+            "codActividad": "6201",
+            "descActividad": "Servicios de software",
+            "telefono": "70000001",
+            "correo": "cliente@example.com",
+            "direccion": {
+                "departamento": "05",
+                "municipio": "01",
+                "complemento": "San Salvador",
+            },
         },
         "cuerpoDocumento": [
             {

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -20,6 +20,15 @@ def _sample_receptor():
         "nrc": "1234567",
         "nombre": "Cliente",
         "bienTitulo": "01",
+        "codActividad": "6201",
+        "descActividad": "Servicios de software",
+        "telefono": "70000001",
+        "correo": "cliente@example.com",
+        "direccion": {
+            "departamento": "05",
+            "municipio": "01",
+            "complemento": "San Salvador",
+        },
     }
 
 
@@ -105,6 +114,15 @@ def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
             "numDocumento": "12345678-9",
             "nombre": "Cliente",
             "bienTitulo": "01",
+            "codActividad": "6201",
+            "descActividad": "Servicios de software",
+            "telefono": "70000001",
+            "correo": "cliente@example.com",
+            "direccion": {
+                "departamento": "05",
+                "municipio": "01",
+                "complemento": "San Salvador",
+            },
         },
         "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
     }
@@ -200,6 +218,15 @@ def test_receptor_dui_sin_nrc(monkeypatch):
         "nrc": "1234567",
         "nombre": "Cliente",
         "bienTitulo": "01",
+        "codActividad": "6201",
+        "descActividad": "Servicios de software",
+        "telefono": "70000001",
+        "correo": "cliente@example.com",
+        "direccion": {
+            "departamento": "05",
+            "municipio": "01",
+            "complemento": "San Salvador",
+        },
     }
     factura = {
         "identificacion": {"tipoDte": "03", "codigoGeneracion": "1", "fecEmi": "2024-01-01"},
@@ -227,6 +254,15 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
         "numDocumento": "0614-140710-001-2",
         "nombre": "Cliente",
         "bienTitulo": "01",
+        "codActividad": "6201",
+        "descActividad": "Servicios de software",
+        "telefono": "70000001",
+        "correo": "cliente@example.com",
+        "direccion": {
+            "departamento": "05",
+            "municipio": "01",
+            "complemento": "San Salvador",
+        },
     }
     extension = {
         "nombEntrega": "Juan",
@@ -236,6 +272,43 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
     with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
+        )
+
+
+@pytest.mark.parametrize("campo", ["codActividad", "descActividad", "telefono", "correo"])
+def test_receptor_campo_obligatorio_faltante(monkeypatch, campo):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    receptor.pop(campo)
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    with pytest.raises(ValueError, match=f"receptor requiere {campo}"):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
+        )
+
+
+def test_receptor_direccion_complemento_faltante(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    receptor["direccion"].pop("complemento")
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    with pytest.raises(ValueError, match="receptor requiere direccion.complemento"):
         generar_nota_remision_independiente(
             db,
             emisor=emisor,


### PR DESCRIPTION
## Summary
- require codActividad, descActividad, telefono, correo and direccion.complemento in receptor normalization
- add error handling for missing receptor contact fields
- test missing receptor fields and update sample data

## Testing
- `pytest tests/test_nota_remision.py tests/test_generar_nota_remision_json.py tests/test_nr_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf8c8db6e48323bbc3afdf322809c9