### PR TITLE
Corrige cálculo de totales en NCE con detalles

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -295,8 +295,13 @@ def generar_nce_desde_dte(
             )
 
     subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
-    orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (ratio or Decimal_1)
-    iva_val = d2(orig_total - subtotal_ventas)
+    if detalles:
+        iva_val = d2(total_grav * IVA)
+        monto_total_operacion = d2(subtotal_ventas + iva_val)
+    else:
+        orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * (ratio or Decimal_1)
+        iva_val = d2(orig_total - subtotal_ventas)
+        monto_total_operacion = d2(orig_total)
     tributos_resumen = []
     if iva_val > 0:
         tributos_resumen.append(
@@ -306,7 +311,6 @@ def generar_nce_desde_dte(
                 "valor": iva_val,
             }
         )
-    monto_total_operacion = d2(orig_total)
     resumen = {
         "totalNoSuj": d2(total_nosuj),
         "totalExenta": d2(total_exenta),

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -46,6 +46,34 @@ def test_generar_nce_detalles(monkeypatch):
     assert data["resumen"]["totalGravada"] == 10
 
 
+def test_nce_detalles_monto_total(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "precio_unitario": 5,
+            "ventas_gravadas": 5,
+            "ventas_exentas": 0,
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles, motivo="Dev")
+    resumen = nce["resumen"]
+    expected_iva = Decimal("5") * Decimal("0.13")
+    expected_iva = expected_iva.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    assert resumen["montoTotalOperacion"] == Decimal("5") + expected_iva
+    assert resumen["montoTotalOperacion"] != dte_origen["resumen"]["montoTotalOperacion"]
+
+
 def test_generar_nota_debito_detalles(monkeypatch):
     _prep(monkeypatch)
     db = create_db()


### PR DESCRIPTION
## Resumen
- Calcula IVA y monto total de operación desde los detalles de la NCE.
- Ajusta el resumen para usar los nuevos valores calculados.
- Agrega prueba que valida el total de operación con detalles parciales.

## Pruebas
- `pytest tests/test_nota_detalles.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0e84349a08323a686c934ba8a56e7