### PR TITLE
Fix discount type handling in RegisterSaleDialog

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -804,6 +804,9 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         self.product_list.currentRowChanged.connect(self._actualizar_Distribuidor_por_producto)
         # --- FIN BLOQUE NUEVO ---
 
+        # Ajusta el máximo del descuento según el tipo seleccionado
+        self._on_descuento_tipo_changed()
+
     def set_productos_data(self, productos_data):
         self.productos_data = productos_data
 
@@ -850,6 +853,15 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         elif self.tipo_mayorista_total.isChecked():
             self.precio_spin.setEnabled(False)
             self.precio_total_spin.setEnabled(True)
+        self._recalcular_totales()
+
+
+    def _on_descuento_tipo_changed(self):
+        tipo = self.descuento_tipo_combo.currentText()
+        if tipo == "%":
+            self.descuento_spin.setMaximum(100)
+        else:
+            self.descuento_spin.setMaximum(1000000)
         self._recalcular_totales()
 
 


### PR DESCRIPTION
## Summary
- Implement missing `_on_descuento_tipo_changed` in `RegisterSaleDialog` to adjust discount limits and recalculate totals
- Initialize discount limit based on selected type

## Testing
- `pytest` *(fails: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3703bcb3c83239e45d3e4b3e44240