### PR TITLE
Allow motivo_contin up to 500 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ La función `transmitir_dte(db, venta_id)` utilizará la URL resultante para
 enviar el DTE inmediatamente después de firmarlo en modo normal, o registrará
 un evento pendiente en modo de contingencia.
 
+Cuando se use el modo de contingencia con `tipoContingencia` igual a `5`, el
+campo `motivo_contin` permite describir la causa de la contingencia con una
+longitud de entre 5 y 500 caracteres.
+
 ### Condición de operación
 
 El campo `resumen.condicionOperacion` se normaliza siguiendo el catálogo

--- a/dte.py
+++ b/dte.py
@@ -1860,8 +1860,10 @@ def generar_dte_json(
         if tipo_contingencia not in catalogos.CONTINGENCIA:
             raise ValueError("tipoContingencia debe estar entre 1 y 5")
         if tipo_contingencia == 5:
-            if not (motivo_contin and 5 <= len(motivo_contin) <= 150):
-                raise ValueError("motivoContin requerido cuando tipoContingencia=5")
+            if not (motivo_contin and 5 <= len(motivo_contin) <= 500):
+                raise ValueError(
+                    "motivoContin debe tener entre 5 y 500 caracteres cuando tipoContingencia=5"
+                )
         else:
             motivo_contin = None
     else:
@@ -2579,8 +2581,10 @@ def validate_dte_json(
             raise ValueError("tipoContingencia debe estar entre 1 y 5")
         ident["tipoContingencia"] = tipo_cont
         if tipo_cont == 5:
-            if not (motivo and 5 <= len(motivo) <= 150):
-                raise ValueError("motivoContin requerido cuando tipoContingencia=5")
+            if not (motivo and 5 <= len(motivo) <= 500):
+                raise ValueError(
+                    "motivoContin debe tener entre 5 y 500 caracteres cuando tipoContingencia=5"
+                )
             ident["motivoContin"] = motivo
         else:
             ident["motivoContin"] = None

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -428,6 +428,18 @@ def test_ident_contingencia_rechazos(dte_metadata_factory, db_fixture):
         validate_dte_json(dte, db=db_fixture)
 
 
+def test_motivo_contin_longitud(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoOperacion"] = 2
+    dte["identificacion"]["tipoContingencia"] = 5
+    dte["identificacion"]["motivoContin"] = "x" * 500
+    validate_dte_json(dte, db=db_fixture)
+
+    dte["identificacion"]["motivoContin"] = "y" * 501
+    with pytest.raises(ValueError):
+        validate_dte_json(dte, db=db_fixture)
+
+
 def test_fecha_hora_format(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["fecEmi"] = "01-01-2024"


### PR DESCRIPTION
## Summary
- expand motivo_contin validation to accept up to 500 characters
- document new limit and add test coverage

## Testing
- `pytest tests/test_dte_validation.py tests/test_generar_dte_json.py -q` (fails: NRC requerido and other validation errors)
- `pytest tests/test_dte_validation.py::test_motivo_contin_longitud -q`


------
https://chatgpt.com/codex/tasks/task_e_68c097ac89688323b8a9489a80b05b08