### PR TITLE
Require documento_relacionado for notas de remisión

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -219,6 +219,12 @@ def generar_nota_remision(
             raise ValueError(f"{key} requerido")
     limpiar_documentos(ext)
 
+    if not documento_relacionado:
+        raise ValueError("documento_relacionado es obligatorio")
+    numero_doc = documento_relacionado[0].get("numeroDocumento")
+    if not numero_doc:
+        raise ValueError("documento_relacionado requiere numeroDocumento")
+
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
     identificacion = {
@@ -236,9 +242,6 @@ def generar_nota_remision(
         "tipoMoneda": "USD",
     }
 
-    numero_doc = None
-    if documento_relacionado:
-        numero_doc = documento_relacionado[0].get("numeroDocumento")
     items = _build_items(detalles, numero_doc)
 
     resumen = {
@@ -265,14 +268,11 @@ def generar_nota_remision(
         "extension": ext,
         "resumen": resumen,
         "apendice": None,
+        "documentoRelacionado": documento_relacionado,
     }
-    if documento_relacionado:
-        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
     result = sanitize_dte_payload(data, schema)
-    if not documento_relacionado:
-        result.pop("documentoRelacionado", None)
     return result
 
 
@@ -331,6 +331,7 @@ def generar_nota_remision_desde_db(
     detalles = extra.get("items") or []
     receptor = extra.get("receptor") or {}
     extension = extra.get("extension") or {}
+    documento_relacionado = extra.get("documento_relacionado")
 
     emisor = _load_datos_negocio()
     return generar_nota_remision(
@@ -339,6 +340,7 @@ def generar_nota_remision_desde_db(
         receptor=receptor,
         detalles=detalles,
         extension=extension,
+        documento_relacionado=documento_relacionado,
         ambiente=ambiente,
     )
 

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -7,8 +7,8 @@ el Ministerio de Hacienda de El Salvador para una Nota de Remisión (``tipoDte``
 
 * :func:`generar_nota_remision_desde_factura` crea la nota a partir de un DTE de
   origen reutilizando la información de emisor, receptor y detalles.
-* :func:`generar_nota_remision_independiente` permite crear una nota sin
-  documento relacionado especificando manualmente todos los datos.
+* :func:`generar_nota_remision_independiente` permite crear una nota
+  especificando manualmente todos los datos y el documento relacionado.
 """
 from __future__ import annotations
 
@@ -131,7 +131,7 @@ def _generar_base(
     receptor: dict,
     detalles: Iterable[dict],
     extension: Optional[dict] = None,
-    documento_relacionado: Optional[list[dict]] = None,
+    documento_relacionado: list[dict],
     ambiente: str = "00",
 ) -> dict:
     """Construye la estructura base común de una NR."""
@@ -139,6 +139,12 @@ def _generar_base(
     limpiar_documentos(emisor)
     receptor.setdefault("bienTitulo", "01")
     receptor = normalizar_receptor(receptor)
+
+    if not documento_relacionado:
+        raise ValueError("documento_relacionado es obligatorio")
+    numero_doc = documento_relacionado[0].get("numeroDocumento")
+    if not numero_doc:
+        raise ValueError("documento_relacionado requiere numeroDocumento")
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
@@ -157,9 +163,6 @@ def _generar_base(
         "tipoMoneda": "USD",
     }
 
-    numero_doc = None
-    if documento_relacionado:
-        numero_doc = documento_relacionado[0].get("numeroDocumento")
     items = _build_items(detalles, numero_doc)
 
     ext = {
@@ -201,14 +204,11 @@ def _generar_base(
         "extension": ext,
         "resumen": resumen,
         "apendice": None,
+        "documentoRelacionado": documento_relacionado,
     }
-    if documento_relacionado:
-        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
     result = sanitize_dte_payload(data, schema)
-    if not documento_relacionado:
-        result.pop("documentoRelacionado", None)
     return result
 
 
@@ -263,10 +263,11 @@ def generar_nota_remision_independiente(
     emisor: dict,
     receptor: dict,
     detalles: Iterable[dict],
+    documento_relacionado: list[dict],
     extension: Optional[dict] = None,
     ambiente: str = "00",
 ) -> dict:
-    """Genera una NR sin documento relacionado."""
+    """Genera una NR especificando todos los datos manualmente."""
 
     if not (emisor and receptor and detalles):
         raise ValueError("emisor, receptor y detalles son obligatorios")
@@ -294,7 +295,7 @@ def generar_nota_remision_independiente(
         receptor=receptor,
         detalles=detalles,
         extension=ext,
-        documento_relacionado=None,
+        documento_relacionado=documento_relacionado,
         ambiente=ambiente,
     )
 

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,5 +1,6 @@
 import fitz
 from decimal import Decimal
+import pytest
 from db import DB
 from nota_debito_electronica import generar_nde_desde_dte
 from dte import generar_dte_json
@@ -270,15 +271,14 @@ def test_generar_nota_remision_sin_documento_relacionado(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
-    data = generar_nota_remision(
-        db,
-        emisor=datos,
-        receptor=receptor,
-        detalles=detalles,
-        extension=extension,
-    )
-    assert "documentoRelacionado" not in data
-    assert str(data["resumen"]["montoTotalOperacion"]) == "0.00"
+    with pytest.raises(ValueError):
+        generar_nota_remision(
+            db,
+            emisor=datos,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
+        )
 
 
 def test_generar_nota_remision_desde_db_independiente(monkeypatch):
@@ -311,11 +311,24 @@ def test_generar_nota_remision_desde_db_independiente(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
-    extra = {"items": detalles, "receptor": receptor, "extension": extension}
+    doc_rel = [
+        {
+            "tipoDocumento": "03",
+            "tipoGeneracion": 1,
+            "numeroDocumento": "ABC",
+            "fechaEmision": "2024-01-01",
+        }
+    ]
+    extra = {
+        "items": detalles,
+        "receptor": receptor,
+        "extension": extension,
+        "documento_relacionado": doc_rel,
+    }
     nota_id = db.agregar_nota("remision", None, "2024-01-01", 0, "Envio", detalles=extra)
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["receptor"]["nombre"] == "Cliente"
-    assert "documentoRelacionado" not in data
+    assert data["documentoRelacionado"][0]["numeroDocumento"] == "ABC"
 
 
 def test_generar_nota_remision_desde_db_factura_sin_venta(monkeypatch):

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -7,6 +7,7 @@ from nota_remision_electronica import (
     generar_nota_remision_independiente,
 )
 import dte
+import pytest
 
 
 def _sample_emisor():
@@ -30,6 +31,17 @@ def _sample_receptor():
             "complemento": "San Salvador",
         },
     }
+
+
+def _sample_doc_rel():
+    return [
+        {
+            "tipoDocumento": "03",
+            "tipoGeneracion": 1,
+            "numeroDocumento": "XYZ",
+            "fechaEmision": "2024-01-01",
+        }
+    ]
 
 
 def test_nr_desde_factura_documento_relacionado(monkeypatch):
@@ -163,9 +175,13 @@ def test_nr_independiente_extension(monkeypatch):
         emisor=emisor,
         receptor=receptor,
         detalles=detalles,
+        documento_relacionado=_sample_doc_rel(),
         extension=extension,
     )
-    assert "documentoRelacionado" not in data
+    doc_rel = data["documentoRelacionado"][0]
+    assert doc_rel["numeroDocumento"] == "XYZ"
+    item = data["cuerpoDocumento"][0]
+    assert item["numeroDocumento"] == "XYZ"
     ext = data["extension"]
     assert ext["nombEntrega"] == "Juan"
     assert ext["nombRecibe"] == "Ana"
@@ -181,6 +197,24 @@ def test_nr_independiente_extension(monkeypatch):
     assert float(res["descuNoSuj"]) == 0.0
     assert float(res["descuExenta"]) == 0.0
     assert float(res["descuGravada"]) == 0.0
+
+
+def test_nr_independiente_documento_relacionado_requerido(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    emisor = _sample_emisor()
+    receptor = _sample_receptor()
+    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    with pytest.raises(ValueError):
+        generar_nota_remision_independiente(
+            db,
+            emisor=emisor,
+            receptor=receptor,
+            detalles=detalles,
+            extension=extension,
+            documento_relacionado=[],
+        )
 
 
 def test_nr_independiente_extension_sin_observaciones(monkeypatch):
@@ -201,6 +235,7 @@ def test_nr_independiente_extension_sin_observaciones(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -224,6 +259,7 @@ def test_nr_independiente_extension_observaciones_vacia(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -246,6 +282,7 @@ def test_nr_item_validation(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
     extension = {
@@ -260,6 +297,7 @@ def test_nr_item_validation(monkeypatch):
         emisor=emisor,
         receptor=receptor,
         detalles=[{"descripcion": "Prod", "cantidad": 1, "uniMedida": 1}],
+        documento_relacionado=_sample_doc_rel(),
         extension=extension,
     )
     assert data["cuerpoDocumento"][0]["uniMedida"] == 59
@@ -335,6 +373,7 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -347,13 +386,20 @@ def test_receptor_campo_obligatorio_faltante(monkeypatch, campo):
     receptor = _sample_receptor()
     receptor.pop(campo)
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
-    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     with pytest.raises(ValueError, match=f"receptor requiere {campo}"):
         generar_nota_remision_independiente(
             db,
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -365,12 +411,19 @@ def test_receptor_direccion_complemento_faltante(monkeypatch):
     receptor = _sample_receptor()
     receptor["direccion"].pop("complemento")
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
-    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     with pytest.raises(ValueError, match="receptor requiere direccion.complemento"):
         generar_nota_remision_independiente(
             db,
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )

--- a/tests/test_nota_remision_dialog.py
+++ b/tests/test_nota_remision_dialog.py
@@ -44,7 +44,19 @@ def test_nr_dialog_receptor_fields(db_conn, qt_app):
     assert data is not None
     detalles, extension, receptor = data
     nr = generar_nota_remision_independiente(
-        db_conn, emisor=_sample_emisor(), receptor=receptor, detalles=detalles, extension=extension
+        db_conn,
+        emisor=_sample_emisor(),
+        receptor=receptor,
+        detalles=detalles,
+        extension=extension,
+        documento_relacionado=[
+            {
+                "tipoDocumento": "03",
+                "tipoGeneracion": 1,
+                "numeroDocumento": "XYZ",
+                "fechaEmision": "2024-01-01",
+            }
+        ],
     )
     rec = nr["receptor"]
     assert rec["codActividad"] == "6201"


### PR DESCRIPTION
## Summary
- enforce documento_relacionado in nota de remisión generators and propagate numeroDocumento to items
- remove fallback deletion of documentoRelacionado
- add tests covering missing documento_relacionado scenarios

## Testing
- `pytest tests/test_nota_debito_remision.py::test_generar_nota_remision_sin_documento_relacionado -q`
- `pytest tests/test_nota_remision.py -q`
- `pytest tests/test_nota_remision_dialog.py::test_nr_dialog_receptor_fields -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfa168d2f48323b1eaa80db77ef5db