### PR TITLE
Handle Decimal values when posting DTE JSON

### DIFF
--- a/tests/test_dtejson_object.py
+++ b/tests/test_dtejson_object.py
@@ -1,4 +1,5 @@
 import os
+from decimal import Decimal
 
 import utils.jws as jws
 
@@ -28,3 +29,30 @@ def test_sign_json_sends_dtejson_as_object(monkeypatch):
 
     assert token == "<JWS>"
     assert isinstance(captured["json"]["dteJson"], dict)
+
+
+def test_sign_json_converts_decimal_values(monkeypatch):
+    monkeypatch.setenv("SEND_DTEJSON_AS_OBJECT", "1")
+    monkeypatch.setattr(jws, "SEND_DTEJSON_AS_OBJECT", True)
+    monkeypatch.setattr(jws, "_ensure_cert_file", lambda nit: None)
+
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["json"] = json
+        class R:
+            status_code = 200
+            text = "OK"
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"status": "OK", "body": "<JWS>"}
+        return R()
+
+    monkeypatch.setattr(jws.requests, "post", fake_post)
+
+    payload = {"identificacion": {"version": "1", "tipoDte": "01"}, "monto": Decimal("1.50")}
+    jws.sign_json(payload, nit="X", passwordPri="Y")
+
+    assert isinstance(captured["json"]["dteJson"], dict)
+    assert isinstance(captured["json"]["dteJson"]["monto"], float)

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -118,11 +118,12 @@ def sign_json(
         if tipo_dte is None:
             tipo_dte = ident.get("tipoDte")
 
+    dte_json = json.loads(payload_str) if SEND_DTEJSON_AS_OBJECT else payload_str
     body = {
         "nit": nit,
         "activo": activo,
         "passwordPri": passwordPri,
-        "dteJson": payload_obj if SEND_DTEJSON_AS_OBJECT else payload_str,
+        "dteJson": dte_json,
     }
     if version is not None:
         body["version"] = version


### PR DESCRIPTION
## Summary
- ensure sign_json removes Decimal instances when sending DTE as object
- cover Decimal conversion with new test

## Testing
- `pytest tests/test_dtejson_object.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3b13476408323a4660ee7f223e621