### PR TITLE
Add municipality-aware address formatting for PDFs

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -8,6 +8,7 @@ from reportlab.graphics.shapes import Drawing
 from reportlab.lib.units import mm
 
 from utils.pdf_utils import draw_wrapped_text
+import utils.catalogos as catalogos
 from dte import generar_cabecera_dte_data
 from db import DB
 from urllib.parse import urlencode
@@ -36,6 +37,19 @@ def build_qr_value(
     }
 
     return base_url + "?" + urlencode(params)
+
+
+def format_direccion(direccion):
+    """Format a ``direccion`` dict into "Municipio, complemento"."""
+    if not direccion:
+        return ""
+    departamento = str(direccion.get("departamento", "")).zfill(2)
+    municipio = str(direccion.get("municipio", "")).zfill(2)
+    complemento = direccion.get("complemento", "")
+    codigo_municipio = f"{departamento}{municipio}" if departamento or municipio else ""
+    nombre_municipio = catalogos.get_value("CAT-013", codigo_municipio) or ""
+    parts = [p for p in (nombre_municipio, complemento) if p]
+    return ", ".join(parts)
 
 
 def generar_factura_electronica_pdf(
@@ -229,7 +243,7 @@ def generar_factura_electronica_pdf(
         f"Nombre: {datos_negocio.get('nombre', '')}",
         f"NIT: {datos_negocio.get('nit', '')}  NRC: {datos_negocio.get('nrc', '')}",
         f"Giro: {datos_negocio.get('descActividad', '')}",
-        f"Dirección: {datos_negocio.get('direccion', {}).get('complemento', '')}",
+        f"Dirección: {format_direccion(datos_negocio.get('direccion'))}",
     ]
     if telefono:
         emisor_lines.append(f"Número Teléfono: {telefono}")
@@ -270,12 +284,15 @@ def generar_factura_electronica_pdf(
     text_y -= 12
     c.drawString(emisor_x + 5, text_y, f"Giro: {datos_negocio.get('descActividad', '')}")
     text_y -= 12
-    c.drawString(
+    direccion_emisor = format_direccion(datos_negocio.get("direccion"))
+    text_y = draw_wrapped_text(
+        c,
+        f"Dirección: {direccion_emisor}",
         emisor_x + 5,
         text_y,
-        f"Dirección: {datos_negocio.get('direccion', {}).get('complemento', '')}",
+        box_w - 10,
+        line_h,
     )
-    text_y -= 12
     if telefono:
         c.drawString(emisor_x + 5, text_y, f"Número Teléfono: {telefono}")
         text_y -= 12
@@ -315,7 +332,15 @@ def generar_factura_electronica_pdf(
         text_y -= line_h
 
     text_y -= line_h
-    c.drawString(left_x, text_y, f"Dirección: {cliente.get('direccion', '')}")
+    direccion = format_direccion(cliente.get("direccion"))
+    text_y = draw_wrapped_text(
+        c,
+        f"Dirección: {direccion}",
+        left_x,
+        text_y,
+        box_w - 10,
+        line_h,
+    )
 
     if venta.get('venta_a_cuenta_de') or venta.get('documento_venta_a_cuenta'):
         text_y -= line_h

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -3,6 +3,7 @@ import fitz
 from urllib.parse import urlparse, parse_qs
 import factura_sv
 from factura_sv import generar_factura_electronica_pdf, build_qr_value
+import utils.catalogos as catalogos
 
 
 def _sample_data(tipo):
@@ -183,4 +184,41 @@ def test_contingencia_draws_message(tmp_path):
     with fitz.open(out) as doc:
         text = ''.join(p.get_text() for p in doc)
     assert 'TRANSMISIÓN DIFERIDA' in text
+
+
+def test_direccion_includes_municipio(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        catalogos,
+        "get_value",
+        lambda cat, code, default=None: "La Libertad Centro" if code == "0524" else default,
+    )
+    venta, detalles = _sample_data('Crédito Fiscal')
+    direccion = {
+        'departamento': '05',
+        'municipio': '24',
+        'complemento': 'Colonia El Centro con una avenida realmente muy larga para pruebas',
+    }
+    cliente = {'nombre': 'Ana', 'direccion': direccion}
+    datos_negocio = {
+        'nombre': 'Neg',
+        'nit': '',
+        'nrc': '',
+        'descActividad': '',
+        'direccion': direccion,
+    }
+    out = tmp_path / 'dir.pdf'
+    generar_factura_electronica_pdf(
+        venta,
+        detalles,
+        cliente,
+        {},
+        'Crédito Fiscal',
+        archivo=str(out),
+        datos_negocio=datos_negocio,
+    )
+    with fitz.open(out) as doc:
+        lines = ''.join(p.get_text() for p in doc).splitlines()
+    idx = next(i for i, ln in enumerate(lines) if ln.startswith('Dirección:'))
+    assert 'La Libertad Centro' in lines[idx]
+    assert 'realmente muy larga para pruebas' in lines[idx + 1]
 

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -5,6 +5,7 @@ from dte import generar_dte_json
 from nota_credito_electronica import generar_nce_desde_dte, generar_nce_desde_nota
 import pytest
 from factura_sv import generar_nota_credito_pdf
+import utils.catalogos as catalogos
 
 
 def create_db():
@@ -224,3 +225,31 @@ def test_nota_credito_pdf(tmp_path):
     assert "Tipo Modelo:" in text
     assert "Tipo Operación:" in text
     assert "Fecha Generación:" in text
+
+
+def test_nota_credito_direccion(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        catalogos,
+        "get_value",
+        lambda cat, code, default=None: "La Libertad Centro" if code == "0524" else default,
+    )
+    venta, detalles = _sample_data()
+    direccion = {
+        'departamento': '05',
+        'municipio': '24',
+        'complemento': 'Colonia El Centro con una avenida realmente muy larga para pruebas',
+    }
+    out = tmp_path / 'nc_dir.pdf'
+    generar_nota_credito_pdf(
+        venta,
+        detalles,
+        {'direccion': direccion},
+        {},
+        archivo=str(out),
+        datos_negocio={'direccion': direccion},
+    )
+    with fitz.open(out) as doc:
+        lines = ''.join(p.get_text() for p in doc).splitlines()
+    idx = next(i for i, ln in enumerate(lines) if ln.startswith('Dirección:'))
+    assert 'La Libertad Centro' in lines[idx]
+    assert 'realmente muy larga para pruebas' in lines[idx + 1]


### PR DESCRIPTION
## Summary
- format direccion using catalogos for municipality name
- wrap emisor and receptor addresses in PDF output
- test that factura and nota credito PDFs show municipality and wrap within margins

## Testing
- `pytest tests/test_factura_pdf.py::test_direccion_includes_municipio tests/test_nota_credito.py::test_nota_credito_direccion -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c0815cdfac83238e0b4a80a5298391