### PR TITLE
Remove forbidden fields from ticket receptor JSON

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2081,6 +2081,9 @@ def generar_dte_json(
         )
         if not dir_ok:
             receptor = None
+        elif receptor:
+            for f in ("nit", "nombreComercial"):
+                receptor.pop(f, None)
     else:
         if not compl or len(str(compl)) < 5:
             receptor["direccion"]["complemento"] = "SIN DIRECCION"

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -108,3 +108,6 @@ def test_generar_ticket_con_receptor_valido(monkeypatch):
     assert "extra" not in data
     assert data["receptor"] is not None
     assert data["receptor"].get("direccion", {}).get("complemento") == "Colonia ABC"
+    rec = data["receptor"]
+    assert "nit" not in rec
+    assert "nombreComercial" not in rec


### PR DESCRIPTION
## Summary
- drop `nit` and `nombreComercial` from ticket receptor section to match schema
- verify ticket JSON receptor omits those fields in tests

## Testing
- `pytest` *(fails: 47 errors)*
- `pytest tests/test_ticket_nitless.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3b80e94508323bb8d9bba767cbc8f