### PR TITLE
Permitir clientes sin campos obligatorios

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -59,6 +59,15 @@ def validar_nit(nit):
         or re.match(dui_pattern, nit)
     )
 
+def validar_dui(dui):
+    """Valida un número de DUI salvadoreño."""
+    import re
+    if not dui:
+        return False
+    # Formato ########-# o #########
+    dui_pattern = r"^\d{8}-?\d$"
+    return bool(re.match(dui_pattern, dui))
+
 def validar_email(email):
     import re
     return bool(re.match(r"^[^@]+@[^@]+\.[^@]+$", email))
@@ -2573,50 +2582,31 @@ class ClienteDialog(QDialog):
 
 
     def _validar_y_accept(self):
-        if not self.nombre_edit.text().strip():
-            QMessageBox.warning(self, "Validación", "El nombre es obligatorio.")
-            return
         nrc = self.nrc_edit.text().strip()
-        if not nrc:
-            QMessageBox.warning(self, "Validación", "El NRC es obligatorio.")
-            return
-        if not validar_nrc(nrc):
+        if nrc and not validar_nrc(nrc):
             QMessageBox.warning(self, "Validación", "Ingrese un NRC válido.")
             return
         nit = self.nit_edit.text().strip()
-        if not nit:
-            QMessageBox.warning(self, "Validación", "El NIT es obligatorio.")
-            return
-        if not validar_nit(nit):
+        if nit and not validar_nit(nit):
             QMessageBox.warning(self, "Validación", "Ingrese un NIT válido.")
             return
-        telefono = self.telefono_edit.text().strip()
-        if not telefono:
-            QMessageBox.warning(self, "Validación", "El teléfono es obligatorio.")
+        dui = self.dui_edit.text().strip()
+        if dui and not validar_dui(dui):
+            QMessageBox.warning(self, "Validación", "Ingrese un DUI válido.")
             return
-        if not validar_telefono(telefono):
+        telefono = self.telefono_edit.text().strip()
+        if telefono and not validar_telefono(telefono):
             QMessageBox.warning(self, "Validación", "Ingrese un teléfono válido.")
             return
         email = self.email_edit.text().strip()
-        if not email:
-            QMessageBox.warning(
-                self,
-                "Validación",
-                "El correo electrónico es obligatorio.",
-            )
+        if email and not validar_email(email):
+            QMessageBox.warning(self, "Validación", "Ingrese un correo electrónico válido.")
             return
-        if not validar_email(email):
-            QMessageBox.warning(
-                self,
-                "Validación",
-                "Ingrese un correo electrónico válido.",
-            )
-            return
-        nit = self.nit_edit.text().strip()
-        db = getattr(getattr(self.parent(), "manager", None), "db", None)
-        if db and db.nit_exists(nit, exclude_id=self._cliente_id):
-            QMessageBox.warning(self, "Validación", "El NIT ya está registrado.")
-            return
+        if nit:
+            db = getattr(getattr(self.parent(), "manager", None), "db", None)
+            if db and db.nit_exists(nit, exclude_id=self._cliente_id):
+                QMessageBox.warning(self, "Validación", "El NIT ya está registrado.")
+                return
         self.accept()
 
     def get_data(self):

--- a/tests/test_cliente_dialog.py
+++ b/tests/test_cliente_dialog.py
@@ -34,26 +34,16 @@ def qt_app(monkeypatch):
 
 @pytest.mark.parametrize(
     'field,value', [
-        ('nrc_edit', ''),
         ('nrc_edit', 'bad'),
-        ('nit_edit', ''),
         ('nit_edit', 'bad'),
-        ('telefono_edit', ''),
+        ('dui_edit', 'bad'),
         ('telefono_edit', '12345'),
-        ('email_edit', ''),
         ('email_edit', 'bademail'),
     ],
 )
 def test_invalid_fields(monkeypatch, qt_app, field, value):
     db = DummyDB()
     dialog = make_dialog(db)
