### PR TITLE
Add default DTE transmission mode helper and contingency defaults

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -411,6 +411,23 @@ def _load_datos_negocio():
     return {}
 
 
+def get_default_modo_transmision() -> str:
+    """Return the default transmission mode.
+
+    This reads ``dte_api.modo_transmision`` from ``datos_negocio.json`` and
+    normalizes the value to ``"contingencia"`` or ``"normal"``. If the value
+    is missing or unrecognized, ``"normal"`` is returned.
+    """
+
+    datos = _load_datos_negocio()
+    modo = datos.get("dte_api", {}).get("modo_transmision", "")
+    if isinstance(modo, str):
+        modo_norm = modo.strip().lower()
+        if modo_norm.startswith("2") or "contingencia" in modo_norm:
+            return "contingencia"
+    return "normal"
+
+
 DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(0, 15)}
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
@@ -1732,7 +1749,7 @@ def generar_dte_json(
     tipo_dte: str = "01",
     *,
     ambiente: str = "00",
-    tipo_operacion: int = 1,
+    tipo_operacion: int | None = None,
     tipo_contingencia: int | None = None,
     motivo_contin: str | None = None,
     tipo_modelo: int | None = None,
@@ -1747,6 +1764,10 @@ def generar_dte_json(
     if not row:
         raise ValueError("Venta no encontrada")
     venta = dict(row)
+
+    if tipo_operacion is None:
+        modo = get_default_modo_transmision()
+        tipo_operacion = 2 if modo == "contingencia" else 1
 
     if ambiente not in ("00", "01"):
         ambiente_cfg = str(ambiente).lower()
@@ -1807,6 +1828,13 @@ def generar_dte_json(
     motivo_contin = kwargs.get(
         "motivoContin", kwargs.get("motivo_contin", motivo_contin)
     )
+
+    if tipo_operacion == 2:
+        cfg = datos.get("dte_api", {})
+        if tipo_contingencia in (None, ""):
+            tipo_contingencia = cfg.get("tipo_contingencia", tipo_contingencia)
+        if motivo_contin in (None, ""):
+            motivo_contin = cfg.get("motivo_contin", motivo_contin)
 
     # Normalización de tipos
     try:

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -98,11 +98,22 @@ def generate_invoice_pdf(manager, venta_id):
     if not venta_data.get("documento_venta_a_cuenta"):
         venta_data["documento_venta_a_cuenta"] = extra.get("documento_venta_a_cuenta", "")
     sello_recepcion = venta_data.get("sello_recepcion") or extra.get("selloRecibido", "")
-    tipo_operacion = venta_data.get("tipo_operacion") or extra.get("tipoOperacion") or 1
+    default_tipo = 2 if dte.get_default_modo_transmision() == "contingencia" else 1
+    tipo_operacion = (
+        venta_data.get("tipo_operacion")
+        or extra.get("tipoOperacion")
+        or default_tipo
+    )
     tipo_contingencia = (
         venta_data.get("tipo_contingencia") or extra.get("tipoContingencia")
     )
     motivo_contin = venta_data.get("motivo_contin") or extra.get("motivoContin")
+    if tipo_operacion == 2:
+        cfg = dte._load_datos_negocio().get("dte_api", {})
+        if tipo_contingencia is None:
+            tipo_contingencia = cfg.get("tipo_contingencia")
+        if motivo_contin is None:
+            motivo_contin = cfg.get("motivo_contin")
     ambiente = venta_data.get("ambiente") or extra.get("ambiente") or "00"
     if ambiente not in ("00", "01"):
         amb_cfg = str(ambiente).lower()
@@ -128,6 +139,8 @@ def generate_invoice_pdf(manager, venta_id):
             tipo_contingencia=tipo_contingencia,
             motivo_contin=motivo_contin,
         )
+    except AttributeError:
+        json_data = build_invoice_json(venta_data, cliente or {}, detalles)
     except ValueError:
         logger.exception("Error al generar el DTE real")
         raise


### PR DESCRIPTION
## Summary
- add `get_default_modo_transmision` helper to read default transmission mode
- auto-select `tipo_operacion` based on default mode and propagate contingency settings
- ensure invoice generation falls back gracefully when DTE build fails

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_transmission_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c087d7adf08323acf02c238f246dee