### PR TITLE
Update IVA rate to 13 percent

### DIFF
--- a/ui/components/EditableNotaTable.vue
+++ b/ui/components/EditableNotaTable.vue
@@ -331,7 +331,7 @@ function calcIva(item: NotaItem) {
   if (item.ivaInc) {
     return toBaseIva(monto).iva;
   }
-  return monto * 0.20;
+  return fromBaseIva(monto).iva;
 }
 function calcTotal(item: NotaItem) {
   const monto = getMonto(item);

--- a/ui/services/useIvaConversion.ts
+++ b/ui/services/useIvaConversion.ts
@@ -1,12 +1,13 @@
 /**
- * Utilidades para convertir montos con IVA del 20%.
+ * Utilidades para convertir montos con IVA del 13%.
  *
  * - Cuando un precio tiene `ivaIncluido = true`, usa `toBaseIva` para separar
  *   el total en base imponible e impuesto.
  * - Cuando `ivaIncluido = false`, parte de la base con `fromBaseIva` para
  *   obtener el total con IVA.
  */
-const IVA_FACTOR = 1.20;
+const IVA_FACTOR = 1.13;
+const IVA_RATE = IVA_FACTOR - 1;
 
 function roundHalfUp(value: number, decimals = 2): number {
   const factor = Math.pow(10, decimals);
@@ -18,7 +19,7 @@ function roundHalfUp(value: number, decimals = 2): number {
  */
 export function toBaseIva(total: number): { base: number; iva: number } {
   const base = roundHalfUp(total / IVA_FACTOR, 2);
-  const iva = roundHalfUp(total - base, 2);
+  const iva = roundHalfUp(base * IVA_RATE, 2);
   return { base, iva };
 }
 
@@ -26,7 +27,7 @@ export function toBaseIva(total: number): { base: number; iva: number } {
  * Convierte una base imponible con `ivaIncluido = false` al total con IVA.
  */
 export function fromBaseIva(base: number): { total: number; iva: number } {
-  const total = roundHalfUp(base * IVA_FACTOR, 2);
-  const iva = roundHalfUp(total - base, 2);
+  const iva = roundHalfUp(base * IVA_RATE, 2);
+  const total = roundHalfUp(base + iva, 2);
   return { total, iva };
 }

--- a/ui/tests/EditableNotaTable.spec.ts
+++ b/ui/tests/EditableNotaTable.spec.ts
@@ -121,18 +121,18 @@ describe('EditableNotaTable', () => {
       }
     });
     const ajusteInput = wrapper.find('input.ajuste');
-    await ajusteInput.setValue('120');
+    await ajusteInput.setValue('113');
     await wrapper.vm.$nextTick();
     let cells = wrapper.findAll('tbody td');
     expect(cells[12].text()).toBe('100.00');
-    expect(cells[13].text()).toBe('20.00');
-    expect(cells[14].text()).toBe('120.00');
+    expect(cells[13].text()).toBe('13.00');
+    expect(cells[14].text()).toBe('113.00');
     await wrapper.setProps({ ivaIncluido: false });
     await ajusteInput.setValue('100');
     await wrapper.vm.$nextTick();
     cells = wrapper.findAll('tbody td');
     expect(cells[12].text()).toBe('100.00');
-    expect(cells[13].text()).toBe('20.00');
-    expect(cells[14].text()).toBe('120.00');
+    expect(cells[13].text()).toBe('13.00');
+    expect(cells[14].text()).toBe('113.00');
   });
 });

