### PR TITLE
Omitir DUI en emisor

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2646,10 +2646,8 @@ def validate_dte_json(
     emisor = payload.get("emisor", {})
     emisor["nit"] = _clean_nit(emisor.get("nit") or negocio.get("nit"))
     emisor["nrc"] = _clean_nrc(emisor.get("nrc") or negocio.get("nrc"))
-    if tipo_dte != "03":
-        emisor["dui"] = _clean_dui(emisor.get("dui") or negocio.get("dui"))
-    else:
-        emisor.pop("dui", None)
+    # ``dui`` is not permitted for the emisor by the DTE schema
+    emisor.pop("dui", None)
     emisor.setdefault("nombre", negocio.get("nombre"))
     emisor.setdefault("nombreComercial", negocio.get("nombreComercial"))
     emisor.setdefault(

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -61,7 +61,8 @@ def test_generar_dte_json_basic(tmp_path):
 
     datos = {
         "nit": "06141990011019",
-        "nrc": "12345678",
+        "nrc": "1234567",
+        "dui": "01234567-8",
         "nombre": "Mi Negocio",
         "nombreComercial": "Mi Negocio",
         "cod_giro": "123456",
@@ -91,7 +92,7 @@ def test_generar_dte_json_basic(tmp_path):
     prod_id = db.cursor.lastrowid
     db.add_cliente(
         "Cliente",
-        "123",
+        "1234567",
         "06141990011019",
         "",
         "giro",
@@ -107,13 +108,14 @@ def test_generar_dte_json_basic(tmp_path):
     )
     db.add_detalle_venta(venta_id, prod_id, 1, 10, vendedor_id=vend_id)
 
-    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
 
     idf = data["identificacion"]
     res = data["resumen"]
 
     assert idf["tipoDte"] == "01"
     assert idf["ambiente"] in ("00", "01")
+    assert "dui" not in data["emisor"]
 
     def q2(x):
         return Decimal(str(x)).quantize(Decimal("0.01"))


### PR DESCRIPTION
## Summary
- Evitar que los DTE incluyan el campo `dui` en la sección de `emisor`
- Verificar mediante pruebas que el `dui` no se inserte al generar un DTE

## Testing
- `pytest tests/test_dte_payload_cleanup.py tests/test_generar_dte_json.py::test_generar_dte_json_basic -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed3a1f748323bc2c17bf4ec9ed09