### PR TITLE
Allow product-only remisiones without related DTE

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1439,7 +1439,11 @@ class FacturacionTab(QWidget):
         nota_id = self.manager.db.agregar_nota(
             "remision", None, fecha, 0, "Remision", detalles=extra
         )
-        nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
+        try:
+            nota_json = generar_nota_remision_desde_db(self.manager.db, nota_id)
+        except ValueError as exc:
+            QMessageBox.critical(self, "Nota", str(exc))
+            return
 
         self._guardar_archivos_nota_remision(nota_json)
         QMessageBox.information(self, "Nota", "Nota de remisión generada correctamente")

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -125,6 +125,35 @@ def normalizar_receptor(receptor: dict) -> dict:
     return receptor
 
 
+def _normalizar_documento_relacionado(doc_rel: list[dict]) -> list[dict]:
+    """Valida y normaliza ``documento_relacionado`` si está presente."""
+
+    if not isinstance(doc_rel, list) or not doc_rel:
+        raise ValueError("documento_relacionado debe ser una lista no vacía")
+    doc = doc_rel[0] or {}
+    tipo = doc.get("tipoDocumento")
+    numero = doc.get("numeroDocumento")
+    fecha = doc.get("fechaEmision")
+    if tipo not in {"01", "03", "11"}:
+        raise ValueError("tipoDocumento inválido en documento_relacionado")
+    if not numero or not fecha:
+        raise ValueError(
+            "documento_relacionado requiere numeroDocumento y fechaEmision"
+        )
+    try:
+        datetime.fromisoformat(fecha)
+    except Exception as exc:
+        raise ValueError("fechaEmision inválida en documento_relacionado") from exc
+    return [
+        {
+            "tipoDocumento": tipo,
+            "tipoGeneracion": 2,
+            "numeroDocumento": numero,
+            "fechaEmision": fecha,
+        }
+    ]
+
+
 def generar_nota_remision(
     db: DB,
     factura: Optional[dict] = None,
@@ -187,10 +216,8 @@ def generar_nota_remision(
                 receptor.setdefault("numDocumento", ext.get("docuRecibe"))
         receptor.setdefault("bienTitulo", "01")
     else:
-        if not (emisor and receptor and detalles and documento_relacionado):
-            raise ValueError(
-                "emisor, receptor, detalles y documento_relacionado son obligatorios"
-            )
+        if not (emisor and receptor and detalles):
+            raise ValueError("emisor, receptor y detalles son obligatorios")
         if not detalles:
             raise ValueError("Se requiere al menos un detalle")
         if not extension:
@@ -239,7 +266,13 @@ def generar_nota_remision(
         "tipoMoneda": "USD",
     }
 
-    numero_doc = documento_relacionado[0].get("numeroDocumento") if documento_relacionado else None
+    if documento_relacionado:
+        documento_relacionado = _normalizar_documento_relacionado(documento_relacionado)
+    numero_doc = (
+        documento_relacionado[0].get("numeroDocumento")
+        if documento_relacionado
+        else None
+    )
     items = _build_items(detalles, numero_doc)
 
     resumen = {
@@ -266,11 +299,15 @@ def generar_nota_remision(
         "extension": ext,
         "resumen": resumen,
         "apendice": None,
-        "documentoRelacionado": documento_relacionado,
     }
+    if documento_relacionado:
+        data["documentoRelacionado"] = documento_relacionado
 
     schema = catalogos.get_dte_schema("04")
-    return sanitize_dte_payload(data, schema)
+    data = sanitize_dte_payload(data, schema)
+    if data.get("documentoRelacionado") is None:
+        data.pop("documentoRelacionado", None)
+    return data
 
 
 def generar_nota_remision_desde_db(

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -269,6 +269,10 @@ def test_generar_nota_remision_sin_documento_relacionado(monkeypatch):
         "nombre": "Cliente",
         "tipoDocumento": "13",
         "numDocumento": "12345678-9",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "cliente@example.com",
         "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
     }
     detalles = [
@@ -281,16 +285,15 @@ def test_generar_nota_remision_sin_documento_relacionado(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
-    doc_rel = _doc_rel()
     data = generar_nota_remision(
         db,
         emisor=datos,
         receptor=receptor,
         detalles=detalles,
-        documento_relacionado=doc_rel,
         extension=extension,
     )
-    assert data["documentoRelacionado"][0]["numeroDocumento"] == doc_rel[0]["numeroDocumento"]
+    assert "documentoRelacionado" not in data
+    assert "numeroDocumento" not in data["cuerpoDocumento"][0]
     assert str(data["resumen"]["montoTotalOperacion"]) == "0.00"
 
 


### PR DESCRIPTION
## Summary
- make `documentoRelacionado` optional for notas de remisión
- handle generation errors when creating remisiones from products
- cover remisión without related document in tests

## Testing
- `pytest tests/test_nota_debito_remision.py::test_generar_nota_remision_sin_documento_relacionado -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfa9edf96c8323bed945874a76bc07