### PR TITLE
Use JSON resumen totals when generating invoice PDFs

### DIFF
--- a/tests/test_credito_fiscal_pdf_iva.py
+++ b/tests/test_credito_fiscal_pdf_iva.py
@@ -42,7 +42,7 @@ def test_credito_fiscal_pdf_calcula_iva(tmp_path, monkeypatch):
     db = FakeDB()
     venta = {"id": 1, "fecha": "2024-01-01", "total": 11.3}
     db._ventas.append(venta)
-    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10, "iva": 1.3}]
     db.credito[1] = {"sumas": 10, "descuentos": 0, "iva": 0, "subtotal": 0, "ventas_exentas": 0, "ventas_no_sujetas": 0}
     man = Manager(db)
 
@@ -60,7 +60,16 @@ def test_credito_fiscal_pdf_calcula_iva(tmp_path, monkeypatch):
         ident = data.setdefault("identificacion", {})
         ident["codigoGeneracion"] = uuid.uuid4().hex
         ident["numeroControl"] = uuid.uuid4().hex[:8].upper()
-        data.setdefault("resumen", {})["totalPagar"] = venta.get("total")
+        resumen = {
+            "sumas": 10,
+            "descuentos": 0,
+            "iva": 1.3,
+            "subtotal": 11.3,
+            "ventasExentas": 0,
+            "ventasNoSujetas": 0,
+            "totalPagar": venta.get("total"),
+        }
+        data["resumen"] = resumen
         return data
 
     captured = {}
@@ -91,7 +100,7 @@ def test_pdf_total_precios_incluyen_iva(tmp_path, monkeypatch):
         "extra": json.dumps({"precios_incluyen_iva": True}),
     }
     db._ventas.append(venta)
-    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 15}]
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 15, "iva": 1.72566372}]
     man = Manager(db)
 
     pdf_path = tmp_path / "fact.pdf"
@@ -108,7 +117,18 @@ def test_pdf_total_precios_incluyen_iva(tmp_path, monkeypatch):
         ident = data.setdefault("identificacion", {})
         ident["codigoGeneracion"] = uuid.uuid4().hex
         ident["numeroControl"] = uuid.uuid4().hex[:8].upper()
-        data.setdefault("resumen", {})["totalPagar"] = venta.get("total")
+        base = 13.27433628
+        iva = 1.72566372
+        resumen = {
+            "sumas": base,
+            "descuentos": 0,
+            "iva": iva,
+            "subtotal": base + iva,
+            "ventasExentas": 0,
+            "ventasNoSujetas": 0,
+            "totalPagar": venta.get("total"),
+        }
+        data["resumen"] = resumen
         return data
 
     captured = {}
@@ -125,8 +145,8 @@ def test_pdf_total_precios_incluyen_iva(tmp_path, monkeypatch):
 
     generate_invoice_pdf(man, 1)
 
-    base, iva = to_base_iva(15)
-    assert pytest.approx(captured["venta"]["subtotal"], 0.01) == float(base)
+    base, iva = 13.27433628, 1.72566372
+    assert pytest.approx(captured["venta"]["subtotal"], 0.01) == 15
     assert pytest.approx(captured["venta"]["iva"], 0.01) == float(iva)
     assert pytest.approx(captured["venta"]["total"], 0.01) == 15
     assert pytest.approx(captured["detalles"][0]["iva"], 0.01) == float(iva)

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -8,6 +8,7 @@ import dte
 from sales_tab import SalesTab
 from utils.doc_generation import generate_invoice_pdf
 import facturacion_tab
+from utils import docs
 
 class FakeDB:
     def __init__(self):
@@ -94,8 +95,18 @@ def test_facturacion_tab_generate_invoice_creates_json(tmp_path):
         pdf_path.parent.mkdir(parents=True, exist_ok=True)
         return str(pdf_path), str(json_path)
 
+    def fake_generar(db_, vid, **_):
+        venta = next(v for v in db_.get_ventas() if v["id"] == vid)
+        detalles = db_.get_detalles_venta(vid)
+        data = docs.build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident.setdefault("codigoGeneracion", uuid.uuid4().hex)
+        ident.setdefault("numeroControl", uuid.uuid4().hex[:8].upper())
+        return data
+
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
 
     tab._generate_invoice_pdf(1)
     monkeypatch.undo()

