### PR TITLE
Calcular IVA desde to_base_iva para CCF

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1073,7 +1073,13 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         )
         total_descu = money(descu_no_suj + descu_exenta + descu_gravada)
         if tipo_dte in {"03", "05", "06"}:
-            if "sumas" in fiscal:
+            if tipo_dte == "03" and (
+                "sumas" not in fiscal or "iva" not in fiscal
+            ):
+                base_calc, iva_calc = to_base_iva(items_total)
+                total_gravada = money(fiscal.get("sumas", base_calc))
+                total_iva = money(fiscal.get("iva", iva_calc))
+            elif "sumas" in fiscal:
                 total_gravada = money(fiscal["sumas"])
                 total_iva = money(fiscal.get("iva", 0))
             else:
@@ -2159,15 +2165,17 @@ def generar_dte_json(
                     bruto_final = d4(bruto - descu_total)
                     if bruto_final < 0:
                         bruto_final = D("0")
-                    base_pre = money(bruto / D("1.13"))
-                    base_final = money(bruto_final / D("1.13"))
+                    base_pre_prec, iva_pre_prec = to_base_iva(bruto)
+                    base_fin_prec, iva_fin_prec = to_base_iva(bruto_final)
+                    base_pre = money(base_pre_prec)
+                    base_final = money(base_fin_prec)
+                    iva_val_pre = money(iva_pre_prec)
+                    iva_val = money(iva_fin_prec)
                     descuento_base = money(base_pre - base_final)
+                    iva_desc = money(iva_val_pre - iva_val)
                     precio = d4(money(base_pre / cant))
                     monto_descu = descuento_base
                     venta_gravada = base_final
-                    iva_val_pre = money(base_pre * D("0.13"))
-                    iva_desc = money(descuento_base * D("0.13"))
-                    iva_val = money(iva_val_pre - iva_desc)
                     line_total = money(base_final + iva_val)
                     bruto_total += bruto
                     descuentos_total += descuento_base

--- a/tests/test_credito_fiscal_pdf_iva.py
+++ b/tests/test_credito_fiscal_pdf_iva.py
@@ -13,6 +13,25 @@ class FakeDB:
         self._ventas = []
         self.detalles = {}
         self.credito = {}
+        self.clientes = {}
+        self.cursor = self.FakeCursor(self)
+
+    class FakeCursor:
+        def __init__(self, db):
+            self.db = db
+
+        def execute(self, _query, params):
+            vid = params[0]
+            row = next((v for v in self.db._ventas if v["id"] == vid), None)
+
+            class Result:
+                def __init__(self, row):
+                    self.row = row
+
+                def fetchone(self):
+                    return self.row
+
+            return Result(row)
 
     def get_ventas(self):
         return self._ventas
@@ -23,11 +42,17 @@ class FakeDB:
     def get_detalles_venta(self, vid):
         return self.detalles.get(vid, [])
 
+    def get_cliente(self, cid):
+        return self.clientes.get(cid)
+
     def get_trabajador(self, vid):
         return None
 
     def add_factura_pdf(self, *a):
         pass
+
+    def next_dte_correlativo(self, *a, **k):
+        return 1
 
 
 class Manager:
@@ -151,3 +176,22 @@ def test_pdf_total_precios_incluyen_iva(tmp_path, monkeypatch):
     assert pytest.approx(captured["venta"]["total"], 0.01) == 15
     assert pytest.approx(captured["detalles"][0]["iva"], 0.01) == float(iva)
     assert pytest.approx(captured["detalles"][0]["ventas_gravadas"], 0.01) == float(base)
+
+
+def test_credito_fiscal_resumen_iva(tmp_path):
+    from decimal import Decimal
+    from dte import calcular_resumen
+
+    resumen = calcular_resumen(
+        Decimal("18"),
+        {"total": 18},
+        fiscal={},
+        extra={"precios_incluyen_iva": True},
+        tipo_dte="03",
+    )
+    sumas = float(resumen.get("totalGravada"))
+    iva = float(resumen.get("tributos")[0]["valor"]) if resumen.get("tributos") else 0
+    total = float(resumen.get("totalPagar"))
+    assert pytest.approx(sumas, 0.01) == 15.93
+    assert pytest.approx(iva, 0.01) == 2.07
+    assert pytest.approx(total, 0.01) == 18.00


### PR DESCRIPTION
## Summary
- Calcular base e IVA usando `to_base_iva` en precios con IVA incluido
- Derivar sumas e IVA cuando faltan en el resumen de CCF
- Añadir prueba para totales de factura con IVA incluido

## Testing
- `pytest tests/test_credito_fiscal_pdf_iva.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1ee8c3d4483238c2c1e371ee96196