### PR TITLE
feat: track metadata for DTE transmissions

### DIFF
--- a/db.py
+++ b/db.py
@@ -510,6 +510,8 @@ class DB:
                 modo TEXT,
                 estado TEXT,
                 sello TEXT,
+                tipo_dte TEXT,
+                codigo_generacion TEXT,
                 fecha_hora TEXT,
                 respuesta TEXT,
 
@@ -2030,21 +2032,43 @@ class DB:
                     pass
         return rows
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
+    def registrar_envio_dte(
+        self,
+        venta_id,
+        modo,
+        estado,
+        sello,
+        tipo_dte="",
+        codigo_generacion="",
+        respuesta_json="",
+    ):
         """Guarda un registro del estado de transmisión de un DTE."""
+        self.ensure_column("dte_envios", "tipo_dte", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         self.ensure_column("dte_envios", "respuesta", "TEXT")
         fecha_hora = datetime.now().isoformat()
         self.cursor.execute(
             """
-            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO dte_envios (venta_id, modo, estado, sello, tipo_dte, codigo_generacion, fecha_hora, respuesta)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (venta_id, modo, estado, sello, fecha_hora, respuesta_json),
+            (
+                venta_id,
+                modo,
+                estado,
+                sello,
+                tipo_dte,
+                codigo_generacion,
+                fecha_hora,
+                respuesta_json,
+            ),
         )
         self.conn.commit()
 
     def consultar_envio_dte(self, venta_id):
         """Devuelve el JSON almacenado en ``dte_envios.respuesta``."""
+        self.ensure_column("dte_envios", "tipo_dte", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         self.ensure_column("dte_envios", "respuesta", "TEXT")
         row = self.cursor.execute(
             "SELECT respuesta FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
@@ -2059,6 +2083,8 @@ class DB:
 
     def listar_dtes(self, fecha_inicio=None, fecha_fin=None, estado=None):
         """Lista registros de ``dte_envios`` filtrando por fecha y estado."""
+        self.ensure_column("dte_envios", "tipo_dte", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         self.ensure_column("dte_envios", "respuesta", "TEXT")
         query = "SELECT * FROM dte_envios WHERE 1=1"
         params = []

--- a/dte.py
+++ b/dte.py
@@ -4317,7 +4317,14 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(None, "orphan", "Rechazado", "")
+        db.registrar_envio_dte(
+            None,
+            "orphan",
+            "Rechazado",
+            "",
+            meta.get("tipoDte"),
+            meta.get("codigoGeneracion"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -4325,6 +4332,8 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         "orphan",
         estado,
         sello,
+        meta.get("tipoDte"),
+        meta.get("codigoGeneracion"),
         json.dumps(respuesta, ensure_ascii=False),
     )
     if estado == "Rechazado":
@@ -4439,6 +4448,8 @@ def _enviar_documento(
             modo,
             "Pendiente",
             "",
+            meta.get("tipoDte"),
+            meta.get("codigoGeneracion"),
             json.dumps({"jws": signed}, ensure_ascii=False),
         )
         return {"estado": "Pendiente"}
@@ -4470,7 +4481,14 @@ def _enviar_documento(
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(doc_id, modo, "Rechazado", "")
+        db.registrar_envio_dte(
+            doc_id,
+            modo,
+            "Rechazado",
+            "",
+            meta.get("tipoDte"),
+            meta.get("codigoGeneracion"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -4478,6 +4496,8 @@ def _enviar_documento(
         modo,
         estado,
         sello,
+        meta.get("tipoDte"),
+        meta.get("codigoGeneracion"),
         json.dumps(respuesta, ensure_ascii=False),
     )
     if estado == "Rechazado":
@@ -4625,6 +4645,9 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     url = f"{pu.scheme}://{pu.netloc}/fesv/contingencia"
     signed = jws.sign_json(data)
     token = auth.get_token()
+    ident = data.get("identificacion") or {}
+    tipo = ident.get("tipoDte") or ident.get("tipoDocumento")
+    codigo = ident.get("codigoGeneracion")
 
     try:
         respuesta = _post_evento(url, token, signed, data)
@@ -4637,7 +4660,7 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(evento_id, "evento", "Rechazado", "")
+        db.registrar_envio_dte(evento_id, "evento", "Rechazado", "", tipo, codigo)
         raise
 
     db.registrar_envio_dte(
@@ -4645,6 +4668,8 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
         "evento",
         estado,
         sello,
+        tipo,
+        codigo,
         json.dumps(respuesta, ensure_ascii=False),
     )
     if estado == "Rechazado":

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -682,14 +682,19 @@ class InventoryManager:
                     ),
                 )
 
+            if data.get("dte_envios"):
+                self.db.ensure_column("dte_envios", "tipo_dte", "TEXT")
+                self.db.ensure_column("dte_envios", "codigo_generacion", "TEXT")
             for de in data.get("dte_envios", []):
                 self.db.cursor.execute(
-                    "INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO dte_envios (venta_id, modo, estado, sello, tipo_dte, codigo_generacion, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         venta_id_map.get(de.get("venta_id")),
                         de.get("modo"),
                         de.get("estado"),
                         de.get("sello"),
+                        de.get("tipo_dte"),
+                        de.get("codigo_generacion"),
                         de.get("fecha_hora"),
                         de.get("respuesta"),
                     ),

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -366,14 +366,14 @@ def test_post_dte_invalid_tipo(monkeypatch):
 def test_consultar_envio_dte():
     db = DB(":memory:")
     venta = create_sale(db)
-    db.registrar_envio_dte(venta, "normal", "Transmitido", "S", '{"ok": true}')
+    db.registrar_envio_dte(venta, "normal", "Transmitido", "S", "01", "ABC", '{"ok": true}')
     assert db.consultar_envio_dte(venta) == {"ok": True}
 
 
 def test_consultar_envio_dte_texto():
     db = DB(":memory:")
     venta = create_sale(db)
-    db.registrar_envio_dte(venta, "normal", "Rechazado", "", "error")
+    db.registrar_envio_dte(venta, "normal", "Rechazado", "", "01", "XYZ", "error")
     assert db.consultar_envio_dte(venta) == {}
 
 
@@ -381,8 +381,8 @@ def test_listar_dtes():
     db = DB(":memory:")
     v1 = create_sale(db)
     v2 = create_sale(db)
-    db.registrar_envio_dte(v1, "normal", "Transmitido", "S", '{"ok": true}')
-    db.registrar_envio_dte(v2, "normal", "Rechazado", "", "error")
+    db.registrar_envio_dte(v1, "normal", "Transmitido", "S", "01", "AAA", '{"ok": true}')
+    db.registrar_envio_dte(v2, "normal", "Rechazado", "", "01", "BBB", "error")
     today = datetime.now().date().isoformat()
     rows = db.listar_dtes(today, today, "Transmitido")
     assert len(rows) == 1

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -53,9 +53,25 @@ class FakeDB:
     def get_factura_pdf(self, vid):
         return self.factura_path
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
+    def registrar_envio_dte(
+        self,
+        venta_id,
+        modo,
+        estado,
+        sello,
+        tipo_dte="",
+        codigo_generacion="",
+        respuesta_json="",
+    ):
         self.envios.append(
-            {"venta_id": venta_id, "modo": modo, "estado": estado, "sello": sello}
+            {
+                "venta_id": venta_id,
+                "modo": modo,
+                "estado": estado,
+                "sello": sello,
+                "tipo_dte": tipo_dte,
+                "codigo_generacion": codigo_generacion,
+            }
         )
 
 

--- a/tests/test_export_import_transmission_records.py
+++ b/tests/test_export_import_transmission_records.py
@@ -51,8 +51,17 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
         "2024-01-01", 10, cliente_id=cliente_id, vendedor_id=vend, Distribuidor_id=dist
     )
     db.cursor.execute(
-        "INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?)",
-        (venta_id, "envio", "PROCESADO", "abc", "2024-01-01T00:00:00", "ok"),
+        "INSERT INTO dte_envios (venta_id, modo, estado, sello, tipo_dte, codigo_generacion, fecha_hora, respuesta) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            venta_id,
+            "envio",
+            "PROCESADO",
+            "abc",
+            "01",
+            "CG1",
+            "2024-01-01T00:00:00",
+            "ok",
+        ),
     )
     db.cursor.execute(
         "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo, detalles) VALUES (?, ?, ?, ?, ?, ?)",
@@ -76,15 +85,18 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
 
     cur = man2.db.cursor
     row = cur.execute(
-        "SELECT modo, estado, sello, fecha_hora, respuesta FROM dte_envios"
+        "SELECT modo, estado, sello, tipo_dte, codigo_generacion, fecha_hora, respuesta FROM dte_envios",
     ).fetchone()
     assert (
         row["modo"],
         row["estado"],
         row["sello"],
+        row["tipo_dte"],
+        row["codigo_generacion"],
         row["fecha_hora"],
         row["respuesta"],
-    ) == ("envio", "PROCESADO", "abc", "2024-01-01T00:00:00", "ok")
+    ) == ("envio", "PROCESADO", "abc", "01", "CG1", "2024-01-01T00:00:00", "ok")
+
 
     row = cur.execute(
         "SELECT tipo, fecha, monto, motivo, detalles FROM notas"


### PR DESCRIPTION
## Summary
- store `tipo_dte` and `codigo_generacion` in `dte_envios`
- accept and persist metadata in `registrar_envio_dte`
- handle new fields during inventory import/export and tests

## Testing
- `pytest tests/test_dte_transmision.py::test_consultar_envio_dte tests/test_dte_transmision.py::test_consultar_envio_dte_texto tests/test_dte_transmision.py::test_listar_dtes tests/test_export_import_transmission_records.py::test_export_import_transmission_records tests/test_envio_correo.py::test_save_invoice_does_not_send_or_transmit -q`

------
https://chatgpt.com/codex/tasks/task_e_68c09bf9926c8323adb5c57cd8916c9c