### PR TITLE
Default DTE transmission mode from configuration

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4011,13 +4011,16 @@ def _post_dte(
 
 
 def transmitir_dte(
-    db: DB, venta_id: int, modo: str = "normal", tipo_dte: str = "01"
+    db: DB, venta_id: int, modo: str | None = None, tipo_dte: str = "01"
 ) -> dict:
     """Genera y transmite un DTE reutilizando ``_enviar_documento``.
 
     ``tipo_dte`` permite especificar el código del documento a transmitir,
     usando ``"01"`` para facturas y ``"03"`` para tickets.
     """
+
+    if modo is None:
+        modo = get_default_modo_transmision()
 
     # For contingency mode, simply register the pending state
     if modo == "contingencia":
@@ -4282,8 +4285,11 @@ def _enviar_documento(
     return res
 
 
-def enviar_factura(db: DB, venta_id: int, modo: str = "normal") -> dict:
+def enviar_factura(db: DB, venta_id: int, modo: str | None = None) -> dict:
     """Genera y transmite una factura electrónica."""
+    if modo is None:
+        modo = get_default_modo_transmision()
+
     data = generar_dte_json(db, venta_id)
     data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema("01")
@@ -4301,8 +4307,11 @@ def enviar_factura(db: DB, venta_id: int, modo: str = "normal") -> dict:
     return resp
 
 
-def enviar_nota_credito(db: DB, nota_id: int, modo: str = "normal") -> dict:
+def enviar_nota_credito(db: DB, nota_id: int, modo: str | None = None) -> dict:
     """Genera y transmite una nota de crédito."""
+    if modo is None:
+        modo = get_default_modo_transmision()
+
     data = generar_nota_credito_json(db, nota_id)
     data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema("05")
@@ -4341,8 +4350,11 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
 
 
-def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
+def enviar_nota_debito(db: DB, nota_id: int, modo: str | None = None) -> dict:
     """Genera y transmite una nota de débito."""
+    if modo is None:
+        modo = get_default_modo_transmision()
+
     data = generar_nota_debito_json(db, nota_id)
     data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema("06")
@@ -4381,8 +4393,11 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str = "normal") -> dict:
     return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
 
 
-def enviar_nota_remision(db: DB, nota_id: int, modo: str = "normal") -> dict:
+def enviar_nota_remision(db: DB, nota_id: int, modo: str | None = None) -> dict:
     """Genera y transmite una nota de remisión."""
+    if modo is None:
+        modo = get_default_modo_transmision()
+
     from nota_remision import generar_nota_remision_desde_db
 
     data = generar_nota_remision_desde_db(db, nota_id)

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -30,6 +30,26 @@ def test_transmitir_dte_contingencia(tmp_path):
     assert row["estado"] == "Pendiente"
 
 
+def test_transmitir_dte_default_contingencia(monkeypatch):
+    db = DB(":memory:")
+    venta = create_sale(db)
+
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(
+        "dte.requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
+    )
+
+    res = transmitir_dte(db, venta)
+    assert res["estado"] == "Pendiente"
+    row = db.cursor.execute(
+        "SELECT estado, modo FROM dte_envios WHERE venta_id=?", (venta,)
+    ).fetchone()
+    assert row["estado"] == "Pendiente"
+    assert row["modo"] == "contingencia"
+
+
 def test_transmitir_dte_normal(monkeypatch, tmp_path):
     ambiente = "pruebas"
     db = DB(":memory:")

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -8,6 +8,8 @@ from db import DB
 from dte import (
     enviar_factura,
     enviar_nota_credito,
+    enviar_nota_debito,
+    enviar_nota_remision,
     enviar_evento_contingencia,
     enviar_evento_anulacion,
     _post_dte,
@@ -554,4 +556,129 @@ def test_enviar_evento_anulacion(monkeypatch, tmp_path):
     assert headers["Content-Type"] == "application/json"
     assert headers["Accept"] == "application/json"
     assert headers["User-Agent"] == "Vertex-DTE/1.0"
+
+
+def test_enviar_factura_default_contingencia(monkeypatch):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr("dte.generar_dte_json", lambda db_obj, vid: {})
+    monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
+    monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(
+        "dte.requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
+    )
+
+    res = enviar_factura(db, venta_id)
+    assert res["estado"] == "Pendiente"
+    row = db.cursor.execute(
+        "SELECT estado, modo FROM dte_envios WHERE venta_id=?", (venta_id,)
+    ).fetchone()
+    assert row["estado"] == "Pendiente"
+    assert row["modo"] == "contingencia"
+
+
+def test_enviar_nota_credito_default_contingencia(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    nota_id = db.add_nota(venta_id, "credito", "2024-01-02", 10, "motivo")
+
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(
+        "dte.generar_nota_credito_json",
+        lambda db_obj, nid: {
+            "identificacion": {"fecEmi": "2024-01-02", "numeroControl": "1"},
+            "receptor": {"nombre": "C"},
+            "resumen": {"totalLetras": "X"},
+        },
+    )
+    monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
+    monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(
+        "utils.docs.get_dte_document_paths",
+        lambda *a, **k: (tmp_path / "x.pdf", tmp_path / "x.json"),
+    )
+    monkeypatch.setattr("utils.jws.sign_json", lambda data: "TOKEN")
+    monkeypatch.setattr("utils.stable_json.save_file", lambda *a, **k: None)
+    monkeypatch.setattr("utils.stable_json.stable_stringify", lambda d, indent=2: "{}")
+    monkeypatch.setattr(
+        "dte.requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
+    )
+
+    res = enviar_nota_credito(db, nota_id)
+    assert res["estado"] == "Pendiente"
+    row = db.cursor.execute(
+        "SELECT estado, modo FROM dte_envios WHERE venta_id=?", (nota_id,)
+    ).fetchone()
+    assert row["estado"] == "Pendiente"
+    assert row["modo"] == "contingencia"
+
+
+def test_enviar_nota_debito_default_contingencia(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    nota_id = db.add_nota(venta_id, "debito", "2024-01-02", 10, "motivo")
+
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(
+        "dte.generar_nota_debito_json",
+        lambda db_obj, nid: {
+            "identificacion": {"fecEmi": "2024-01-02", "numeroControl": "1"},
+            "receptor": {"nombre": "C"},
+            "resumen": {"totalLetras": "X"},
+        },
+    )
+    monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
+    monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(
+        "utils.docs.get_dte_document_paths",
+        lambda *a, **k: (tmp_path / "x.pdf", tmp_path / "x.json"),
+    )
+    monkeypatch.setattr("utils.jws.sign_json", lambda data: "TOKEN")
+    monkeypatch.setattr("utils.stable_json.save_file", lambda *a, **k: None)
+    monkeypatch.setattr("utils.stable_json.stable_stringify", lambda d, indent=2: "{}")
+    monkeypatch.setattr(
+        "dte.requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
+    )
+
+    res = enviar_nota_debito(db, nota_id)
+    assert res["estado"] == "Pendiente"
+    row = db.cursor.execute(
+        "SELECT estado, modo FROM dte_envios WHERE venta_id=?", (nota_id,)
+    ).fetchone()
+    assert row["estado"] == "Pendiente"
+    assert row["modo"] == "contingencia"
+
+
+def test_enviar_nota_remision_default_contingencia(monkeypatch):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    nota_id = db.add_nota(venta_id, "remision", "2024-01-02", 10, "motivo")
+
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(
+        "nota_remision.generar_nota_remision_desde_db", lambda db_obj, nid: {}
+    )
+    monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
+    monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(
+        "dte.requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
+    )
+
+    res = enviar_nota_remision(db, nota_id)
+    assert res["estado"] == "Pendiente"
+    row = db.cursor.execute(
+        "SELECT estado, modo FROM dte_envios WHERE venta_id=?", (nota_id,)
+    ).fetchone()
+    assert row["estado"] == "Pendiente"
+    assert row["modo"] == "contingencia"
 


### PR DESCRIPTION
## Summary
- Use configuration-derived default transmission mode when callers omit it
- Add tests to ensure contingency mode defers transmission and marks DTEs as pending

## Testing
- `pytest tests/test_dte_transmision.py::test_transmitir_dte_default_contingencia tests/test_envio_documentos.py::test_enviar_factura_default_contingencia tests/test_envio_documentos.py::test_enviar_nota_credito_default_contingencia tests/test_envio_documentos.py::test_enviar_nota_debito_default_contingencia tests/test_envio_documentos.py::test_enviar_nota_remision_default_contingencia`

------
https://chatgpt.com/codex/tasks/task_e_68c089f8a1e083239cacd31ba507f674