### PR TITLE
Calcular IVA por fórmula inversa en notas

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3306,7 +3306,6 @@ def generar_nde_desde_dte(
         total_grav = Decimal("0")
         total_exenta = Decimal("0")
         total_nosuj = Decimal("0")
-        iva_val = Decimal("0")
         num = 1
         for det in detalles:
             grav = Decimal(str(det.get("ventas_gravadas") or det.get("ventaGravada") or 0))
@@ -3315,9 +3314,6 @@ def generar_nde_desde_dte(
             total_grav += grav
             total_exenta += exenta
             total_nosuj += nosuj
-            iva_val += (grav * Decimal("0.13")).quantize(
-                Decimal("0.01"), rounding=ROUND_HALF_UP
-            )
             precio = det.get("precio_unitario") or det.get("precioUni")
             if precio is None:
                 precio = grav + exenta + nosuj
@@ -3345,12 +3341,15 @@ def generar_nde_desde_dte(
                 }
             )
             num += 1
-        total_grav = d2(total_grav)
-        total_exenta = d2(total_exenta)
-        total_nosuj = d2(total_nosuj)
-        iva_val = d2(iva_val)
-        subtotal_ventas = total_grav + total_exenta + total_nosuj
-        monto_total = d2(subtotal_ventas + iva_val)
+        total_grav = d4(total_grav)
+        total_exenta = d4(total_exenta)
+        total_nosuj = d4(total_nosuj)
+        subtotal_ventas_q4 = total_grav + total_exenta + total_nosuj
+        subtotal_ventas = d2(subtotal_ventas_q4)
+        monto_total = d2(
+            total_grav * Decimal("1.13") + total_exenta + total_nosuj
+        )
+        iva_val = d2(monto_total - subtotal_ventas)
     else:
         if monto is None:
             raise ValueError("Se requiere monto para nota de débito")
@@ -3445,9 +3444,9 @@ def generar_nde_desde_dte(
             }
         )
     resumen = {
-        "totalNoSuj": total_nosuj,
-        "totalExenta": total_exenta,
-        "totalGravada": total_grav,
+        "totalNoSuj": d2(total_nosuj),
+        "totalExenta": d2(total_exenta),
+        "totalGravada": d2(total_grav),
         "subTotal": subtotal_ventas,
         "subTotalVentas": subtotal_ventas,
         "descuNoSuj": 0.0,

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -258,16 +258,17 @@ def generar_nce_desde_dte(
                         Decimal(str(items[first_idx]["precioUni"])) + diff
                     ).quantize(Q4)
             total_grav = base_q4
-            subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
+            subtotal_ventas_q4 = (total_grav + total_exenta + total_nosuj).quantize(Q4)
+            subtotal_ventas = d2(subtotal_ventas_q4)
             monto_total_operacion = d2(monto_abs)
+            iva_val = d2(monto_total_operacion - subtotal_ventas)
         else:
-            subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
-            # Cuando los montos se calculan a partir de ``detalles`` evitamos
-            # recurrir al total original del documento de origen. El IVA se obtiene
-            # directamente de las ventas gravadas parciales y el total de la
-            # operación se compone sumando dicho IVA al subtotal calculado.
-            iva_val = d2(total_grav * IVA)
-            monto_total_operacion = d2(subtotal_ventas + iva_val)
+            subtotal_ventas_q4 = (total_grav + total_exenta + total_nosuj).quantize(Q4)
+            subtotal_ventas = d2(subtotal_ventas_q4)
+            monto_total_operacion = d2(
+                total_grav * (Decimal("1") + IVA) + total_exenta + total_nosuj
+            )
+            iva_val = d2(monto_total_operacion - subtotal_ventas)
     else:
         if monto is not None:
             monto_abs = Decimal(str(monto)).copy_abs()
@@ -283,8 +284,8 @@ def generar_nce_desde_dte(
             total_grav = base_redondeada.quantize(Q4)
             total_exenta = Decimal_0
             total_nosuj = Decimal_0
-            subtotal_ventas = total_grav
-            iva_val = d2(monto_total_operacion - base_redondeada)
+            subtotal_ventas = d2(total_grav)
+            iva_val = d2(monto_total_operacion - subtotal_ventas)
             num = 1
             pct_text = _pct_label(ratio) if ratio is not None else "100"
             if total_grav > 0:

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -161,20 +161,22 @@ def generar_nde_desde_dte(
         total_grav = d4(total_grav)
         total_exenta = d4(total_exenta)
         total_nosuj = d4(total_nosuj)
-        subtotal_ventas = total_grav + total_exenta + total_nosuj
+        subtotal_ventas_q4 = total_grav + total_exenta + total_nosuj
+        subtotal_ventas = d2(subtotal_ventas_q4)
 
         user_total = Decimal(str(monto)) if monto is not None else None
         if user_total is not None and user_total >= subtotal_ventas:
-            iva_val = d2(user_total - subtotal_ventas)
             monto_total = d2(user_total)
+            iva_val = d2(monto_total - subtotal_ventas)
         else:
-            iva_val = d2(total_grav * Decimal("0.13"))
-            monto_total = d2(subtotal_ventas + iva_val)
+            monto_total = d2(
+                total_grav * Decimal("1.13") + total_exenta + total_nosuj
+            )
+            iva_val = d2(monto_total - subtotal_ventas)
 
         total_grav = d2(total_grav)
         total_exenta = d2(total_exenta)
         total_nosuj = d2(total_nosuj)
-        subtotal_ventas = d2(subtotal_ventas)
     else:
         if monto is None:
             raise ValueError("Se requiere monto para nota de débito")
@@ -270,9 +272,9 @@ def generar_nde_desde_dte(
             }
         )
     resumen = {
-        "totalNoSuj": total_nosuj,
-        "totalExenta": total_exenta,
-        "totalGravada": total_grav,
+        "totalNoSuj": d2(total_nosuj),
+        "totalExenta": d2(total_exenta),
+        "totalGravada": d2(total_grav),
         "subTotal": subtotal_ventas,
         "subTotalVentas": subtotal_ventas,
         "descuNoSuj": 0.0,


### PR DESCRIPTION
## Resumen
- Calcula monto gravado e IVA en notas de crédito y débito usando fórmula inversa a partir del precio final
- Ajusta generador de notas en `dte.py` para evitar desajustes por redondeo

## Pruebas
- `pytest tests/test_nota_credito.py tests/test_nota_detalles.py tests/test_nce_detalles_total.py tests/test_notas_iva_incluido.py tests/test_notas_precio_uni.py tests/test_ccf_precios_iva_incluido.py tests/test_iva_conversion_prorrateo.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1e52e987483239d072a4f79c58021