### PR TITLE
Auto-refresh invoices and account history

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -409,6 +409,14 @@ class FacturacionTab(QWidget):
         # deleted sales or missing files from showing as "Sin venta".
         self._get_invoices_from_db()
         self.load_invoices()
+        # Periodically refresh to show newly generated invoices without
+        # requiring the user to press the "Actualizar" button. This keeps
+        # the table in sync with the underlying data and any invoices
+        # created from other parts of the application.
+        self._refresh_timer = QTimer(self)
+        self._refresh_timer.setInterval(10000)  # 10 seconds
+        self._refresh_timer.timeout.connect(self.refresh_and_reload)
+        self._refresh_timer.start()
 
     def _setup_ui(self):
         main_layout = QHBoxLayout(self)

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -73,6 +73,11 @@ class ExportThread(QThread):
 
 
 class MainWindow(QMainWindow):
+    # Generic signal emitted whenever sales or payment data changes. Tabs
+    # that need to stay in sync can listen for this signal to refresh
+    # immediately instead of waiting for the periodic timers.
+    data_changed = pyqtSignal()
+
     def __init__(self, user=None):
         super().__init__()
         self.user = user or {"username": "admin", "role": "admin"}
@@ -87,6 +92,18 @@ class MainWindow(QMainWindow):
         self._setup_ui()
         self._apply_styles()
         QTimer.singleShot(0, self._verificar_firmador)
+
+        # Timer to periodically refresh the "Estados de cuenta" table so it
+        # stays synchronized with new sales or payments made from any tab.
+        self._historial_timer = QTimer(self)
+        self._historial_timer.setInterval(10000)  # 10 seconds
+        self._historial_timer.timeout.connect(self._mostrar_historial_general)
+        self._historial_timer.start()
+
+        # When data changes elsewhere emit a signal so the tabs refresh
+        # immediately instead of waiting for the timer interval.
+        self.data_changed.connect(self.facturacion_tab.refresh_and_reload)
+        self.data_changed.connect(self._mostrar_historial_general)
 
     def iniciar_firmador(self):
         """Lanza el servicio externo de firmado de documentos."""
@@ -792,6 +809,9 @@ class MainWindow(QMainWindow):
                 QMessageBox.information(self, "Venta", f"Venta registrada correctamente.\nTotal: ${total:.2f}")
                 self._actualizar_historial()
                 self._actualizar_inventario_actual()  # <-- AGREGA ESTA LÍNEA AQUÍ
+                # Notify other tabs that the underlying data changed so they
+                # can refresh immediately.
+                self.data_changed.emit()
 
         except Exception as e:
             QMessageBox.critical(self, "Error al registrar venta", str(e))
@@ -942,6 +962,8 @@ class MainWindow(QMainWindow):
                 QMessageBox.information(self, "Venta a Crédito Fiscal", f"Venta registrada correctamente.\nTotal: ${venta_total:.2f}")
                 self._actualizar_historial()
                 self._actualizar_inventario_actual()
+                # Trigger refresh in other tabs immediately
+                self.data_changed.emit()
 
         except Exception as e:
             QMessageBox.critical(self, "Error al registrar venta a crédito fiscal", str(e))


### PR DESCRIPTION
## Summary
- refresh Facturacion tab automatically via QTimer
- auto-update account history using a timer
- emit signal after sales to update views immediately

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q --maxfail=1` *(fails: datos_negocio.json inválido)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c10b240c8323a0fab3f452357092