### PR TITLE
Accept optional DB in InventoryManager

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -19,8 +19,8 @@ class InventoryManagerError(Exception):
 
 
 class InventoryManager:
-    def __init__(self, page_size=50):
-        self.db = DB()
+    def __init__(self, db: DB | None = None, page_size: int = 50):
+        self.db = db or DB()
         self.page_size = page_size
         self.current_page = 0
         self._filter_vendedor_id = None

--- a/tests/test_detalle_venta_vendedor.py
+++ b/tests/test_detalle_venta_vendedor.py
@@ -18,10 +18,9 @@ def test_detalle_venta_con_vendedor():
     assert detalles[0]["vendedor_id"] == vendedor_id
 
 
-def test_import_detalles_venta_uses_vendedor_map(tmp_path, monkeypatch):
+def test_import_detalles_venta_uses_vendedor_map(tmp_path):
     import inventory_manager
-    monkeypatch.setattr(inventory_manager, 'DB', lambda: DB(":memory:"))
-    man = inventory_manager.InventoryManager()
+    man = inventory_manager.InventoryManager(DB(":memory:"))
 
     data = {
         "vendedores": [{"id": 1, "nombre": "Luis"}],

--- a/tests/test_export_import_transmission_records.py
+++ b/tests/test_export_import_transmission_records.py
@@ -37,8 +37,7 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
         inventory_manager.InventoryManager, "refresh_data", dummy_refresh
     )
 
-    monkeypatch.setattr(inventory_manager, "DB", lambda: DB(":memory:"))
-    man1 = inventory_manager.InventoryManager()
+    man1 = inventory_manager.InventoryManager(DB(":memory:"))
     db = man1.db
     db.add_Distribuidor("D1")
     dist = db.cursor.lastrowid
@@ -71,7 +70,7 @@ def test_export_import_transmission_records(monkeypatch, tmp_path):
     export_file = tmp_path / "export.json"
     man1.exportar_inventario_json(str(export_file))
 
-    man2 = inventory_manager.InventoryManager()
+    man2 = inventory_manager.InventoryManager(DB(":memory:"))
     man2.importar_inventario_json(str(export_file))
 
     cur = man2.db.cursor

--- a/tests/test_export_skips_unsynced_sales.py
+++ b/tests/test_export_skips_unsynced_sales.py
@@ -7,9 +7,8 @@ class MemoryDB(im.DB):
         super().__init__(db_name=":memory:")
 
 
-def test_export_skips_unsynced_sales(monkeypatch, tmp_path):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    man = im.InventoryManager()
+def test_export_skips_unsynced_sales(tmp_path):
+    man = im.InventoryManager(MemoryDB())
     db = man.db
 
     db.add_cliente("Cliente", "", "", "", "", "", "", "", "", "")

--- a/tests/test_fiscal_sales_cleanup.py
+++ b/tests/test_fiscal_sales_cleanup.py
@@ -28,9 +28,8 @@ def make_inv(path):
     return p
 
 
