### PR TITLE
Validate positive quantity in nota remision items

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -39,12 +39,17 @@ def _build_items(
 ) -> list[dict]:
     """Construye items con montos forzados a ``0.00``.
 
-    Además normaliza ``uniMedida`` contra el catálogo CAT-014, usando ``59``
-    (Unidad) cuando el detalle no provee una unidad válida.  Si
-    ``numero_documento`` se proporciona se añade a cada ítem.
+    Además valida que ``cantidad`` sea mayor que cero y normaliza
+    ``uniMedida`` contra el catálogo CAT-014, usando ``59`` (Unidad) cuando el
+    detalle no provee una unidad válida.  Si ``numero_documento`` se
+    proporciona se añade a cada ítem.
     """
     items: list[dict] = []
     for num, det in enumerate(detalles, 1):
+        cantidad = det.get("cantidad", 1)
+        if cantidad <= 0:
+            raise ValueError("cantidad debe ser mayor que cero")
+
         uni = det.get("uniMedida", 59)
         try:
             uni = int(uni)
@@ -57,7 +62,7 @@ def _build_items(
             "tipoItem": det.get("tipoItem", 1),
             "codigo": det.get("codigo", f"NR{num:03d}"),
             "descripcion": det.get("descripcion", f"Item {num}"),
-            "cantidad": det.get("cantidad", 1),
+            "cantidad": cantidad,
             "uniMedida": uni,
             "precioUni": 0.0,
             "montoDescu": 0.0,

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -2,6 +2,7 @@ import pytest
 import warnings
 
 from db import DB
+from nota_remision import generar_nota_remision
 from nota_remision_electronica import (
     generar_nota_remision_desde_factura,
     generar_nota_remision_independiente,
@@ -248,6 +249,21 @@ def test_nr_item_validation(monkeypatch):
             detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
             extension=extension,
         )
+    with pytest.raises(ValueError):
+        extension = {
+            "nombEntrega": "X",
+            "docuEntrega": "123",
+            "nombRecibe": "Y",
+            "docuRecibe": "456",
+            "observaciones": "Obs",
+        }
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=[{"descripcion": "Prod", "cantidad": -1, "uniMedida": 59}],
+            extension=extension,
+        )
     extension = {
         "nombEntrega": "X",
         "docuEntrega": "123",
@@ -263,6 +279,36 @@ def test_nr_item_validation(monkeypatch):
         extension=extension,
     )
     assert data["cuerpoDocumento"][0]["uniMedida"] == 59
+
+
+def test_nr_item_validation_regular(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    extension = {
+        "nombEntrega": "X",
+        "docuEntrega": "123",
+        "nombRecibe": "Y",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    with pytest.raises(ValueError):
+        generar_nota_remision(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=[{"descripcion": "Prod", "cantidad": 0}],
+            extension=extension,
+        )
+    with pytest.raises(ValueError):
+        generar_nota_remision(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=[{"descripcion": "Prod", "cantidad": -1}],
+            extension=extension,
+        )
 
 
 def test_receptor_dui_sin_nrc(monkeypatch):


### PR DESCRIPTION
## Summary
- enforce cantidad > 0 in nota_remision item builder
- test that nota_remision and electronica versions reject zero/negative quantities

## Testing
- `pytest tests/test_nota_remision.py::test_nr_item_validation tests/test_nota_remision.py::test_nr_item_validation_regular -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfa1670dac83238a092e73870138a2