### PR TITLE
Ensure client info preserved in invoice JSON

### DIFF
--- a/tests/test_doc_utils.py
+++ b/tests/test_doc_utils.py
@@ -17,3 +17,19 @@ def test_get_document_paths_and_list(tmp_path):
         f.write('{}')
     res = docs.list_documents(root=tmp_path)
     assert {'tipo': 'Ticket', 'pdf': pdf, 'json': js} in res
+
+
+def test_build_invoice_json_preserves_address():
+    cliente = {
+        'nombre': 'Ariel',
+        'direccion': '6a calle oriente',
+        'nrc': '123456-7',
+        'telefono': '2222-3333',
+        'correo': 'ariel@example.com',
+    }
+    data = docs.build_invoice_json({'fecha': '2024-01-01'}, cliente, [])
+    rec = data.get('receptor', {})
+    assert rec.get('direccion', {}).get('complemento') == '6a calle oriente'
+    assert rec.get('nrc') == '123456-7'
+    assert rec.get('telefono') == '2222-3333'
+    assert rec.get('correo') == 'ariel@example.com'

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 
-from dte import _map_departamento, _map_municipio
+from dte import _map_departamento, _map_municipio, _build_receptor_direccion
 
 # Base path is repository root two levels up from this file
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -123,10 +123,34 @@ def build_invoice_json(venta, cliente, detalles, template_path=TEMPLATE_PATH):
     if cliente:
         if cliente.get('nombre'):
             rec['nombre'] = cliente['nombre']
-        if cliente.get('direccion'):
-            rec['direccion'] = cliente['direccion']
         if cliente.get('nit'):
             rec['nit'] = cliente['nit']
+        if cliente.get('nrc'):
+            rec['nrc'] = cliente['nrc']
+        if cliente.get('telefono'):
+            rec['telefono'] = cliente['telefono']
+        correo = cliente.get('correo') or cliente.get('email')
+        if correo:
+            rec['correo'] = correo
+        if cliente.get('nombre_comercial'):
+            rec['nombreComercial'] = cliente['nombre_comercial']
+        if cliente.get('nombreComercial'):
+            rec['nombreComercial'] = cliente['nombreComercial']
+        if cliente.get('codActividad'):
+            rec['codActividad'] = cliente['codActividad']
+        if cliente.get('giro'):
+            rec['descActividad'] = cliente['giro']
+        direccion = cliente.get('direccion')
+        if direccion or cliente.get('departamento') or cliente.get('municipio'):
+            if isinstance(direccion, dict):
+                dir_src = direccion.copy()
+            else:
+                dir_src = {'complemento': direccion} if direccion else {}
+            if cliente.get('departamento') is not None and 'departamento' not in dir_src:
+                dir_src['departamento'] = cliente.get('departamento')
+            if cliente.get('municipio') is not None and 'municipio' not in dir_src:
+                dir_src['municipio'] = cliente.get('municipio')
+            rec['direccion'] = _build_receptor_direccion(dir_src)
     data['receptor'] = rec
 
     cuerpo = []


### PR DESCRIPTION
## Summary
- Normalize client address using `_build_receptor_direccion` when building invoice JSONs
- Populate receiver section with NRC, phone, email and other client fields
- Test that client address `6a calle oriente` is preserved in generated JSON

## Testing
- `pytest tests/test_doc_utils.py::test_build_invoice_json_preserves_address tests/test_transmission_mode.py::test_build_json_includes_transmission tests/test_credito_fiscal_pdf_iva.py::test_credito_fiscal_pdf_calcula_iva -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0fdeeea648323a74025b5309eee40