### PR TITLE
Corrige monto de operación en NCE parcial

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -223,6 +223,9 @@ def generar_nce_desde_dte(
         total_grav = total_grav.quantize(Q4)
         total_exenta = total_exenta.quantize(Q4)
         total_nosuj = total_nosuj.quantize(Q4)
+        subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
+        iva_val = d2(total_grav * IVA)
+        monto_total_operacion = d2(subtotal_ventas + iva_val)
     else:
         ratio_val = ratio or Decimal_1
         total_grav = (Decimal(str(orig_resumen.get("totalGravada", 0))) * ratio_val).quantize(Q4)
@@ -290,9 +293,11 @@ def generar_nce_desde_dte(
                     "codTributo": None,
                 }
             )
+        subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
+        orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * ratio_val
+        iva_val = d2(orig_total - subtotal_ventas)
+        monto_total_operacion = d2(orig_total)
 
-    subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
-    iva_val = d2(total_grav * IVA)
     tributos_resumen = []
     if iva_val > 0:
         tributos_resumen.append(
@@ -302,7 +307,6 @@ def generar_nce_desde_dte(
                 "valor": iva_val,
             }
         )
-    monto_total_operacion = d2(subtotal_ventas + iva_val)
     resumen = {
         "totalNoSuj": d2(total_nosuj),
         "totalExenta": d2(total_exenta),

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -1,5 +1,5 @@
 import fitz
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from db import DB
 from dte import generar_dte_json
 from nota_credito_electronica import generar_nce_desde_dte, generar_nce_desde_nota
@@ -127,7 +127,10 @@ def test_nota_credito_precio_uni(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles)
     item = data["cuerpoDocumento"][0]
     assert item["precioUni"] == Decimal("7.9600")
-    assert data["resumen"]["montoTotalOperacion"] == 9.0
+    iva = Decimal("7.96") * Decimal("0.13")
+    iva = iva.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    expected_total = Decimal("7.96") + iva
+    assert data["resumen"]["montoTotalOperacion"] == expected_total
 
 
 def test_generar_nce_rechaza_monto_excedido(monkeypatch):

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -71,6 +71,34 @@ def test_generar_nce_detalles_tributos(monkeypatch):
     assert data["resumen"]["tributos"][0]["valor"] == expected_iva
 
 
+def test_generar_nce_detalles_monto_total(monkeypatch):
+    _prep(monkeypatch)
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 20)
+    db.add_detalle_venta(venta_id, pid, 2, 10, vendedor_id=vid)
+    detalles = [
+        {
+            "cantidad": 1,
+            "descripcion": "Prod",
+            "precio_unitario": 10,
+            "ventas_gravadas": 10,
+            "ventas_exentas": 0,
+            "ventas_no_sujetas": 0,
+        }
+    ]
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
+    nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
+    resumen = nce["resumen"]
+    expected_iva = Decimal("10") * Decimal("0.13")
+    expected_total = Decimal("10") + expected_iva
+    assert resumen["montoTotalOperacion"] == expected_total
+    assert resumen["montoTotalOperacion"] < dte_origen["resumen"]["montoTotalOperacion"]
+
+
 def test_generar_nota_debito_detalles(monkeypatch):
     _prep(monkeypatch)
     db = create_db()


### PR DESCRIPTION
## Summary
- Calcula IVA y monto total de operación basado en detalles en `generar_nce_desde_dte`
- Ajusta tributos y resumen para usar estos montos
- Agrega prueba que verifica que `montoTotalOperacion` refleja solo los detalles incluidos y actualiza test existente

## Testing
- `pytest tests/test_nota_detalles.py::test_generar_nce_detalles tests/test_nota_detalles.py::test_generar_nce_detalles_tributos tests/test_nota_detalles.py::test_generar_nce_detalles_monto_total tests/test_nota_credito.py::test_nota_credito_precio_uni tests/test_nota_credito.py::test_nota_credito_total_nueve -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0ec6457348323bba966dcdc96eb5e