### PR TITLE
Asigna tipoDocumento DUI automáticamente en tickets

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1938,6 +1938,10 @@ def generar_dte_json(
     if tipo_doc is not None:
         tipo_doc = str(tipo_doc)
     num_doc = rec.get("numDocumento")
+    if isinstance(num_doc, str):
+        num_doc = num_doc.strip()
+        if tipo_doc is None and re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
+            tipo_doc = "13"
     nit = _clean_nit(rec.get("nit"))
     if fiscal:
         tipo_doc = fiscal.get("tipoDocumento") or tipo_doc

--- a/tests/test_ticket_dui.py
+++ b/tests/test_ticket_dui.py
@@ -1,0 +1,30 @@
+from db import DB
+from dte import generar_ticket_json
+
+
+def test_generar_ticket_json_asigna_tipo_dui(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": None},
+    )
+
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = generar_ticket_json(
+        db,
+        venta_id,
+        extra={"receptor": {"numDocumento": "12345678-9"}},
+    )
+    rec = data["receptor"]
+    assert rec["tipoDocumento"] == "13"


### PR DESCRIPTION
## Summary
- Detecta DUIs en generar_dte_json y asigna tipoDocumento "13" cuando no se especifica tipo
- Añade prueba que verifica que generar_ticket_json establece tipoDocumento=13 al recibir un DUI

## Testing
- `pytest` *(falla: 46 errors during collection)*
- `pytest tests/test_ticket_dui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e60128b483239de31ee23d482489