### PR TITLE
Fix IVA-included price handling in PDF generation

### DIFF
--- a/tests/test_credito_fiscal_pdf_iva.py
+++ b/tests/test_credito_fiscal_pdf_iva.py
@@ -2,6 +2,8 @@ import json
 import uuid
 import pytest
 
+from utils.monto import to_base_iva
+
 from utils.doc_generation import generate_invoice_pdf
 from utils.docs import build_invoice_json
 
@@ -78,3 +80,54 @@ def test_credito_fiscal_pdf_calcula_iva(tmp_path, monkeypatch):
     assert pytest.approx(captured["venta"]["iva"], 0.01) == 1.3
     assert pytest.approx(captured["detalles"][0]["iva"], 0.01) == 1.3
     assert pytest.approx(captured["detalles"][0]["ventas_gravadas"], 0.01) == 10
+
+
+def test_pdf_total_precios_incluyen_iva(tmp_path, monkeypatch):
+    db = FakeDB()
+    venta = {
+        "id": 1,
+        "fecha": "2024-01-01",
+        "total": 15,
+        "extra": json.dumps({"precios_incluyen_iva": True}),
+    }
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 15}]
+    man = Manager(db)
+
+    pdf_path = tmp_path / "fact.pdf"
+    json_path = tmp_path / "fact.json"
+
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf_path), str(json_path)
+
+    def fake_generar(db_, vid, **_):
+        venta = next(v for v in db_.get_ventas() if v["id"] == vid)
+        detalles = db_.get_detalles_venta(vid)
+        data = build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident["codigoGeneracion"] = uuid.uuid4().hex
+        ident["numeroControl"] = uuid.uuid4().hex[:8].upper()
+        data.setdefault("resumen", {})["totalPagar"] = venta.get("total")
+        return data
+
+    captured = {}
+
+    def fake_pdf(venta_d, detalles_d, cliente, distribuidor, tipo_doc, archivo="", **_):
+        captured["venta"] = venta_d
+        captured["detalles"] = detalles_d
+        with open(archivo, "wb") as fh:
+            fh.write(b"pdf")
+
+    monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
+    monkeypatch.setattr("utils.doc_generation.generar_factura_electronica_pdf", fake_pdf)
+
+    generate_invoice_pdf(man, 1)
+
+    base, iva = to_base_iva(15)
+    assert pytest.approx(captured["venta"]["subtotal"], 0.01) == float(base)
+    assert pytest.approx(captured["venta"]["iva"], 0.01) == float(iva)
+    assert pytest.approx(captured["venta"]["total"], 0.01) == 15
+    assert pytest.approx(captured["detalles"][0]["iva"], 0.01) == float(iva)
+    assert pytest.approx(captured["detalles"][0]["ventas_gravadas"], 0.01) == float(base)

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -7,7 +7,7 @@ import dte
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado
 from dte import generar_ticket_json, generar_dte_json
-from utils.monto import monto_a_texto_sv, iva_item
+from utils.monto import monto_a_texto_sv, iva_item, to_base_iva
 from utils.docs import get_document_paths, build_invoice_json
 from utils.jws import sign_and_save
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
@@ -29,6 +29,16 @@ def generate_invoice_pdf(manager, venta_id):
     if credito_info:
         venta_data.update(credito_info)
 
+    # Parse extra information early to know if prices include IVA
+    extra = venta_data.get("extra") or {}
+    if isinstance(extra, str):
+        try:
+            extra = json.loads(extra)
+        except Exception:
+            extra = {}
+    venta_data["extra"] = extra
+    precios_incluyen_iva = bool(extra.get("precios_incluyen_iva"))
+
     if venta_data.get("vendedor_id"):
         trabajador = manager.db.get_trabajador(venta_data["vendedor_id"])
         if trabajador:
@@ -37,30 +47,44 @@ def generate_invoice_pdf(manager, venta_id):
     sumas = descuentos = 0
     ventas_exentas = ventas_no_sujetas = iva = 0
     for d in detalles:
-        base_total = d.get("precio_unitario", 0) * d.get("cantidad", 0)
+        unit = d.get("precio_unitario", 0)
+        cantidad = d.get("cantidad", 0)
+        line_total = unit * cantidad
         desc = d.get("descuento", 0)
         if d.get("descuento_tipo") == "%":
-            desc = base_total * d.get("descuento", 0) / 100
-        base = base_total - desc
+            desc = line_total * d.get("descuento", 0) / 100
+        line_total_desc = line_total - desc
         iva_item_val = d.get("iva", 0)
         tipo = d.get("tipo_fiscal", "").lower()
         if tipo == "venta exenta":
-            d["ventas_exentas"] = base
-            ventas_exentas += base
+            d["ventas_exentas"] = line_total_desc
+            ventas_exentas += line_total_desc
         elif tipo == "venta no sujeta":
-            d["ventas_no_sujetas"] = base
-            ventas_no_sujetas += base
+            d["ventas_no_sujetas"] = line_total_desc
+            ventas_no_sujetas += line_total_desc
         else:
-            if credito_info and not iva_item_val:
-                iva_item_val = float(iva_item(base))
+            if precios_incluyen_iva:
+                base_total_dec, _ = to_base_iva(line_total)
+                base_dec, iva_dec = to_base_iva(line_total_desc)
+                base_total = float(base_total_dec)
+                base = float(base_dec)
+                iva_item_val = float(iva_dec)
                 d["iva"] = iva_item_val
+                sumas += base_total
+                descuentos += base_total - base
+            else:
+                base_total = line_total
+                base = line_total_desc
+                if credito_info and not iva_item_val:
+                    iva_item_val = float(iva_item(base))
+                    d["iva"] = iva_item_val
+                sumas += base_total
+                descuentos += desc
             d["ventas_gravadas"] = base
-            sumas += base_total
-            descuentos += desc
             iva += iva_item_val
 
-    subtotal = (sumas - descuentos) + iva
-    total = subtotal + ventas_exentas + ventas_no_sujetas
+    subtotal = sumas - descuentos
+    total = subtotal + iva + ventas_exentas + ventas_no_sujetas
     venta_data.update(
         {
             "sumas": sumas,
@@ -88,12 +112,6 @@ def generate_invoice_pdf(manager, venta_id):
             None,
         )
 
-    extra = venta_data.get("extra") or {}
-    if isinstance(extra, str):
-        try:
-            extra = json.loads(extra)
-        except Exception:
-            extra = {}
     if not venta_data.get("venta_a_cuenta_de"):
         venta_data["venta_a_cuenta_de"] = extra.get("venta_a_cuenta_de", "")
     if not venta_data.get("documento_venta_a_cuenta"):


### PR DESCRIPTION
## Summary
- Split IVA when unit prices already include tax during PDF creation
- Compute subtotal as base amount and add IVA once to the total
- Add regression test ensuring a $15 sale with IVA included stays $15 in the PDF data

## Testing
- `pytest tests/test_credito_fiscal_pdf_iva.py::test_pdf_total_precios_incluyen_iva -q --no-cov`
- `pytest -q` *(fails: libGL.so.1 missing; ModuleNotFoundError: fastapi)*


------
https://chatgpt.com/codex/tasks/task_e_68c10814dc508323a2a7a7a15faa7af6