### PR TITLE
Add metadata fields to DTE send logs

### DIFF
--- a/db.py
+++ b/db.py
@@ -510,6 +510,10 @@ class DB:
                 modo TEXT,
                 estado TEXT,
                 sello TEXT,
+                ambiente TEXT,
+                version TEXT,
+                tipo_dte TEXT,
+                codigo_generacion TEXT,
                 fecha_hora TEXT,
                 respuesta TEXT,
 
@@ -2030,22 +2034,55 @@ class DB:
                     pass
         return rows
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
+    def registrar_envio_dte(
+        self,
+        venta_id,
+        modo,
+        estado,
+        sello,
+        respuesta_json="",
+        ambiente=None,
+        version=None,
+        tipo_dte=None,
+        codigo_generacion=None,
+    ):
         """Guarda un registro del estado de transmisión de un DTE."""
         self.ensure_column("dte_envios", "respuesta", "TEXT")
+        self.ensure_column("dte_envios", "ambiente", "TEXT")
+        self.ensure_column("dte_envios", "version", "TEXT")
+        self.ensure_column("dte_envios", "tipo_dte", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         fecha_hora = datetime.now().isoformat()
         self.cursor.execute(
             """
-            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO dte_envios (
+                venta_id, modo, estado, sello, ambiente, version, tipo_dte,
+                codigo_generacion, fecha_hora, respuesta
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (venta_id, modo, estado, sello, fecha_hora, respuesta_json),
+            (
+                venta_id,
+                modo,
+                estado,
+                sello,
+                ambiente,
+                version,
+                tipo_dte,
+                codigo_generacion,
+                fecha_hora,
+                respuesta_json,
+            ),
         )
         self.conn.commit()
 
     def consultar_envio_dte(self, venta_id):
         """Devuelve el JSON almacenado en ``dte_envios.respuesta``."""
         self.ensure_column("dte_envios", "respuesta", "TEXT")
+        self.ensure_column("dte_envios", "ambiente", "TEXT")
+        self.ensure_column("dte_envios", "version", "TEXT")
+        self.ensure_column("dte_envios", "tipo_dte", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         row = self.cursor.execute(
             "SELECT respuesta FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
             (venta_id,),
@@ -2060,6 +2097,10 @@ class DB:
     def listar_dtes(self, fecha_inicio=None, fecha_fin=None, estado=None):
         """Lista registros de ``dte_envios`` filtrando por fecha y estado."""
         self.ensure_column("dte_envios", "respuesta", "TEXT")
+        self.ensure_column("dte_envios", "ambiente", "TEXT")
+        self.ensure_column("dte_envios", "version", "TEXT")
+        self.ensure_column("dte_envios", "tipo_dte", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         query = "SELECT * FROM dte_envios WHERE 1=1"
         params = []
         if fecha_inicio:

--- a/dte.py
+++ b/dte.py
@@ -4123,7 +4123,17 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(None, "orphan", "Rechazado", "")
+        db.registrar_envio_dte(
+            None,
+            "orphan",
+            "Rechazado",
+            "",
+            "",
+            meta.get("ambiente"),
+            meta.get("version"),
+            meta.get("tipoDte"),
+            meta.get("codigoGeneracion"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -4132,6 +4142,10 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         estado,
         sello,
         json.dumps(respuesta, ensure_ascii=False),
+        meta.get("ambiente"),
+        meta.get("version"),
+        meta.get("tipoDte"),
+        meta.get("codigoGeneracion"),
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)
@@ -4197,7 +4211,7 @@ def _enviar_documento(
     """
     config = _load_dte_api_config()
     if modo == "contingencia":
-        db.registrar_envio_dte(doc_id, modo, "Pendiente", "")
+        db.registrar_envio_dte(doc_id, modo, "Pendiente", "", "")
         return {"estado": "Pendiente"}
 
     if not data.get("resumen", {}).get("totalLetras"):
@@ -4265,7 +4279,17 @@ def _enviar_documento(
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(doc_id, modo, "Rechazado", "")
+        db.registrar_envio_dte(
+            doc_id,
+            modo,
+            "Rechazado",
+            "",
+            "",
+            meta.get("ambiente"),
+            meta.get("version"),
+            meta.get("tipoDte"),
+            meta.get("codigoGeneracion"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -4274,6 +4298,10 @@ def _enviar_documento(
         estado,
         sello,
         json.dumps(respuesta, ensure_ascii=False),
+        meta.get("ambiente"),
+        meta.get("version"),
+        meta.get("tipoDte"),
+        meta.get("codigoGeneracion"),
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)
@@ -4420,6 +4448,13 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     signed = jws.sign_json(data)
     token = auth.get_token()
 
+    meta = {
+        "ambiente": data.get("ambiente"),
+        "version": data.get("version"),
+        "tipoDte": data.get("tipoDte") or data.get("tipoDocumento"),
+        "codigoGeneracion": data.get("codigoGeneracion") or data.get("codigoGeneracionR"),
+    }
+
     try:
         respuesta = _post_dte(url, token, signed, data)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
@@ -4431,7 +4466,17 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(evento_id, "evento", "Rechazado", "")
+        db.registrar_envio_dte(
+            evento_id,
+            "evento",
+            "Rechazado",
+            "",
+            "",
+            meta.get("ambiente"),
+            meta.get("version"),
+            meta.get("tipoDte"),
+            meta.get("codigoGeneracion"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -4440,6 +4485,10 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
         estado,
         sello,
         json.dumps(respuesta, ensure_ascii=False),
+        meta.get("ambiente"),
+        meta.get("version"),
+        meta.get("tipoDte"),
+        meta.get("codigoGeneracion"),
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -684,12 +684,21 @@ class InventoryManager:
 
             for de in data.get("dte_envios", []):
                 self.db.cursor.execute(
-                    "INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?)",
+                    """
+                    INSERT INTO dte_envios (
+                        venta_id, modo, estado, sello, ambiente, version, tipo_dte,
+                        codigo_generacion, fecha_hora, respuesta
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
                     (
                         venta_id_map.get(de.get("venta_id")),
                         de.get("modo"),
                         de.get("estado"),
                         de.get("sello"),
+                        de.get("ambiente"),
+                        de.get("version"),
+                        de.get("tipo_dte"),
+                        de.get("codigo_generacion"),
                         de.get("fecha_hora"),
                         de.get("respuesta"),
                     ),

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -53,7 +53,18 @@ class FakeDB:
     def get_factura_pdf(self, vid):
         return self.factura_path
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
+    def registrar_envio_dte(
+        self,
+        venta_id,
+        modo,
+        estado,
+        sello,
+        respuesta_json="",
+        ambiente=None,
+        version=None,
+        tipo_dte=None,
+        codigo_generacion=None,
+    ):
         self.envios.append(
             {"venta_id": venta_id, "modo": modo, "estado": estado, "sello": sello}
         )

--- a/tests/test_export_import_transmission_records.py
+++ b/tests/test_export_import_transmission_records.py
@@ -51,8 +51,24 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
         "2024-01-01", 10, cliente_id=cliente_id, vendedor_id=vend, Distribuidor_id=dist
     )
     db.cursor.execute(
-        "INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?)",
-        (venta_id, "envio", "PROCESADO", "abc", "2024-01-01T00:00:00", "ok"),
+        """
+        INSERT INTO dte_envios (
+            venta_id, modo, estado, sello, ambiente, version, tipo_dte,
+            codigo_generacion, fecha_hora, respuesta
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            venta_id,
+            "envio",
+            "PROCESADO",
+            "abc",
+            "00",
+            "1",
+            "01",
+            "ABC",
+            "2024-01-01T00:00:00",
+            "ok",
+        ),
     )
     db.cursor.execute(
         "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?, ?, ?, ?, ?, ?)",
@@ -76,15 +92,29 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
 
     cur = man2.db.cursor
     row = cur.execute(
-        "SELECT modo, estado, sello, fecha_hora, respuesta FROM dte_envios"
+        "SELECT modo, estado, sello, ambiente, version, tipo_dte, codigo_generacion, fecha_hora, respuesta FROM dte_envios"
     ).fetchone()
     assert (
         row["modo"],
         row["estado"],
         row["sello"],
+        row["ambiente"],
+        row["version"],
+        row["tipo_dte"],
+        row["codigo_generacion"],
         row["fecha_hora"],
         row["respuesta"],
-    ) == ("envio", "PROCESADO", "abc", "2024-01-01T00:00:00", "ok")
+    ) == (
+        "envio",
+        "PROCESADO",
+        "abc",
+        "00",
+        "1",
+        "01",
+        "ABC",
+        "2024-01-01T00:00:00",
+        "ok",
+    )
 
     row = cur.execute(
         "SELECT tipo, fecha, monto, motivo, detalles FROM notas"
@@ -113,3 +143,4 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
         "/tmp/ticket.pdf",
         "2024-01-01",
     )
+


### PR DESCRIPTION
## Summary
- track `ambiente`, `version`, `tipo_dte`, and `codigo_generacion` in `dte_envios`
- pass new metadata from DTE transmission helpers
- import/export transmission records with new columns

## Testing
- `pytest tests/test_export_import_transmission_records.py -q`
- `pytest tests/test_contingencia_api.py -q`
- `pytest tests/test_notas_api.py -q`
- `pytest` *(fails: tests/test_import_trabajador_sales.py, tests/test_import_vendor_mapping.py, tests/test_invoice_json_save.py, tests/test_iva_conversion_prorrateo.py, tests/test_iva_por_item.py, tests/test_load_inventory_ui.py, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c097b173508323a7f439585db62db7