### PR TITLE
Check signer availability before starting

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import (
     QDateEdit, QCheckBox, QTextEdit, QAbstractItemView, QHeaderView, QSizePolicy,
     QInputDialog
 )
-from PyQt5.QtCore import Qt, QDate, QThread, pyqtSignal
+from PyQt5.QtCore import Qt, QDate, QThread, pyqtSignal, QTimer
 from PyQt5.QtGui import QColor
 import os
 import json
@@ -35,7 +35,7 @@ from factura_sv import generar_factura_electronica_pdf
 from decimal import Decimal, ROUND_HALF_UP
 from utils.monto import monto_a_texto_sv
 from utils.jws import sign_json
-from utils.firmador import iniciar_firmador, detener_firmador
+from utils.firmador import iniciar_firmador, detener_firmador, firmador_activo
 import logging
 
 logger = logging.getLogger(__name__)
@@ -83,10 +83,14 @@ class MainWindow(QMainWindow):
         self._mark_saved()
         self._setup_ui()
         self._apply_styles()
+        QTimer.singleShot(0, self._verificar_firmador)
 
     def iniciar_firmador(self):
         """Lanza el servicio externo de firmado de documentos."""
         if self.firmador_proc and self.firmador_proc.poll() is None:
+            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
+            return
+        if firmador_activo():
             QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
             return
         try:
@@ -94,8 +98,22 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "Firmador", "Firmador iniciado correctamente.")
         except FileNotFoundError as exc:
             QMessageBox.critical(self, "Error", f"No se encontró el firmador:\n{exc}")
+        except RuntimeError:
+            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
         except Exception as exc:
             QMessageBox.critical(self, "Error", f"No se pudo iniciar el firmador:\n{exc}")
+
+    def _verificar_firmador(self):
+        if firmador_activo():
+            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
+        else:
+            resp = QMessageBox.question(
+                self,
+                "Firmador",
+                "El firmador no está corriendo y es necesario para generar facturas. ¿Desea iniciarlo?",
+            )
+            if resp == QMessageBox.Yes:
+                self.iniciar_firmador()
 
     def generar_factura_pdf(self):
         """Función de generación de facturas no disponible."""

--- a/utils/firmador.py
+++ b/utils/firmador.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -6,8 +7,22 @@ from typing import Optional
 # Almacena el proceso para poder detenerlo posteriormente
 _FIRMADOR_PROC: Optional[subprocess.Popen] = None
 
+FIRMADOR_HOST = "127.0.0.1"
+FIRMADOR_PORT = 8080
+
+
+def firmador_activo() -> bool:
+    """Comprueba si el firmador ya está en ejecución."""
+    try:
+        with socket.create_connection((FIRMADOR_HOST, FIRMADOR_PORT), timeout=1):
+            return True
+    except OSError:
+        return False
+
 def iniciar_firmador() -> subprocess.Popen:
     """Inicia el servicio ``svfe-api-firmador`` usando el JDK empaquetado."""
+    if firmador_activo():
+        raise RuntimeError("El firmador ya está en ejecución")
     base = Path(__file__).resolve().parent.parent / "svfe-api-firmador"
     java_home = base / "vendor" / "jdk"
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- add `firmador_activo` helper to test signer service availability
- verify signer presence on app startup and before launching new process

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c0fdcfdba083239468179cdfc4d8c6