### PR TITLE
Registrar tipo y motivo de contingencia en facturas

### DIFF
--- a/api/facturas.py
+++ b/api/facturas.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from facturas_db.facturas_repo import FacturasRepo
 from models.factura import Factura
+from pydantic import BaseModel
 import logging
 
 logger = logging.getLogger(__name__)
@@ -8,13 +9,21 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 repo = FacturasRepo()
 
+
+class ContingenciaIn(BaseModel):
+    tipoContingencia: int
+    motivoContin: str | None = None
+
+
 @app.post("/api/facturas/{factura_id}/contingencia")
-def guardar_en_contingencia(factura_id: int):
+def guardar_en_contingencia(factura_id: int, data: ContingenciaIn):
     factura = repo.get(factura_id)
     if not factura:
         raise HTTPException(status_code=404, detail="Factura no encontrada")
     if factura.estado_envio == "Enviado":
         raise HTTPException(status_code=400, detail="Factura ya enviada")
-    repo.guardar_en_contingencia(factura_id)
+    repo.guardar_en_contingencia(
+        factura_id, data.tipoContingencia, data.motivoContin
+    )
     logger.info("accion=forzar_contingencia_por_usuario factura_id=%s", factura_id)
     return {"ok": True, "factura": factura.to_dict()}

--- a/facturas_db/facturas_repo.py
+++ b/facturas_db/facturas_repo.py
@@ -14,10 +14,17 @@ class FacturasRepo:
     def get(self, factura_id: int) -> Optional[Factura]:
         return self._data.get(factura_id)
 
-    def guardar_en_contingencia(self, factura_id: int) -> Optional[Factura]:
+    def guardar_en_contingencia(
+        self,
+        factura_id: int,
+        tipo_contingencia: int,
+        motivo_contin: str | None = None,
+    ) -> Optional[Factura]:
         factura = self.get(factura_id)
         if not factura:
             return None
         factura.modo_transmision = "contingencia"
         factura.estado_envio = "Pendiente"
+        factura.tipo_contingencia = tipo_contingencia
+        factura.motivo_contin = motivo_contin
         return factura

--- a/models/factura.py
+++ b/models/factura.py
@@ -5,10 +5,14 @@ class Factura:
     id: int
     modo_transmision: str = "normal"
     estado_envio: str = "Pendiente"
+    tipo_contingencia: int | None = None
+    motivo_contin: str | None = None
 
     def to_dict(self) -> dict:
         return {
             "id": self.id,
             "modo_transmision": self.modo_transmision,
             "estado_envio": self.estado_envio,
+            "tipo_contingencia": self.tipo_contingencia,
+            "motivo_contin": self.motivo_contin,
         }

--- a/tests/test_contingencia_api.py
+++ b/tests/test_contingencia_api.py
@@ -9,21 +9,40 @@ def setup_function(_):
 
 def test_guardar_en_contingencia_actualiza_estado():
     repo.add(Factura(id=1))
-    resp = client.post('/api/facturas/1/contingencia')
+    resp = client.post(
+        '/api/facturas/1/contingencia',
+        json={'tipoContingencia': 1, 'motivoContin': ''},
+    )
     assert resp.status_code == 200
     factura = repo.get(1)
     assert factura.modo_transmision == 'contingencia'
     assert factura.estado_envio == 'Pendiente'
+    assert factura.tipo_contingencia == 1
+    assert factura.motivo_contin == ''
 
 def test_guardar_en_contingencia_idempotente():
-    repo.add(Factura(id=2, modo_transmision='contingencia', estado_envio='Pendiente'))
-    resp = client.post('/api/facturas/2/contingencia')
+    repo.add(
+        Factura(
+            id=2,
+            modo_transmision='contingencia',
+            estado_envio='Pendiente',
+            tipo_contingencia=1,
+        )
+    )
+    resp = client.post(
+        '/api/facturas/2/contingencia',
+        json={'tipoContingencia': 1, 'motivoContin': ''},
+    )
     assert resp.status_code == 200
     factura = repo.get(2)
     assert factura.modo_transmision == 'contingencia'
     assert factura.estado_envio == 'Pendiente'
+    assert factura.tipo_contingencia == 1
 
 def test_guardar_en_contingencia_rechaza_enviado():
     repo.add(Factura(id=3, estado_envio='Enviado'))
-    resp = client.post('/api/facturas/3/contingencia')
+    resp = client.post(
+        '/api/facturas/3/contingencia',
+        json={'tipoContingencia': 1, 'motivoContin': ''},
+    )
     assert resp.status_code == 400

