### PR TITLE
feat: unify line total calculations

### DIFF
--- a/db.py
+++ b/db.py
@@ -6,6 +6,9 @@ import threading
 from pathlib import Path
 from decimal import Decimal
 
+from utils.line_totals import compute_line_totals
+from utils.monto import d8
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -570,6 +573,10 @@ class DB:
             ("detalles_venta", "comision REAL DEFAULT 0"),
             ("detalles_venta", "iva_tipo TEXT"),
             ("detalles_venta", "tipo_fiscal TEXT"),
+            ("detalles_venta", "desc_con_iva REAL DEFAULT 0"),
+            ("detalles_venta", "base REAL DEFAULT 0"),
+            ("detalles_venta", "total REAL DEFAULT 0"),
+            ("detalles_venta", "unit_con_iva_efectivo REAL DEFAULT 0"),
             ("ventas_credito_fiscal", "sumas REAL DEFAULT 0"),
             ("ventas_credito_fiscal", "iva REAL DEFAULT 0"),
             ("ventas_credito_fiscal", "subtotal REAL DEFAULT 0"),
@@ -1210,13 +1217,71 @@ class DB:
             logger.exception("Error al eliminar venta: %s", e)
 
     # CRUD DETALLES_VENTA
-    def add_detalle_venta(self, venta_id, producto_id, cantidad, precio_unitario, descuento=0, descuento_tipo="", iva=0, comision=0, iva_tipo="", tipo_fiscal="", extra=None, precio_con_iva=0, vendedor_id=None):
+    def add_detalle_venta(
+        self,
+        venta_id,
+        producto_id,
+        cantidad,
+        precio_unitario,
+        descuento=0,
+        descuento_tipo="",
+        iva=0,
+        comision=0,
+        iva_tipo="",
+        tipo_fiscal="",
+        extra=None,
+        precio_con_iva=0,
+        vendedor_id=None,
+        desc_con_iva=0,
+        base=0,
+        total=0,
+        unit_con_iva_efectivo=0,
+    ):
         try:
             extra_json = json.dumps(extra) if extra else None
-            self.cursor.execute("""
-                INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra_json, precio_con_iva, vendedor_id))
+            self.cursor.execute(
+                """
+                INSERT INTO detalles_venta (
+                    venta_id,
+                    producto_id,
+                    cantidad,
+                    precio_unitario,
+                    descuento,
+                    descuento_tipo,
+                    iva,
+                    comision,
+                    iva_tipo,
+                    tipo_fiscal,
+                    extra,
+                    precio_con_iva,
+                    vendedor_id,
+                    desc_con_iva,
+                    base,
+                    total,
+                    unit_con_iva_efectivo
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    venta_id,
+                    producto_id,
+                    cantidad,
+                    precio_unitario,
+                    descuento,
+                    descuento_tipo,
+                    iva,
+                    comision,
+                    iva_tipo,
+                    tipo_fiscal,
+                    extra_json,
+                    precio_con_iva,
+                    vendedor_id,
+                    desc_con_iva,
+                    base,
+                    total,
+                    unit_con_iva_efectivo,
+                ),
+            )
             self.conn.commit()
         except Exception as e:
             logger.exception("Error al agregar detalle de venta: %s", e)
@@ -1816,16 +1881,61 @@ class DB:
         return [dict(row) for row in self.cursor.fetchall()]
 
     def add_venta_detallada(self, data):
-        # data es un dict con los campos de la tabla ventas
-        # Inserta la venta principal
         self.ensure_column("ventas", "estado", "TEXT DEFAULT 'Pagada'")
+        detalles = data.get("detalles", [])
+        total = Decimal("0")
+        prepared: list[dict] = []
+        for d in detalles:
+            cantidad = Decimal(str(d.get("cantidad") or 0))
+            precio_iva = Decimal(
+                str(
+                    d.get("precio_con_iva")
+                    or d.get("precio_unit_con_iva")
+                    or d.get("precio_unitario")
+                    or 0
+                )
+            )
+            descuento = Decimal(
+                str(d.get("descuento") or d.get("descuento_valor") or 0)
+            )
+            descuento_tipo = d.get("descuento_tipo") or "$"
+            tipo_fiscal = d.get("tipo_fiscal") or "Venta gravada"
+            iva_rate = Decimal("0.13") if tipo_fiscal == "Venta gravada" else Decimal("0")
+            calcs = compute_line_totals(
+                cantidad,
+                precio_iva,
+                descuento,
+                descuento_tipo,
+                iva_rate,
+            )
+            precio_unitario = d8(calcs["base"] / cantidad) if cantidad else Decimal("0")
+            prepared.append(
+                {
+                    "producto_id": d.get("producto_id"),
+                    "cantidad": float(d8(cantidad)),
+                    "precio_unitario": float(precio_unitario),
+                    "descuento": float(d8(descuento)),
+                    "descuento_tipo": descuento_tipo,
+                    "iva": float(calcs["iva"]),
+                    "tipo_fiscal": tipo_fiscal,
+                    "extra": d.get("extra"),
+                    "precio_con_iva": float(d8(precio_iva)),
+                    "vendedor_id": d.get("vendedor_id"),
+                    "desc_con_iva": float(calcs["desc_con_iva"]),
+                    "base": float(calcs["base"]),
+                    "total": float(calcs["total_con_iva"]),
+                    "unit_con_iva_efectivo": float(calcs["unit_con_iva_efectivo"]),
+                }
+            )
+            total += calcs["total_con_iva"]
+
+        total = d8(total)
         fecha = data.get("fecha", "")
-        total = data.get("total", 0)
         cliente_id = data.get("cliente_id")
         Distribuidor_id = data.get("Distribuidor_id")
         estado = data.get("estado", "Pagada")
         cols = ["fecha", "total", "estado", "sincronizada"]
-        vals = [fecha, total, estado, 1]
+        vals = [fecha, float(total), estado, 1]
         if cliente_id is not None:
             cols.append("cliente_id")
             vals.append(cliente_id)
