### PR TITLE
Fix nota de remisión generation requirements

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -187,8 +187,10 @@ def generar_nota_remision(
                 receptor.setdefault("numDocumento", ext.get("docuRecibe"))
         receptor.setdefault("bienTitulo", "01")
     else:
-        if not (emisor and receptor and detalles):
-            raise ValueError("emisor, receptor y detalles son obligatorios")
+        if not (emisor and receptor and detalles and documento_relacionado):
+            raise ValueError(
+                "emisor, receptor, detalles y documento_relacionado son obligatorios"
+            )
         if not detalles:
             raise ValueError("Se requiere al menos un detalle")
         if not extension:
@@ -211,6 +213,7 @@ def generar_nota_remision(
 
     ext = {k: v for k, v in ext.items() if k in allowed_ext_keys}
     limpiar_documentos(emisor)
+    emisor.setdefault("tipoEstablecimiento", "01")
     receptor.setdefault("bienTitulo", "01")
     receptor = normalizar_receptor(receptor)
     for key in ("docuEntrega", "docuRecibe"):
@@ -236,9 +239,7 @@ def generar_nota_remision(
         "tipoMoneda": "USD",
     }
 
-    numero_doc = None
-    if documento_relacionado:
-        numero_doc = documento_relacionado[0].get("numeroDocumento")
+    numero_doc = documento_relacionado[0].get("numeroDocumento") if documento_relacionado else None
     items = _build_items(detalles, numero_doc)
 
     resumen = {
@@ -265,15 +266,11 @@ def generar_nota_remision(
         "extension": ext,
         "resumen": resumen,
         "apendice": None,
+        "documentoRelacionado": documento_relacionado,
     }
-    if documento_relacionado:
-        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
-    result = sanitize_dte_payload(data, schema)
-    if not documento_relacionado:
-        result.pop("documentoRelacionado", None)
-    return result
+    return sanitize_dte_payload(data, schema)
 
 
 def generar_nota_remision_desde_db(
@@ -331,6 +328,7 @@ def generar_nota_remision_desde_db(
     detalles = extra.get("items") or []
     receptor = extra.get("receptor") or {}
     extension = extra.get("extension") or {}
+    doc_rel = extra.get("documento_relacionado")
 
     emisor = _load_datos_negocio()
     return generar_nota_remision(
@@ -338,6 +336,7 @@ def generar_nota_remision_desde_db(
         emisor=emisor,
         receptor=receptor,
         detalles=detalles,
+        documento_relacionado=doc_rel,
         extension=extension,
         ambiente=ambiente,
     )

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -7,8 +7,9 @@ el Ministerio de Hacienda de El Salvador para una Nota de Remisión (``tipoDte``
 
 * :func:`generar_nota_remision_desde_factura` crea la nota a partir de un DTE de
   origen reutilizando la información de emisor, receptor y detalles.
-* :func:`generar_nota_remision_independiente` permite crear una nota sin
-  documento relacionado especificando manualmente todos los datos.
+* :func:`generar_nota_remision_independiente` permite crear una nota
+  especificando manualmente todos los datos, incluido su documento
+  relacionado.
 """
 from __future__ import annotations
 
@@ -135,8 +136,11 @@ def _generar_base(
     ambiente: str = "00",
 ) -> dict:
     """Construye la estructura base común de una NR."""
+    if not documento_relacionado:
+        raise ValueError("documento_relacionado es obligatorio")
 
     limpiar_documentos(emisor)
+    emisor.setdefault("tipoEstablecimiento", "01")
     receptor.setdefault("bienTitulo", "01")
     receptor = normalizar_receptor(receptor)
 
@@ -157,9 +161,7 @@ def _generar_base(
         "tipoMoneda": "USD",
     }
 
-    numero_doc = None
-    if documento_relacionado:
-        numero_doc = documento_relacionado[0].get("numeroDocumento")
+    numero_doc = documento_relacionado[0].get("numeroDocumento")
     items = _build_items(detalles, numero_doc)
 
     ext = {
@@ -201,15 +203,11 @@ def _generar_base(
         "extension": ext,
         "resumen": resumen,
         "apendice": None,
+        "documentoRelacionado": documento_relacionado,
     }
-    if documento_relacionado:
-        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
-    result = sanitize_dte_payload(data, schema)
-    if not documento_relacionado:
-        result.pop("documentoRelacionado", None)
-    return result
+    return sanitize_dte_payload(data, schema)
 
 
 def generar_nota_remision_desde_factura(
@@ -263,13 +261,16 @@ def generar_nota_remision_independiente(
     emisor: dict,
     receptor: dict,
     detalles: Iterable[dict],
+    documento_relacionado: list[dict],
     extension: Optional[dict] = None,
     ambiente: str = "00",
 ) -> dict:
-    """Genera una NR sin documento relacionado."""
+    """Genera una NR independiente especificando su documento relacionado."""
 
-    if not (emisor and receptor and detalles):
-        raise ValueError("emisor, receptor y detalles son obligatorios")
+    if not (emisor and receptor and detalles and documento_relacionado):
+        raise ValueError(
+            "emisor, receptor, detalles y documento_relacionado son obligatorios"
+        )
     if not extension:
         raise ValueError("extension es obligatoria")
     required_ext = [
@@ -294,7 +295,7 @@ def generar_nota_remision_independiente(
         receptor=receptor,
         detalles=detalles,
         extension=ext,
-        documento_relacionado=None,
+        documento_relacionado=documento_relacionado,
         ambiente=ambiente,
     )
 

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -35,6 +35,17 @@ def _sample_data():
     return venta, detalles
 
 
+def _doc_rel():
+    return [
+        {
+            "tipoDocumento": "03",
+            "tipoGeneracion": 2,
+            "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fechaEmision": "2024-01-01",
+        }
+    ]
+
+
 def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     datos = {
         "nit": "0614-140710-001-2",
@@ -270,14 +281,16 @@ def test_generar_nota_remision_sin_documento_relacionado(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    doc_rel = _doc_rel()
     data = generar_nota_remision(
         db,
         emisor=datos,
         receptor=receptor,
         detalles=detalles,
+        documento_relacionado=doc_rel,
         extension=extension,
     )
-    assert "documentoRelacionado" not in data
+    assert data["documentoRelacionado"][0]["numeroDocumento"] == doc_rel[0]["numeroDocumento"]
     assert str(data["resumen"]["montoTotalOperacion"]) == "0.00"
 
 
@@ -311,11 +324,16 @@ def test_generar_nota_remision_desde_db_independiente(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
-    extra = {"items": detalles, "receptor": receptor, "extension": extension}
+    extra = {
+        "items": detalles,
+        "receptor": receptor,
+        "extension": extension,
+        "documento_relacionado": _doc_rel(),
+    }
     nota_id = db.agregar_nota("remision", None, "2024-01-01", 0, "Envio", detalles=extra)
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["receptor"]["nombre"] == "Cliente"
-    assert "documentoRelacionado" not in data
+    assert data["documentoRelacionado"]
 
 
 def test_generar_nota_remision_desde_db_factura_sin_venta(monkeypatch):

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -32,6 +32,17 @@ def _sample_receptor():
     }
 
 
+def _sample_doc_rel():
+    return [
+        {
+            "tipoDocumento": "03",
+            "tipoGeneracion": 2,
+            "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fechaEmision": "2024-01-01",
+        }
+    ]
+
+
 def test_nr_desde_factura_documento_relacionado(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")
@@ -158,20 +169,25 @@ def test_nr_independiente_extension(monkeypatch):
         "observaciones": "Obs",
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    doc_rel = _sample_doc_rel()
     data = generar_nota_remision_independiente(
         db,
         emisor=emisor,
         receptor=receptor,
         detalles=detalles,
+        documento_relacionado=doc_rel,
         extension=extension,
     )
-    assert "documentoRelacionado" not in data
+    assert data["documentoRelacionado"][0]["numeroDocumento"] == doc_rel[0]["numeroDocumento"]
+    item = data["cuerpoDocumento"][0]
+    assert item["numeroDocumento"] == doc_rel[0]["numeroDocumento"]
     ext = data["extension"]
     assert ext["nombEntrega"] == "Juan"
     assert ext["nombRecibe"] == "Ana"
     assert ext["docuEntrega"] == "06141407100012"
     assert ext["docuRecibe"] == "12345678"
     assert "-" not in data["emisor"]["nit"]
+    assert data["emisor"]["tipoEstablecimiento"] == "01"
     assert " " not in data["receptor"]["numDocumento"]
     rec = data["receptor"]
     assert "nombreComercial" in rec
@@ -201,6 +217,7 @@ def test_nr_independiente_extension_sin_observaciones(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -224,6 +241,7 @@ def test_nr_independiente_extension_observaciones_vacia(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -246,6 +264,7 @@ def test_nr_item_validation(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=[{"descripcion": "Prod", "cantidad": 0, "uniMedida": 59}],
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
     extension = {
@@ -260,6 +279,7 @@ def test_nr_item_validation(monkeypatch):
         emisor=emisor,
         receptor=receptor,
         detalles=[{"descripcion": "Prod", "cantidad": 1, "uniMedida": 1}],
+        documento_relacionado=_sample_doc_rel(),
         extension=extension,
     )
     assert data["cuerpoDocumento"][0]["uniMedida"] == 59
@@ -335,6 +355,7 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -354,6 +375,7 @@ def test_receptor_campo_obligatorio_faltante(monkeypatch, campo):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
 
@@ -372,5 +394,6 @@ def test_receptor_direccion_complemento_faltante(monkeypatch):
             emisor=emisor,
             receptor=receptor,
             detalles=detalles,
+            documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )

--- a/tests/test_nota_remision_dialog.py
+++ b/tests/test_nota_remision_dialog.py
@@ -35,6 +35,17 @@ def _build_dialog(db_conn):
     return dialog
 
 
+def _doc_rel():
+    return [
+        {
+            "tipoDocumento": "03",
+            "tipoGeneracion": 2,
+            "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fechaEmision": "2024-01-01",
+        }
+    ]
+
+
 def test_nr_dialog_receptor_fields(db_conn, qt_app):
     dialog = _build_dialog(db_conn)
     cli_item = QListWidgetItem("Cli")
@@ -44,7 +55,12 @@ def test_nr_dialog_receptor_fields(db_conn, qt_app):
     assert data is not None
     detalles, extension, receptor = data
     nr = generar_nota_remision_independiente(
-        db_conn, emisor=_sample_emisor(), receptor=receptor, detalles=detalles, extension=extension
+        db_conn,
+        emisor=_sample_emisor(),
+        receptor=receptor,
+        detalles=detalles,
+        documento_relacionado=_doc_rel(),
+        extension=extension,
     )
     rec = nr["receptor"]
     assert rec["codActividad"] == "6201"


### PR DESCRIPTION
## Summary
- Require `documentoRelacionado` and default `tipoEstablecimiento` when building notas de remisión
- Update independent NR API to pass document reference and adjust tests

## Testing
- `pytest` *(fails: multiple assertion and schema alignment errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9de631f08323ab1bb1f70745a926