### PR TITLE
feat: add quick range filter to estado de cuenta

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -29,7 +29,7 @@ CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.js
 LAST_INVENTORY_PATH = os.path.join(os.path.dirname(__file__), "ultimo_inventario.json")
 from sales_tab import SalesTab
 from facturacion_tab import FacturacionTab
-from datetime import datetime
+from datetime import datetime, date, timedelta
 
 from num2words import num2words  # Instala las dependencias con: pip install -r requirements.txt
 
@@ -511,20 +511,23 @@ class MainWindow(QMainWindow):
         self.estado_search_bar = QLineEdit()
         self.estado_search_bar.setPlaceholderText("Buscar por código o nombre...")
         self.estado_filtrar_fechas = QCheckBox("Filtrar por fechas")
+        self.estado_quick_range = QComboBox()
+        self.estado_quick_range.addItems(
+            ["Personalizado", "Hoy", "Esta semana", "Este mes", "Este año"]
+        )
         self.estado_fecha_inicio = QDateEdit(QDate.currentDate())
         self.estado_fecha_inicio.setCalendarPopup(True)
         self.estado_fecha_fin = QDateEdit(QDate.currentDate())
         self.estado_fecha_fin.setCalendarPopup(True)
-        self.estado_anio_actual = QCheckBox("Año en curso")
         self.btn_generar_estado = QPushButton("Generar")
         controles.addWidget(self.estado_tipo_combo)
         controles.addWidget(self.estado_search_bar)
         controles.addWidget(self.estado_filtrar_fechas)
+        controles.addWidget(self.estado_quick_range)
         controles.addWidget(QLabel("Desde"))
         controles.addWidget(self.estado_fecha_inicio)
         controles.addWidget(QLabel("Hasta"))
         controles.addWidget(self.estado_fecha_fin)
-        controles.addWidget(self.estado_anio_actual)
         controles.addWidget(self.btn_generar_estado)
         estado_layout.addLayout(controles)
 
@@ -555,9 +558,16 @@ class MainWindow(QMainWindow):
         self.estado_tipo_combo.currentIndexChanged.connect(self._mostrar_historial_general)
         self.estado_search_bar.textChanged.connect(self._mostrar_historial_general)
         self.btn_generar_estado.clicked.connect(self._abrir_generar_estado_dialog)
-        self.estado_anio_actual.toggled.connect(self._toggle_estado_fechas)
         self.estado_filtrar_fechas.toggled.connect(self._toggle_estado_filtro_fechas)
         self.estado_filtrar_fechas.toggled.connect(self._mostrar_historial_general)
+        self.estado_quick_range.currentIndexChanged.connect(
+            self._apply_estado_quick_range
+        )
+        self.estado_quick_range.currentIndexChanged.connect(
+            self._mostrar_historial_general
+        )
+        self.estado_fecha_inicio.dateChanged.connect(self._mostrar_historial_general)
+        self.estado_fecha_fin.dateChanged.connect(self._mostrar_historial_general)
 
         self._actualizar_tabla_trabajadores()
         self._toggle_estado_filtro_fechas(False)
@@ -1737,18 +1747,51 @@ class MainWindow(QMainWindow):
             )
 
 
-    def _toggle_estado_fechas(self, checked: bool):
-        """Habilita o deshabilita las fechas manuales."""
-        if checked:
-            self.estado_fecha_inicio.setDate(QDate(QDate.currentDate().year(), 1, 1))
-            self.estado_fecha_fin.setDate(QDate.currentDate())
-        self._toggle_estado_filtro_fechas(self.estado_filtrar_fechas.isChecked())
-
     def _toggle_estado_filtro_fechas(self, checked: bool):