@@ -1837,18 +1947,27 @@ class DB:
         self.cursor.execute(query, vals)
         venta_id = self.cursor.lastrowid
 
-        # Si hay detalles de venta en el dict, agrégalos
-        detalles = data.get("detalles", [])
-        for d in detalles:
-            self.cursor.execute("""
-                INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario)
-                VALUES (?, ?, ?, ?)
-            """, (
+        for d in prepared:
+            self.add_detalle_venta(
                 venta_id,
                 d.get("producto_id"),
                 d.get("cantidad"),
-                d.get("precio_unitario")
-            ))
+                d.get("precio_unitario"),
+                d.get("descuento"),
+                d.get("descuento_tipo"),
+                d.get("iva"),
+                d.get("comision", 0),
+                d.get("iva_tipo", ""),
+                d.get("tipo_fiscal"),
+                d.get("extra"),
+                d.get("precio_con_iva"),
+                d.get("vendedor_id"),
+                d.get("desc_con_iva"),
+                d.get("base"),
+                d.get("total"),
+                d.get("unit_con_iva_efectivo"),
+            )
+
         self.conn.commit()
 
     def add_trabajador(self, data, commit: bool = True):

--- a/dte.py
+++ b/dte.py
@@ -28,7 +28,8 @@ from utils.catalogos import (
 import logging
 import warnings
 import xml.etree.ElementTree as ET
-from utils.monto import monto_a_texto_sv, to_base_iva, d2, d4, d8
+from utils.monto import monto_a_texto_sv, to_base_iva, d2, d4, d8, money
+from utils.line_totals import compute_line_totals
 from utils.sanitize import limpiar_documentos, limpiar_doc, solo_digitos
 from num2words import num2words
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
@@ -199,20 +200,6 @@ getcontext().rounding = ROUND_HALF_UP
 
 # Helper alias for ``Decimal``
 D = Decimal
-
-
-def d1(value: "object") -> D:
-    """Return ``value`` as :class:`Decimal` with 1 decimal place."""
-    return D(str(value)).quantize(D("0.1"), rounding=ROUND_HALF_UP)
-
-
-def money(value) -> D:
-    """
-    Convierte `value` a Decimal con 2 decimales (multipleOf 0.01) usando ROUND_HALF_UP.
-    Acepta str, int, float, Decimal. Devuelve Decimal cuantizado a 0.01.
-    """
-    return D(str(value)).quantize(D("0.01"), rounding=ROUND_HALF_UP)
-
 
 def _precios_incluyen_iva_from(
     extra: dict | None, override: bool | None = None
@@ -1163,8 +1150,8 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
     resumen["ivaRete1"] = money(fiscal.get("iva_rete1", resumen.get("ivaRete1", 0)))
     resumen["reteRenta"] = money(fiscal.get("rete_renta", resumen.get("reteRenta", 0)))
 
-    if tipo_dte not in {"03", "05", "06"}:
-        resumen["totalIva"] = total_iva
+    # Incluir totalIva en todos los tipos de DTE
+    resumen["totalIva"] = total_iva
 
     if tipo_dte in {"01", "03", "05", "06"}:
         condicion = extra.get("condicion_operacion")
@@ -1234,7 +1221,7 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
         "numPagoElectronico",
         "tributos",
     }
-    special_d4_fields = {"totalExenta", "totalNoSuj"}
+    special_d4_fields = set() if tipo_dte == "03" else {"totalExenta", "totalNoSuj"}
     for key, val in list(resumen.items()):
         if key in excl:
             continue
@@ -1319,8 +1306,8 @@ def recalcular_totales(
             _precio = D(str(_it.get("precioUni") or 0))
             _descu = D(str(_it.get("montoDescu") or 0))
             if _descu:
-                total_final = d4(_cant * _precio - _descu)
-                unit_pf = d4(total_final / _cant) if _cant else d4(0)
+                total_final = d8(_cant * _precio - _descu)
+                unit_pf = d8(total_final / _cant) if _cant else d8(0)
                 _it["precioUni"] = unit_pf
                 _it.pop("montoDescu", None)
         resumen["descuNoSuj"] = resumen["descuExenta"] = resumen["descuGravada"] = resumen["totalDescu"] = money(0)
@@ -1378,26 +1365,23 @@ def recalcular_totales(
             iva_total += esperado_iva
             venta_gravada_sum += linea
         elif tipo_dte == "03":
-            pf_line = d8(cant * precio - monto_descu)
-            if pf_line < 0:
-                pf_line = d8(0)
-            base_8d = pf_line / D("1.13")
-            precio_u = d4(base_8d / cant) if cant > 0 else d4(0)
-            base_line = d4(precio_u * cant)
-            iva_val = d4(pf_line - base_line)
+            precio_u = d8(precio)
+            base_line = d8(D(str(item.get("ventaGravada") or 0)))
+            iva_val = d8(D(str(item.get("ivaItem") or 0)))
+            pf_line = d8(base_line + iva_val)
             bases_pre.append(base_line)
             bases.append(base_line)
             ivas.append(iva_val)
-            pf_line_q = d4(base_line + iva_val)
-            bruto_sum += pf_line_q
-            bruto_linea_sum += d4(cant * precio)
+            bruto_sum += pf_line
+            bruto_linea_sum += d8(cant * precio_u)
             cantidades.append(cant)
             prices.append(precio_u)
-            item.pop("montoDescu", None)
-            item.pop("ivaItem", None)
-            item["ventaExenta"] = d4(0)
-            item["ventaNoSuj"] = d4(0)
-            item["noGravado"] = d4(0)
+            item["montoDescu"] = d8(0)
+            item["ventaGravada"] = base_line
+            item["ivaItem"] = iva_val
+            item["ventaExenta"] = d8(D(str(item.get("ventaExenta") or 0)))
+            item["ventaNoSuj"] = d8(D(str(item.get("ventaNoSuj") or 0)))
+            item["noGravado"] = d8(D(str(item.get("noGravado") or 0)))
         else:
             bruto_linea = money(cant * precio)
             bruto_linea_sum += bruto_linea
@@ -1423,7 +1407,8 @@ def recalcular_totales(
             item["ventaExenta"] = money(0)
             item["ventaNoSuj"] = money(0)
             item["noGravado"] = money(0)
-    if tipo_dte != "01":
+    # En FC (03) los ítems ya traen base/IVA correctos; no redistribuir.
+    if tipo_dte in {"05", "06"}:
         if bases:
             bruto_total = bruto_sum
             base_total = money(bruto_total / D("1.13"))
@@ -1441,13 +1426,13 @@ def recalcular_totales(
             total_venta = D("0")
             for idx, item in enumerate(cuerpo):
                 if idx < len(bases):
-                    base_val = d4(bases[idx])
+                    base_val = d8(bases[idx])
                     cant = cantidades[idx]
-                    iva_val = d4(ivas[idx])
-                    pf_neto = d4(base_val + iva_val)
+                    iva_val = d8(ivas[idx])
+                    pf_neto = d8(base_val + iva_val)
                     item["ventaGravada"] = base_val
-                    precio_u = prices[idx] if idx < len(prices) else d4(0)
-                    item["precioUni"] = precio_u if cant > 0 else d4(0)
+                    precio_u = prices[idx] if idx < len(prices) else d8(0)
+                    item["precioUni"] = precio_u if cant > 0 else d8(0)
                     item.pop("ivaItem", None)
                     item.pop("montoDescu", None)
                     if base_val + iva_val != pf_neto:
@@ -1487,25 +1472,33 @@ def recalcular_totales(
             venta_gravada_sum = D("0")
             iva_total = D("0")
             venta_total_sum = D("0")
+    elif tipo_dte == "03":
+        venta_gravada_sum = sum(bases)
+        iva_total = sum(ivas)
+        venta_total_sum = bruto_sum
+    else:
+        venta_gravada_sum = D("0")
+        iva_total = D("0")
+        venta_total_sum = D("0")
 
-        if tipo_dte in {"03", "05", "06"}:
-            if colapso_desc:
-                sub_total_ventas = money(sum(bases))
-                descu_gravada_sum = money(0)
-            else:
-                sub_total_ventas = money(sum(bases_pre))
-                descu_gravada_sum = money(
-                    sum(bp - b for bp, b in zip(bases_pre, bases))
-                )
+    if tipo_dte in {"03", "05", "06"}:
+        if colapso_desc:
+            sub_total_ventas = money(sum(bases))
+            descu_gravada_sum = money(0)
         else:
-            if precios_flag:
-                sub_total_ventas = money(sum(bases_pre))
-                descu_gravada_sum = money(
-                    sum(bp - b for bp, b in zip(bases_pre, bases))
-                )
-            else:
-                sub_total_ventas = money(venta_gravada_sum)
-                descu_gravada_sum = money(0)
+            sub_total_ventas = money(sum(bases_pre))
+            descu_gravada_sum = money(
+                sum(bp - b for bp, b in zip(bases_pre, bases))
+            )
+    else:
+        if precios_flag:
+            sub_total_ventas = money(sum(bases_pre))
+            descu_gravada_sum = money(
+                sum(bp - b for bp, b in zip(bases_pre, bases))
+            )
+        else:
+            sub_total_ventas = money(venta_gravada_sum)
+            descu_gravada_sum = money(0)
 
     venta_gravada_sum = venta_gravada_sum
     total_iva_sum = d4(iva_total)
@@ -2116,8 +2109,14 @@ def generar_dte_json(
         precios_incluyen_iva = True
         extra["precios_incluyen_iva"] = True
 
-    def _zero_or_d4(value: D) -> D:
-        dec = d4(value)
+    q_item = d8 if tipo_dte == "03" else d4
+    q_qty = d8 if tipo_dte == "03" else d4
+    # Quantizers per field (por tipo de DTE)
+    q_field_item = d8 if tipo_dte == "03" else d4  # ventaGravada/Exenta/NoSuj por ítem
+    q_field_iva = d8 if tipo_dte == "03" else d2   # ivaItem por ítem
+
+    def _zero_or_item(value: D) -> D:
+        dec = q_item(value)
         return D("0.0") if dec == 0 else dec
 
     def _zero_or_d2(value: D) -> D:
@@ -2126,15 +2125,25 @@ def generar_dte_json(
 
     for idx, d in enumerate(detalles, 1):
         try:
-            cant = d1(D(str(d.get("cantidad") or 0)))
+            cant = q_qty(D(str(d.get("cantidad") or 0)))
         except Exception:
-            cant = d1(D(0))
+            cant = q_qty(D(0))
         if cant <= 0:
-            cant = d1(D("1"))
+            cant = q_qty(D("1"))
         try:
-            precio_raw = d4(D(str(d.get("precio_unitario") or 0)))
+            precio_raw = q_item(
+                D(
+                    str(
+                        d.get("precio_con_iva")
+                        or d.get("precio_unit_con_iva")
+                        or d.get("precio_unitario_con_iva")
+                        or d.get("precio_unitario")
+                        or 0
+                    )
+                )
+            )
         except Exception:
-            precio_raw = d4(D(0))
+            precio_raw = q_item(D(0))
         try:
             tipo_item = int(d.get("tipoItem", 1))
         except Exception:
@@ -2162,31 +2171,37 @@ def generar_dte_json(
 
         tipo_fiscal_item = str(d.get("tipo_fiscal", "")).lower()
         if tipo_fiscal_item == "venta exenta":
-            precio = d4(precio_raw)
-            bruto = d4(cant * precio)
-            monto_descu = _calc_desc(bruto)
-            line_total = d4(bruto - monto_descu)
-            if line_total < 0:
-                line_total = D("0")
-            bruto_total += bruto
-            descuentos_total += monto_descu
+            calcs = compute_line_totals(cant, precio_raw, desc_raw, desc_tipo, iva_rate=D("0"))
+            line_total = calcs["total_con_iva"]
+            precio = q_item(calcs["unit_con_iva_efectivo"])
             venta_gravada = D("0")
-            venta_exenta = d2(line_total)
+            venta_exenta = q_item(line_total)
             venta_no_suj = D("0")
             iva_val = D("0")
+            if tipo_dte in {"03", "05", "06"}:
+                monto_descu = D("0")
+                bruto_total += line_total
+                sub_total_ventas += line_total  # base = total, IVA=0
+            else:
+                monto_descu = calcs["desc_con_iva"]
+                bruto_total += calcs["bruto"]
+                descuentos_total += calcs["desc_con_iva"]
         elif tipo_fiscal_item == "venta no sujeta":
-            precio = d4(precio_raw)
-            bruto = d4(cant * precio)
-            monto_descu = _calc_desc(bruto)
-            line_total = d4(bruto - monto_descu)
-            if line_total < 0:
-                line_total = D("0")
-            bruto_total += bruto
-            descuentos_total += monto_descu
+            calcs = compute_line_totals(cant, precio_raw, desc_raw, desc_tipo, iva_rate=D("0"))
+            line_total = calcs["total_con_iva"]
+            precio = q_item(calcs["unit_con_iva_efectivo"])
             venta_gravada = D("0")
             venta_exenta = D("0")
-            venta_no_suj = d2(line_total)
+            venta_no_suj = q_item(line_total)
             iva_val = D("0")
+            if tipo_dte in {"03", "05", "06"}:
+                monto_descu = D("0")
+                bruto_total += line_total
+                sub_total_ventas += line_total  # base = total, IVA=0
+            else:
+                monto_descu = calcs["desc_con_iva"]
+                bruto_total += calcs["bruto"]
+                descuentos_total += calcs["desc_con_iva"]
         else:
             if tipo_dte == "01":
                 origen = (
@@ -2208,19 +2223,18 @@ def generar_dte_json(
                 descuentos_total += monto_descu
             elif precios_incluyen_iva:
                 if tipo_dte in {"03", "05", "06"}:
-                    bruto = d4(cant * precio_raw)
-                    descu_total = _calc_desc(bruto)
-                    bruto_final = d4(bruto - descu_total)
-                    if bruto_final < 0:
-                        bruto_final = D("0")
-                    base_final = money(bruto_final / D("1.13"))
-                    iva_val = d4(bruto_final - base_final)
-                    precio = d4(money(bruto_final / cant))
+                    calcs = compute_line_totals(cant, precio_raw, desc_raw, desc_tipo)
+                    line_total = calcs["total_con_iva"]
+                    venta_gravada = calcs["base"]
+                    iva_val = calcs["iva"]
+                    iva_total += iva_val
+                    # FC (03): precioUni debe ser unitario SIN IVA (base/cant)
+                    precio = (
+                        q_item(calcs["base"] / cant) if cant > 0 else q_item(D("0"))
+                    )
                     monto_descu = D("0")
-                    venta_gravada = base_final
-                    line_total = bruto_final
-                    bruto_total += bruto_final
-                    sub_total_ventas += base_final
+                    bruto_total += line_total
+                    sub_total_ventas += venta_gravada
                 else:
                     bruto = d4(cant * precio_raw)
                     monto_descu = _calc_desc(bruto)
@@ -2250,7 +2264,8 @@ def generar_dte_json(
             venta_exenta = D("0")
             venta_no_suj = D("0")
         items_total += line_total
-        iva_total += iva_val
+        if tipo_dte not in {"03", "05", "06"}:
+            iva_total += iva_val
         try:
             commission_total += D(str(d.get("comision") or 0))
         except Exception:
@@ -2283,17 +2298,19 @@ def generar_dte_json(
             "descripcion": d.get("descripcion"),
             "cantidad": cant,
             "uniMedida": uni_medida,
-            "precioUni": d4(precio),
-            "montoDescu": d4(monto_descu),
+            "precioUni": q_item(precio),
+            "montoDescu": q_item(monto_descu),
             "ventaNoSuj": venta_no_suj,
             "ventaExenta": venta_exenta,
             "ventaGravada": venta_gravada,
-            "psv": money(0),
-            "noGravado": money(0),
+            "psv": q_item(0),
+            "noGravado": q_item(0),
             "tributos": [],
         }
-        if tipo_dte == "01":
-            item_data["ivaItem"] = money(iva_val)
+        if tipo_dte in {"01", "03"}:
+            item_data["ivaItem"] = (
+                q_field_iva(iva_val) if tipo_dte == "03" else money(iva_val)
+            )
         if tipo_dte == "01":
             item_data["codTributo"] = None
             item_data["tributos"] = None
@@ -2308,7 +2325,7 @@ def generar_dte_json(
                 item_data["codTributo"] = None
             item_data["tributos"] = trib_list
         for key in ("ventaNoSuj", "ventaExenta", "ventaGravada"):
-            item_data[key] = _zero_or_d4(D(str(item_data[key])))
+            item_data[key] = _zero_or_item(D(str(item_data[key])))
         total_no_suj_sum += D(str(item_data["ventaNoSuj"]))
         total_exenta_sum += D(str(item_data["ventaExenta"]))
         total_gravada_sum += D(str(item_data["ventaGravada"]))
@@ -2318,11 +2335,11 @@ def generar_dte_json(
     items_total = money(items_total)
     bruto_total = money(bruto_total)
     descuentos_total = money(descuentos_total)
-    total_no_suj_sum = _zero_or_d4(total_no_suj_sum)
-    total_exenta_sum = _zero_or_d4(total_exenta_sum)
+    total_no_suj_sum = _zero_or_item(total_no_suj_sum)
+    total_exenta_sum = _zero_or_item(total_exenta_sum)
     total_gravada_sum = _zero_or_d2(total_gravada_sum)
     total_no_gravado_sum = money(total_no_gravado_sum)
-    total_iva_sum = d4(iva_total)
+    total_iva_sum = money(iva_total)
     sub_total_ventas = money(sub_total_ventas)
     descu_gravada_sum = money(descu_gravada_sum)
 
@@ -2353,8 +2370,8 @@ def generar_dte_json(
         tipo_dte=tipo_dte,
     )
 
-    resumen["totalNoSuj"] = _zero_or_d4(total_no_suj_sum)
-    resumen["totalExenta"] = _zero_or_d4(total_exenta_sum)
+    resumen["totalNoSuj"] = _zero_or_item(total_no_suj_sum)
+    resumen["totalExenta"] = _zero_or_item(total_exenta_sum)
     resumen["totalGravada"] = _zero_or_d2(total_gravada_sum)
 
     # Las siguientes validaciones se omiten para permitir diferencias entre el
@@ -2456,7 +2473,7 @@ def generar_dte_json(
         if last_grav is not None:
             item = cuerpo[last_grav]
             iva_val = D(str(item.get("ivaItem") or 0))
-            item["ivaItem"] = d4(iva_val + diff)
+            item["ivaItem"] = q_field_iva(iva_val + diff)
             resumen["totalIva"] = d2(D(str(resumen.get("totalIva", 0))) + diff)
             resumen["montoTotalOperacion"] = d2(dte_total + diff)
             resumen["totalPagar"] = resumen.get("totalPagar", resumen["montoTotalOperacion"])
@@ -2466,8 +2483,8 @@ def generar_dte_json(
             if cuerpo:
                 item = cuerpo[-1]
                 qty = D(str(item.get("cantidad") or 1))
-                unit_adj = d4(diff / qty)
-                item["precioUni"] = d4(D(str(item.get("precioUni"))) + unit_adj)
+                unit_adj = q_item(diff / qty)
+                item["precioUni"] = q_item(D(str(item.get("precioUni"))) + unit_adj)
                 if D(str(item.get("ventaExenta") or 0)) > 0:
                     campo = "ventaExenta"
                     resumen_key = "totalExenta"
@@ -2477,12 +2494,12 @@ def generar_dte_json(
                 else:
                     campo = "ventaGravada"
                     resumen_key = "totalGravada"
-                item[campo] = d4(D(str(item.get(campo))) + diff)
+                item[campo] = q_field_item(D(str(item.get(campo))) + diff)
                 resumen[resumen_key] = d2(D(str(resumen.get(resumen_key, 0))) + diff)
                 resumen["montoTotalOperacion"] = d2(dte_total + diff)
                 resumen["totalPagar"] = d2(D(str(resumen.get("totalPagar", dte_total))) + diff)
     # SERIALIZE-GUARD BEGIN
-    special_d4_fields = {"totalExenta", "totalNoSuj"}
+    special_d4_fields = set() if tipo_dte == "03" else {"totalExenta", "totalNoSuj"}
     for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):
         if k in resumen:
             val = D(str(resumen[k]))
@@ -2551,8 +2568,6 @@ def generar_dte_json(
         dec = money(value)
         return D("0.0") if dec == 0 else dec
 
-    special_d4_fields = {"totalExenta", "totalNoSuj"}
-
     for k, v in list(resumen.items()):
         if k in {
             "totalLetras",
@@ -2562,7 +2577,7 @@ def generar_dte_json(
             "tributos",
         }:
             continue
-        qfn = _zero_or_d4 if k in special_d4_fields else _quantize_money
+        qfn = _zero_or_item if k in special_d4_fields else _quantize_money
         resumen[k] = qfn(D(str(v)))
 
     if resumen.get("tributos"):
@@ -2675,6 +2690,11 @@ def validate_dte_json(
     else:
         tipo_dte_val = str(tipo_dte_val).zfill(2)
     ident["tipoDte"] = tipo_dte_val
+    tipo_dte = tipo_dte_val
+    # Cuantizadores por tipo: en FC (03) los ítems usan 8 decimales
+    q_item = d8 if tipo_dte == "03" else d4
+    q_qty = d8 if tipo_dte == "03" else d4
+    q_field = d8 if tipo_dte == "03" else d2
     if tipo_dte_val not in catalogos.DTE_TIPOS:
         raise ValueError("tipoDte inválido")
     if tipo_dte_val in {"03", "05", "06"}:
@@ -2979,6 +2999,8 @@ def validate_dte_json(
             "noGravado",
             "ivaItem",
         }
+    if tipo_dte == "03":
+        allowed_item_keys.add("ivaItem")
     precio_key = "precioUni"
     iva_key = "ivaItem" if "ivaItem" in allowed_item_keys else None
 
@@ -3041,34 +3063,34 @@ def validate_dte_json(
             item.setdefault(iva_key, cero)
 
         # --- Cálculo de base ---
-        cantidad = d1(D(str(item.get("cantidad") or 0)))
-        precio = d8(D(str(item.get(precio_key) or 0)))
+        cantidad = q_qty(D(str(item.get("cantidad") or 0)))
+        precio = q_item(D(str(item.get(precio_key) or 0)))
         item["cantidad"] = cantidad
         item[precio_key] = precio
-        monto_descu = d8(D(str(item.get("montoDescu") or 0)))
+        monto_descu = q_field(D(str(item.get("montoDescu") or 0)))
         if monto_descu < 0:
             monto_descu = cero
-        base = d8(cantidad * precio - monto_descu)
+        base = q_field(cantidad * precio - monto_descu)
         if base < 0:
             base = cero
 
         # Determinar tipo de venta
         if D(str(item.get("ventaExenta") or 0)) > 0:
-            item["ventaExenta"] = d2(base)
+            item["ventaExenta"] = q_field(base)
             item["ventaGravada"] = cero
             item["ventaNoSuj"] = cero
             item["noGravado"] = cero
         elif D(str(item.get("ventaNoSuj") or 0)) > 0:
-            item["ventaNoSuj"] = d2(base)
+            item["ventaNoSuj"] = q_field(base)
             item["ventaGravada"] = cero
             item["noGravado"] = cero
         elif D(str(item.get("noGravado") or 0)) > 0:
-            item["noGravado"] = d2(base)
+            item["noGravado"] = q_field(base)
             item["ventaGravada"] = cero
             item["ventaNoSuj"] = cero
 
         else:
-            item["ventaGravada"] = d2(base)
+            item["ventaGravada"] = q_field(base)
             item["ventaExenta"] = cero
             item["ventaNoSuj"] = cero
             item["noGravado"] = cero
@@ -3127,19 +3149,19 @@ def validate_dte_json(
                 if tipo_dte == "01":
                     item[iva_key] = money(D(str(item.get(iva_key))))
                 else:
-                    item[iva_key] = d8(D(str(item.get(iva_key))))
+                    item[iva_key] = q_field(D(str(item.get(iva_key))))
             else:
                 iva_calc = venta_gravada_val * D("0.13") if venta_gravada_val > 0 else cero
-                item[iva_key] = money(iva_calc) if tipo_dte == "01" else d8(iva_calc)
+                item[iva_key] = money(iva_calc) if tipo_dte == "01" else q_field(iva_calc)
 
-        # Totales a 2 decimales y normalizar -0.00
+        # Totales normalizados según el tipo de DTE y eliminar -0.00
         for k in ("ventaGravada", "ventaExenta", "ventaNoSuj", "psv", "noGravado"):
-            val = d2(item.get(k, cero))
+            val = q_field(item.get(k, cero))
             item[k] = cero if val == 0 else val
-        item["montoDescu"] = d2(monto_descu)
+        item["montoDescu"] = q_field(monto_descu)
         if iva_key:
             iva_val = D(str(item.get(iva_key) or 0))
-            iva_val_q = money(iva_val) if tipo_dte == "01" else d8(iva_val)
+            iva_val_q = money(iva_val) if tipo_dte == "01" else q_field(iva_val)
             item[iva_key] = cero if iva_val_q == 0 else iva_val_q
     payload["cuerpoDocumento"] = cuerpo
 
@@ -3159,10 +3181,11 @@ def validate_dte_json(
                 pass
     payload["resumen"] = resumen
 
-    # Recalcular totales y ajustar discrepancias
-    cambios = recalcular_totales(payload, precios_incluyen_iva=precios_flag)
-    if cambios:
-        print("Advertencia: se corrigieron campos de resumen: " + ", ".join(cambios))
+    # Recalcular totales y ajustar discrepancias (excepto para FC ya normalizado)
+    if tipo_dte != "03":
+        cambios = recalcular_totales(payload, precios_incluyen_iva=precios_flag)
+        if cambios:
+            print("Advertencia: se corrigieron campos de resumen: " + ", ".join(cambios))
 
     ident = payload.get("identificacion", {})
     if ident.get("tipoDte") == "01":
@@ -3213,7 +3236,7 @@ def validate_dte_json(
                 p["plazo"] = ""
 
     # Verificación de centavos exactos en totales clave
-    special_d4_fields = {"totalExenta", "totalNoSuj"}
+    special_d4_fields = set() if tipo_dte == "03" else {"totalExenta", "totalNoSuj"}
     for k in ("totalIva", "montoTotalOperacion", "totalPagar", "totalNoGravado"):
         if k in resumen:
             val = D(str(resumen[k]))
@@ -3292,12 +3315,11 @@ def validate_dte_json(
         return D("0.0") if dec == 0 else dec
 
     for item in payload.get("cuerpoDocumento", []):
-        # cantidad se cuantiza a un decimal
-        item["cantidad"] = _zero_or(item.get("cantidad", D("0")), d1)
-        # precio unitario y ventas: 4 decimales cuando es mayor a 0
-        item[precio_key] = _zero_or(item.get(precio_key, D("0")), d4)
+        # cuantizar cantidad y precios según tipo de DTE
+        item["cantidad"] = _zero_or(item.get("cantidad", D("0")), q_qty)
+        item[precio_key] = _zero_or(item.get(precio_key, D("0")), q_item)
         if iva_key and iva_key in item:
-            item[iva_key] = _zero_or(item.get(iva_key, D("0")), d2)
+            item[iva_key] = _zero_or(item.get(iva_key, D("0")), q_field)
         for k in (
             "montoDescu",
             "ventaNoSuj",
@@ -3306,11 +3328,13 @@ def validate_dte_json(
             "psv",
             "noGravado",
         ):
-            qfn = d4 if k in {"ventaNoSuj", "ventaExenta", "ventaGravada"} else d2
+            if tipo_dte == "03":
+                qfn = q_field
+            else:
+                qfn = d4 if k in {"ventaNoSuj", "ventaExenta", "ventaGravada"} else d2
             item[k] = _zero_or(item.get(k, D("0")), qfn)
 
     resumen = payload.get("resumen", {})
-    special_d4_fields = {"totalExenta", "totalNoSuj"}
     for k, v in list(resumen.items()):
         if k in {
             "totalLetras",

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -6,8 +6,11 @@ from datetime import datetime, timedelta
 import os
 import logging
 import sqlite3
+from decimal import Decimal as D
 from paths import DATOS_NEGOCIO_PATH
 from utils.stable_json import DecimalEncoder
+from utils.line_totals import compute_line_totals
+from utils.monto import d8
 
 logger = logging.getLogger(__name__)
 
@@ -904,7 +907,51 @@ class InventoryManager:
         self.refresh_data()
 
     def registrar_venta_detallada(self, venta_data):
-        self.db.add_venta_detallada(venta_data)
+        detalles = []
+        total = D("0")
+        for item in venta_data.get("detalles", []):
+            cantidad = D(str(item.get("cantidad") or 0))
+            precio_con_iva = D(
+                str(
+                    item.get("precio_unit_con_iva")
+                    or item.get("precio_con_iva")
+                    or item.get("precio_unitario")
+                    or 0
+                )
+            )
+            descuento_valor = D(
+                str(item.get("descuento_valor") or item.get("descuento") or 0)
+            )
+            descuento_tipo = item.get("descuento_tipo", "$")
+            tipo_fiscal = item.get("tipo_fiscal", "Venta gravada")
+            iva_rate = D("0.13") if tipo_fiscal == "Venta gravada" else D("0")
+            calcs = compute_line_totals(
+                cantidad,
+                precio_con_iva,
+                descuento_valor,
+                descuento_tipo,
+                iva_rate,
+            )
+            detalle = {
+                "producto_id": item.get("producto_id"),
+                "cantidad": float(d8(cantidad)),
+                "precio_unitario": float(d8(calcs["base"] / cantidad)) if cantidad else 0,
+                "descuento": float(d8(descuento_valor)),
+                "descuento_tipo": descuento_tipo,
+                "iva": float(calcs["iva"]),
+                "tipo_fiscal": tipo_fiscal,
+                "precio_con_iva": float(d8(precio_con_iva)),
+                "desc_con_iva": float(calcs["desc_con_iva"]),
+                "base": float(calcs["base"]),
+                "total": float(calcs["total_con_iva"]),
+                "unit_con_iva_efectivo": float(calcs["unit_con_iva_efectivo"]),
+            }
+            detalles.append(detalle)
+            total += calcs["total_con_iva"]
+        data = dict(venta_data)
+        data["detalles"] = detalles
+        data["total"] = float(d8(total))
+        self.db.add_venta_detallada(data)
         self.refresh_data()
 
 class ProductTableModel(QAbstractTableModel):

--- a/tests/test_compute_line_totals.py
+++ b/tests/test_compute_line_totals.py
@@ -1,0 +1,199 @@
+from decimal import Decimal as D
+
+import json
+
+from db import DB
+from dte import generar_dte_json, FC_SCHEMA, RESOLVER, DTE_VERSIONES
+from jsonschema import Draft7Validator
+from utils.line_totals import compute_line_totals
+from utils.monto import d2, d4, d8
+import dte as dte_module
+import svfe.config as svfe_config
+
+
+def _setup_datos_negocio(tmp_path):
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "06", "municipio": "10", "complemento": "Calle 1"},
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.DATOS_NEGOCIO_PATH = str(tmp_file)
+    svfe_config.load_datos_negocio = lambda: datos
+
+
+def test_sale_total_equals_preview():
+    line1 = compute_line_totals(D('1'), D('12'), D('5'), '%')
+    line2 = compute_line_totals(D('1'), D('12'), D('6'), '%')
+    total = d2(line1['total_con_iva'] + line2['total_con_iva'])
+    assert total == D('22.68')
+    assert d2(line1['total_con_iva']) == D('11.40')
+    assert d2(line2['total_con_iva']) == D('11.28')
+
+
+
+def test_discount_amount_clamped():
+    data = compute_line_totals(D('1'), D('10'), D('15'), '$')
+    assert data['total_con_iva'] == D('0')
+    assert data['desc_con_iva'] == D('10')
+
+
+def test_save_sale_equals_preview_totals(tmp_path):
+    _setup_datos_negocio(tmp_path)
+    db = DB(':memory:')
+    venta = {
+        'fecha': '2024-01-01',
+        'detalles': [
+            {
+                'cantidad': D('1'),
+                'precio_unit_con_iva': D('12'),
+                'descuento': D('5'),
+                'descuento_tipo': '%',
+                'tipo_fiscal': 'Venta gravada',
+            },
+            {
+                'cantidad': D('1'),
+                'precio_unit_con_iva': D('12'),
+                'descuento': D('6'),
+                'descuento_tipo': '%',
+                'tipo_fiscal': 'Venta gravada',
+            },
+        ],
+    }
+    db.add_venta_detallada(venta)
+    row = db.cursor.execute('SELECT id, total FROM ventas').fetchone()
+    assert d2(D(str(row['total']))) == D('22.68')
+    venta_id = row['id']
+    db.cursor.execute('SELECT SUM(total) as s FROM detalles_venta WHERE venta_id=?', (venta_id,))
+    sum_det = D(str(db.cursor.fetchone()['s']))
+    assert d2(sum_det) == D('22.68')
+
+
+def test_exenta_no_sujeta_saved_totals(tmp_path):
+    _setup_datos_negocio(tmp_path)
+    db = DB(':memory:')
+    db.cursor.execute("INSERT INTO clientes (codigo, nombre, nit) VALUES ('C1','Cliente','06141990011019')")
+    cliente_id = db.cursor.lastrowid
+    venta = {
+        'fecha': '2024-01-01',
+        'cliente_id': cliente_id,
+        'detalles': [
+            {
+                'cantidad': D('1'),
+                'precio_unit_con_iva': D('10'),
+                'descuento': D('0'),
+                'descuento_tipo': '$',
+                'tipo_fiscal': 'Venta exenta',
+            }
+        ],
+    }
+    db.add_venta_detallada(venta)
+    venta_id = db.cursor.execute('SELECT id FROM ventas').fetchone()['id']
+    det = db.cursor.execute(
+        'SELECT base, iva, total FROM detalles_venta WHERE venta_id=?',
+        (venta_id,),
+    ).fetchone()
+    assert D(str(det['iva'])) == D('0')
+    assert D(str(det['base'])) == D(str(det['total']))
+
+
+def test_mayorista_total_to_unit():
+    total = D('100')
+    qty = D('5')
+    unit_price = total / qty
+    calcs = compute_line_totals(qty, unit_price)
+    assert calcs['total_con_iva'] == d8(total)
+    assert calcs['unit_con_iva_efectivo'] == d8(unit_price)
+
+
+def _create_fc_sale(db, detalles):
+    db.add_vendedor('V1')
+    vid = db.cursor.lastrowid
+    db.add_cliente(
+        'Cliente',
+        '123',
+        '06141990011019',
+        '',
+        'giro',
+        '70000001',
+        '',
+        'C',
+        '06',
+        '01',
+    )
+    cid = db.cursor.lastrowid
+    total_venta = d8(sum(d['total'] for d in detalles))
+    venta_id = db.add_venta_credito_fiscal(
+        cid,
+        '2024-01-01',
+        float(total_venta),
+        '12345678',
+        '06141990011019',
+        'giro',
+        extra={'precios_incluyen_iva': True},
+    )
+    for idx, det in enumerate(detalles, 1):
+        db.add_producto(f'Prod{idx}', f'P{idx}', None, vid, None, 0, 0, 0, 10)
+        pid = db.cursor.lastrowid
+        db.add_detalle_venta(
+            venta_id,
+            pid,
+            float(det['cantidad']),
+            float(det['precio_unit_con_iva']),
+            descuento=float(det['descuento']),
+            descuento_tipo=det['descuento_tipo'],
+            tipo_fiscal=det.get('tipo_fiscal', 'Venta gravada'),
+            precio_con_iva=float(det['precio_unit_con_iva']),
+            desc_con_iva=float(det['desc_con_iva']),
+            base=float(det['base']),
+            total=float(det['total']),
+            unit_con_iva_efectivo=float(det['unit_con_iva_efectivo']),
+        )
+    return venta_id
+
+
+def test_dte_fc_absorbs_discount_in_unit_price(tmp_path):
+    _setup_datos_negocio(tmp_path)
+    db = DB(':memory:')
+    detalles = []
+    calcs_list = []
+    for desc in (D('5'), D('6')):
+        calcs = compute_line_totals(D('1'), D('12'), desc, '%')
+        calcs_list.append(calcs)
+        detalles.append(
+            {
+                'cantidad': D('1'),
+                'precio_unit_con_iva': D('12'),
+                'descuento': desc,
+                'descuento_tipo': '%',
+                'desc_con_iva': calcs['desc_con_iva'],
+                'base': calcs['base'],
+                'total': calcs['total_con_iva'],
+                'unit_con_iva_efectivo': calcs['unit_con_iva_efectivo'],
+            }
+        )
+    venta_id = _create_fc_sale(db, detalles)
+    data = generar_dte_json(db, venta_id, tipo_dte='03')
+    items = data['cuerpoDocumento']
+    resumen = data['resumen']
+    assert all(D(str(i['montoDescu'])) == D('0') for i in items)
+    for item, calcs, det in zip(items, calcs_list, detalles):
+        qty = det['cantidad']
+        expected_precio = d8(calcs['base'] / qty) if qty > 0 else d8(0)
+        assert D(str(item['precioUni'])) == expected_precio
+        assert D(str(item['ventaGravada'])) == d8(calcs['base'])
+        assert D(str(item['ivaItem'])) == d8(calcs['iva'])
+    assert D(str(resumen['totalPagar'])) == D('22.68')
+    assert D(str(resumen['montoTotalOperacion'])) == D('22.68')
+    assert D(str(resumen['totalIva'])) == D('2.61')
+
+
+

--- a/utils/line_totals.py
+++ b/utils/line_totals.py
@@ -1,0 +1,58 @@
+from decimal import Decimal as D
+
+from .monto import d8, IVA_TASA
+
+def compute_line_totals(quantity, unit_price_iva, discount=D('0'), discount_type='$', iva_rate=IVA_TASA):
+    """Compute monetary values for a sale line.
+
+    Parameters
+    ----------
+    quantity: Decimal or convertible
+        Quantity of items.
+    unit_price_iva: Decimal or convertible
+        Unit price **including** IVA.
+    discount: Decimal or convertible
+        Discount value. Interpreted as percentage when ``discount_type`` is
+        "%". Any negative discount is treated as ``0``.
+    discount_type: str
+        Either "%" for percentage or "$" for absolute amount.
+    iva_rate: Decimal
+        IVA rate to apply. Use ``0`` for exenta/no sujeta lines.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``bruto``, ``desc_con_iva``, ``total_con_iva``,
+        ``base``, ``iva`` and ``unit_con_iva_efectivo``. All values are
+        quantized to 8 decimal places using ``ROUND_HALF_UP``.
+    """
+    q = D(str(quantity))
+    p = D(str(unit_price_iva))
+    if q <= 0:
+        q = D('0')
+    bruto = d8(q * p)
+
+    desc = D(str(discount))
+    if desc < 0:
+        desc = D('0')
+    if discount_type == '%':
+        desc_val = d8(bruto * desc / D('100'))
+    else:
+        desc_val = d8(desc)
+    if desc_val > bruto:
+        desc_val = bruto
+    total = d8(bruto - desc_val)
+    if iva_rate and iva_rate != 0:
+        base = d8(total / (D('1') + D(str(iva_rate))))
+    else:
+        base = total
+    iva = d8(total - base)
+    unit_con_iva_efectivo = d8(total / q) if q != 0 else D('0')
+    return {
+        'bruto': bruto,
+        'desc_con_iva': desc_val,
+        'total_con_iva': total,
+        'base': base,
+        'iva': iva,
+        'unit_con_iva_efectivo': unit_con_iva_efectivo,
+    }

--- a/utils/monto.py
+++ b/utils/monto.py
@@ -28,6 +28,11 @@ def d4(value):
     return D(str(value)).quantize(Q4, rounding=ROUND_HALF_UP)
 
 
+def money(value):
+    """Return ``value`` quantized to 2 decimal places (multiple of 0.01)."""
+    return D(str(value)).quantize(Q2, rounding=ROUND_HALF_UP)
+
+
 def iva_item(base_gravada):
     """Return IVA amount for an item based on taxable base."""
     return d8(D(str(base_gravada)) * IVA_TASA)


### PR DESCRIPTION
## Summary
- preserve IVA fields and 8-decimal precision for credit-fiscal items during DTE validation
- reconcile cent-level adjustments using the same precision to keep `precioUni` and `ivaItem` aligned
- always include `totalIva` in generated summaries for consistent totals
- use field-specific quantizers in cent-closure adjustments to avoid precision loss
- import shared `money` helper and apply IVA-specific quantization in credit-fiscal items
- remove unused quantizer and centralize special total rounding to avoid conflicting rules

## Testing
- `pytest tests/test_compute_line_totals.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3579a55d08323a92e7f2ce4495b2f