### PR TITLE
Fix rounding for credit note totals

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -236,12 +236,19 @@ def generar_nce_desde_dte(
         if monto is not None:
             monto_abs = Decimal(str(monto)).copy_abs()
             monto_total_operacion = d2(monto_abs)
-            base, _ = to_base_iva(monto_abs)
-            total_grav = base.quantize(Q4)
+            base_precisa, _ = to_base_iva(monto_abs)
+            # El monto de la nota ya incluye IVA, por lo que se separa la
+            # porción gravada manteniendo mayor precisión (8 decimales) y
+            # posteriormente se redondea a 2 decimales para las secciones que
+            # lo requieren.  El IVA se obtiene como la diferencia entre el
+            # total ingresado por el usuario y la base gravada redondeada,
+            # asegurando que ambos componentes sumen el total original.
+            base_redondeada = d2(base_precisa)
+            total_grav = base_redondeada.quantize(Q4)
             total_exenta = Decimal_0
             total_nosuj = Decimal_0
             subtotal_ventas = total_grav
-            iva_val = d2(monto_total_operacion - d2(total_grav))
+            iva_val = d2(monto_total_operacion - base_redondeada)
             num = 1
             pct_text = _pct_label(ratio) if ratio is not None else "100"
             if total_grav > 0:

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -217,8 +217,42 @@ def test_nota_credito_un_dolar(monkeypatch):
     assert stored == Decimal("1")
     nce = generar_nce_desde_nota(db, nota_id)
     resumen = nce["resumen"]
+    item = nce["cuerpoDocumento"][0]
     assert resumen["montoTotalOperacion"] == Decimal("1.00")
+    assert item["precioUni"] == Decimal("0.8800")
+    assert resumen["totalGravada"] == Decimal("0.88")
     iva = resumen["tributos"][0]["valor"] if resumen["tributos"] else Decimal("0")
+    assert iva == Decimal("0.12")
+    assert resumen["totalGravada"] + iva == resumen["montoTotalOperacion"]
+
+
+def test_nota_credito_dos_centavos(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2024-01-02', 0.02, '')",
+        (venta_id,),
+    ).lastrowid
+    nce = generar_nce_desde_nota(db, nota_id)
+    resumen = nce["resumen"]
+    assert resumen["montoTotalOperacion"] == Decimal("0.02")
+    assert resumen["totalGravada"] == Decimal("0.02")
+    iva = resumen["tributos"][0]["valor"] if resumen["tributos"] else Decimal("0")
+    assert iva == Decimal("0.00")
     assert resumen["totalGravada"] + iva == resumen["montoTotalOperacion"]
 
 


### PR DESCRIPTION
## Summary
- preserve credit note totals by computing IVA split at high precision before rounding
- add regression test for two-cent credit note

## Testing
- `pytest tests/test_nota_credito.py -q --disable-warnings --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4bfe64883239345b65efac08cca