### PR TITLE
Guardar datos completos del cliente al generar nota de remisión

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -114,6 +114,7 @@ class NotaRemisionExtWidget(QWidget):
     def __init__(self, db, parent=None):
         super().__init__(parent)
         self.db = db
+        self.cli_data = None
         self._build_ui()
 
     def _build_ui(self):
@@ -255,6 +256,7 @@ class NotaRemisionExtWidget(QWidget):
     def _seleccionar_cliente(self, item):
         data = item.data(Qt.UserRole) if item else None
         if isinstance(data, dict):
+            self.cli_data = data
             self.nomb_recibe.setText(data.get("nombre", ""))
             nrc = data.get("nrc") or ""
             if nrc:
@@ -266,6 +268,8 @@ class NotaRemisionExtWidget(QWidget):
                 self.docu_recibe.setText(limpiar_doc(doc))
                 self.nrc_recibe.clear()
                 self.tipo_doc_recibe = "13"
+        else:
+            self.cli_data = None
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.KeyPress:
@@ -477,12 +481,29 @@ class NotaRemisionDialog(QDialog):
         extension = self.ext_widget.get_data()
         tipo_doc = extension.pop("tipoDocRecibe")
         nrc = extension.pop("nrcRecibe", "")
+        cli = self.ext_widget.cli_data or {}
+        complemento = cli.get("direccion") or cli.get("otros") or ""
+        if not cli or not complemento:
+            QMessageBox.warning(
+                self,
+                "Nota",
+                "Seleccione un cliente con dirección válida",
+            )
+            return None
         receptor = {
             "nombre": extension.get("nombRecibe"),
             "tipoDocumento": tipo_doc,
             "numDocumento": extension.get("docuRecibe"),
             "bienTitulo": "01",
-            "direccion": {"departamento": "05", "municipio": "24", "complemento": ""},
+            "codActividad": cli.get("codActividad"),
+            "descActividad": cli.get("giro"),
+            "telefono": cli.get("telefono"),
+            "correo": cli.get("email"),
+            "direccion": {
+                "departamento": cli.get("departamento"),
+                "municipio": cli.get("municipio"),
+                "complemento": complemento,
+            },
         }
         if tipo_doc == "36" and nrc:
             receptor["nrc"] = nrc
@@ -1409,7 +1430,10 @@ class FacturacionTab(QWidget):
         dialog = NotaRemisionDialog(self.manager.db, self.manager._products, self)
         if dialog.exec_() != QDialog.Accepted:
             return
-        detalles, extension, receptor = dialog.get_data()
+        data = dialog.get_data()
+        if not data:
+            return
+        detalles, extension, receptor = data
         fecha = QDate.currentDate().toString("yyyy-MM-dd")
         extra = {"items": detalles, "receptor": receptor, "extension": extension}
         nota_id = self.manager.db.agregar_nota(

--- a/tests/test_nota_remision_dialog.py
+++ b/tests/test_nota_remision_dialog.py
@@ -1,0 +1,65 @@
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QListWidgetItem
+
+from facturacion_tab import NotaRemisionDialog, QMessageBox
+from nota_remision_electronica import generar_nota_remision_independiente
+
+
+def _sample_emisor():
+    return {"nit": "0614-140710-001-2", "nrc": "1234567"}
+
+
+def _sample_cliente(complemento="Calle 1"):
+    return {
+        "nombre": "Ana",
+        "nit": "0614-123456-102-3",
+        "nrc": "1234567",
+        "codActividad": "6201",
+        "giro": "Servicios de software",
+        "telefono": "70000001",
+        "email": "ana@example.com",
+        "departamento": "05",
+        "municipio": "24",
+        "direccion": complemento,
+    }
+
+
+def _build_dialog(db_conn):
+    dialog = NotaRemisionDialog(db_conn, productos=[{"codigo": "P1", "nombre": "Prod"}])
+    dialog.prod_cb.setCurrentIndex(0)
+    dialog._add_item()
+    dialog.ext_widget.nomb_entrega.setText("Juan")
+    dialog.ext_widget.docu_entrega.setText("061234567")
+    dialog.ext_widget.ext_obs.setPlainText("Obs")
+    return dialog
+
+
+def test_nr_dialog_receptor_fields(db_conn, qt_app):
+    dialog = _build_dialog(db_conn)
+    cli_item = QListWidgetItem("Cli")
+    cli_item.setData(Qt.UserRole, _sample_cliente())
+    dialog.ext_widget._seleccionar_cliente(cli_item)
+    data = dialog.get_data()
+    assert data is not None
+    detalles, extension, receptor = data
+    nr = generar_nota_remision_independiente(
+        db_conn, emisor=_sample_emisor(), receptor=receptor, detalles=detalles, extension=extension
+    )
+    rec = nr["receptor"]
+    assert rec["codActividad"] == "6201"
+    assert rec["descActividad"] == "Servicios de software"
+    assert rec["telefono"] == "70000001"
+    assert rec["correo"] == "ana@example.com"
+    assert rec["direccion"]["complemento"] == "Calle 1"
+
+
+def test_nr_dialog_requires_address(monkeypatch, db_conn, qt_app):
+    dialog = _build_dialog(db_conn)
+    cli_item = QListWidgetItem("Cli")
+    cli_item.setData(Qt.UserRole, _sample_cliente(complemento=""))
+    dialog.ext_widget._seleccionar_cliente(cli_item)
+    called = {}
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: called.setdefault("warn", True))
+    assert dialog.get_data() is None
+    assert called.get("warn")


### PR DESCRIPTION
## Summary
- Guardar el diccionario completo del cliente en `NotaRemisionExtWidget`
- Construir receptor de nota de remisión con `cli_data` y validar dirección
- Añadir pruebas para asegurar que receptor tiene actividad, contacto y dirección

## Testing
- `pytest tests/test_nota_remision_dialog.py -q`
- `pytest -q` *(fails: numerous tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf93240e4c8323b2d0e2b7a504faec