### PR TITLE
Preserva numDocumento y tipoDocumento en DTE 03

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2021,7 +2021,10 @@ def generar_dte_json(
             "correo",
             "direccion",
         ]
-        for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+        fields_to_remove = ["noRemision", "ordenNo"]
+        if tipo_dte != "03":
+            fields_to_remove.extend(["numDocumento", "tipoDocumento"])
+        for f in fields_to_remove:
             receptor.pop(f, None)
 
     for f in required_rec_fields:
@@ -2764,8 +2767,11 @@ def validate_dte_json(
         receptor["numDocumento"] = num_doc
     else:
         receptor["nit"] = _clean_nit(nit_field)
-        receptor.pop("tipoDocumento", None)
-        receptor.pop("numDocumento", None)
+        if receptor.get("numDocumento") or receptor.get("tipoDocumento"):
+            limpiar_documentos(receptor)
+        else:
+            receptor.pop("tipoDocumento", None)
+            receptor.pop("numDocumento", None)
 
     receptor.pop("giro", None)
     dir_rec = receptor.get("direccion")
@@ -2808,7 +2814,10 @@ def validate_dte_json(
         ]
         for f in required_rec_fields:
             receptor.setdefault(f, None)
-        for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+        fields_to_remove = ["noRemision", "ordenNo"]
+        if tipo_dte != "03":
+            fields_to_remove.extend(["numDocumento", "tipoDocumento"])
+        for f in fields_to_remove:
             receptor.pop(f, None)
     payload["receptor"] = receptor
 

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -1682,6 +1682,68 @@ def test_generar_dte_json_cons_final_rechaza_iva_en_tributos(tmp_path):
         generar_dte_json(db, venta_id)
 
 
+@pytest.mark.parametrize(
+    "doc,tipo_doc",
+    [
+        ("06141990011019", "36"),  # NIT
+        ("01234567-8", "13"),  # DUI
+    ],
+)
+def test_generar_dte_json_cf_documento_preservado(tmp_path, doc, tipo_doc):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+
+    # Cliente siempre con NIT válido para DTE-03
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+    extra = {
+        "precios_incluyen_iva": False,
+        "receptor": {"numDocumento": doc, "tipoDocumento": tipo_doc},
+    }
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, extra=extra)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    receptor = data["receptor"]
+    assert receptor["tipoDocumento"] == tipo_doc
+    assert receptor["numDocumento"] == doc.replace("-", "")
+
+
 def test_generar_dte_json_dte03_descuento_colapsado(tmp_path):
     import dte as dte_module
 


### PR DESCRIPTION
## Summary
- Evita descartar `numDocumento` y `tipoDocumento` cuando el DTE es tipo 03, sanitizando los valores si están presentes
- Agrega prueba que verifica que una factura de consumidor final conserva los campos de documento proporcionados

## Testing
- `pytest` *(errores de importación)*
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_cf_documento_preservado -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c1e00ebc148323bfeede474ef96f6e