### PR TITLE
Enable flexible consumer-final invoices via ticket option

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2006,19 +2006,22 @@ def generar_dte_json(
 
     # Campos obligatorios y limpieza de campos no permitidos
     if tipo_dte == "01":
-        required_rec_fields = [
-            "nrc",
-            "nombre",
-            "codActividad",
-            "descActividad",
-            "telefono",
-            "correo",
-            "direccion",
-            "tipoDocumento",
-            "numDocumento",
-        ]
         for f in ("nit", "nombreComercial"):
             receptor.pop(f, None)
+        if extra.get("es_ticket"):
+            required_rec_fields = ["direccion"]
+        else:
+            required_rec_fields = [
+                "nrc",
+                "nombre",
+                "codActividad",
+                "descActividad",
+                "telefono",
+                "correo",
+                "direccion",
+                "tipoDocumento",
+                "numDocumento",
+            ]
     else:
         required_rec_fields = [
             "nit",

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from db import DB
-from dte import generar_ticket_json, recalcular_totales
+from dte import generar_ticket_json, generar_dte_json, recalcular_totales
 from nota_credito_electronica import generar_nce_desde_dte
 
 
@@ -58,3 +58,39 @@ def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
     nce = generar_nce_desde_dte(db, data, Decimal("1"), motivo="Dev")
     assert nce["identificacion"]["tipoDte"] == "05"
     assert nce["documentoRelacionado"][0]["tipoDocumento"] == "03"
+
+
+def test_generar_factura_cf_es_ticket_flexible(monkeypatch):
+    negocio_data = {
+        "nit": "06142816991014",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Comercial",
+        "codActividad": "12345",
+        "descActividad": "Giro",
+        "telefono": "12345678",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "05",
+            "municipio": "24",
+            "complemento": "Dir",
+        },
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: negocio_data)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: negocio_data)
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+
+    db = DB(":memory:")
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = generar_dte_json(db, venta_id, tipo_dte="01", extra={"es_ticket": True})
+    rec = data["receptor"]
+    assert rec["nombre"] is None
+    assert rec["nrc"] is None
+    assert rec["tipoDocumento"] is None
+    assert rec["numDocumento"] is None

--- a/tests/test_transmission_mode.py
+++ b/tests/test_transmission_mode.py
@@ -119,13 +119,19 @@ def test_generate_ticket_pdf_applies_contingency_flags(tmp_path, monkeypatch):
 
     called = {}
 
-    def fake_ticket_json(db_obj, vid, *, tipo_operacion, tipo_contingencia=None, motivo_contin=None, **k):
-        called["args"] = (tipo_operacion, tipo_contingencia, motivo_contin)
+    def fake_dte_json(db_obj, vid, *, tipo_dte, tipo_operacion, tipo_contingencia=None, motivo_contin=None, extra=None, **k):
+        called["args"] = (
+            tipo_dte,
+            tipo_operacion,
+            tipo_contingencia,
+            motivo_contin,
+            extra,
+        )
         return {"resumen": {"totalLetras": "X"}}
 
     monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
     monkeypatch.setattr("utils.doc_generation.generar_ticket_personalizado", fake_gen)
-    monkeypatch.setattr("utils.doc_generation.generar_ticket_json", fake_ticket_json)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_dte_json)
     monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
     monkeypatch.setattr(
         dte, "_load_datos_negocio", lambda: {"dte_api": {"tipo_contingencia": 3, "motivo_contin": "fallo"}}
@@ -133,5 +139,10 @@ def test_generate_ticket_pdf_applies_contingency_flags(tmp_path, monkeypatch):
 
     generate_ticket_pdf(man, 1)
 
-    assert called["args"] == (2, 3, "fallo")
+    tipo_dte, tipo_op, tipo_cont, motivo, extra = called["args"]
+    assert tipo_dte == "01"
+    assert tipo_op == 2
+    assert tipo_cont == 3
+    assert motivo == "fallo"
+    assert extra.get("es_ticket")
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -6,7 +6,7 @@ import logging
 import dte
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado
-from dte import generar_ticket_json, generar_dte_json
+from dte import generar_dte_json
 from utils.monto import monto_a_texto_sv, iva_item, to_base_iva
 from utils.docs import get_document_paths, build_invoice_json
 from utils.jws import sign_and_save
@@ -258,6 +258,7 @@ def generate_ticket_pdf(manager, venta_id):
             extra.setdefault("tipoContingencia", tipo_contingencia)
         if motivo_contin is not None:
             extra.setdefault("motivoContin", motivo_contin)
+    extra.setdefault("es_ticket", True)
 
     cliente = None
     if venta.get("cliente_id"):
@@ -270,12 +271,14 @@ def generate_ticket_pdf(manager, venta_id):
 
     generar_ticket_personalizado(venta, detalles, filename, dte_data=extra)
     if hasattr(manager.db, "cursor"):
-        ticket_json = generar_ticket_json(
+        ticket_json = generar_dte_json(
             manager.db,
             venta_id,
+            tipo_dte="01",
             tipo_operacion=tipo_operacion,
             tipo_contingencia=tipo_contingencia,
             motivo_contin=motivo_contin,
+            extra=extra,
         )
     else:
         venta_data = dict(venta)
@@ -286,6 +289,8 @@ def generate_ticket_pdf(manager, venta_id):
         if not venta_data.get("numero_control"):
             venta_data["numero_control"] = uuid.uuid4().hex[:8].upper()
         ticket_json = build_invoice_json(venta_data, cliente or {}, detalles)
+        ticket_json.setdefault("identificacion", {})["tipoDte"] = "01"
+        ticket_json.setdefault("extra", {})["es_ticket"] = True
     if tipo_operacion == 2:
         manager.db.add_dte_pendiente(venta_id, ticket_json, "2")
     try:


### PR DESCRIPTION
## Summary
- Allow ticket option to generate consumer-final invoices by using DTE type `01`
- Relax receptor requirements for consumer-final invoices flagged as tickets
- Update tests for new ticket behaviour and add coverage for flexible receptor data

## Testing
- `pytest` *(fails: process produced excessive output; unable to confirm completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f0c42864832389f9950784bddc4e