### PR TITLE
Add QR hyperlinks to generated tickets

### DIFF
--- a/tests/test_ticket_qr.py
+++ b/tests/test_ticket_qr.py
@@ -1,0 +1,66 @@
+import io
+
+import fitz
+import cv2
+import numpy as np
+from PIL import Image
+
+from factura_sv import build_qr_url
+from ticket_pdf import generar_ticket_pdf, generar_ticket_personalizado
+
+
+def _decode_qr_from_pdf(path: str) -> str:
+    """Render *path* to an image and decode the QR code."""
+    with fitz.open(path) as doc:
+        page = doc[0]
+        pix = page.get_pixmap(dpi=200)
+        img = Image.open(io.BytesIO(pix.tobytes("png"))).convert("RGB")
+        arr = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
+        det = cv2.QRCodeDetector()
+        data, _, _ = det.detectAndDecode(arr)
+        return data
+
+
+def test_generar_ticket_pdf_qr(tmp_path):
+    dte_json = {
+        "identificacion": {
+            "ambiente": "01",
+            "codigoGeneracion": "ABC",
+            "fechaEmi": "2020-01-01",
+        }
+    }
+    dte_data = {"dteJson": dte_json}
+    venta = {"fecha": "2024-01-01", "total": 10}
+    detalles = [{"descripcion": "Prod", "cantidad": 1, "precio_unitario": 10}]
+    archivo = tmp_path / "t.pdf"
+    generar_ticket_pdf(venta, detalles, archivo=str(archivo), dte_data=dte_data)
+    url = build_qr_url(dte_json)
+    assert _decode_qr_from_pdf(str(archivo)) == url
+    with fitz.open(archivo) as doc:
+        page = doc[0]
+        assert any(l.get("uri") == url for l in page.get_links())
+        text = "".join(p.get_text() for p in doc)
+    assert url not in text
+
+
+def test_generar_ticket_personalizado_qr(tmp_path):
+    dte_json = {
+        "identificacion": {
+            "ambiente": "00",
+            "codigoGeneracion": "XYZ",
+            "fechaEmi": "2020-02-02",
+        }
+    }
+    dte_data = {"dteJson": dte_json}
+    venta = {"total": 5}
+    detalles = []
+    archivo = tmp_path / "p.pdf"
+    generar_ticket_personalizado(venta, detalles, archivo=str(archivo), dte_data=dte_data)
+    url = build_qr_url(dte_json)
+    assert _decode_qr_from_pdf(str(archivo)) == url
+    with fitz.open(archivo) as doc:
+        page = doc[0]
+        assert any(l.get("uri") == url for l in page.get_links())
+        text = "".join(p.get_text() for p in doc)
+    assert url not in text
+

--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -16,8 +16,16 @@ def _with_falta(value):
     return "falta" if not value else str(value)
 
 
-def generar_ticket_pdf(venta, detalles, archivo="ticket.pdf", datos_negocio=None):
+def generar_ticket_pdf(
+    venta,
+    detalles,
+    archivo="ticket.pdf",
+    datos_negocio=None,
+    dte_data=None,
+    qr_url=None,
+):
     """Genera un PDF sencillo tipo ticket para una venta."""
+
     if datos_negocio is None:
         datos_negocio = {}
         if os.path.exists(DATOS_NEGOCIO_PATH):
@@ -26,6 +34,10 @@ def generar_ticket_pdf(venta, detalles, archivo="ticket.pdf", datos_negocio=None
                     datos_negocio = json.load(f)
             except Exception:
                 datos_negocio = {}
+
+    if dte_data:
+        dte_json = dte_data.get("dteJson", dte_data)
+        qr_url = build_qr_url(dte_json)
 
     c = canvas.Canvas(archivo, pagesize=letter)
     width, height = letter
@@ -55,6 +67,22 @@ def generar_ticket_pdf(venta, detalles, archivo="ticket.pdf", datos_negocio=None
     y -= 10
     c.setFont("Helvetica-Bold", 12)
     c.drawRightString(width - 40, y, f"Total: {venta.get('total', 0):.2f}")
+
+    if qr_url:
+        qr_size = 20 * mm
+        qr_code = qr.QrCodeWidget(qr_url)
+        bounds = qr_code.getBounds()
+        w = bounds[2] - bounds[0]
+        h = bounds[3] - bounds[1]
+        d = Drawing(qr_size, qr_size, transform=[qr_size / w, 0, 0, qr_size / h, 0, 0])
+        d.add(qr_code)
+        if y < qr_size + 60:
+            c.showPage()
+            y = height - 40
+        qr_x = (width - qr_size) / 2
+        qr_y = y - qr_size - 20
+        renderPDF.draw(d, c, qr_x, qr_y)
+        c.linkURL(qr_url, (qr_x, qr_y, qr_x + qr_size, qr_y + qr_size), relative=0)
 
     c.showPage()
     c.save()
@@ -225,8 +253,7 @@ def generar_ticket_personalizado(
         qr_x = (width - qr_size) / 2
         qr_y = max(5 * mm, y - qr_size)
         renderPDF.draw(d, c, qr_x, qr_y)
-        c.setFont("Helvetica", 5)
-        c.drawCentredString(width / 2, qr_y - 4, qr_url)
+        c.linkURL(qr_url, (qr_x, qr_y, qr_x + qr_size, qr_y + qr_size), relative=0)
 
     c.showPage()
     c.save()


### PR DESCRIPTION
## Summary
- add optional DTE/QR support to `generar_ticket_pdf`
- make QR images in tickets clickable without URL text
- test QR link generation for basic and personalized tickets

## Testing
- `pytest` *(fails: 47 errors during collection)*
- `pytest tests/test_ticket_qr.py::test_generar_ticket_pdf_qr -q`
- `pytest tests/test_ticket_qr.py::test_generar_ticket_personalizado_qr -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3c136b9ec8323b2954c74a594d624