### PR TITLE
Ajusta previsualización con scroll y expansión

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -21,6 +21,8 @@ from PyQt5.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QPlainTextEdit,
+    QSizePolicy,
+    QScrollArea,
 )
 from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent, QSize
 from PyQt5.QtGui import QPixmap, QDesktopServices
@@ -491,9 +493,12 @@ class FacturacionTab(QWidget):
         self.preview_label = QLabel("Previsualización del PDF")
         self.preview_label.setAlignment(Qt.AlignCenter)
         self.preview_label.setStyleSheet("background:#DDD; padding:20px;")
-        self.preview_label.setFixedSize(QSize(600, 800))
-        self.preview_label.setScaledContents(False)
-        preview_layout.addWidget(self.preview_label)
+        self.preview_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.preview_label.setScaledContents(True)
+        preview_scroll = QScrollArea()
+        preview_scroll.setWidgetResizable(True)
+        preview_scroll.setWidget(self.preview_label)
+        preview_layout.addWidget(preview_scroll)
         main_layout.addLayout(preview_layout, 2)
 
         # Connect signals

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
 
     QHeaderView,
     QSizePolicy,
+    QScrollArea,
 
     QInputDialog,
     QDialog,
@@ -123,10 +124,12 @@ class SalesTab(QWidget):
         self.preview_label = QLabel("Previsualización del PDF")
         self.preview_label.setAlignment(Qt.AlignCenter)
         self.preview_label.setStyleSheet("background:#DDD; padding:20px;")
-        # Avoid stretching the image so the aspect ratio of the PDF is preserved
-        self.preview_label.setFixedSize(QSize(600, 800))
-        self.preview_label.setScaledContents(False)
-        preview_layout.addWidget(self.preview_label)
+        self.preview_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.preview_label.setScaledContents(True)
+        preview_scroll = QScrollArea()
+        preview_scroll.setWidgetResizable(True)
+        preview_scroll.setWidget(self.preview_label)
+        preview_layout.addWidget(preview_scroll)
 
         self.info_label = QLabel()
         preview_layout.addWidget(self.info_label)


### PR DESCRIPTION
## Summary
- Permite que la previsualización del PDF en facturación y ventas se adapte al tamaño de la ventana
- Envuelve la etiqueta de vista previa en un `QScrollArea` y habilita contenido escalable

## Testing
- `pytest -q` *(fails: 57 failed, 150 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a505ae408323b9f63f9f2dc71380