### PR TITLE
Fix missing item preview labels in RegisterSaleDialog

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -655,6 +655,14 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         fiscal_layout.addWidget(self.tipo_fiscal_combo)
         left_layout.addLayout(fiscal_layout)
 
+        # Labels de vista previa del item actual
+        self.item_subtotal_label = QLabel("Subtotal: $0.00")
+        self.item_iva_label = QLabel("IVA: $0.00")
+        left_layout.addWidget(self.item_subtotal_label)
+        left_layout.addWidget(self.item_iva_label)
+        self.item_total_label = QLabel("TOTAL: $0.00")
+        left_layout.addWidget(self.item_total_label)
+
         # Botón agregar a venta
         self.btn_agregar = QPushButton("Agregar a venta")
         left_layout.addWidget(self.btn_agregar)


### PR DESCRIPTION
## Summary
- Define labels for item subtotal, IVA, and total in `RegisterSaleDialog` so totals preview updates correctly when recalculating.

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c255fa85d48323955c4e3d11f0d326