### PR TITLE
Restrict DUI input to 9 digits

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -18,6 +18,7 @@ from PyQt5.QtGui import (
     QDesktopServices,
     QIntValidator,
     QRegularExpressionValidator,
+)
 
 import os
 import shutil
@@ -59,12 +60,11 @@ def validar_nit(nit):
     return bool(re.match(nit_pattern, nit))
 
 def validar_dui(dui):
-    """Valida un número de DUI salvadoreño."""
+    """Valida que el DUI contenga exactamente 9 dígitos."""
     import re
     if not dui:
         return False
-    # Formato ########-# o #########
-    dui_pattern = r"^\d{8}-?\d$"
+    dui_pattern = r"^\d{9}$"
     return bool(re.match(dui_pattern, dui))
 
 def validar_email(email):
@@ -2538,9 +2538,7 @@ class ClienteDialog(QDialog):
         self.nit_edit.setValidator(nit_validator)
         self.nit_edit.setMaxLength(14)
         self.dui_edit = QLineEdit()
-        self.dui_edit.setValidator(
-            QRegularExpressionValidator(QRegularExpression(r"^\d{0,9}$"))
-        )
+        self.dui_edit.setValidator(QIntValidator(0, 999999999))
         self.dui_edit.setMaxLength(9)
         self.giro_edit = QLineEdit()
         self.codActividad_edit = QLineEdit()
@@ -2669,9 +2667,7 @@ class VendedorDialog(QDialog):
         self.codigo_edit = QLineEdit()
         self.nombre_edit = QLineEdit()
         self.dui_edit = QLineEdit()
-        self.dui_edit.setValidator(
-            QRegularExpressionValidator(QRegularExpression(r"^\d{0,9}$"))
-        )
+        self.dui_edit.setValidator(QIntValidator(0, 999999999))
         self.dui_edit.setMaxLength(9)
         self.descripcion_edit = QLineEdit()
         self.Distribuidor_combo = QComboBox()

--- a/tests/test_cliente_dialog.py
+++ b/tests/test_cliente_dialog.py
@@ -68,6 +68,20 @@ def test_nit_max_length(qt_app):
     assert dialog.nit_edit.text() == "1" * 14
 
 
+def test_dui_max_length(qt_app):
+    db = DummyDB()
+    dialog = make_dialog(db)
+    dialog.dui_edit.insert("1" * 10)
+    assert dialog.dui_edit.text() == "1" * 9
+
+
+def test_dui_only_digits(qt_app):
+    db = DummyDB()
+    dialog = make_dialog(db)
+    dialog.dui_edit.insert("abcd")
+    assert dialog.dui_edit.text() == ""
+
+
 def test_optional_fields(monkeypatch, qt_app):
     db = DummyDB()
     dialog = make_dialog(db)

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -41,12 +41,15 @@ def test_validar_nit(nit, expected):
     assert validar_nit(nit) is expected
 
 
-@pytest.mark.parametrize("dui, expected", [
-    ("12345678-9", True),
-    ("123456789", True),
-    ("1234567-89", False),
-    ("abcd", False),
-])
+@pytest.mark.parametrize(
+    "dui, expected",
+    [
+        ("123456789", True),
+        ("12345678-9", False),
+        ("1234567890", False),
+        ("abcd", False),
+    ],
+)
 @pytest.mark.skipif(_dialog_import_error, reason="UI dependencies not available")
 def test_validar_dui(dui, expected):
     assert validar_dui(dui) is expected


### PR DESCRIPTION
## Summary
- ensure client and vendor dialogs only accept numeric DUI entries up to nine digits
- tighten DUI validator to require exactly nine digits
- cover DUI constraints with unit tests

## Testing
- `pytest` *(fails: multiple tests such as tests/test_config_facturacion_datos_negocio.py)*
- `pytest tests/test_cliente_dialog.py::test_dui_max_length tests/test_cliente_dialog.py::test_dui_only_digits tests/test_validaciones_basicas.py::test_validar_dui -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3be726ff48323844b0e5c1bbc573f