### PR TITLE
Handle contingency mode for ticket PDFs and test default transmission

### DIFF
--- a/tests/test_transmission_mode.py
+++ b/tests/test_transmission_mode.py
@@ -1,5 +1,6 @@
 import pytest
 from pathlib import Path
+import json
 import dte
 from utils.docs import build_invoice_json
 from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
@@ -86,4 +87,51 @@ def test_generate_ticket_registers_pending(tmp_path, monkeypatch):
 
     generate_ticket_pdf(man, 1)
     assert db.pending == [(1, "2")]
+
+
+def test_get_default_modo_transmision_reads_file(tmp_path, monkeypatch):
+    datos = {"dte_api": {"modo_transmision": "contingencia"}}
+    cfg = tmp_path / "datos_negocio.json"
+    cfg.write_text(json.dumps(datos), encoding="utf-8")
+    monkeypatch.setattr(dte, "DATOS_NEGOCIO_PATH", str(cfg))
+    assert dte.get_default_modo_transmision() == "contingencia"
+    datos["dte_api"]["modo_transmision"] = "normal"
+    cfg.write_text(json.dumps(datos), encoding="utf-8")
+    assert dte.get_default_modo_transmision() == "normal"
+
+
+def test_generate_ticket_pdf_applies_contingency_flags(tmp_path, monkeypatch):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-01-01", "total": 5}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 5, "descripcion": "P"}]
+    db.cursor = object()
+    man = Manager(db)
+    pdf = tmp_path / "ticket.pdf"
+    js = tmp_path / "ticket.json"
+
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf), str(js)
+
+    def fake_gen(venta, detalles, fname, dte_data=None):
+        Path(fname).write_text("PDF")
+
+    called = {}
+
+    def fake_ticket_json(db_obj, vid, *, tipo_operacion, tipo_contingencia=None, motivo_contin=None, **k):
+        called["args"] = (tipo_operacion, tipo_contingencia, motivo_contin)
+        return {"resumen": {"totalLetras": "X"}}
+
+    monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_ticket_personalizado", fake_gen)
+    monkeypatch.setattr("utils.doc_generation.generar_ticket_json", fake_ticket_json)
+    monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
+    monkeypatch.setattr(
+        dte, "_load_datos_negocio", lambda: {"dte_api": {"tipo_contingencia": 3, "motivo_contin": "fallo"}}
+    )
+
+    generate_ticket_pdf(man, 1)
+
+    assert called["args"] == (2, 3, "fallo")
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -217,6 +217,19 @@ def generate_ticket_pdf(manager, venta_id):
 
     default_tipo = 2 if dte.get_default_modo_transmision() == "contingencia" else 1
     tipo_operacion = extra.get("tipoOperacion") or default_tipo
+    tipo_contingencia = extra.get("tipoContingencia")
+    motivo_contin = extra.get("motivoContin")
+    if tipo_operacion == 2:
+        cfg = dte._load_datos_negocio().get("dte_api", {})
+        if tipo_contingencia is None:
+            tipo_contingencia = cfg.get("tipo_contingencia")
+        if motivo_contin is None:
+            motivo_contin = cfg.get("motivo_contin")
+        extra.setdefault("tipoOperacion", 2)
+        if tipo_contingencia is not None:
+            extra.setdefault("tipoContingencia", tipo_contingencia)
+        if motivo_contin is not None:
+            extra.setdefault("motivoContin", motivo_contin)
 
     cliente = None
     if venta.get("cliente_id"):
@@ -230,7 +243,11 @@ def generate_ticket_pdf(manager, venta_id):
     generar_ticket_personalizado(venta, detalles, filename, dte_data=extra)
     if hasattr(manager.db, "cursor"):
         ticket_json = generar_ticket_json(
-            manager.db, venta_id, tipo_operacion=tipo_operacion
+            manager.db,
+            venta_id,
+            tipo_operacion=tipo_operacion,
+            tipo_contingencia=tipo_contingencia,
+            motivo_contin=motivo_contin,
         )
     else:
         venta_data = dict(venta)


### PR DESCRIPTION
## Summary
- populate contingency fields when generating ticket PDFs and JSONs
- add tests for default transmission mode and contingency propagation

## Testing
- `pytest tests/test_transmission_mode.py::test_get_default_modo_transmision_reads_file tests/test_transmission_mode.py::test_generate_ticket_pdf_applies_contingency_flags -q`
- `pytest -q` *(fails: ImportError libGL.so.1; ModuleNotFoundError fastapi)*


------
https://chatgpt.com/codex/tasks/task_e_68c09ec62b0c83238223aaee41628c99