### PR TITLE
Infer ticket DUI type

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -433,6 +433,7 @@ DEPARTAMENTO_CODES = {f"{i:02d}" for i in range(0, 15)}
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 PHONE_RE = re.compile(r"^\+?\d{8,15}$")
+DUI_RE = re.compile(r"^[0-9]{8}-[0-9]$")
 
 
 def _map_departamento(nombre: str | None) -> str:
@@ -2021,8 +2022,11 @@ def generar_dte_json(
             "correo",
             "direccion",
         ]
-        for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+        for f in ("noRemision", "ordenNo"):
             receptor.pop(f, None)
+        if not receptor.get("numDocumento"):
+            receptor.pop("numDocumento", None)
+            receptor.pop("tipoDocumento", None)
 
     for f in required_rec_fields:
         receptor.setdefault(f, None)
@@ -2725,6 +2729,13 @@ def validate_dte_json(
     receptor = payload.get("receptor", {})
     nit_field = receptor.get("nit")
     tipo_doc = receptor.get("tipoDocumento")
+    raw_num_doc = receptor.get("numDocumento")
+    if isinstance(raw_num_doc, str):
+        raw_num_doc = "".join(c for c in raw_num_doc if c.isdigit() or c == "-")
+    else:
+        raw_num_doc = ""
+    if tipo_doc is None and DUI_RE.fullmatch(raw_num_doc):
+        tipo_doc = "13"
     if tipo_dte != "03":
         if nit_field is not None:
             receptor["numDocumento"] = _clean_nit(nit_field)
@@ -2764,8 +2775,15 @@ def validate_dte_json(
         receptor["numDocumento"] = num_doc
     else:
         receptor["nit"] = _clean_nit(nit_field)
-        receptor.pop("tipoDocumento", None)
-        receptor.pop("numDocumento", None)
+        limpiar_documentos(receptor)
+        num_doc = solo_digitos(receptor.get("numDocumento"))
+        if tipo_doc or num_doc:
+            tipo_doc = str(tipo_doc or "13")
+            receptor["tipoDocumento"] = tipo_doc
+            receptor["numDocumento"] = num_doc
+        else:
+            receptor.pop("tipoDocumento", None)
+            receptor.pop("numDocumento", None)
 
     receptor.pop("giro", None)
     dir_rec = receptor.get("direccion")
@@ -2808,8 +2826,11 @@ def validate_dte_json(
         ]
         for f in required_rec_fields:
             receptor.setdefault(f, None)
-        for f in ("noRemision", "ordenNo", "numDocumento", "tipoDocumento"):
+        for f in ("noRemision", "ordenNo"):
             receptor.pop(f, None)
+        if not receptor.get("numDocumento"):
+            receptor.pop("numDocumento", None)
+            receptor.pop("tipoDocumento", None)
     payload["receptor"] = receptor
 
     cuerpo = payload.get("cuerpoDocumento", [])

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -6,15 +6,24 @@ from nota_credito_electronica import generar_nce_desde_dte
 
 def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
     # Mock dependencies for business data and validation
-    monkeypatch.setattr(
-        "svfe.config.load_datos_negocio",
-        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
-    )
-    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
     monkeypatch.setattr(
         "dte._build_receptor_direccion",
         lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
     )
+    monkeypatch.setattr("dte.recalcular_totales", lambda *a, **k: [])
 
     db = DB(":memory:")
     db.add_vendedor("V1")
@@ -44,3 +53,49 @@ def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
     nce = generar_nce_desde_dte(db, data, Decimal("1"), motivo="Dev")
     assert nce["identificacion"]["tipoDte"] == "05"
     assert nce["documentoRelacionado"][0]["tipoDocumento"] == "03"
+
+
+def test_generar_ticket_json_dui_auto_tipo(monkeypatch):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+    monkeypatch.setattr("dte.recalcular_totales", lambda *a, **k: [])
+
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "",  # sin NIT
+        "",
+        "giro",
+        "",
+        "",
+        "",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cliente_id)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    db.update_venta_extra(venta_id, {"receptor": {"numDocumento": "01234567-8"}})
+
+    data = generar_ticket_json(db, venta_id)
+    assert data["receptor"]["tipoDocumento"] == "13"


### PR DESCRIPTION
## Summary
- detect DUI numbers in validate_dte_json and set missing tipoDocumento to 13
- keep numDocumento/tipoDocumento for ticket DTEs
- add regression test ensuring generar_ticket_json infers tipoDocumento from DUI

## Testing
- `pytest tests/test_ticket_nitless.py::test_generar_ticket_json_dui_auto_tipo -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e00ebe7883239198cc2135f1203b