### PR TITLE
Store tickets as pending in contingency mode

### DIFF
--- a/tests/test_transmission_mode.py
+++ b/tests/test_transmission_mode.py
@@ -1,6 +1,8 @@
 import pytest
+from pathlib import Path
+import dte
 from utils.docs import build_invoice_json
-from utils.doc_generation import generate_invoice_pdf
+from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
 
 class FakeDB:
     def __init__(self):
@@ -60,4 +62,28 @@ def test_generate_invoice_registers_pending(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
     generate_invoice_pdf(man, 1)
     assert db.pending
+
+
+def test_generate_ticket_registers_pending(tmp_path, monkeypatch):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 5}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 5, "descripcion": "P"}]
+    man = Manager(db)
+    pdf = tmp_path / "ticket.pdf"
+    js = tmp_path / "ticket.json"
+
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf), str(js)
+
+    def fake_gen(venta, detalles, fname, dte_data=None):
+        Path(fname).write_text("PDF")
+
+    monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_ticket_personalizado", fake_gen)
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+
+    generate_ticket_pdf(man, 1)
+    assert db.pending == [(1, "2")]
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -215,6 +215,9 @@ def generate_ticket_pdf(manager, venta_id):
         except Exception:
             extra = {}
 
+    default_tipo = 2 if dte.get_default_modo_transmision() == "contingencia" else 1
+    tipo_operacion = extra.get("tipoOperacion") or default_tipo
+
     cliente = None
     if venta.get("cliente_id"):
         cliente = next((c for c in manager._clientes if c["id"] == venta["cliente_id"]), None)
@@ -226,14 +229,20 @@ def generate_ticket_pdf(manager, venta_id):
 
     generar_ticket_personalizado(venta, detalles, filename, dte_data=extra)
     if hasattr(manager.db, "cursor"):
-        ticket_json = generar_ticket_json(manager.db, venta_id)
+        ticket_json = generar_ticket_json(
+            manager.db, venta_id, tipo_operacion=tipo_operacion
+        )
     else:
         venta_data = dict(venta)
+        if tipo_operacion == 2:
+            venta_data["tipo_operacion"] = 2
         if not venta_data.get("codigo_generacion"):
             venta_data["codigo_generacion"] = uuid.uuid4().hex
         if not venta_data.get("numero_control"):
             venta_data["numero_control"] = uuid.uuid4().hex[:8].upper()
         ticket_json = build_invoice_json(venta_data, cliente or {}, detalles)
+    if tipo_operacion == 2:
+        manager.db.add_dte_pendiente(venta_id, ticket_json, "2")
     try:
         resumen = ticket_json.get("resumen", {})
         condicion = normalize_condicion_operacion(


### PR DESCRIPTION
## Summary
- detect default transmission mode in `generate_ticket_pdf`
- queue tickets for later transmission when in contingency mode
- test pending ticket registration when operating in contingency mode

## Testing
- `pytest` *(fails: 46 errors during collection)*
- `pytest tests/test_transmission_mode.py::test_generate_ticket_registers_pending -q`


------
https://chatgpt.com/codex/tasks/task_e_68c090d7334c83239cd01b95fe82e979