### PR TITLE
Persist JWS for contingency DTE transmission

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4022,10 +4022,6 @@ def transmitir_dte(
     if modo is None:
         modo = get_default_modo_transmision()
 
-    # For contingency mode, simply register the pending state
-    if modo == "contingencia":
-        return _enviar_documento(db, venta_id, {}, modo)
-
     if tipo_dte == "03":
         data = generar_ticket_json(db, venta_id)
     else:
@@ -4196,9 +4192,6 @@ def _enviar_documento(
     Si ``jws_token`` se proporciona, se reutiliza en lugar de firmar nuevamente.
     """
     config = _load_dte_api_config()
-    if modo == "contingencia":
-        db.registrar_envio_dte(doc_id, modo, "Pendiente", "")
-        return {"estado": "Pendiente"}
 
     if not data.get("resumen", {}).get("totalLetras"):
         raise ValueError("El total en letras es obligatorio")
@@ -4237,6 +4230,20 @@ def _enviar_documento(
         raise ValueError(f"DTE inválido: {exc}") from exc
 
     signed = jws_token or jws.sign_json(data)
+
+    if modo == "contingencia":
+        try:
+            _save_signed_dte(data, signed)
+        except Exception:
+            pass
+        db.registrar_envio_dte(
+            doc_id,
+            modo,
+            "Pendiente",
+            "",
+            json.dumps({"jws": signed}, ensure_ascii=False),
+        )
+        return {"estado": "Pendiente"}
 
     # Verify that metadata matches the signed payload and update it
     payload = _decode_jws_payload(signed)

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -19,9 +19,17 @@ def create_sale(db):
     return venta_id
 
 
-def test_transmitir_dte_contingencia(tmp_path):
+def test_transmitir_dte_contingencia(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
+    monkeypatch.setattr(dte, "generar_dte_json", lambda *a, **k: {"resumen": {"totalLetras": "X"}})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(dte, "_save_signed_dte", lambda *a, **k: None)
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     res = transmitir_dte(db, venta, modo="contingencia")
     assert res["estado"] == "Pendiente"
     row = db.cursor.execute(
@@ -35,11 +43,18 @@ def test_transmitir_dte_default_contingencia(monkeypatch):
     venta = create_sale(db)
 
     monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(dte, "generar_dte_json", lambda *a, **k: {"resumen": {"totalLetras": "X"}})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(dte, "_save_signed_dte", lambda *a, **k: None)
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
     monkeypatch.setattr(
         "dte.requests.post",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
     )
+    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
 
     res = transmitir_dte(db, venta)
     assert res["estado"] == "Pendiente"

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -564,9 +564,16 @@ def test_enviar_factura_default_contingencia(monkeypatch):
 
     monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
-    monkeypatch.setattr("dte.generar_dte_json", lambda db_obj, vid: {})
+    monkeypatch.setattr(
+        "dte.generar_dte_json",
+        lambda db_obj, vid: {"resumen": {"totalLetras": "X"}},
+    )
     monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
     monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr("dte._save_signed_dte", lambda *a, **k: None)
+    monkeypatch.setattr("utils.jws.sign_json", lambda data: "TOKEN")
     monkeypatch.setattr(
         "dte.requests.post",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
@@ -598,6 +605,9 @@ def test_enviar_nota_credito_default_contingencia(monkeypatch, tmp_path):
     )
     monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
     monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr("dte._save_signed_dte", lambda *a, **k: None)
     monkeypatch.setattr(
         "utils.docs.get_dte_document_paths",
         lambda *a, **k: (tmp_path / "x.pdf", tmp_path / "x.json"),
@@ -636,6 +646,8 @@ def test_enviar_nota_debito_default_contingencia(monkeypatch, tmp_path):
     )
     monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
     monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
     monkeypatch.setattr(
         "utils.docs.get_dte_document_paths",
         lambda *a, **k: (tmp_path / "x.pdf", tmp_path / "x.json"),
@@ -665,10 +677,15 @@ def test_enviar_nota_remision_default_contingencia(monkeypatch):
     monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
     monkeypatch.setattr(
-        "nota_remision.generar_nota_remision_desde_db", lambda db_obj, nid: {}
+        "nota_remision.generar_nota_remision_desde_db",
+        lambda db_obj, nid: {"resumen": {"totalLetras": "X"}},
     )
     monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
     monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr("dte._save_signed_dte", lambda *a, **k: None)
+    monkeypatch.setattr("utils.jws.sign_json", lambda data: "TOKEN")
     monkeypatch.setattr(
         "dte.requests.post",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),


### PR DESCRIPTION
## Summary
- ensure `transmitir_dte` generates and signs DTEs even in contingency mode
- persist signed JWS and register `Pendiente` state when `_enviar_documento` runs in contingency
- adjust tests for new contingency signing behaviour

## Testing
- `pytest tests/test_dte_transmision.py::test_transmitir_dte_contingencia tests/test_dte_transmision.py::test_transmitir_dte_default_contingencia tests/test_envio_documentos.py::test_enviar_factura_default_contingencia tests/test_envio_documentos.py::test_enviar_nota_credito_default_contingencia tests/test_envio_documentos.py::test_enviar_nota_debito_default_contingencia tests/test_envio_documentos.py::test_enviar_nota_remision_default_contingencia`
- `pytest` *(fails: Interrupted: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c097ac111083238af62b24679c9905