### PR TITLE
Valida observaciones en notas de remisión independientes

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -189,6 +189,7 @@ def generar_nota_remision(
             "docuEntrega",
             "nombRecibe",
             "docuRecibe",
+            "observaciones",
         ]
         missing = [k for k in required_ext if not extension.get(k)]
         if missing:
@@ -196,8 +197,6 @@ def generar_nota_remision(
                 "Faltan campos obligatorios en extension: " + ", ".join(missing)
             )
         ext = {k: extension.get(k) for k in required_ext}
-        if extension.get("observaciones"):
-            ext["observaciones"] = extension.get("observaciones")
 
     ext = {k: v for k, v in ext.items() if k in allowed_ext_keys}
     limpiar_documentos(emisor)

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -261,13 +261,28 @@ def generar_nota_remision_independiente(
 
     if not (emisor and receptor and detalles):
         raise ValueError("emisor, receptor y detalles son obligatorios")
+    if not extension:
+        raise ValueError("extension es obligatoria")
+    required_ext = [
+        "nombEntrega",
+        "docuEntrega",
+        "nombRecibe",
+        "docuRecibe",
+        "observaciones",
+    ]
+    missing = [k for k in required_ext if not extension.get(k)]
+    if missing:
+        raise ValueError(
+            "Faltan campos obligatorios en extension: " + ", ".join(missing)
+        )
+    ext = {k: extension.get(k) for k in required_ext}
 
     return _generar_base(
         db,
         emisor=emisor,
         receptor=receptor,
         detalles=detalles,
-        extension=extension,
+        extension=ext,
         documento_relacionado=None,
         ambiente=ambiente,
     )

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -165,13 +165,41 @@ def test_nr_independiente_extension(monkeypatch):
     assert float(res["descuGravada"]) == 0.0
 
 
+def test_nr_independiente_extension_sin_observaciones(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "0614-140710-001-2",
+        "nombRecibe": "Ana",
+        "docuRecibe": "1234 5678",
+    }
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
+        )
+
+
 def test_nr_item_validation(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")
     emisor = _sample_emisor()
     receptor = _sample_receptor()
     with pytest.raises(ValueError):
-        extension = {"nombEntrega": "X", "docuEntrega": "123", "nombRecibe": "Y", "docuRecibe": "456"}
+        extension = {
+            "nombEntrega": "X",
+            "docuEntrega": "123",
+            "nombRecibe": "Y",
+            "docuRecibe": "456",
+            "observaciones": "Obs",
+        }
         generar_nota_remision_independiente(
             db,
             emisor=emisor,
@@ -179,7 +207,13 @@ def test_nr_item_validation(monkeypatch):
             detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
             extension=extension,
         )
-    extension = {"nombEntrega": "X", "docuEntrega": "123", "nombRecibe": "Y", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "X",
+        "docuEntrega": "123",
+        "nombRecibe": "Y",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     data = generar_nota_remision_independiente(
         db,
         emisor=emisor,
@@ -233,6 +267,7 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
         "docuEntrega": "0614-140710-001-2",
         "nombRecibe": "Ana",
         "docuRecibe": "1234 5678",
+        "observaciones": "Obs",
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- exige campo `observaciones` en la extensión de notas de remisión independientes
- replica la validación en la versión electrónica
- añade pruebas para ausencia de `observaciones`

## Testing
- `pytest tests/test_nota_remision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf8c8914d8832387c0e630608fd960