### PR TITLE
Add messaging for signer service status

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -88,24 +88,42 @@ class MainWindow(QMainWindow):
     def iniciar_firmador(self):
         """Lanza el servicio externo de firmado de documentos."""
         if self.firmador_proc and self.firmador_proc.poll() is None:
-            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
+            QMessageBox.information(
+                self,
+                "Firmador",
+                "El firmador ya está corriendo, no es necesario volver a ejecutarlo.",
+            )
             return
         if firmador_activo():
-            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
+            QMessageBox.information(
+                self,
+                "Firmador",
+                "El firmador ya está corriendo, no es necesario volver a ejecutarlo.",
+            )
             return
         try:
             self.firmador_proc = iniciar_firmador()
-            QMessageBox.information(self, "Firmador", "Firmador iniciado correctamente.")
+            QMessageBox.information(
+                self, "Firmador", "El firmador está corriendo."
+            )
         except FileNotFoundError as exc:
             QMessageBox.critical(self, "Error", f"No se encontró el firmador:\n{exc}")
         except RuntimeError:
-            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
+            QMessageBox.information(
+                self,
+                "Firmador",
+                "El firmador ya está corriendo, no es necesario volver a ejecutarlo.",
+            )
         except Exception as exc:
             QMessageBox.critical(self, "Error", f"No se pudo iniciar el firmador:\n{exc}")
 
     def _verificar_firmador(self):
         if firmador_activo():
-            QMessageBox.information(self, "Firmador", "El firmador ya está en ejecución.")
+            QMessageBox.information(
+                self,
+                "Firmador",
+                "El firmador ya está corriendo, no es necesario volver a ejecutarlo.",
+            )
         else:
             resp = QMessageBox.question(
                 self,

--- a/utils/firmador.py
+++ b/utils/firmador.py
@@ -22,7 +22,9 @@ def firmador_activo() -> bool:
 def iniciar_firmador() -> subprocess.Popen:
     """Inicia el servicio ``svfe-api-firmador`` usando el JDK empaquetado."""
     if firmador_activo():
-        raise RuntimeError("El firmador ya está en ejecución")
+        raise RuntimeError(
+            "El firmador ya está corriendo, no es necesario volver a ejecutarlo."
+        )
     base = Path(__file__).resolve().parent.parent / "svfe-api-firmador"
     java_home = base / "vendor" / "jdk"
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- notify when signer starts running
- warn when signer is already running

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d192c0a48323b63b1d1b1e1b9147