### PR TITLE
Fix consumer invoice totals for consumer invoices

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2294,10 +2294,9 @@ def generar_dte_json(
                         total_final = D("0")
                     base_total = money(total_final / D("1.13"))
                     iva_val = d4(total_final - base_total)
-                    base_total = money(total_final - iva_val)
-                    precio = d4(money(base_total / cant))
-                    venta_gravada = base_total
-                    line_total = base_total + iva_val
+                    precio = q_item(money(total_final / cant)) if cant > 0 else q_item(D("0"))
+                    venta_gravada = q_item(total_final)
+                    line_total = venta_gravada
                     bruto_total += bruto
                     descuentos_total += monto_descu
             else:


### PR DESCRIPTION
## Summary
- ensure consumer invoices store unit prices and taxable amounts with IVA included
- keep IVA informational by computing it from the final price

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_cons_final_precio_neto -q` *(fails: NRC requerido (6–7 dígitos))*

------
https://chatgpt.com/codex/tasks/task_e_68c3922a59808323945d3475bd79fde0