### PR TITLE
Add public consultation QR to DTE PDFs

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -7,7 +7,8 @@ from reportlab.lib.units import mm
 from reportlab.lib import colors
 
 from utils.pdf_utils import draw_wrapped_text
-from factura_sv import build_qr_value
+from factura_sv import build_qr_url
+from datetime import datetime
 
 
 def generar_cabecera_dte(
@@ -83,13 +84,21 @@ def generar_cabecera_dte(
     # QR en el centro
     qr_x = 40 + box_w + col_margin + 3
     qr_y = box_y + (box_h - qr_size) / 2
-    qr_env = 1 if ambiente in ("00", "produccion") else 2
-    qr_value = build_qr_value(
-        qr_env,
-        codigo_generacion,
-        tipo_dte,
-        numero_control,
-    )
+    if not fecha_emision and fecha_generacion:
+        try:
+            fecha_emision = datetime.strptime(
+                fecha_generacion.split(",")[0].strip(), "%d/%m/%Y"
+            ).strftime("%Y-%m-%d")
+        except Exception:
+            fecha_emision = datetime.now().strftime("%Y-%m-%d")
+    dte = {
+        "identificacion": {
+            "ambiente": ambiente,
+            "codigoGeneracion": codigo_generacion,
+            "fecEmi": fecha_emision,
+        }
+    }
+    qr_value = build_qr_url(dte)
     qr_code = qr.QrCodeWidget(qr_value)
     bounds = qr_code.getBounds()
     w = bounds[2] - bounds[0]
@@ -97,6 +106,8 @@ def generar_cabecera_dte(
     d = Drawing(qr_size, qr_size, transform=[qr_size / w, 0, 0, qr_size / h, 0, 0])
     d.add(qr_code)
     renderPDF.draw(d, c, qr_x, qr_y)
+    c.setFont("Helvetica", 6)
+    c.drawCentredString(qr_x + qr_size / 2, qr_y - 8, qr_value)
 
     # --- Caja derecha ---
     right_x = 40 + box_w + col_margin + qr_size + col_margin

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -14,28 +14,20 @@ from db import DB
 from urllib.parse import urlencode
 import json
 import os
+from datetime import datetime
 from paths import DATOS_NEGOCIO_PATH
 
 
-def build_qr_value(
-    ambiente: int,
-    codigo_generacion: str,
-    tipo_dte: str,
-    numero_documento: str,
-) -> str:
-    """Return the URL used for the DTE QR code."""
+def build_qr_url(dte: dict) -> str:
+    """Return the public consultation URL for a DTE."""
 
-    base_url = (
-        "https://www.mh.gob.sv/consulta-dte" if ambiente == 1 else "https://apitest.mh.gob.sv/consulta-dte"
-    )
-
-    params = {
-        "ambiente": ambiente,
-        "codigoGeneracion": codigo_generacion,
-        "tipoDte": tipo_dte,
-        "numeroDocumento": numero_documento,
-    }
-
+    ident = dte.get("identificacion", {}) if isinstance(dte, dict) else {}
+    ambiente = str(ident.get("ambiente", "00")).strip()
+    ambiente = "01" if ambiente == "01" else "00"
+    codigo = ident.get("codigoGeneracion")
+    fecha = ident.get("fecEmi") or ident.get("fechaEmi")
+    base_url = "https://admin.factura.gob.sv/consultaPublica"
+    params = {"ambiente": ambiente, "codGen": codigo, "fechaEmi": fecha}
     return base_url + "?" + urlencode(params)
 
 
@@ -115,6 +107,13 @@ def generar_factura_electronica_pdf(
         fecha_generacion = fecha_generacion or cab["fecha_generacion"]
         sello_recepcion = sello_recepcion or cab["sello_recepcion"]
 
+    try:
+        fecha_emision = datetime.strptime(
+            fecha_generacion.split(",")[0].strip(), "%d/%m/%Y"
+        ).strftime("%Y-%m-%d")
+    except Exception:
+        fecha_emision = datetime.now().strftime("%Y-%m-%d")
+
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter
     x_margin = 30
@@ -179,20 +178,22 @@ def generar_factura_electronica_pdf(
     # --- Código QR ---
     qr_x = x_margin + box_w + col_margin + 5
     qr_y = box_y + (box_h - qr_size) / 2
-    qr_env = 1 if ambiente == "01" else 2
-    qr_value = build_qr_value(
-        qr_env,
-        codigo_generacion,
-        tipo_dte,
-        numero_control,
+    qr_url = build_qr_url(
+        {"identificacion": {
+            "ambiente": ambiente,
+            "codigoGeneracion": codigo_generacion,
+            "fecEmi": fecha_emision,
+        }}
     )
-    qr_code = qr.QrCodeWidget(qr_value)
+    qr_code = qr.QrCodeWidget(qr_url)
     bounds = qr_code.getBounds()
     w = bounds[2] - bounds[0]
     h = bounds[3] - bounds[1]
     d = Drawing(qr_size, qr_size, transform=[qr_size / w, 0, 0, qr_size / h, 0, 0])
     d.add(qr_code)
     renderPDF.draw(d, c, qr_x, qr_y)
+    c.setFont("Helvetica", 6)
+    c.drawCentredString(qr_x + qr_size / 2, qr_y - 10, qr_url)
 
     # --- Caja derecha con datos de operación ---
     right_x = x_margin + box_w + col_margin + qr_size + col_margin

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -2,7 +2,7 @@ import pytest
 import fitz
 from urllib.parse import urlparse, parse_qs
 import factura_sv
-from factura_sv import generar_factura_electronica_pdf, build_qr_value
+from factura_sv import generar_factura_electronica_pdf, build_qr_url
 import utils.catalogos as catalogos
 
 
@@ -118,37 +118,39 @@ def test_total_letras_is_wrapped(tmp_path):
     assert any('71/100 DÓLARES' in ln for ln in lines)
 
 
-def test_qr_value_contains_params():
-    url = build_qr_value(
-        2,
-        'ABC',
-        '01',
-        'NC-1',
+def test_qr_url_contains_params():
+    url = build_qr_url(
+        {
+            'identificacion': {
+                'ambiente': '00',
+                'codigoGeneracion': 'ABC',
+                'fecEmi': '2025-01-01',
+            }
+        }
     )
-    assert url.startswith('https://apitest.mh.gob.sv/consulta-dte?')
-    assert 'codigoGeneracion=ABC' in url
-    assert 'numeroDocumento=NC-1' in url
-    assert 'tipoDte=01' in url
-    assert 'ambiente=2' in url
+    assert url.startswith('https://admin.factura.gob.sv/consultaPublica?')
+    assert 'codGen=ABC' in url
+    assert 'fechaEmi=2025-01-01' in url
+    assert 'ambiente=00' in url
 
 
 def test_qr_url_matches_environment(tmp_path, monkeypatch):
     venta, detalles = _sample_data('Crédito Fiscal')
     captured = []
 
-    def fake_build_qr_value(ambiente, codigo_generacion, tipo_dte, numero_documento):
-        url = build_qr_value(ambiente, codigo_generacion, tipo_dte, numero_documento)
+    def fake_build_qr_url(dte):
+        url = build_qr_url(dte)
         captured.append(url)
         return url
 
-    monkeypatch.setattr(factura_sv, 'build_qr_value', fake_build_qr_value)
+    monkeypatch.setattr(factura_sv, 'build_qr_url', fake_build_qr_url)
 
     scenarios = [
-        ('01', 'https://www.mh.gob.sv/consulta-dte', '1'),
-        ('00', 'https://apitest.mh.gob.sv/consulta-dte', '2'),
+        ('01', '01'),
+        ('00', '00'),
     ]
 
-    for env, expected_base, expected_param in scenarios:
+    for env, expected_param in scenarios:
         captured.clear()
         out = tmp_path / f'fact_{env}.pdf'
         generar_factura_electronica_pdf(
@@ -163,7 +165,7 @@ def test_qr_url_matches_environment(tmp_path, monkeypatch):
         )
         assert captured, 'QR value not generated'
         url = captured[0]
-        assert url.startswith(expected_base)
+        assert url.startswith('https://admin.factura.gob.sv/consultaPublica')
         qs = parse_qs(urlparse(url).query)
         assert qs.get('ambiente') == [expected_param]
 

--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -1,10 +1,14 @@
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
+from reportlab.graphics.barcode import qr
+from reportlab.graphics.shapes import Drawing
+from reportlab.graphics import renderPDF
 from datetime import datetime
 import json
 import os
 from paths import DATOS_NEGOCIO_PATH
+from factura_sv import build_qr_url
 
 
 def _with_falta(value):
@@ -101,6 +105,8 @@ def generar_ticket_personalizado(
 
     sello = dte_data.get("selloRecibido", "falta")
     firma = dte_data.get("firmaElectronica", "falta")
+    dte_json = dte_data.get("dteJson", {})
+    qr_url = build_qr_url(dte_json) if dte_json else None
 
     def _flatten(data, prefix=""):
         lines = []
@@ -207,6 +213,20 @@ def generar_ticket_personalizado(
     for line in dte_lines:
         c.drawString(5 * mm, y, _with_falta(line))
         y -= line_height
+    y -= line_height
+    if qr_url:
+        qr_size = 20 * mm
+        qr_code = qr.QrCodeWidget(qr_url)
+        bounds = qr_code.getBounds()
+        w = bounds[2] - bounds[0]
+        h = bounds[3] - bounds[1]
+        d = Drawing(qr_size, qr_size, transform=[qr_size / w, 0, 0, qr_size / h, 0, 0])
+        d.add(qr_code)
+        qr_x = (width - qr_size) / 2
+        qr_y = max(5 * mm, y - qr_size)
+        renderPDF.draw(d, c, qr_x, qr_y)
+        c.setFont("Helvetica", 5)
+        c.drawCentredString(width / 2, qr_y - 4, qr_url)
 
     c.showPage()
     c.save()


### PR DESCRIPTION
## Summary
- add `build_qr_url` to build Ministerio de Hacienda public consultation link
- embed QR code and printable URL in DTE and ticket PDFs
- adjust tests for new QR URL

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 and ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d723fc10832396b0aaf80805a0b6