### PR TITLE
Evita campos de documento en CCF

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2031,9 +2031,7 @@ def generar_dte_json(
             "correo",
             "direccion",
         ]
-        fields_to_remove = ["noRemision", "ordenNo"]
-        if tipo_dte != "03":
-            fields_to_remove.extend(["numDocumento", "tipoDocumento"])
+        fields_to_remove = ["noRemision", "ordenNo", "numDocumento", "tipoDocumento"]
         for f in fields_to_remove:
             receptor.pop(f, None)
 
@@ -2739,8 +2737,12 @@ def validate_dte_json(
 
     receptor = payload.get("receptor", {})
     nit_field = receptor.get("nit")
-    tipo_doc = receptor.get("tipoDocumento")
-    if tipo_dte != "03":
+    if tipo_dte == "03":
+        receptor["nit"] = _clean_nit(nit_field)
+        receptor.pop("tipoDocumento", None)
+        receptor.pop("numDocumento", None)
+    else:
+        tipo_doc = receptor.get("tipoDocumento")
         if nit_field is not None:
             receptor["numDocumento"] = _clean_nit(nit_field)
             if tipo_doc is None:
@@ -2777,13 +2779,6 @@ def validate_dte_json(
             receptor.pop("nrc", None)
         receptor["tipoDocumento"] = tipo_doc
         receptor["numDocumento"] = num_doc
-    else:
-        receptor["nit"] = _clean_nit(nit_field)
-        if receptor.get("numDocumento") or receptor.get("tipoDocumento"):
-            limpiar_documentos(receptor)
-        else:
-            receptor.pop("tipoDocumento", None)
-            receptor.pop("numDocumento", None)
 
     receptor.pop("giro", None)
     dir_rec = receptor.get("direccion")
@@ -2826,9 +2821,7 @@ def validate_dte_json(
         ]
         for f in required_rec_fields:
             receptor.setdefault(f, None)
-        fields_to_remove = ["noRemision", "ordenNo"]
-        if tipo_dte != "03":
-            fields_to_remove.extend(["numDocumento", "tipoDocumento"])
+        fields_to_remove = ["noRemision", "ordenNo", "numDocumento", "tipoDocumento"]
         for f in fields_to_remove:
             receptor.pop(f, None)
     payload["receptor"] = receptor


### PR DESCRIPTION
## Summary
- omite campos de documento del receptor al generar comprobantes de crédito fiscal

## Testing
- `pytest` (errors: Interrupted: 46 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68c1efce0a0c83238a48761f1f7685f1