### PR TITLE
Handle string client addresses in invoices

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -40,9 +40,19 @@ def build_qr_value(
 
 
 def format_direccion(direccion):
-    """Format a ``direccion`` dict into "Municipio, complemento"."""
+    """Format a ``direccion`` into "Municipio, complemento".
+
+    ``direccion`` can be either a mapping with ``departamento`` and
+    ``municipio`` codes plus a ``complemento`` field or a plain string. When a
+    string is provided it is returned unchanged.
+    """
+
     if not direccion:
         return ""
+
+    if isinstance(direccion, str):
+        return direccion
+
     departamento = str(direccion.get("departamento", "")).zfill(2)
     municipio = str(direccion.get("municipio", "")).zfill(2)
     complemento = direccion.get("complemento", "")
@@ -332,7 +342,12 @@ def generar_factura_electronica_pdf(
         text_y -= line_h
 
     text_y -= line_h
-    direccion = format_direccion(cliente.get("direccion"))
+    cliente_dir = {
+        "departamento": cliente.get("departamento"),
+        "municipio": cliente.get("municipio"),
+        "complemento": cliente.get("direccion"),
+    }
+    direccion = format_direccion(cliente_dir)
     text_y = draw_wrapped_text(
         c,
         f"Dirección: {direccion}",

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -193,18 +193,22 @@ def test_direccion_includes_municipio(tmp_path, monkeypatch):
         lambda cat, code, default=None: "La Libertad Centro" if code == "0524" else default,
     )
     venta, detalles = _sample_data('Crédito Fiscal')
-    direccion = {
+    cliente = {
+        'nombre': 'Ana',
         'departamento': '05',
         'municipio': '24',
-        'complemento': 'Colonia El Centro con una avenida realmente muy larga para pruebas',
+        'direccion': 'Colonia El Centro con una avenida realmente muy larga para pruebas',
     }
-    cliente = {'nombre': 'Ana', 'direccion': direccion}
     datos_negocio = {
         'nombre': 'Neg',
         'nit': '',
         'nrc': '',
         'descActividad': '',
-        'direccion': direccion,
+        'direccion': {
+            'departamento': '05',
+            'municipio': '24',
+            'complemento': 'Colonia El Centro con una avenida realmente muy larga para pruebas',
+        },
     }
     out = tmp_path / 'dir.pdf'
     generar_factura_electronica_pdf(
@@ -221,4 +225,20 @@ def test_direccion_includes_municipio(tmp_path, monkeypatch):
     idx = next(i for i, ln in enumerate(lines) if ln.startswith('Dirección:'))
     assert 'La Libertad Centro' in lines[idx]
     assert 'realmente muy larga para pruebas' in lines[idx + 1]
+
+
+def test_direccion_as_text(tmp_path):
+    venta, detalles = _sample_data('Crédito Fiscal')
+    cliente = {'nombre': 'Ana', 'direccion': 'Colonia Escalón, calle 1'}
+    out = tmp_path / 'dir_text.pdf'
+    generar_factura_electronica_pdf(
+        venta,
+        detalles,
+        cliente,
+        {},
+        'Crédito Fiscal',
+        archivo=str(out),
+        datos_negocio={},
+    )
+    assert out.exists()
 


### PR DESCRIPTION
## Summary
- Allow `format_direccion` to accept either dicts or plain strings
- Build client address dictionary from separate department/municipality fields before formatting
- Add regression test ensuring textual client addresses generate invoices without errors

## Testing
- `pytest tests/test_factura_pdf.py::test_direccion_includes_municipio tests/test_factura_pdf.py::test_direccion_as_text -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b49c41488323a84c79be81f3b2c4