### PR TITLE
Handle invoice generation errors

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -561,11 +561,19 @@ class SalesTab(QWidget):
                 file_path = self._generate_ticket_pdf(venta_id)
                 doc_type = "Ticket"
             elif clicked == factura_btn:
-                file_path = self._generate_invoice_pdf(venta_id)
+                try:
+                    file_path = self._generate_invoice_pdf(venta_id)
+                except ValueError as e:
+                    QMessageBox.warning(self, "Guardar factura", str(e))
+                    return
             else:
                 return
         else:
-            file_path = self._generate_invoice_pdf(venta_id)
+            try:
+                file_path = self._generate_invoice_pdf(venta_id)
+            except ValueError as e:
+                QMessageBox.warning(self, "Guardar factura", str(e))
+                return
         if not file_path:
             QMessageBox.warning(self, "Guardar factura", "No se pudo generar el documento.")
             return

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -229,3 +229,30 @@ def test_save_invoice_fail_no_email(
 
     assert "email" not in called
 
+
+def test_save_invoice_handles_generation_error(
+    qt_app, monkeypatch, venta_factory, cliente_factory, producto_factory
+):
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
+
+    def fail(self, vid):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(SalesTab, "_generate_invoice_pdf", fail)
+
+    message = {}
+
+    def fake_warning(parent, title, text):
+        message["text"] = text
+
+    monkeypatch.setattr(QMessageBox, "warning", fake_warning)
+
+    tab.sales_table.selectRow(0)
+    tab.save_invoice()
+
+    assert message["text"] == "boom"
+    assert db.saved is None
+


### PR DESCRIPTION
## Summary
- prevent unhandled invoice generation errors by showing a warning and stopping the save
- add regression test verifying invoice generation errors are surfaced and saving is aborted

## Testing
- `pytest tests/test_envio_correo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a8ff3d148323838bcb944310b11a