### PR TITLE
Handle receptor DUI fallback

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2954,6 +2954,13 @@ def validate_dte_json(
                         tipo_doc = "36"
             receptor.pop("nit", None)
             limpiar_documentos(receptor)
+            dui = receptor.get("dui")
+            num_doc_val = receptor.get("numDocumento")
+            if dui and not num_doc_val:
+                receptor["numDocumento"] = dui
+                if not tipo_doc:
+                    tipo_doc = "13"
+            receptor.pop("dui", None)
             num_doc = solo_digitos(receptor.get("numDocumento"))
             nrc_raw = receptor.get("nrc")
             nrc_digits = solo_digitos(nrc_raw) if nrc_raw is not None else ""

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -82,6 +82,20 @@ def test_receptor_dui_ignores_empty_nit(dte_metadata_factory, db_fixture):
     assert rec["tipoDocumento"] == "13"
 
 
+def test_receptor_dui_only(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    rec = dte["receptor"]
+    rec.pop("numDocumento", None)
+    rec.pop("tipoDocumento", None)
+    rec.pop("nrc", None)
+    rec["dui"] = "01234567-8"
+    validate_dte_json(dte, db=db_fixture)
+    rec = dte["receptor"]
+    assert rec["numDocumento"] == "012345678"
+    assert rec["tipoDocumento"] == "13"
+    assert "dui" not in rec
+
+
 def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["codigoGeneracion"] = "not-a-uuid"


### PR DESCRIPTION
## Summary
- Fill missing receptor numDocumento from DUI and default tipoDocumento to 13
- Remove DUI field after migration to numDocumento
- Test validation accepts receptor with only DUI

## Testing
- `pytest --no-cov tests/test_dte_validation.py::test_receptor_dui_only tests/test_dte_validation.py::test_receptor_dui_ignores_empty_nit tests/test_dte_valido_pasa -q`


------
https://chatgpt.com/codex/tasks/task_e_68c42eccf7088323be54a1de43281e2a