--- a/ui/services/facturasApi.ts
+++ b/ui/services/facturasApi.ts
@@ -1,6 +1,12 @@
-export async function guardarEnContingencia(facturaId: string) {
+export async function guardarEnContingencia(
+  facturaId: string,
+  tipoContingencia: number,
+  motivoContin = ''
+) {
   const res = await fetch(`/api/facturas/${facturaId}/contingencia`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tipoContingencia, motivoContin })
   });
   if (!res.ok) {
     throw new Error('Error al guardar en contingencia');

--- a/ui/tests/FacturaForm.spec.ts
+++ b/ui/tests/FacturaForm.spec.ts
@@ -20,7 +20,7 @@ describe('FacturaForm', () => {
     const dialog = wrapper.findComponent({ name: 'ConfirmDialog' });
     expect(dialog.exists()).toBe(true);
     await dialog.vm.$emit('confirm');
-    expect(api.guardarEnContingencia).toHaveBeenCalledWith('1');
+    expect(api.guardarEnContingencia).toHaveBeenCalledWith('1', 1, '');
   });
 
   it('muestra diálogo de error y guarda en contingencia tras fallo', async () => {
@@ -32,7 +32,7 @@ describe('FacturaForm', () => {
     const errorDialog = dialogs.find(d => d.props('title') === 'Error al enviar a Hacienda');
     expect(errorDialog).toBeTruthy();
     await errorDialog!.vm.$emit('confirm');
-    expect(api.guardarEnContingencia).toHaveBeenCalledWith('2');
+    expect(api.guardarEnContingencia).toHaveBeenCalledWith('2', 1, '');
   });
 
   it('no llama API al cancelar', async () => {
@@ -43,5 +43,25 @@ describe('FacturaForm', () => {
     const dialog = wrapper.findComponent({ name: 'ConfirmDialog' });
     await dialog.vm.$emit('cancel');
     expect(api.guardarEnContingencia).not.toHaveBeenCalled();
+  });
+
+  it('muestra controles de contingencia y envía los datos seleccionados', async () => {
+    const wrapper = mount(FacturaForm, {
+      props: { facturaId: '4', config: { modoContingencia: true } }
+    });
+    const select = wrapper.find('select');
+    expect(select.exists()).toBe(true);
+    await select.setValue('5');
+    const input = wrapper.find('input');
+    expect(input.exists()).toBe(true);
+    await input.setValue('fallo electrico');
+    await wrapper.find('button').trigger('click');
+    const dialog = wrapper.findComponent({ name: 'ConfirmDialog' });
+    await dialog.vm.$emit('confirm');
+    expect(api.guardarEnContingencia).toHaveBeenCalledWith(
+      '4',
+      5,
+      'fallo electrico'
+    );
   });
 });

--- a/ui/ventas/FacturaForm.vue
+++ b/ui/ventas/FacturaForm.vue
@@ -1,5 +1,11 @@
 <template>
   <div>
+    <div v-if="props.config?.modoContingencia">
+      <select v-model.number="tipoContingencia">
+        <option v-for="n in 5" :key="n" :value="n">{{ n }}</option>
+      </select>
+      <input v-if="tipoContingencia === 5" v-model="motivoContin" />
+    </div>
     <button @click="onSave">Guardar y Enviar</button>
     <ConfirmDialog
       v-model="confirmVisible"
@@ -29,6 +35,8 @@ const props = defineProps<{ facturaId: string; config: { modoContingencia: boole
 
 const confirmVisible = ref(false);
 const errorVisible = ref(false);
+const tipoContingencia = ref(1);
+const motivoContin = ref('');
 
 async function onSave() {
   if (props.config?.modoContingencia) {
@@ -43,7 +51,11 @@ async function onSave() {
 }
 
 async function saveContingencia() {
-  await guardarEnContingencia(props.facturaId);
+  await guardarEnContingencia(
+    props.facturaId,
+    tipoContingencia.value,
+    motivoContin.value
+  );
 }
 
 function enviarAHacienda() {


### PR DESCRIPTION
## Summary
- Mostrar select para tipo de contingencia e input de motivo cuando aplica
- Enviar tipo y motivo de contingencia a backend y guardarlos
- Probar controles de contingencia en el formulario y propagación a la API

## Testing
- `npm test`
- `pytest tests/test_contingencia_api.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b49c6e4083238ca0feb4a6a96d36