### PR TITLE
Remove redundant resumen refresh in RegisterSaleDialog

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -1107,8 +1107,6 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             self._actualizar_tabla()
             self._recalcular_totales()
             self._actualizar_resumen()
-            self._actualizar_resumen()
-            self._actualizar_resumen()
 
     def _validar_y_accept(self):
         if not self.product_list.currentItem():


### PR DESCRIPTION
## Summary
- avoid redundant resumen updates when removing sale items

## Testing
- `python -m pytest` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c25ef0bdd4832388e6fcdf94d47c48