### PR TITLE
Skip NIT validation when receptor uses DUI

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1293,11 +1293,12 @@ def recalcular_totales(
         # o si ``extra['es_ticket']`` está definido y es verdadero.
         receptor = data.get("receptor")
         if receptor and not extra_conf.get("es_ticket"):
-            nit = str(receptor.get("nit") or "")
-            if not (len(nit) == 14 and nit.isdigit()):
-                raise ValueError(
-                    "receptor.nit debe tener 14 dígitos sin guiones"
-                )
+            if not (receptor.get("dui") or receptor.get("numDocumento")):
+                nit = str(receptor.get("nit") or "")
+                if nit and not (len(nit) == 14 and nit.isdigit()):
+                    raise ValueError(
+                        "receptor.nit debe tener 14 dígitos sin guiones"
+                    )
     else:
         precios_flag = _precios_incluyen_iva_from(extra_conf, precios_incluyen_iva)
 

--- a/tests/test_dte_validation.py
+++ b/tests/test_dte_validation.py
@@ -110,6 +110,17 @@ def test_receptor_dui_num_documento_vacio(dte_metadata_factory, db_fixture):
     assert "dui" not in rec
 
 
+def test_dte_tipo_03_dui_sin_nit(dte_metadata_factory, db_fixture):
+    dte = dte_metadata_factory()
+    dte["identificacion"]["tipoDte"] = "03"
+    rec = dte["receptor"]
+    rec.pop("numDocumento", None)
+    rec.pop("tipoDocumento", None)
+    rec.pop("nrc", None)
+    rec["dui"] = "01234567-8"
+    validate_dte_json(dte, db=db_fixture)
+
+
 def test_codigo_generacion_debe_ser_uuid_v4(dte_metadata_factory, db_fixture):
     dte = dte_metadata_factory()
     dte["identificacion"]["codigoGeneracion"] = "not-a-uuid"


### PR DESCRIPTION
## Summary
- relax NIT requirement for credit-fiscal DTEs when receptor is identified by DUI or numDocumento
- add regression test for DUI-only receptor on type 03 DTE

## Testing
- `pytest tests/test_dte_validation.py::test_dte_tipo_03_dui_sin_nit -q`


------
https://chatgpt.com/codex/tasks/task_e_68c434c374848323bb91a5f9a2627e32