### PR TITLE
Handle DUI-only receptors

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2957,7 +2957,7 @@ def validate_dte_json(
             dui = receptor.get("dui")
             num_doc_val = receptor.get("numDocumento")
             if dui and not num_doc_val:
-                receptor["numDocumento"] = dui
+                receptor["numDocumento"] = solo_digitos(dui)
                 if not tipo_doc:
                     tipo_doc = "13"
             receptor.pop("dui", None)

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -96,6 +96,20 @@ def test_receptor_dui_only(dte_metadata_factory, db_fixture):
     assert "dui" not in rec
 
 
+def test_receptor_dui_num_documento_vacio(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    rec = dte["receptor"]
+    rec["dui"] = "01234567-8"
+    rec["numDocumento"] = ""
+    rec.pop("tipoDocumento", None)
+    rec.pop("nrc", None)
+    validate_dte_json(dte, db=db_fixture)
+    rec = dte["receptor"]
+    assert rec["numDocumento"] == "012345678"
+    assert rec["tipoDocumento"] == "13"
+    assert "dui" not in rec
+
+
 def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["codigoGeneracion"] = "not-a-uuid"


### PR DESCRIPTION
## Summary
- normalize receptor `dui` into `numDocumento` and default `tipoDocumento` to `13`
- test validation with receptor providing only a DUI

## Testing
- `pytest tests/test_dte_validation.py::test_receptor_dui_only tests/test_dte_validation.py::test_receptor_dui_num_documento_vacio -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4323dc30c8323a36218d20c5ff3fd