### PR TITLE
Remove QR text and make codes clickable

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -106,8 +106,7 @@ def generar_cabecera_dte(
     d = Drawing(qr_size, qr_size, transform=[qr_size / w, 0, 0, qr_size / h, 0, 0])
     d.add(qr_code)
     renderPDF.draw(d, c, qr_x, qr_y)
-    c.setFont("Helvetica", 6)
-    c.drawCentredString(qr_x + qr_size / 2, qr_y - 8, qr_value)
+    c.linkURL(qr_value, (qr_x, qr_y, qr_x + qr_size, qr_y + qr_size), relative=0)
 
     # --- Caja derecha ---
     right_x = 40 + box_w + col_margin + qr_size + col_margin

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -192,8 +192,7 @@ def generar_factura_electronica_pdf(
     d = Drawing(qr_size, qr_size, transform=[qr_size / w, 0, 0, qr_size / h, 0, 0])
     d.add(qr_code)
     renderPDF.draw(d, c, qr_x, qr_y)
-    c.setFont("Helvetica", 6)
-    c.drawCentredString(qr_x + qr_size / 2, qr_y - 10, qr_url)
+    c.linkURL(qr_url, (qr_x, qr_y, qr_x + qr_size, qr_y + qr_size), relative=0)
 
     # --- Caja derecha con datos de operación ---
     right_x = x_margin + box_w + col_margin + qr_size + col_margin


### PR DESCRIPTION
## Summary
- hide printed QR URLs from invoice and header PDFs
- add clickable hyperlinks over QR codes

## Testing
- `pytest` *(fails: 47 errors during collection)*
- `python dte_header_pdf.py`
- `python - <<'PY' from factura_sv import generar_factura_electronica_pdf; ...`

------
https://chatgpt.com/codex/tasks/task_e_68c3c1310be88323bd773e2b2407ceb0