-        self.estado_anio_actual.setEnabled(checked)
-        manual = checked and not self.estado_anio_actual.isChecked()
-        self.estado_fecha_inicio.setEnabled(manual)
-        self.estado_fecha_fin.setEnabled(manual)
+        self.estado_quick_range.setEnabled(checked)
+        custom = self.estado_quick_range.currentIndex() == 0
+        self.estado_fecha_inicio.setEnabled(checked and custom)
+        self.estado_fecha_fin.setEnabled(checked and custom)
+        if checked:
+            self._apply_estado_quick_range()
+
+    def _apply_estado_quick_range(self):
+        if not self.estado_filtrar_fechas.isChecked():
+            return
+        option = self.estado_quick_range.currentText()
+        today = date.today()
+        if option == "Hoy":
+            self.estado_fecha_inicio.setDate(QDate(today))
+            self.estado_fecha_fin.setDate(QDate(today))
+            self.estado_fecha_inicio.setEnabled(False)
+            self.estado_fecha_fin.setEnabled(False)
+        elif option == "Esta semana":
+            start = today - timedelta(days=today.weekday())
+            end = start + timedelta(days=6)
+            self.estado_fecha_inicio.setDate(QDate(start))
+            self.estado_fecha_fin.setDate(QDate(end))
+            self.estado_fecha_inicio.setEnabled(False)
+            self.estado_fecha_fin.setEnabled(False)
+        elif option == "Este mes":
+            start = today.replace(day=1)
+            if today.month == 12:
+                end = date(today.year, 12, 31)
+            else:
+                end = date(today.year, today.month + 1, 1) - timedelta(days=1)
+            self.estado_fecha_inicio.setDate(QDate(start))
+            self.estado_fecha_fin.setDate(QDate(end))
+            self.estado_fecha_inicio.setEnabled(False)
+            self.estado_fecha_fin.setEnabled(False)
+        elif option == "Este año":
+            start = date(today.year, 1, 1)
+            end = date(today.year, 12, 31)
+            self.estado_fecha_inicio.setDate(QDate(start))
+            self.estado_fecha_fin.setDate(QDate(end))
+            self.estado_fecha_inicio.setEnabled(False)
+            self.estado_fecha_fin.setEnabled(False)
+        else:
+            self.estado_fecha_inicio.setEnabled(True)
+            self.estado_fecha_fin.setEnabled(True)
 
     def _abrir_generar_estado_dialog(self):
         """Abre la ventana de generación de estados de cuenta."""
@@ -1758,9 +1801,10 @@ class MainWindow(QMainWindow):
         dialog.stack.setCurrentIndex(tipo_idx)
         if self.estado_filtrar_fechas.isChecked():
             dialog.filtrar_fechas_chk.setChecked(True)
-            if self.estado_anio_actual.isChecked():
+            if self.estado_quick_range.currentText() == "Este año":
                 dialog.anio_actual.setChecked(True)
             else:
+                dialog.anio_actual.setChecked(False)
                 dialog.fecha_inicio.setDate(self.estado_fecha_inicio.date())
                 dialog.fecha_fin.setDate(self.estado_fecha_fin.date())
         else:
@@ -1773,9 +1817,10 @@ class MainWindow(QMainWindow):
         dialog.stack.setCurrentIndex(1)
         if self.estado_filtrar_fechas.isChecked():
             dialog.filtrar_fechas_chk.setChecked(True)
-            if self.estado_anio_actual.isChecked():
+            if self.estado_quick_range.currentText() == "Este año":
                 dialog.anio_actual.setChecked(True)
             else:
+                dialog.anio_actual.setChecked(False)
                 dialog.fecha_inicio.setDate(self.estado_fecha_inicio.date())
                 dialog.fecha_fin.setDate(self.estado_fecha_fin.date())
         else:
@@ -1788,12 +1833,8 @@ class MainWindow(QMainWindow):
         tipo = "cliente" if self.estado_tipo_combo.currentText() == "Cliente" else "vendedor"
 
         if self.estado_filtrar_fechas.isChecked():
-            if self.estado_anio_actual.isChecked():
-                inicio = QDate(QDate.currentDate().year(), 1, 1).toPyDate()
-                fin = QDate.currentDate().toPyDate()
-            else:
-                inicio = self.estado_fecha_inicio.date().toPyDate()
-                fin = self.estado_fecha_fin.date().toPyDate()
+            inicio = self.estado_fecha_inicio.date().toPyDate()
+            fin = self.estado_fecha_fin.date().toPyDate()
         else:
             inicio = None
             fin = None


### PR DESCRIPTION
## Summary
- add `estado_quick_range` combo box to estados de cuenta tab with several date presets
- compute date presets and disable manual dates via `_apply_estado_quick_range`
- update signals and dialogs to react to quick range changes in real time

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c107f13c8323b9c0a7e404e6bb8a