--- a/tests/test_preview_cleanup.py
+++ b/tests/test_preview_cleanup.py
@@ -10,7 +10,7 @@ class FakeDB:
         self._ventas = []
         self.detalles = {}
         self.pdfs = {}
-    def get_ventas(self):
+    def get_ventas(self, *a, **k):
         return self._ventas
     def get_venta_credito_fiscal(self, vid):
         return None

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -44,8 +44,6 @@ def generate_invoice_pdf(manager, venta_id):
         if trabajador:
             venta_data["vendedor_nombre"] = trabajador.get("nombre", "")
 
-    sumas = descuentos = 0
-    ventas_exentas = ventas_no_sujetas = iva = 0
     for d in detalles:
         unit = d.get("precio_unitario", 0)
         cantidad = d.get("cantidad", 0)
@@ -58,49 +56,24 @@ def generate_invoice_pdf(manager, venta_id):
         tipo = d.get("tipo_fiscal", "").lower()
         if tipo == "venta exenta":
             d["ventas_exentas"] = line_total_desc
-            ventas_exentas += line_total_desc
         elif tipo == "venta no sujeta":
             d["ventas_no_sujetas"] = line_total_desc
-            ventas_no_sujetas += line_total_desc
         else:
             if precios_incluyen_iva:
-                base_total_dec, _ = to_base_iva(line_total)
-                base_dec, iva_dec = to_base_iva(line_total_desc)
-                base_total = float(base_total_dec)
-                base = float(base_dec)
-                iva_item_val = float(iva_dec)
-                d["iva"] = iva_item_val
-                sumas += base_total
-                descuentos += base_total - base
+                if iva_item_val:
+                    base = line_total_desc - iva_item_val
+                else:
+                    base_dec, iva_dec = to_base_iva(line_total_desc)
+                    base = float(base_dec)
+                    iva_item_val = float(iva_dec)
+                    d["iva"] = iva_item_val
             else:
-                base_total = line_total
                 base = line_total_desc
                 if credito_info and not iva_item_val:
                     iva_item_val = float(iva_item(base))
                     d["iva"] = iva_item_val
-                sumas += base_total
-                descuentos += desc
             d["ventas_gravadas"] = base
-            iva += iva_item_val
 
-    subtotal = sumas - descuentos + iva
-    total = subtotal + ventas_exentas + ventas_no_sujetas
-    venta_data.update(
-        {
-            "sumas": sumas,
-            "descuentos": descuentos,
-            "iva": iva,
-            "ventas_exentas": ventas_exentas,
-            "ventas_no_sujetas": ventas_no_sujetas,
-            "subtotal": subtotal,
-            "total": total,
-        }
-    )
-    if not venta_data.get("total_letras"):
-        try:
-            venta_data["total_letras"] = monto_a_texto_sv(total)
-        except Exception:
-            venta_data["total_letras"] = ""
 
     cliente = None
     if venta.get("cliente_id"):
@@ -181,6 +154,24 @@ def generate_invoice_pdf(manager, venta_id):
     except ValueError:
         logger.exception("Error al generar el DTE real")
         raise
+    resumen = json_data.get("resumen", {})
+    venta_data.update(
+        {
+            "sumas": resumen.get("sumas", 0),
+            "descuentos": resumen.get("descuentos", 0),
+            "iva": resumen.get("iva", 0),
+            "subtotal": resumen.get("subtotal", 0),
+            "ventas_exentas": resumen.get("ventasExentas", 0),
+            "ventas_no_sujetas": resumen.get("ventasNoSujetas", 0),
+            "total": resumen.get("totalPagar", 0),
+        }
+    )
+    if not venta_data.get("total_letras"):
+        try:
+            venta_data["total_letras"] = monto_a_texto_sv(venta_data.get("total", 0))
+        except Exception:
+            venta_data["total_letras"] = ""
+
     ident = json_data.get("identificacion", {})
     codigo_generacion = ident.get("codigoGeneracion")
     numero_control = ident.get("numeroControl")


### PR DESCRIPTION
## Summary
- derive invoice totals from `json_data['resumen']` and populate `venta_data`
- avoid recalculating line IVA when provided and adjust tests for JSON-driven totals

## Testing
- `pytest tests/test_credito_fiscal_pdf_iva.py tests/test_preview_cleanup.py tests/test_invoice_json_save.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1d518522c832394e6e09b460bfb49