### PR TITLE
Fix venta_total adjustment and add zero-total DTE test

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1116,7 +1116,7 @@ def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01")
             venta_total = money(venta)
         except Exception:
             venta_total = None
-    if venta_total is not None:
+    if venta_total is not None and venta_total > D("0"):
         diff = money(venta_total - total_pagar)
         if diff != 0:
             total_iva = money(total_iva + diff)

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -2014,3 +2014,58 @@ def test_cliente_email_alias(tmp_path):
 
     data = dte_module.generar_dte_json(db, venta_id)
     assert data["receptor"]["correo"] == "cliente@example.com"
+
+
+def test_generar_dte_json_total_venta_cero(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+    dte_module._load_datos_negocio = lambda: {**datos, "nrc": "1234567"}
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 0, cliente_id=cliente_id)
+    db.add_detalle_venta(venta_id, pid, 1, 13, vendedor_id=vid)
+
+    data = generar_dte_json(db, venta_id)
+    item = data["cuerpoDocumento"][0]
+    res = data["resumen"]
+    D = Decimal
+    assert D(str(res["totalPagar"])) == D("13.00")
+    assert D(str(res["subTotalVentas"])) == D("13.00")
+    assert D(str(res["totalIva"])) == D("1.50")
+    assert D(str(item["ventaGravada"])) == D("13.00")
+    assert D(str(item["ivaItem"])) == D("1.50")


### PR DESCRIPTION
## Summary
- avoid adjusting summary totals when venta_total is non-positive
- add regression test ensuring DTE summary respects item totals when sale total is zero

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_cons_final_precio_neto tests/test_generar_dte_json.py::test_generar_dte_json_total_venta_cero -q` *(fails: NRC requerido (6–7 dígitos))*

------
https://chatgpt.com/codex/tasks/task_e_68c397923254832389b5d46735ac7c1d