--- a/ui/tests/NotaForm.spec.ts
+++ b/ui/tests/NotaForm.spec.ts
@@ -70,12 +70,12 @@ describe('NotaForm', () => {
     const radioMonto = wrapper.find('input[value="monto"]');
     await radioMonto.setValue();
     const input = wrapper.find('input[type="number"]');
-    await input.setValue('12');
+    await input.setValue('11.3');
     await wrapper.vm.$nextTick();
     const cells = wrapper.findAll('tbody td');
     expect(cells[1].text()).toBe('10.00');
-    expect(cells[4].text()).toBe('2.00');
-    expect(cells[5].text()).toBe('12.00');
+    expect(cells[4].text()).toBe('1.30');
+    expect(cells[5].text()).toBe('11.30');
   });
 
   it('interpreta monto como base cuando ivaIncluido está inactivo', async () => {
@@ -94,8 +94,8 @@ describe('NotaForm', () => {
     await wrapper.vm.$nextTick();
     const cells = wrapper.findAll('tbody td');
     expect(cells[1].text()).toBe('10.00');
-    expect(cells[4].text()).toBe('2.00');
-    expect(cells[5].text()).toBe('12.00');
+    expect(cells[4].text()).toBe('1.30');
+    expect(cells[5].text()).toBe('11.30');
   });
 
   it('muestra bloques de factura y nota y solo nota cambia', async () => {
@@ -273,7 +273,7 @@ describe('NotaForm', () => {
     await wrapper.vm.$nextTick();
     const resumen = wrapper.find('.nota-resumen').text();
     expect(resumen).toContain('Base gravada: 100.00');
-    expect(resumen).toContain('IVA: 20.00');
-    expect(resumen).toContain('Total: 120.00');
+    expect(resumen).toContain('IVA: 13.00');
+    expect(resumen).toContain('Total: 113.00');
   });
 });

--- a/ui/tests/prorrateo.spec.ts
+++ b/ui/tests/prorrateo.spec.ts
@@ -6,7 +6,7 @@ describe('prorratearGlobal', () => {
     ventas_gravadas: 100,
     ventas_exentas: 50,
     ventas_no_sujetas: 25,
-    iva: 20,
+    iva: 13,
   };
 
   it('prorratea según porcentaje', () => {
@@ -14,15 +14,15 @@ describe('prorratearGlobal', () => {
     expect(res.ventas_gravadas).toBeCloseTo(10);
     expect(res.ventas_exentas).toBeCloseTo(5);
     expect(res.ventas_no_sujetas).toBeCloseTo(2.5);
-    expect(res.iva).toBeCloseTo(2);
-    expect(res.total).toBeCloseTo(19.5);
+    expect(res.iva).toBeCloseTo(1.3);
+    expect(res.total).toBeCloseTo(18.8);
   });
 
   it('prorratea según monto', () => {
-    const res = prorratearGlobal(factura, { monto: 19.5 });
+    const res = prorratearGlobal(factura, { monto: 18.8 });
     expect(res.ventas_gravadas).toBeCloseTo(10);
-    expect(res.iva).toBeCloseTo(2);
-    expect(res.total).toBeCloseTo(19.5);
+    expect(res.iva).toBeCloseTo(1.3);
+    expect(res.total).toBeCloseTo(18.8);
   });
 });
 

--- a/ui/tests/useIvaConversion.spec.ts
+++ b/ui/tests/useIvaConversion.spec.ts
@@ -3,14 +3,14 @@ import { toBaseIva, fromBaseIva } from '../services/useIvaConversion';
 
 describe('useIvaConversion', () => {
   it('convierte total a base e iva', () => {
-    const { base, iva } = toBaseIva(120);
+    const { base, iva } = toBaseIva(113);
     expect(base).toBe(100);
-    expect(iva).toBe(20);
+    expect(iva).toBe(13);
   });
 
   it('convierte base a total e iva', () => {
     const { total, iva } = fromBaseIva(100);
-    expect(total).toBe(120);
-    expect(iva).toBe(20);
+    expect(total).toBe(113);
+    expect(iva).toBe(13);
   });
 });


### PR DESCRIPTION
## Summary
- use new IVA conversion factor of 1.13 and derive rate
- update note table calculations to rely on conversion helpers
- adjust tests for 13% VAT

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ddfc02988323af2b6b3b9e6e7cf9