### PR TITLE
Enforce observaciones field in Nota de Remisión extension

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -206,6 +206,8 @@ def generar_nota_remision(
                 "Faltan campos obligatorios en extension: " + ", ".join(missing)
             )
         ext = {k: extension.get(k) for k in required_ext}
+        if not str(ext.get("observaciones", "")).strip():
+            raise ValueError("observaciones es obligatoria")
 
     ext = {k: v for k, v in ext.items() if k in allowed_ext_keys}
     limpiar_documentos(emisor)

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -285,6 +285,8 @@ def generar_nota_remision_independiente(
             "Faltan campos obligatorios en extension: " + ", ".join(missing)
         )
     ext = {k: extension.get(k) for k in required_ext}
+    if not str(ext.get("observaciones", "")).strip():
+        raise ValueError("observaciones es obligatoria")
 
     return _generar_base(
         db,

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -205,6 +205,29 @@ def test_nr_independiente_extension_sin_observaciones(monkeypatch):
         )
 
 
+def test_nr_independiente_extension_observaciones_vacia(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "0614-140710-001-2",
+        "nombRecibe": "Ana",
+        "docuRecibe": "1234 5678",
+        "observaciones": "   ",
+    }
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
+        )
+
+
 def test_nr_item_validation(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")


### PR DESCRIPTION
## Summary
- validate non-empty `observaciones` in Nota de Remisión extensions
- mirror validation in electronic note generator
- test missing and blank `observaciones` in NR extensions

## Testing
- `pytest tests/test_nota_remision.py::test_nr_independiente_extension_sin_observaciones tests/test_nota_remision.py::test_nr_independiente_extension_observaciones_vacia -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf85bea1848323b1551ffc5f6367b8