### PR TITLE
Include tickets in billing tab

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -435,7 +435,10 @@ class FacturacionTab(QWidget):
             "Todos",
             "Consumidor final",
             "Crédito fiscal",
+            "Ticket",
             "Nota de débito",
+            "Nota de crédito",
+            "Nota de remisión",
         ])
         filter_layout.addWidget(self.tipo_filter)
 
@@ -722,6 +725,7 @@ class FacturacionTab(QWidget):
         folders = [
             CF_DIR,
             CREDITO_DIR,
+            TICKETS_DIR,
             NOTAS_DEBITO_DIR,
             NOTAS_CREDITO_DIR,
             NOTAS_REMISION_DIR,
@@ -734,6 +738,8 @@ class FacturacionTab(QWidget):
                 tipo = "Consumidor final"
             elif folder == CREDITO_DIR or "credito_fiscal" in folder:
                 tipo = "Crédito fiscal"
+            elif folder == TICKETS_DIR or "tickets" in folder:
+                tipo = "Ticket"
             elif folder == NOTAS_DEBITO_DIR or "notas_debito" in folder:
                 tipo = "Nota de débito"
             elif folder == NOTAS_CREDITO_DIR or "notas_credito" in folder:

--- a/tests/test_facturacion_tickets.py
+++ b/tests/test_facturacion_tickets.py
@@ -26,7 +26,10 @@ def test_documents_listed_from_files(qt_app, tmp_path, monkeypatch):
 
     monkeypatch.setattr(facturacion_tab, "CF_DIR", str(cf_dir))
     monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "facturas_credito_fiscal"))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(tmp_path / "tickets"))
     monkeypatch.setattr(facturacion_tab, "NOTAS_DEBITO_DIR", str(tmp_path / "notas_debito"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_CREDITO_DIR", str(tmp_path / "notas_credito"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_REMISION_DIR", str(tmp_path / "notas_remision"))
     monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
 
     tab = facturacion_tab.FacturacionTab(man)
@@ -45,10 +48,37 @@ def test_document_marked_incomplete_when_missing_pair(qt_app, tmp_path, monkeypa
 
     monkeypatch.setattr(facturacion_tab, "CF_DIR", str(tmp_path / "facturas_consumidor_final"))
     monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(cf_dir))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(tmp_path / "tickets"))
     monkeypatch.setattr(facturacion_tab, "NOTAS_DEBITO_DIR", str(tmp_path / "notas_debito"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_CREDITO_DIR", str(tmp_path / "notas_credito"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_REMISION_DIR", str(tmp_path / "notas_remision"))
     monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
 
     tab = facturacion_tab.FacturacionTab(man)
     docs = tab._scan_documents()
     match = next(d for d in docs if d.get("pdf") == str(pdf_path))
     assert match.get("estado") == "Incompleta"
+
+
+def test_ticket_documents_listed(qt_app, tmp_path, monkeypatch):
+    ticket_dir = tmp_path / "tickets"
+    ticket_dir.mkdir()
+    pdf_path = ticket_dir / "20240103_Test_1_Ticket.pdf"
+    pdf_path.write_text("pdf")
+    json_path = ticket_dir / "20240103_Test_1_Ticket.json"
+    json_path.write_text("{}")
+
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(tmp_path / "facturas_consumidor_final"))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "facturas_credito_fiscal"))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(ticket_dir))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_DEBITO_DIR", str(tmp_path / "notas_debito"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_CREDITO_DIR", str(tmp_path / "notas_credito"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_REMISION_DIR", str(tmp_path / "notas_remision"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    tab = facturacion_tab.FacturacionTab(man)
+    docs = tab._scan_documents()
+    assert any(d.get("pdf") == str(pdf_path) and d.get("tipo") == "Ticket" for d in docs)


### PR DESCRIPTION
## Summary
- show Ticket files in billing table and allow filtering by their type
- add regression test ensuring ticket documents are listed

## Testing
- `pytest tests/test_facturacion_tickets.py::test_ticket_documents_listed -q`
- `pytest tests/test_facturacion_tab_loading.py::test_loads_documents -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2782424d08323aa25b74d6e0be75a