-
-    dialog.nombre_edit.setText('Nombre')
-    dialog.nombre_comercial_edit.setText('Comercial')
-    dialog.nrc_edit.setText('1234567')
-    dialog.nit_edit.setText('1234-123456-123-1')
-    dialog.telefono_edit.setText('1234-5678')
-    dialog.email_edit.setText('test@example.com')
 
     getattr(dialog, field).setText(value)
 
@@ -69,16 +59,27 @@ def test_invalid_fields(monkeypatch, qt_app, field, value):
     assert not accepted.get('called')
 
 
+def test_optional_fields(monkeypatch, qt_app):
+    db = DummyDB()
+    dialog = make_dialog(db)
+
+    warnings = {}
+    monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: warnings.setdefault('called', True))
+
+    accepted = {}
+    dialog.accept = lambda: accepted.setdefault('called', True)
+
+    dialog._validar_y_accept()
+
+    assert not warnings.get('called')
+    assert accepted.get('called')
+
+
 def test_duplicate_nit(monkeypatch, qt_app):
     db = DummyDB(existing_nits={'1234-123456-123-1'})
     dialog = make_dialog(db)
 
-    dialog.nombre_edit.setText('Nombre')
-    dialog.nombre_comercial_edit.setText('Comercial')
-    dialog.nrc_edit.setText('1234567')
     dialog.nit_edit.setText('1234-123456-123-1')
-    dialog.telefono_edit.setText('1234-5678')
-    dialog.email_edit.setText('test@example.com')
 
     warnings = {}
     monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: warnings.setdefault('called', True))
@@ -96,12 +97,7 @@ def test_nombre_comercial_included(monkeypatch, qt_app):
     db = DummyDB()
     dialog = make_dialog(db)
 
-    dialog.nombre_edit.setText('Nombre')
     dialog.nombre_comercial_edit.setText('Comercial')
-    dialog.nrc_edit.setText('1234567')
-    dialog.nit_edit.setText('1234-123456-123-1')
-    dialog.telefono_edit.setText('1234-5678')
-    dialog.email_edit.setText('test@example.com')
 
     warnings = {}
     monkeypatch.setattr(QMessageBox, 'warning', lambda *a, **k: warnings.setdefault('called', True))

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -9,12 +9,13 @@ from pathlib import Path
 try:
     from dialogs import (
         validar_nit,
+        validar_dui,
         validar_nrc,
         validar_email,
         validar_telefono,
     )
 except Exception:  # pragma: no cover - missing UI deps
-    validar_nit = validar_nrc = validar_email = validar_telefono = None
+    validar_nit = validar_dui = validar_nrc = validar_email = validar_telefono = None
     _dialog_import_error = True
 else:  # pragma: no cover
     _dialog_import_error = False
@@ -37,6 +38,17 @@ from utils import catalogos
 @pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_nit(nit, expected):
     assert validar_nit(nit) is expected
+
+
+@pytest.mark.parametrize("dui, expected", [
+    ("12345678-9", True),
+    ("123456789", True),
+    ("1234567-89", False),
+    ("abcd", False),
+])
+@pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
+def test_validar_dui(dui, expected):
+    assert validar_dui(dui) is expected
 
 
 @pytest.mark.parametrize("nrc, expected", [


### PR DESCRIPTION
## Summary
- Permite registrar o editar clientes sin campos obligatorios
- Valida NIT y DUI solo si se proporcionan
- Agrega pruebas para validaciones opcionales y de DUI

## Testing
- `pytest` *(falló: 46 errores en la recolección)*
- `pytest tests/test_cliente_dialog.py::test_invalid_fields tests/test_cliente_dialog.py::test_optional_fields tests/test_cliente_dialog.py::test_duplicate_nit tests/test_cliente_dialog.py::test_nombre_comercial_included tests/test_validaciones_basicas.py::test_validar_nit tests/test_validaciones_basicas.py::test_validar_dui tests/test_validaciones_basicas.py::test_validar_nrc tests/test_validaciones_basicas.py::test_validar_email tests/test_validaciones_basicas.py::test_validar_telefono`

------
https://chatgpt.com/codex/tasks/task_e_68c20db97c648323b789fe2fea570b16