### PR TITLE
feat: add dui to business data

### DIFF
--- a/datos_negocio.json
+++ b/datos_negocio.json
@@ -13,6 +13,7 @@
   },
   "nit": "09061712791014",
   "nrc": "2301408",
+  "dui": "000868547",
   "nombre": "Karol Yamileth Cruz Escobar",
   "nombreComercial": "Farmacia Santa Catalina",
   "codActividad": "46484",

--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -13,11 +13,12 @@ from PyQt5.QtWidgets import (
     QFileDialog, QDialogButtonBox, QListView, QFrame
 )
 from PyQt5.QtCore import Qt, QDate, QUrl
-from PyQt5.QtGui import QColor, QDesktopServices
+from PyQt5.QtGui import QColor, QDesktopServices, QIntValidator
 import os
 import shutil
 
 from utils import jws
+from utils.sanitize import solo_digitos
 from svfe.config import CAT012_DEPARTAMENTOS, CAT013_MUNICIPIOS
 
 getcontext().prec = 4
@@ -2883,6 +2884,9 @@ class DatosNegocioDialog(QDialog):
         form = QFormLayout()
         self.nit = QLineEdit()
         self.nrc = QLineEdit()
+        self.dui = QLineEdit()
+        self.dui.setValidator(QIntValidator(0, 999999999))
+        self.dui.setMaxLength(9)
         self.nombre = QLineEdit()
         self.nombre_comercial = QLineEdit()
         self.cod_giro = QLineEdit()
@@ -2908,6 +2912,7 @@ class DatosNegocioDialog(QDialog):
         )
         form.addRow("NIT:", self.nit)
         form.addRow("NRC:", self.nrc)
+        form.addRow("DUI:", self.dui)
         form.addRow("Nombre:", self.nombre)
         form.addRow("Nombre comercial:", self.nombre_comercial)
         form.addRow("Código giro:", self.cod_giro)
@@ -2953,6 +2958,7 @@ class DatosNegocioDialog(QDialog):
         return {
             "nit": self.nit.text(),
             "nrc": self.nrc.text(),
+            "dui": solo_digitos(self.dui.text()),
             "nombre": self.nombre.text(),
             "nombreComercial": self.nombre_comercial.text(),
             "cod_giro": self.cod_giro.text(),
@@ -2971,6 +2977,7 @@ class DatosNegocioDialog(QDialog):
     def set_data(self, datos):
         self.nit.setText(datos.get("nit", ""))
         self.nrc.setText(datos.get("nrc", ""))
+        self.dui.setText(datos.get("dui", ""))
         self.nombre.setText(datos.get("nombre", ""))
         self.nombre_comercial.setText(datos.get("nombreComercial", ""))
         self.cod_giro.setText(datos.get("cod_giro") or datos.get("codActividad", ""))

--- a/dte.py
+++ b/dte.py
@@ -483,6 +483,13 @@ def _clean_nrc(nrc):
     return None
 
 
+def _clean_dui(dui):
+    if not dui:
+        return None
+    digits = "".join(c for c in str(dui) if c.isdigit())
+    return digits or None
+
+
 # --- Dirección --------------------------------------------------------------
 
 # Mapeos básicos de departamentos y municipios utilizados para normalizar la
@@ -2577,6 +2584,7 @@ def validate_dte_json(
     emisor = payload.get("emisor", {})
     emisor["nit"] = _clean_nit(emisor.get("nit") or negocio.get("nit"))
     emisor["nrc"] = _clean_nrc(emisor.get("nrc") or negocio.get("nrc"))
+    emisor["dui"] = _clean_dui(emisor.get("dui") or negocio.get("dui"))
     emisor.setdefault("nombre", negocio.get("nombre"))
     emisor.setdefault("nombreComercial", negocio.get("nombreComercial"))
     emisor.setdefault(

--- a/tests/test_dte_payload_cleanup.py
+++ b/tests/test_dte_payload_cleanup.py
@@ -52,12 +52,14 @@ def test_sanitize_dte_payload_adds_required_fields_and_cleans_docs(dte_metadata_
     payload.pop("extension", None)
     payload.pop("apendice", None)
     payload["emisor"]["nit"] = "0614-123456-001-1"
+    payload["emisor"]["dui"] = "01234567-8"
     payload["receptor"]["numDocumento"] = "01234567-8"
     clean = dte.sanitize_dte_payload(payload)
     assert clean["ventaTercero"] is None
     assert clean["extension"] is None
     assert clean["apendice"] is None
     assert clean["emisor"]["nit"] == "06141234560011"
+    assert clean["emisor"]["dui"] == "012345678"
     assert clean["receptor"]["numDocumento"] == "012345678"
 
 


### PR DESCRIPTION
## Summary
- allow entering business DUI with numeric validation
- include DUI in DTE payloads and sanitize
- document sample DUI field in datos_negocio.json

## Testing
- `pytest` *(fails: many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c076fa3488832392341cf1df70697b