### PR TITLE
Allow ticket generation without receptor NIT

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2499,6 +2499,10 @@ def generar_dte_json(
         "apendice": None,
         "ventaTercero": None,
         "extension": extension,
+        # ``extra`` se utiliza únicamente durante la validación para
+        # transmitir banderas internas como ``es_ticket``.  No forma parte
+        # del DTE final y se eliminará después de la validación.
+        "extra": extra,
     }
 
     try:

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -5,16 +5,24 @@ from nota_credito_electronica import generar_nce_desde_dte
 
 
 def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
-    # Mock dependencies for business data and validation
-    monkeypatch.setattr(
-        "svfe.config.load_datos_negocio",
-        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
-    )
-    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
-    monkeypatch.setattr(
-        "dte._build_receptor_direccion",
-        lambda src: {"departamento": "05", "municipio": "24", "complemento": None},
-    )
+    # Mock dependencies for business data
+    negocio_data = {
+        "nit": "06142816991014",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Comercial",
+        "codActividad": "12345",
+        "descActividad": "Giro",
+        "telefono": "12345678",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "05",
+            "municipio": "24",
+            "complemento": "Dir",
+        },
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: negocio_data)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: negocio_data)
 
     db = DB(":memory:")
     db.add_vendedor("V1")


### PR DESCRIPTION
## Summary
- pass `extra` metadata during DTE generation so ticket validations skip NIT requirement
- adjust ticket test to use full business data and rely on real validation

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1; ModuleNotFoundError: fastapi)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_ticket_nitless.py -o addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed344a048323a15190cc30e69276