### PR TITLE
Ensure fixed-size PDF previews

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QPlainTextEdit,
 )
-from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent
+from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent, QSize
 from PyQt5.QtGui import QPixmap, QDesktopServices
 import os
 import re
@@ -491,6 +491,8 @@ class FacturacionTab(QWidget):
         self.preview_label = QLabel("Previsualización del PDF")
         self.preview_label.setAlignment(Qt.AlignCenter)
         self.preview_label.setStyleSheet("background:#DDD; padding:20px;")
+        self.preview_label.setFixedSize(QSize(600, 800))
+        self.preview_label.setScaledContents(False)
         preview_layout.addWidget(self.preview_label)
         main_layout.addLayout(preview_layout, 2)
 
@@ -1665,8 +1667,8 @@ class FacturacionTab(QWidget):
             if pixmap.isNull():
                 raise RuntimeError("failed to load image")
             scaled = pixmap.scaled(
-                int(self.preview_label.width() * 0.9),
-                int(self.preview_label.height() * 0.9),
+                600,
+                800,
                 Qt.KeepAspectRatio,
                 Qt.SmoothTransformation,
             )

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QComboBox,
 )
-from PyQt5.QtCore import Qt, QDate, QUrl
+from PyQt5.QtCore import Qt, QDate, QUrl, QSize
 from PyQt5.QtGui import QDesktopServices, QPixmap
 from datetime import datetime, date, timedelta
 from factura_sv import generar_factura_electronica_pdf
@@ -124,6 +124,7 @@ class SalesTab(QWidget):
         self.preview_label.setAlignment(Qt.AlignCenter)
         self.preview_label.setStyleSheet("background:#DDD; padding:20px;")
         # Avoid stretching the image so the aspect ratio of the PDF is preserved
+        self.preview_label.setFixedSize(QSize(600, 800))
         self.preview_label.setScaledContents(False)
         preview_layout.addWidget(self.preview_label)
 
@@ -511,10 +512,10 @@ class SalesTab(QWidget):
             pixmap = QPixmap(png_path)
             if pixmap.isNull():
                 raise RuntimeError("failed to load image")
-            # Scale down a bit but keep the PDF aspect ratio intact
+            # Scale to fixed dimensions while preserving the PDF aspect ratio
             scaled = pixmap.scaled(
-                int(self.preview_label.width() * 0.9),
-                int(self.preview_label.height() * 0.9),
+                600,
+                800,
                 Qt.KeepAspectRatio,
                 Qt.SmoothTransformation,
             )


### PR DESCRIPTION
## Summary
- Set a fixed 600x800 size for PDF preview labels and disable automatic scaling
- Use constant dimensions when scaling preview pixmaps for consistent display

## Testing
- `pytest` *(fails: multiple tests failing during run)*

------
https://chatgpt.com/codex/tasks/task_e_68c0816e249c8323a3007b70a5d753c7