### PR TITLE
Handle blank NIT for DUI receptor

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2946,10 +2946,13 @@ def validate_dte_json(
             receptor.pop("numDocumento", None)
         else:
             tipo_doc = receptor.get("tipoDocumento")
-            if nit_field is not None:
-                receptor["numDocumento"] = _clean_nit(nit_field)
-                if tipo_doc is None:
-                    tipo_doc = "36"
+            if nit_field:
+                cleaned_nit = _clean_nit(nit_field)
+                if cleaned_nit:
+                    receptor["numDocumento"] = cleaned_nit
+                    if tipo_doc is None:
+                        tipo_doc = "36"
+            receptor.pop("nit", None)
             limpiar_documentos(receptor)
             num_doc = solo_digitos(receptor.get("numDocumento"))
             nrc_raw = receptor.get("nrc")

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -69,6 +69,19 @@ def test_longitud_num_documento_invalida(dte_metadata_factory, db_fixture):
         validate_dte_json(dte, db=db_fixture)
 
 
+def test_receptor_dui_ignores_empty_nit(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    rec = dte["receptor"]
+    rec["tipoDocumento"] = "13"
+    rec["numDocumento"] = "01234567-8"
+    rec["nit"] = ""
+    validate_dte_json(dte, db=db_fixture)
+    rec = dte["receptor"]
+    assert "nit" not in rec
+    assert rec["numDocumento"] == "012345678"
+    assert rec["tipoDocumento"] == "13"
+
+
 def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["codigoGeneracion"] = "not-a-uuid"


### PR DESCRIPTION
## Summary
- avoid overriding receptor numDocumento with blank NITs
- remove unused NIT key before cleaning receptor data
- cover DUI with empty NIT in validation tests

## Testing
- `pytest` *(fails: ERROR tests/test_manual_invoice.py ... test_vendedor_codigo_unique.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c4291584488323b08a806e065a9eb5