### PR TITLE
Handle empty NIT and email

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -53,8 +53,13 @@ def get_field(obj, key, default=0):
     return default
 
 def validar_nit(nit):
-    """Valida que el NIT contenga exactamente 14 dígitos."""
+    """Valida que el NIT contenga exactamente 14 dígitos.
+
+    Una cadena vacía se considera válida para permitir que el campo sea opcional.
+    """
     import re
+    if nit == "":
+        return True
     if not nit:
         return False
     nit_pattern = r"^\d{14}$"
@@ -69,7 +74,15 @@ def validar_dui(dui):
     return bool(re.match(dui_pattern, dui))
 
 def validar_email(email):
+    """Valida un formato básico de correo electrónico.
+
+    Una cadena vacía se considera válida para permitir que el campo sea opcional.
+    """
     import re
+    if email == "":
+        return True
+    if not email:
+        return False
     return bool(re.match(r"^[^@]+@[^@]+\.[^@]+$", email))
 
 def validar_nrc(nrc):

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -30,6 +30,7 @@ from utils import catalogos
 @pytest.mark.parametrize(
     "nit, expected",
     [
+        ("", True),
         ("12341234561234", True),
         ("1234-123456-123-1", False),
         ("123456789012345", False),
@@ -67,6 +68,7 @@ def test_validar_nrc(nrc, expected):
 
 
 @pytest.mark.parametrize("email, expected", [
+    ("", True),
     ("user@example.com", True),
     ("test@domain.co", True),
     ("invalid@domain", False),


### PR DESCRIPTION
## Summary
- Allow empty strings to pass NIT and email validation
- Add tests for empty NIT and email cases

## Testing
- `pytest tests/test_validaciones_basicas.py::test_validar_nit tests/test_validaciones_basicas.py::test_validar_email -q`
- `pytest tests/test_validaciones_basicas.py -q` *(fails: ValueError: NRC requerido)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c4355b93dc8323a989e650950e08aa