### PR TITLE
Make worker fields optional

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -3548,31 +3548,20 @@ class TrabajadorDialog(QDialog):
         nit = self.nit.text().strip()
         email = self.email.text().strip()
 
-        if not codigo:
-            QMessageBox.warning(self, "Validación", "El código es obligatorio.")
+        if nit and not validar_nit(nit):
+            QMessageBox.warning(self, "Validación", "El NIT ingresado no es válido.")
             return
-        if not nombre:
-            QMessageBox.warning(self, "Validación", "El nombre es obligatorio.")
-            return
-        if not nit:
-            QMessageBox.warning(self, "Validación", "El NIT es obligatorio.")
-            return
-        if not validar_nit(nit):
-            QMessageBox.warning(self, "Validación", "Ingrese un NIT válido.")
-            return
-        if not email:
-            QMessageBox.warning(self, "Validación", "El correo electrónico es obligatorio.")
-            return
-        if not validar_email(email):
-            QMessageBox.warning(self, "Validación", "Ingrese un correo electrónico válido.")
+        if email and not validar_email(email):
+            QMessageBox.warning(self, "Validación", "El correo electrónico ingresado no es válido.")
             return
 
-        db = getattr(getattr(self.parent(), "manager", None), "db", None)
-        if db:
-            for t in db.get_trabajadores():
-                if t.get("codigo") == codigo and t.get("id") != self._trabajador_id:
-                    QMessageBox.warning(self, "Validación", "El código ya está registrado.")
-                    return
+        if codigo:
+            db = getattr(getattr(self.parent(), "manager", None), "db", None)
+            if db:
+                for t in db.get_trabajadores():
+                    if t.get("codigo") == codigo and t.get("id") != self._trabajador_id:
+                        QMessageBox.warning(self, "Validación", "El código ya está registrado.")
+                        return
 
         self.accept()
 


### PR DESCRIPTION
## Summary
- Allow TrabajadorDialog code, name, NIT and email fields to be optional
- Validate NIT and email only when provided and adjust messages
- Check for duplicate worker code only when a code is given

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c119344483239a714a6bc38dacd0