### PR TITLE
Centraliza correlativo DTE y prueba secuencial

### DIFF
--- a/db.py
+++ b/db.py
@@ -1504,6 +1504,12 @@ class DB:
 
     def next_dte_correlativo(self, tipo: str, sucursal: str, punto: str) -> int:
         """Obtiene y actualiza el correlativo para la combinación dada."""
+        logger.debug(
+            "next_dte_correlativo llamado tipo=%s sucursal=%s punto=%s",
+            tipo,
+            sucursal,
+            punto,
+        )
         with self.lock:
             with self.conn:
                 self.cursor.execute(
@@ -1523,7 +1529,8 @@ class DB:
                         "INSERT INTO dte_correlativos (tipo, sucursal, punto, correlativo) VALUES (?, ?, ?, ?)",
                         (tipo, sucursal, punto, correlativo),
                     )
-            return correlativo
+        logger.debug("Correlativo asignado %s", correlativo)
+        return correlativo
 
     def add_dte_pendiente(self, venta_id, dte_json, modo):
         """Registra un DTE pendiente de transmisión a Hacienda."""

--- a/dte.py
+++ b/dte.py
@@ -1649,11 +1649,19 @@ def recalcular_totales(
 
 
 
-def generar_numero_control(db: DB, tipo: str, sucursal: str, punto: str) -> str:
-    """Genera un número de control secuencial."""
-    correlativo = db.next_dte_correlativo(tipo, sucursal, punto)
+def _format_numero_control(tipo: str, sucursal: str, punto: str, correlativo: int) -> str:
+    """Formatea el número de control usando ``correlativo``."""
     secuencia = str(correlativo).zfill(15)
     return f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
+
+
+def generar_numero_control(
+    db: DB, tipo: str, sucursal: str, punto: str
+) -> tuple[str, int]:
+    """Genera un número de control secuencial y devuelve también el correlativo."""
+    correlativo = db.next_dte_correlativo(tipo, sucursal, punto)
+    numero_control = _format_numero_control(tipo, sucursal, punto, correlativo)
+    return numero_control, correlativo
 
 
 def identificacion_a_xml(ident: dict) -> str:
@@ -1702,11 +1710,12 @@ def generar_cabecera_dte_data(
     sucursal = _norm3(sucursal)
     punto = _norm3(punto)
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control(db, tipo_dte, sucursal, punto)
+    numero_control, correlativo = generar_numero_control(db, tipo_dte, sucursal, punto)
     fecha_generacion = datetime.now().strftime("%d/%m/%Y, %I:%M %p")
     return {
         "codigo_generacion": codigo_generacion,
         "numero_control": numero_control,
+        "correlativo": correlativo,
         "sello_recepcion": None,
         "tipo_modelo": tipo_modelo,
         "tipo_operacion": tipo_operacion,
@@ -1778,7 +1787,7 @@ def generar_dte_json(
     pto = _norm3(cod_punto)
     # Generar identificadores con formatos oficiales
     codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control = generar_numero_control(db, tipo_dte, suc, pto)
+    numero_control, correlativo = generar_numero_control(db, tipo_dte, suc, pto)
 
 
     now = datetime.now(TZ_EL_SALVADOR)
@@ -2448,7 +2457,13 @@ def generar_dte_json(
         "extension": extension,
     }
 
-    validate_dte_json(result, db=db, precios_incluyen_iva=False)
+    try:
+        validate_dte_json(
+            result, db=db, precios_incluyen_iva=False, correlativo=correlativo
+        )
+    except TypeError:
+        # Compatibilidad con versiones parcheadas sin parámetro ``correlativo``
+        validate_dte_json(result, db=db, precios_incluyen_iva=False)
     result.pop("extra", None)
     return json.loads(stable_stringify(result), parse_float=Decimal)
 
@@ -2458,6 +2473,7 @@ def validate_dte_json(
     *,
     db: DB,
     precios_incluyen_iva: bool | None = None,
+    correlativo: int | None = None,
 ) -> None:
     """Basic validation and normalization for DTE payload antes de firmar."""
     # Normalización omitida para preservar códigos con ceros a la izquierda
@@ -2629,7 +2645,11 @@ def validate_dte_json(
     numero_control = ident.get("numeroControl")
     regex_nc = r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$"
     if not (isinstance(numero_control, str) and re.fullmatch(regex_nc, numero_control)):
-        ident["numeroControl"] = generar_numero_control(db, tipo, suc, pto)
+        if correlativo is None:
+            numero_control, correlativo = generar_numero_control(db, tipo, suc, pto)
+        else:
+            numero_control = _format_numero_control(tipo, suc, pto, correlativo)
+        ident["numeroControl"] = numero_control
     numero_control = ident.get("numeroControl")
     if not re.fullmatch(regex_nc, numero_control):
         raise ValueError("numeroControl inválido")

--- a/tests/test_dte_correlativo.py
+++ b/tests/test_dte_correlativo.py
@@ -1,0 +1,69 @@
+import json
+from db import DB
+import dte as dte_module
+
+
+def _setup_datos_negocio(tmp_path):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "codActividad": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "06", "municipio": "10", "complemento": "Calle 1"},
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: datos
+    import svfe.config as svfe_config
+
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+    return datos
+
+
+def _setup_db():
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 13)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "1234567",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01", 13, cliente_id=cid, extra={"precios_incluyen_iva": True}
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 13, vendedor_id=vid)
+    return db, venta_id
+
+
+def test_correlativo_incrementa_secuencialmente(tmp_path):
+    _setup_datos_negocio(tmp_path)
+    db, venta_id = _setup_db()
+
+    dte1 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
+    dte2 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
+    dte3 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
+
+    n1 = dte1["identificacion"]["numeroControl"]
+    n2 = dte2["identificacion"]["numeroControl"]
+    n3 = dte3["identificacion"]["numeroControl"]
+
+    assert n1.endswith("000000000000001")
+    assert n2.endswith("000000000000002")
+    assert n3.endswith("000000000000003")


### PR DESCRIPTION
## Summary
- centraliza la generación del número de control reutilizando el correlativo
- añade logging para depurar llamadas a `next_dte_correlativo`
- agrega prueba que verifica correlativos consecutivos

## Testing
- `pytest tests/test_dte_correlativo.py tests/test_dte_validation.py::test_numero_control_secuencial_por_combinacion -q`

------
https://chatgpt.com/codex/tasks/task_e_68c07de03e708323913c424c45cdd778