### PR TITLE
feat: organize DTE outputs

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3874,14 +3874,34 @@ def _write_json(path: str, data):
         save_file(path, stable_stringify(data, indent=2))
 
 
-def _dte_base_dir(dte_data: dict) -> str:
-    """Return destination directory for ``dte_data`` grouped by tipoDte."""
+def _dte_base_dir(dte_data: dict, fallido: bool = False) -> str:
+    """Return destination directory for ``dte_data`` grouped by tipoDte.
+
+    The ``fallido`` flag controls whether the DTE should be stored under the
+    accepted directory (``dtes/``) or the rejected one (``dte_fallidos/``).
+    """
+
     ident = dte_data.get("identificacion", {})
     tipo = str(ident.get("tipoDte", "")).zfill(2)
-    base = os.path.join(os.path.dirname(__file__), "dtes")
-    mapping = {"01": "fcf", "03": "ccf"}
+    root = "dte_fallidos" if fallido else "dtes"
+    base = os.path.join(os.path.dirname(__file__), root)
+    mapping = {
+        "01": "fcf",  # Factura consumidor final
+        "03": "ccf",  # Comprobante de crédito fiscal
+        "04": "nr",   # Nota de remisión
+        "05": "nc",   # Nota de crédito
+        "06": "nd",   # Nota de débito
+        "07": "cr",   # Comprobante de retención
+        "08": "cl",   # Comprobante de liquidación
+        "09": "dcl",  # Documento contable de liquidación
+        "11": "fex",  # Factura de exportación
+        "14": "fse",  # Factura de sujeto excluido
+        "15": "cd",   # Comprobante de donación
+    }
     folder = mapping.get(tipo)
-    return os.path.join(base, folder) if folder else base
+    path = os.path.join(base, folder) if folder else base
+    os.makedirs(path, exist_ok=True)
+    return path
 
 
 def _save_signed_dte(dte_data: dict, jws_token: str) -> None:


### PR DESCRIPTION
## Summary
- allow choosing base directory for accepted or failed DTEs
- expand DTE type mapping and ensure directories exist

## Testing
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c206fca5708323b83da121163578d5