### PR TITLE
feat: soporte de lotes de dte

### DIFF
--- a/db.py
+++ b/db.py
@@ -2030,16 +2030,33 @@ class DB:
                     pass
         return rows
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
+    def registrar_envio_dte(
+        self,
+        venta_id,
+        modo,
+        estado,
+        sello,
+        respuesta_json="",
+        codigo_lote=None,
+    ):
         """Guarda un registro del estado de transmisión de un DTE."""
         self.ensure_column("dte_envios", "respuesta", "TEXT")
+        self.ensure_column("dte_envios", "codigo_lote", "TEXT")
         fecha_hora = datetime.now().isoformat()
         self.cursor.execute(
             """
-            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta, codigo_lote)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (venta_id, modo, estado, sello, fecha_hora, respuesta_json),
+            (
+                venta_id,
+                modo,
+                estado,
+                sello,
+                fecha_hora,
+                respuesta_json,
+                codigo_lote,
+            ),
         )
         self.conn.commit()
 

--- a/dte.py
+++ b/dte.py
@@ -4362,6 +4362,102 @@ def enviar_dte_a_hacienda(jws_token: str) -> dict:
     return respuesta
 
 
+def enviar_lote_dtes(pendientes, db: DB | None = None):
+    """Agrupa ``pendientes`` y envía lotes de hasta 100 DTE.
+
+    ``pendientes`` debe ser un iterable de pares ``(venta_id, dte_data)``.
+    Cada lote se firma individualmente y se envía en una única petición.
+    El ``codigoLote`` devuelto se almacena en ``dte_envios`` para cada DTE.
+    """
+
+    db = db or DB()
+    pendientes = list(pendientes)
+    if not pendientes:
+        return []
+
+    cfg = _load_dte_api_config()
+    url = cfg["url"].rstrip("/") + "/lote"
+    token = auth.get_token()
+
+    resultados = []
+    for i in range(0, len(pendientes), 100):
+        bloque = pendientes[i : i + 100]
+        detalle = []
+        ambiente = version = None
+        for venta_id, data in bloque:
+            ident = data.get("identificacion") or data.get("identificador") or {}
+            ambiente = ambiente or ident.get("ambiente")
+            version = version or ident.get("version")
+            firmado = jws.sign_json(data)
+            detalle.append(
+                {
+                    "venta_id": venta_id,
+                    "codigoGeneracion": ident.get("codigoGeneracion"),
+                    "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
+                    "documento": firmado,
+                }
+            )
+
+        body = {
+            "ambiente": ambiente,
+            "version": version,
+            "idEnvio": 1,
+            "cantidadDocumentos": len(detalle),
+            "detalle": [
+                {
+                    "codigoGeneracion": d["codigoGeneracion"],
+                    "tipoDte": d["tipoDte"],
+                    "documento": d["documento"],
+                }
+                for d in detalle
+            ],
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+
+        try:
+            resp = requests.post(url, headers=headers, json=body, timeout=20)
+            data_resp = resp.json() if resp.content else {}
+        except Exception as exc:  # pragma: no cover - defensive
+            data_resp = {"estado": "Error", "detalle": str(exc)}
+
+        codigo_lote = data_resp.get("codigoLote") or data_resp.get("codigoGeneracion")
+        estado = data_resp.get("estado") or data_resp.get("estadoLote") or ""
+        for d in detalle:
+            db.registrar_envio_dte(
+                d["venta_id"],
+                "lote",
+                estado or "Pendiente",
+                "",
+                json.dumps(data_resp, ensure_ascii=False),
+                codigo_lote=codigo_lote,
+            )
+        resultados.append(data_resp)
+
+    return resultados
+
+
+def consultar_estado_lote(codigo_lote: str) -> dict:
+    """Consulta el estado de un lote previamente enviado."""
+
+    cfg = _load_dte_api_config()
+    url = cfg["url"].rstrip("/") + f"/lote/{codigo_lote}"
+    token = auth.get_token()
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=20)
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"estado": "Error", "detalle": str(exc)}
+
+
 def _parse_error_response(respuesta: dict) -> str:
     """Construye un mensaje de error a partir de ``descripcionMsg`` y ``observaciones``."""
     partes = []

--- a/tests/test_lote_dte.py
+++ b/tests/test_lote_dte.py
@@ -1,0 +1,112 @@
+import dte
+import auth
+from utils import jws
+
+
+def _make_dte(idx):
+    return {
+        "identificacion": {
+            "version": 1,
+            "ambiente": "00",
+            "tipoDte": "01",
+            "codigoGeneracion": f"COD{idx}",
+        }
+    }
+
+
+def test_enviar_lote_dtes_envia_lote_y_registra_codigo(monkeypatch):
+    pendientes = [(i + 1, _make_dte(i)) for i in range(3)]
+
+    monkeypatch.setattr(jws, "sign_json", lambda data: f"signed-{data['identificacion']['codigoGeneracion']}")
+
+    captured = {"posts": []}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["posts"].append((url, json))
+
+        class Resp:
+            content = b"{}"
+
+            def json(self):
+                return {"codigoLote": "L123", "estado": "RECIBIDO"}
+
+        return Resp()
+
+    monkeypatch.setattr(dte.requests, "post", fake_post)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(auth, "get_token", lambda: "TOKEN")
+
+    class DummyDB:
+        def __init__(self):
+            self.reg = []
+
+        def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json="", codigo_lote=None):
+            self.reg.append((venta_id, modo, estado, codigo_lote))
+
+    db = DummyDB()
+
+    resp = dte.enviar_lote_dtes(pendientes, db=db)
+
+    assert len(captured["posts"]) == 1
+    url, body = captured["posts"][0]
+    assert url == "http://example/lote"
+    assert body["cantidadDocumentos"] == 3
+    assert db.reg == [
+        (1, "lote", "RECIBIDO", "L123"),
+        (2, "lote", "RECIBIDO", "L123"),
+        (3, "lote", "RECIBIDO", "L123"),
+    ]
+    assert resp[0]["codigoLote"] == "L123"
+
+
+def test_enviar_lote_dtes_divide_batches(monkeypatch):
+    pendientes = [(i, _make_dte(i)) for i in range(101)]
+    monkeypatch.setattr(jws, "sign_json", lambda data: "x")
+    posts = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        posts.append(json)
+
+        class Resp:
+            content = b"{}"
+
+            def json(self):
+                return {"codigoLote": "L", "estado": "RECIBIDO"}
+
+        return Resp()
+
+    monkeypatch.setattr(dte.requests, "post", fake_post)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(auth, "get_token", lambda: "TOKEN")
+
+    class DummyDB:
+        def registrar_envio_dte(self, *a, **k):
+            pass
+
+    dte.enviar_lote_dtes(pendientes, db=DummyDB())
+
+    assert len(posts) == 2
+    assert posts[0]["cantidadDocumentos"] == 100
+    assert posts[1]["cantidadDocumentos"] == 1
+
+
+def test_consultar_estado_lote(monkeypatch):
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(auth, "get_token", lambda: "TOKEN")
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["url"] = url
+
+        class Resp:
+            def json(self):
+                return {"estado": "EN_PROCESO"}
+
+        return Resp()
+
+    monkeypatch.setattr(dte.requests, "get", fake_get)
+
+    resp = dte.consultar_estado_lote("ABC")
+
+    assert captured["url"] == "http://example/lote/ABC"
+    assert resp["estado"] == "EN_PROCESO"


### PR DESCRIPTION
## Summary
- soporta envíos de DTE por lotes con registro de `codigoLote`
- añade consulta de estado para lotes
- prueba el envío y seguimiento de lotes

## Testing
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c09b8d604c8323a35a3092c1edd788