### PR TITLE
Handle ticket creation when missing DUI/NIT

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -612,15 +612,7 @@ class FacturacionTab(QWidget):
         rows = []
         to_delete = []
         for rec in records:
-            venta = cur.execute(
-                """
-                SELECT v.id, v.fecha, v.total, v.estado, c.nombre AS cliente
-                FROM ventas v
-                LEFT JOIN clientes c ON c.id = v.cliente_id
-                WHERE v.id=?
-                """,
-                (rec["venta_id"],),
-            ).fetchone()
+            venta = self.manager.db.get_venta_by_id(rec["venta_id"])
             ruta = rec["ruta"]
             if not venta or not ruta or not os.path.exists(ruta):
                 to_delete.append((rec["id"],))
@@ -633,14 +625,22 @@ class FacturacionTab(QWidget):
                 except Exception:
                     fdate = None
             fecha_str = fdate.strftime("%Y-%m-%d %H:%M") if fdate else fecha_creacion
+            getter = getattr(self.manager.db, "get_cliente", None)
+            cliente = None
+            if venta.get("cliente_id") and getter:
+                try:
+                    cliente = getter(venta.get("cliente_id"))
+                except Exception:
+                    cliente = None
+            row_type = "ticket" if self._is_ticket_sale(venta) else "venta"
             rows.append(
                 {
-                    "row_type": "venta",
+                    "row_type": row_type,
                     "id": venta["id"],
                     "name": os.path.splitext(os.path.basename(ruta))[0],
                     "fecha": fecha_str,
                     "_parsed_fecha": fdate,
-                    "cliente": venta["cliente"] or "",
+                    "cliente": cliente.get("nombre", "") if cliente else "",
                     "total": venta["total"],
                     "estado": venta["estado"],
                     "tipo": rec["tipo"],
@@ -1584,15 +1584,11 @@ class FacturacionTab(QWidget):
                 pdf_path = self.manager.db.get_factura_pdf(venta_id)
                 if pdf_path:
                     base_paths.add(os.path.splitext(pdf_path)[0])
-                ticket_path = self.manager.db.get_ticket_pdf(venta_id)
-                if ticket_path:
-                    base_paths.add(os.path.splitext(ticket_path)[0])
-            else:
-                ticket_path = data.get("pdf")
-                if ticket_path:
-                    base_paths.add(os.path.splitext(ticket_path)[0])
-                    json_path = data.get("json") or os.path.splitext(ticket_path)[0] + ".json"
-                    base_paths.add(os.path.splitext(json_path)[0])
+            ticket_path = self.manager.db.get_ticket_pdf(venta_id)
+            if ticket_path:
+                base_paths.add(os.path.splitext(ticket_path)[0])
+                json_path = data.get("json") or os.path.splitext(ticket_path)[0] + ".json"
+                base_paths.add(os.path.splitext(json_path)[0])
         else:
             for p in [data.get("pdf"), data.get("json")]:
                 if p:
@@ -1638,12 +1634,9 @@ class FacturacionTab(QWidget):
                 os.remove(p)
             except OSError:
                 pass
-        if row_type == "venta":
-            if pdf_path:
+        if row_type in ("venta", "ticket"):
+            if row_type == "venta" and pdf_path:
                 self.manager.db.delete_factura_pdf(venta_id)
-            if ticket_path:
-                self.manager.db.delete_ticket_pdf(venta_id)
-        elif row_type == "ticket":
             if ticket_path:
                 self.manager.db.delete_ticket_pdf(venta_id)
         QMessageBox.information(self, "Eliminar", "Archivos eliminados")
@@ -1662,7 +1655,7 @@ class FacturacionTab(QWidget):
             self.preview_label.setText("Previsualización del PDF")
             self._clear_preview_files()
             return
-        if data.get("row_type") == "venta":
+        if data.get("row_type") in ("venta", "ticket"):
             self._update_preview(data.get("id"))
         else:
             pdf = data.get("pdf")
@@ -1682,6 +1675,31 @@ class FacturacionTab(QWidget):
                 pass
         self.preview_pdf_file = None
         self.preview_image_file = None
+
+    def _is_ticket_sale(self, venta):
+        """Return True if the sale should be treated as a ticket."""
+        getter_cf = getattr(self.manager.db, "get_venta_credito_fiscal", None)
+        if getter_cf:
+            try:
+                if getter_cf(venta["id"]):
+                    return False
+            except Exception:
+                pass
+        cid = venta.get("cliente_id")
+        if not cid:
+            return True
+        cliente = None
+        getter = getattr(self.manager.db, "get_cliente", None)
+        if getter:
+            try:
+                cliente = getter(cid)
+            except Exception:
+                cliente = None
+        if not cliente:
+            return True
+        nit = (cliente.get("nit") or "").strip()
+        dui = (cliente.get("dui") or "").strip()
+        return not nit and not dui
 
     def _show_pdf_preview(self, pdf_path):
         self._clear_preview_files()
@@ -1729,7 +1747,7 @@ class FacturacionTab(QWidget):
 
         self._clear_preview_files()
 
-        is_ticket = not venta.get("cliente_id") and not self.manager.db.get_venta_credito_fiscal(venta_id)
+        is_ticket = self._is_ticket_sale(venta)
         if is_ticket:
             pdf_path = self.manager.db.get_ticket_pdf(venta_id)
             if not pdf_path or not os.path.exists(pdf_path):

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -336,6 +336,31 @@ class SalesTab(QWidget):
         self.preview_pdf_file = None
         self.preview_image_file = None
 
+    def _is_ticket_sale(self, venta):
+        """Return True if the sale should be treated as a ticket."""
+        getter_cf = getattr(self.manager.db, "get_venta_credito_fiscal", None)
+        if getter_cf:
+            try:
+                if getter_cf(venta["id"]):
+                    return False
+            except Exception:
+                pass
+        cid = venta.get("cliente_id")
+        if not cid:
+            return True
+        cliente = None
+        getter = getattr(self.manager.db, "get_cliente", None)
+        if getter:
+            try:
+                cliente = getter(cid)
+            except Exception:
+                cliente = None
+        if not cliente:
+            return True
+        nit = (cliente.get("nit") or "").strip()
+        dui = (cliente.get("dui") or "").strip()
+        return not nit and not dui
+
     def _update_email_preview(self):
         self.email_subject_edit.setText(self.email_subject)
         self.email_body_edit.setPlainText(self.email_body)
@@ -482,7 +507,7 @@ class SalesTab(QWidget):
 
         self._clear_preview_files()
 
-        is_ticket = not venta.get("cliente_id") and not self.manager.db.get_venta_credito_fiscal(venta_id)
+        is_ticket = self._is_ticket_sale(venta)
         if is_ticket:
             pdf_path = self.manager.db.get_ticket_pdf(venta_id)
         else:
@@ -546,31 +571,13 @@ class SalesTab(QWidget):
         if not venta or int(venta.get("id", 0)) != venta_id:
             QMessageBox.warning(self, "Guardar factura", "No se encontró la venta seleccionada.")
             return
-        credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
-        doc_type = "Factura"
-        if not credito_info and not venta.get("cliente_id"):
-            box = QMessageBox(self)
-            box.setWindowTitle("Tipo de documento")
-            box.setText("¿Desea generar ticket o factura de consumidor final?")
-            ticket_btn = box.addButton("Ticket", QMessageBox.AcceptRole)
-            factura_btn = box.addButton("Factura", QMessageBox.AcceptRole)
-            box.addButton(QMessageBox.Cancel)
-            box.exec_()
-            clicked = box.clickedButton()
-            if clicked == ticket_btn:
-                file_path = self._generate_ticket_pdf(venta_id)
-                doc_type = "Ticket"
-            elif clicked == factura_btn:
-                try:
-                    file_path = self._generate_invoice_pdf(venta_id)
-                except ValueError as e:
-                    QMessageBox.warning(self, "Guardar factura", str(e))
-                    return
-            else:
-                return
+        if self._is_ticket_sale(venta):
+            file_path = self._generate_ticket_pdf(venta_id)
+            doc_type = "Ticket"
         else:
             try:
                 file_path = self._generate_invoice_pdf(venta_id)
+                doc_type = "Factura"
             except ValueError as e:
                 QMessageBox.warning(self, "Guardar factura", str(e))
                 return
@@ -608,7 +615,7 @@ class SalesTab(QWidget):
 
             return
 
-        is_ticket = not venta.get("cliente_id") and not self.manager.db.get_venta_credito_fiscal(venta_id)
+        is_ticket = self._is_ticket_sale(venta)
         if is_ticket:
             pdf_path = self.manager.db.get_ticket_pdf(venta_id)
         else:
@@ -655,17 +662,16 @@ class SalesTab(QWidget):
             "body": self.email_body_edit.toPlainText(),
         }
 
-        credito_info = self.manager.db.get_venta_credito_fiscal(venta_id)
-        if credito_info or venta.get("cliente_id"):
-            doc_type = "factura"
-            pdf_path = self.manager.db.get_factura_pdf(venta_id)
-            if not pdf_path or not os.path.exists(pdf_path):
-                pdf_path = self._generate_invoice_pdf(venta_id)
-        else:
+        if self._is_ticket_sale(venta):
             doc_type = "ticket"
             pdf_path = self.manager.db.get_ticket_pdf(venta_id)
             if not pdf_path or not os.path.exists(pdf_path):
                 pdf_path = self._generate_ticket_pdf(venta_id)
+        else:
+            doc_type = "factura"
+            pdf_path = self.manager.db.get_factura_pdf(venta_id)
+            if not pdf_path or not os.path.exists(pdf_path):
+                pdf_path = self._generate_invoice_pdf(venta_id)
         if not pdf_path or not os.path.exists(pdf_path):
             QMessageBox.warning(self, "Enviar por correo", "No se pudo generar el documento.")
             return

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -255,3 +255,39 @@ def test_save_invoice_ignores_config_transmission(
     tab.save_invoice()
 
     assert "tx" not in called
+
+
+def test_save_invoice_without_docs_generates_ticket(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+):
+    pdf, json_path = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"], nit="", dui="")
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
+
+    def fake_ticket(manager, vid):
+        pdf.write_bytes(b"%PDF")
+        json_path.write_text("{}", encoding="utf-8")
+        manager.db.add_ticket_pdf(vid, str(pdf))
+        return str(pdf)
+
+    monkeypatch.setattr("sales_tab.generate_ticket_pdf", fake_ticket)
+    monkeypatch.setattr(
+        "sales_tab.generate_invoice_pdf",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no invoice")),
+    )
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+    tab.sales_table.selectRow(0)
+    tab.save_invoice()
+
+    assert pdf.exists()
+    assert json_path.exists()
+    assert db.saved == (venta["id"], str(pdf))


### PR DESCRIPTION
## Summary
- Auto-detect consumer sales without DUI/NIT and generate ticket PDFs/JSON without prompting
- Treat such sales as tickets across invoice previews and record loading
- Add regression test for ticket generation when customer lacks identification

## Testing
- `pytest tests/test_sales_tab_email.py::test_save_invoice_without_docs_generates_ticket -q`


------
https://chatgpt.com/codex/tasks/task_e_68c26fda8d448323bc2a69f2bc533adb