### PR TITLE
Handle expired auth tokens during DTE transmission

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -243,10 +243,17 @@ def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[s
         if token_type.lower() == "bearer":
             token_type = "Bearer"
         return token, expires_in, token_type
+    except requests.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response is not None else None
+        if status_code in {401, 403}:
+            raise RuntimeError("Token inválido o caducado") from exc
+        report = f"Error de autenticación al solicitar token en {url}: {exc}"
+        if exc.response is not None:
+            report += f"\nRespuesta: {exc.response.text[:200]}"
+        print(report)
+        raise
     except Exception as exc:
         report = f"Error de autenticación al solicitar token en {url}: {exc}"
-        if isinstance(exc, requests.HTTPError) and exc.response is not None:
-            report += f"\nRespuesta: {exc.response.text[:200]}"
         print(report)
         raise
 

--- a/dte.py
+++ b/dte.py
@@ -4155,9 +4155,22 @@ def _post_dte(
     except Exception:
         data = None
 
+    if resp.status_code in {401, 403}:
+        result = {
+            "estado": "Rechazado",
+            "http_status": 401,
+            "detalle": "Token inválido o caducado",
+        }
+        print(json.dumps(result, ensure_ascii=False))
+        return result
+
     if isinstance(resp.status_code, int) and resp.status_code >= 400:
         detalle = data if data is not None else text
-        result = {"estado": "Rechazado", "http_status": resp.status_code, "detalle": detalle}
+        result = {
+            "estado": "Rechazado",
+            "http_status": resp.status_code,
+            "detalle": detalle,
+        }
         print(json.dumps(result, ensure_ascii=False))
         return result
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -907,6 +907,10 @@ class FacturacionTab(QWidget):
             QMessageBox.warning(self, "Enviar", "Seleccione un documento")
             return
 
+        token_msg = (
+            "El token está desactualizado. Debe generar uno nuevo desde la configuración de facturación."
+        )
+
         factura = None
         rtype = entry.get("row_type")
         if rtype in ("venta", "orphan"):
@@ -932,6 +936,9 @@ class FacturacionTab(QWidget):
                 json_path = factura.get("json")
                 try:
                     resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
+                    if resp.get("http_status") in {401, 403}:
+                        QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
+                        return
                     estado = resp.get("estado")
                     if estado in {"Transmitido", "Recibido", "PROCESADO"}:
                         QMessageBox.information(
@@ -951,6 +958,8 @@ class FacturacionTab(QWidget):
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", "\n".join(exc.errors)
                     )
+                except RuntimeError:
+                    QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
                 except Exception as exc:
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", str(exc)
@@ -961,6 +970,9 @@ class FacturacionTab(QWidget):
                     resp = transmitir_dte(
                         self.manager.db, entry.get("id"), tipo_dte=tipo
                     )
+                    if resp.get("http_status") in {401, 403}:
+                        QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
+                        return
                     estado = resp.get("estado")
                     if estado in {"Transmitido", "Recibido", "PROCESADO"}:
                         QMessageBox.information(
@@ -980,6 +992,8 @@ class FacturacionTab(QWidget):
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", "\n".join(exc.errors)
                     )
+                except RuntimeError:
+                    QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
                 except Exception as exc:
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", str(exc)

--- a/tests/test_token_warning.py
+++ b/tests/test_token_warning.py
@@ -1,0 +1,172 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+from PyQt5.QtWidgets import QApplication, QDialog
+
+import dte
+import auth
+import facturacion_tab
+from db import DB
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+
+def _create_sale(db):
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "C1", None, vid, None, 0, 10, 10, 1)
+    pid = db.cursor.lastrowid
+    db.add_cliente("C", "", "", "", "", "", "c@x.com", "", "", "")
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, vendedor_id=vid)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id, cid
+
+
+def _make_tab(db, cid):
+    man = SimpleNamespace(db=db, _clientes=[{"id": cid, "nombre": "C", "email": "c@x.com"}], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+    tab.table.selectRow(0)
+    return tab
+
+
+def test_post_dte_token_invalid(monkeypatch):
+    monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda doc, data: {})
+    monkeypatch.setattr(dte, "format_cliente_id_from_dui", lambda dui: "cid")
+    monkeypatch.setattr(dte, "detect_user_agent", lambda ua, opts, app_version, client_id: "UA")
+    monkeypatch.setattr(dte, "build_auth_header", lambda auth, app_version, client_id: {})
+
+    class Resp:
+        status_code = 401
+        text = "Unauthorized"
+        def json(self):
+            return {"foo": "bar"}
+    monkeypatch.setattr(dte.requests, "post", lambda *a, **k: Resp())
+    resp = dte._post_dte("https://apitest.dtes.mh.gob.sv/fesv/recepciondte", "tok", "doc")
+    assert resp == {
+        "estado": "Rechazado",
+        "http_status": 401,
+        "detalle": "Token inválido o caducado",
+    }
+
+
+def test_request_new_token_raises_runtimeerror(monkeypatch):
+    class Resp:
+        status_code = 401
+        text = "Unauthorized"
+        def raise_for_status(self):
+            raise requests.HTTPError(response=self)
+        def json(self):
+            return {}
+    import requests
+    monkeypatch.setattr(auth.requests, "post", lambda url, data, headers, timeout: Resp())
+    monkeypatch.setattr(auth, "_get_auth_url", lambda: "http://fake")
+    with pytest.raises(RuntimeError):
+        auth._request_new_token("nit", "pwd")
+
+
+def test_send_selected_invoice_warns_on_token(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_text("pdf")
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text("{}")
+    db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
+
+    tab = _make_tab(db, cid)
+    monkeypatch.setattr(
+        tab, "_selected_entry", lambda: {"row_type": "venta", "id": venta_id}
+    )
+    monkeypatch.setattr(
+        tab,
+        "_selected_factura",
+        lambda: {"venta_id": venta_id, "json": str(json_path), "control": "X"},
+    )
+
+    class DummyCheck:
+        def __init__(self):
+            self._checked = False
+        def setChecked(self, v):
+            self._checked = v
+        def isChecked(self):
+            return self._checked
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+        def exec_(self):
+            self.email_cb.setChecked(False)
+            self.hacienda_cb.setChecked(True)
+            return QDialog.Accepted
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    warnings = {}
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+    def fake_warning(parent, title, message):
+        warnings["msg"] = message
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", fake_warning)
+
+    def fake_transmitir(db_, vid, tipo_dte="01"):
+        return {"http_status": 401}
+    monkeypatch.setattr(facturacion_tab, "transmitir_dte", fake_transmitir)
+
+    tab.send_selected_invoice()
+    assert "token" in warnings["msg"].lower()
+
+
+def test_send_selected_invoice_warns_on_exception(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_text("pdf")
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text("{}")
+    db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
+
+    tab = _make_tab(db, cid)
+    monkeypatch.setattr(
+        tab, "_selected_entry", lambda: {"row_type": "venta", "id": venta_id}
+    )
+    monkeypatch.setattr(
+        tab,
+        "_selected_factura",
+        lambda: {"venta_id": venta_id, "json": str(json_path), "control": "X"},
+    )
+
+    class DummyCheck:
+        def __init__(self):
+            self._checked = False
+        def setChecked(self, v):
+            self._checked = v
+        def isChecked(self):
+            return self._checked
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+        def exec_(self):
+            self.email_cb.setChecked(False)
+            self.hacienda_cb.setChecked(True)
+            return QDialog.Accepted
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    warnings = {}
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+    def fake_warning(parent, title, message):
+        warnings["msg"] = message
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", fake_warning)
+
+    def fake_transmitir(db_, vid, tipo_dte="01"):
+        raise RuntimeError("Token inválido o caducado")
+    monkeypatch.setattr(facturacion_tab, "transmitir_dte", fake_transmitir)
+
+    tab.send_selected_invoice()
+    assert "token" in warnings["msg"].lower()


### PR DESCRIPTION
## Summary
- return a token-specific error when Hacienda responds 401/403 during DTE transmission
- propagate token expiry as a RuntimeError from auth token requests
- warn users in Facturación tab to refresh the token when Hacienda rejects it
- test expired-token handling across DTE post, auth, and UI flows

## Testing
- `pytest tests/test_auth_module.py tests/test_facturacion_tab_actions.py tests/test_token_warning.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1f80ba1188323923ffe214ac5e831