### PR TITLE
feat: unify decimal handling and cent closure

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -28,7 +28,7 @@ from utils.catalogos import (
 import logging
 import warnings
 import xml.etree.ElementTree as ET
-from utils.monto import monto_a_texto_sv, to_base_iva
+from utils.monto import monto_a_texto_sv, to_base_iva, d2, d4, d8
 from utils.sanitize import limpiar_documentos, limpiar_doc, solo_digitos
 from num2words import num2words
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
@@ -197,28 +197,13 @@ def apply_schema_patch(data: dict) -> dict:
 getcontext().prec = 28
 getcontext().rounding = ROUND_HALF_UP
 
-# Helper aliases for precise Decimal arithmetic
+# Helper alias for ``Decimal``
 D = Decimal
 
 
 def d1(value: "object") -> D:
     """Return ``value`` as :class:`Decimal` with 1 decimal place."""
     return D(str(value)).quantize(D("0.1"), rounding=ROUND_HALF_UP)
-
-
-def d2(value: "object") -> D:
-    """Return ``value`` as :class:`Decimal` with 2 decimal places."""
-    return D(str(value)).quantize(D("0.01"), rounding=ROUND_HALF_UP)
-
-
-def d8(value: "object") -> D:
-    """Return ``value`` as :class:`Decimal` with 8 decimal places."""
-    return D(str(value)).quantize(D("0.00000000"), rounding=ROUND_HALF_UP)
-
-
-def d4(value: "object") -> D:
-    """Return ``value`` as :class:`Decimal` with 4 decimal places."""
-    return D(str(value)).quantize(D("0.0001"), rounding=ROUND_HALF_UP)
 
 
 def money(value) -> D:
@@ -2419,6 +2404,46 @@ def generar_dte_json(
         print(
             f"Advertencia: el total a pagar {resumen.get('totalPagar',0):.2f} difiere del calculado {calc_total_commission:.2f}"
         )
+
+    # Aplicar regla de cierre por centavo para alinear Venta vs DTE
+    venta_total = d2(D(str(venta.get("total") or 0)))
+    dte_total = d2(D(str(resumen.get("montoTotalOperacion", 0))))
+    diff = venta_total - dte_total
+    if abs(diff) == D("0.01"):
+        logger.debug("Aplicando cierre por centavo: diff=%s", diff)
+        # Buscar última línea gravada
+        last_grav = None
+        for idx, item in enumerate(cuerpo):
+            if D(str(item.get("ventaGravada") or 0)) > 0:
+                last_grav = idx
+        if last_grav is not None:
+            item = cuerpo[last_grav]
+            iva_val = D(str(item.get("ivaItem") or 0))
+            item["ivaItem"] = d4(iva_val + diff)
+            resumen["totalIva"] = d2(D(str(resumen.get("totalIva", 0))) + diff)
+            resumen["montoTotalOperacion"] = d2(dte_total + diff)
+            resumen["totalPagar"] = resumen.get("totalPagar", resumen["montoTotalOperacion"])
+            resumen["totalPagar"] = d2(D(str(resumen["totalPagar"])) + diff)
+        else:
+            # Sin líneas gravadas; ajustar precio de la última línea
+            if cuerpo:
+                item = cuerpo[-1]
+                qty = D(str(item.get("cantidad") or 1))
+                unit_adj = d4(diff / qty)
+                item["precioUni"] = d4(D(str(item.get("precioUni"))) + unit_adj)
+                if D(str(item.get("ventaExenta") or 0)) > 0:
+                    campo = "ventaExenta"
+                    resumen_key = "totalExenta"
+                elif D(str(item.get("ventaNoSuj") or 0)) > 0:
+                    campo = "ventaNoSuj"
+                    resumen_key = "totalNoSuj"
+                else:
+                    campo = "ventaGravada"
+                    resumen_key = "totalGravada"
+                item[campo] = d4(D(str(item.get(campo))) + diff)
+                resumen[resumen_key] = d2(D(str(resumen.get(resumen_key, 0))) + diff)
+                resumen["montoTotalOperacion"] = d2(dte_total + diff)
+                resumen["totalPagar"] = d2(D(str(resumen.get("totalPagar", dte_total))) + diff)
     # SERIALIZE-GUARD BEGIN
     special_d4_fields = {"totalExenta", "totalNoSuj"}
     for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):

--- a/tests/test_venta_vs_dte_caso_dificil_cf.py
+++ b/tests/test_venta_vs_dte_caso_dificil_cf.py
@@ -1,0 +1,130 @@
+from decimal import Decimal as D
+
+import json
+
+from db import DB
+import dte as dte_module
+from dte import generar_dte_json
+from utils.monto import d2, d4, d8
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_venta_vs_dte_caso_dificil_cf03(tmp_path):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    import svfe.config as svfe_config
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    productos = []
+    for i in range(5):
+        db.add_producto(f"Prod{i}", f"P{i}", None, vid, None, 0, 0, 0, 10)
+        productos.append(db.cursor.lastrowid)
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+
+    items = [
+        {"pid": productos[0], "qty": D("1.5"), "pf_unit": D("10.12345"), "desc_pct": D("5"), "tipo": "venta gravada"},
+        {"pid": productos[1], "qty": D("2.25"), "pf_unit": D("20.98765"), "desc_abs": D("1.2345"), "tipo": "venta gravada"},
+        {"pid": productos[2], "qty": D("0.5"), "pf_unit": D("30.13579"), "tipo": "venta exenta"},
+        {"pid": productos[3], "qty": D("3.333"), "pf_unit": D("5.55555"), "desc_pct": D("10"), "tipo": "venta no sujeta"},
+        {"pid": productos[4], "qty": D("4.75"), "pf_unit": D("7.77777"), "desc_abs": D("0.8765"), "tipo": "venta gravada"},
+    ]
+
+    calcs = []
+    total_pf = D("0")
+    for it in items:
+        pf_line = d8(it["qty"] * it["pf_unit"])
+        if "desc_abs" in it:
+            pf_neto = d8(pf_line - it["desc_abs"])
+        elif "desc_pct" in it:
+            pf_neto = d8(pf_line * (D("1") - it["desc_pct"] / D("100")))
+        else:
+            pf_neto = pf_line
+        if pf_neto < 0:
+            pf_neto = D("0")
+        if it["tipo"] == "venta gravada":
+            base = d4(pf_neto / D("1.13"))
+            iva = d4(pf_neto - base)
+        else:
+            base = d4(pf_neto)
+            iva = d4(pf_neto - base)
+        calcs.append({
+            "qty": it["qty"],
+            "pf_unit": it["pf_unit"],
+            "pf_line": pf_line,
+            "pf_neto": pf_neto,
+            "base": base,
+            "iva": iva,
+        })
+        total_pf += pf_neto
+
+    total_venta = d2(total_pf)
+    venta_id = db.add_venta("2024-01-01", float(total_venta), cliente_id=cid, extra={"precios_incluyen_iva": True})
+
+    for it in items:
+        if "desc_abs" in it:
+            desc = float(it["desc_abs"])
+            desc_tipo = ""
+        elif "desc_pct" in it:
+            desc = float(it["desc_pct"])
+            desc_tipo = "%"
+        else:
+            desc = 0
+            desc_tipo = ""
+        db.add_detalle_venta(
+            venta_id,
+            it["pid"],
+            float(it["qty"]),
+            float(it["pf_unit"]),
+            descuento=desc,
+            descuento_tipo=desc_tipo,
+            tipo_fiscal=it["tipo"],
+            vendedor_id=vid,
+        )
+
+    data = generar_dte_json(db, venta_id, tipo_dte="03")
+    resumen = data["resumen"]
+    assert d2(str(resumen["montoTotalOperacion"])) == total_venta
+
+    iva_sum = d2(sum(D(str(it.get("ivaItem", 0))) for it in data["cuerpoDocumento"]))
+    assert iva_sum == d2(str(resumen.get("totalIva", 0)))
+
+    for calc, item in zip(calcs, data["cuerpoDocumento"]):
+        base = item.get("ventaGravada") or item.get("ventaExenta") or item.get("ventaNoSuj")
+        print(
+            f"{calc['qty']}\t{calc['pf_unit']}\t{calc['pf_line']}\t{calc['pf_neto']}\t{calc['base']}\t{calc['iva']} | {base}\t{item.get('ivaItem',0)}"
+        )

--- a/utils/monto.py
+++ b/utils/monto.py
@@ -5,25 +5,32 @@ from decimal import Decimal, ROUND_HALF_UP, getcontext
 
 getcontext().prec = 28
 
+# Helper aliases and quantization constants
 D = Decimal
 Q8 = D("0.00000001")
+Q4 = D("0.0001")
 Q2 = D("0.01")
 IVA_TASA = D("0.13")
 
 
 def d8(value):
-    """Return value quantized to 8 decimal places."""
-    return D(value).quantize(Q8, rounding=ROUND_HALF_UP)
+    """Return ``value`` quantized to 8 decimal places."""
+    return D(str(value)).quantize(Q8, rounding=ROUND_HALF_UP)
 
 
 def d2(value):
-    """Return value quantized to 2 decimal places."""
-    return D(value).quantize(Q2, rounding=ROUND_HALF_UP)
+    """Return ``value`` quantized to 2 decimal places."""
+    return D(str(value)).quantize(Q2, rounding=ROUND_HALF_UP)
+
+
+def d4(value):
+    """Return ``value`` quantized to 4 decimal places."""
+    return D(str(value)).quantize(Q4, rounding=ROUND_HALF_UP)
 
 
 def iva_item(base_gravada):
     """Return IVA amount for an item based on taxable base."""
-    return d8(D(base_gravada) * IVA_TASA)
+    return d8(D(str(base_gravada)) * IVA_TASA)
 
 
 def to_base_iva(total):
@@ -34,7 +41,7 @@ def to_base_iva(total):
     are quantized to 8 decimal places to avoid floating point artifacts.
     """
 
-    total = D(total)
+    total = D(str(total))
     base = d8(total / (D("1") + IVA_TASA))
     iva = d8(total - base)
     return base, iva


### PR DESCRIPTION
## Summary
- add shared d8/d4/d2 helpers for precise Decimal arithmetic
- adjust DTE generation to apply cent-closing rule
- add test for complex CF sale vs DTE totals

## Testing
- `pytest tests/test_venta_vs_dte_caso_dificil_cf.py::test_venta_vs_dte_caso_dificil_cf03 -q` *(failed: AssertionError: assert Decimal('129.52') == Decimal('128.21'))*

------
https://chatgpt.com/codex/tasks/task_e_68c2778c52c48323942dee7a122dd9f2