-def test_import_resets_fiscal_sales(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    man = im.InventoryManager()
+def test_import_resets_fiscal_sales(tmp_path):
+    man = im.InventoryManager(MemoryDB())
     path = make_inv(tmp_path)
 
     man.importar_inventario_json(str(path))

--- a/tests/test_import_datos_negocio.py
+++ b/tests/test_import_datos_negocio.py
@@ -8,11 +8,10 @@ class MemoryDB(im.DB):
         super().__init__(db_name=":memory:")
 
 def test_import_without_datos_negocio_keeps_existing(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
     datos_path = tmp_path / "datos_negocio.json"
     datos_path.write_text(json.dumps({"nombre": "Original"}))
     monkeypatch.setattr(im, "DATOS_NEGOCIO_PATH", datos_path)
-    manager = im.InventoryManager()
+    manager = im.InventoryManager(MemoryDB())
     data = {
         "Distribuidores": [],
         "vendedores": [],

--- a/tests/test_import_detalle_venta_trabajador.py
+++ b/tests/test_import_detalle_venta_trabajador.py
@@ -7,9 +7,8 @@ class MemoryDB(im.DB):
         super().__init__(db_name=":memory:")
 
 
-def test_import_maps_detalle_trabajador(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_maps_detalle_trabajador(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
 
     data = {
         "Distribuidores": [],

--- a/tests/test_import_inventory_cleanup.py
+++ b/tests/test_import_inventory_cleanup.py
@@ -27,9 +27,8 @@ def _empty_inventory(path):
     return p
 
 
-def test_import_inventory_clears_related_tables(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_inventory_clears_related_tables(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
     db = manager.db
 
     cliente_id = db.add_cliente("Cliente", "", "", "", "", "", "", "", "", "")

--- a/tests/test_import_malformed_json.py
+++ b/tests/test_import_malformed_json.py
@@ -7,9 +7,8 @@ class MemoryDB(im.DB):
         super().__init__(db_name=":memory:")
 
 
-def test_importar_json_malformado(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_importar_json_malformado(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
     bad_file = tmp_path / "malformado.json"
     bad_file.write_text("{", encoding="utf-8")
 

--- a/tests/test_import_products_vendor.py
+++ b/tests/test_import_products_vendor.py
@@ -7,9 +7,8 @@ class MemoryDB(im.DB):
         super().__init__(db_name=":memory:")
 
 
-def test_import_product_vendor_mapping(tmp_path, monkeypatch, producto_factory):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_product_vendor_mapping(tmp_path, producto_factory):
+    manager = im.InventoryManager(MemoryDB())
 
     producto = producto_factory(
         id=10,

--- a/tests/test_import_skips_unsynced_and_cleans_orphans.py
+++ b/tests/test_import_skips_unsynced_and_cleans_orphans.py
@@ -97,9 +97,8 @@ def make_inv(path):
     return p
 
 
-def test_import_skips_unsynced_and_cleans_orphans(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    man = im.InventoryManager()
+def test_import_skips_unsynced_and_cleans_orphans(tmp_path):
+    man = im.InventoryManager(MemoryDB())
     path = make_inv(tmp_path)
     man.importar_inventario_json(str(path))
 

--- a/tests/test_import_trabajador_duplicates.py
+++ b/tests/test_import_trabajador_duplicates.py
@@ -32,9 +32,8 @@ def _inventory_with_duplicate(path):
     return p
 
 
-def test_import_trabajador_duplicate_codigo(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_trabajador_duplicate_codigo(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
     path = _inventory_with_duplicate(tmp_path)
 
     manager.importar_inventario_json(str(path))

--- a/tests/test_import_trabajador_sales.py
+++ b/tests/test_import_trabajador_sales.py
@@ -6,9 +6,8 @@ class MemoryDB(im.DB):
     def __init__(self):
         super().__init__(db_name=":memory:")
 
-def test_import_maps_trabajador_sales(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_maps_trabajador_sales(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
 
     data = {
         "Distribuidores": [],

--- a/tests/test_import_vendor_mapping.py
+++ b/tests/test_import_vendor_mapping.py
@@ -6,9 +6,8 @@ class MemoryDB(im.DB):
     def __init__(self):
         super().__init__(db_name=":memory:")
 
-def test_import_maps_vendors(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_maps_vendors(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
 
     data = {
         "Distribuidores": [{"id": 1, "nombre": "D1"}],

--- a/tests/test_inventory_manager_filters_export.py
+++ b/tests/test_inventory_manager_filters_export.py
@@ -3,9 +3,9 @@ import inventory_manager
 from db import DB
 
 
-def create_manager(monkeypatch):
-    monkeypatch.setattr(inventory_manager, "DB", lambda: DB(":memory:"))
-    man = inventory_manager.InventoryManager()
+def create_manager():
+    db = DB(":memory:")
+    man = inventory_manager.InventoryManager(db)
     db = man.db
     db.add_Distribuidor("D1")
     dist1 = db.cursor.lastrowid
@@ -21,8 +21,8 @@ def create_manager(monkeypatch):
     return man, db, vend1, vend2, dist1, dist2
 
 
-def test_filters_modify_product_set(monkeypatch):
-    man, db, vend1, vend2, dist1, dist2 = create_manager(monkeypatch)
+def test_filters_modify_product_set():
+    man, db, vend1, vend2, dist1, dist2 = create_manager()
 
     assert {p["codigo"] for p in man._products} == {"C1", "C2"}
 
@@ -41,8 +41,8 @@ def test_filters_modify_product_set(monkeypatch):
     assert [p["codigo"] for p in man._products] == ["C2"]
 
 
-def test_export_json_contains_sections(monkeypatch, tmp_path):
-    man, db, vend1, vend2, dist1, dist2 = create_manager(monkeypatch)
+def test_export_json_contains_sections(tmp_path):
+    man, db, vend1, vend2, dist1, dist2 = create_manager()
     db.add_cliente("Cliente", "", "", "", "", "", "", "", "", "")
     cliente_id = db.cursor.lastrowid
     db.add_venta("2024-01-01", 10, cliente_id=cliente_id, vendedor_id=vend1, Distribuidor_id=dist1)

--- a/tests/test_inventory_reset.py
+++ b/tests/test_inventory_reset.py
@@ -21,7 +21,7 @@ def qt_app():
 
 
 def test_inventory_reset_removes_dependencies(qt_app, monkeypatch, tmp_path):
-    monkeypatch.setattr(im, "DB", MemoryDB)
+    monkeypatch.setattr(ui_mainwindow, "DB", MemoryDB)
     monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
     monkeypatch.setattr(ui_mainwindow, "LAST_INVENTORY_PATH", tmp_path / "last.json")
     monkeypatch.setattr(im, "DATOS_NEGOCIO_PATH", tmp_path / "datos_negocio.json")
@@ -73,9 +73,8 @@ def test_inventory_reset_removes_dependencies(qt_app, monkeypatch, tmp_path):
         assert db.cursor.fetchone()[0] == 0
 
 
-def test_import_inventory_creates_relations(tmp_path, monkeypatch):
-    monkeypatch.setattr(im, "DB", MemoryDB)
-    manager = im.InventoryManager()
+def test_import_inventory_creates_relations(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
 
     data = {
         "Distribuidores": [],

--- a/tests/test_vendedor_codigo_unique.py
+++ b/tests/test_vendedor_codigo_unique.py
@@ -3,9 +3,9 @@ import inventory_manager
 from db import DB
 
 
-def create_manager(monkeypatch):
-    monkeypatch.setattr(inventory_manager, "DB", lambda: DB(":memory:"))
-    man = inventory_manager.InventoryManager()
+def create_manager():
+    db = DB(":memory:")
+    man = inventory_manager.InventoryManager(db)
     return man
 
 
@@ -16,8 +16,8 @@ def test_add_vendedor_duplicate_codigo_db():
         db.add_vendedor("V2", codigo="V001")
 
 
-def test_add_vendedor_duplicate_codigo_manager(monkeypatch):
-    man = create_manager(monkeypatch)
+def test_add_vendedor_duplicate_codigo_manager():
+    man = create_manager()
     man.add_vendedor("V1", codigo="V001")
     with pytest.raises(ValueError):
         man.add_vendedor("V2", codigo="V001")

--- a/tools/venta_vs_dte_debug.py
+++ b/tools/venta_vs_dte_debug.py
@@ -40,7 +40,7 @@ def main() -> None:
 
     logging.basicConfig(level=getattr(logging, args.level.upper(), logging.INFO))
     db = DB(args.db_path)
-    manager = InventoryManager(db)
+    manager = InventoryManager(db=db)
     log_venta_vs_dte(manager, args.venta_id)
 
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -11,6 +11,7 @@ import os
 import json
 import sys
 from inventory_manager import InventoryManager
+from db import DB
 from paths import DATOS_NEGOCIO_PATH
 from dialogs import (
     RegisterSaleDialog,
@@ -61,7 +62,7 @@ class ExportThread(QThread):
         main application's connection.
         """
         try:
-            manager = InventoryManager()
+            manager = InventoryManager(DB())
             manager.exportar_inventario_json(
                 self.filename, tab_order=self.tab_order
             )
@@ -76,7 +77,8 @@ class MainWindow(QMainWindow):
         self.user = user or {"username": "admin", "role": "admin"}
         self.setWindowTitle("Inventario Farmacia")
         self.resize(1200, 700)
-        self.manager = InventoryManager()
+        self.db = DB()
+        self.manager = InventoryManager(self.db)
         self.ultimo_archivo_json = None  # Guarda la ruta del último archivo .json usado
         self.firmador_proc = None
         # Contador de cambios en la base de datos para detectar si hay datos sin guardar


### PR DESCRIPTION
## Summary
- allow `InventoryManager` to accept an external DB and default to a new DB when none is provided
- update UI, tools, and tests to pass a DB instance explicitly

## Testing
- `pytest` *(fails: 50 errors during collection)*
- `python tools/venta_vs_dte_debug.py 1 --db /tmp/test.db` *(fails: datos_negocio.json inválido)*

------
https://chatgpt.com/codex/tasks/task_e_68c24b947ee08323b6cdbe3554271d5e