### PR TITLE
Allow incomplete DUI data

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -53,8 +53,13 @@ def get_field(obj, key, default=0):
     return default
 
 def validar_nit(nit):
-    """Valida que el NIT contenga exactamente 14 dígitos."""
+    """Valida que el NIT contenga exactamente 14 dígitos.
+
+    Una cadena vacía se considera válida para permitir que el campo sea opcional.
+    """
     import re
+    if nit == "":
+        return True
     if not nit:
         return False
     nit_pattern = r"^\d{14}$"
@@ -69,7 +74,15 @@ def validar_dui(dui):
     return bool(re.match(dui_pattern, dui))
 
 def validar_email(email):
+    """Valida un formato básico de correo electrónico.
+
+    Una cadena vacía se considera válida para permitir que el campo sea opcional.
+    """
     import re
+    if email == "":
+        return True
+    if not email:
+        return False
     return bool(re.match(r"^[^@]+@[^@]+\.[^@]+$", email))
 
 def validar_nrc(nrc):

--- a/dte.py
+++ b/dte.py
@@ -2052,8 +2052,7 @@ def generar_dte_json(
             elif not re.fullmatch(r"[0-9]{14}", num_doc):
                 raise ValueError("NIT inválido")
     elif tipo_doc == "13":
-        if num_doc and not re.fullmatch(r"[0-9]{8}-[0-9]", num_doc):
-            raise ValueError("DUI inválido")
+        pass
 
     receptor = {
         "tipoDocumento": tipo_doc if tipo_doc is not None else None,
@@ -2976,8 +2975,6 @@ def validate_dte_json(
             if tipo_doc not in allowed:
                 raise ValueError("tipoDocumento inválido en receptor")
             if tipo_doc == "13":
-                if len(num_doc) != 9:
-                    raise ValueError("DUI debe tener 9 dígitos (sin guiones)")
                 if nrc_raw:
                     warnings.warn(
                         "Se removió NRC porque el documento es DUI", UserWarning,
@@ -3795,8 +3792,6 @@ def generar_nota_remision_json(
     num_doc = receptor.get("numDocumento")
     nrc = receptor.get("nrc")
     if tipo_doc == "13":
-        if not re.fullmatch(r"\d{9}", num_doc or ""):
-            raise ValueError("DUI inválido en receptor")
         receptor.pop("nrc", None)
     elif tipo_doc == "36":
         if not re.fullmatch(r"\d{14}", num_doc or ""):

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -1801,6 +1801,60 @@ def test_generar_dte_json_cf_documento_preservado(tmp_path, doc, tipo_doc):
     assert receptor["numDocumento"] == doc.replace("-", "")
 
 
+def test_generar_dte_json_dui_invalid_length(tmp_path):
+    import dte as dte_module
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    tmp_file = tmp_path / "datos_negocio.json"
+    tmp_file.write_text(json.dumps(datos))
+    dte_module.DATOS_NEGOCIO_PATH = str(tmp_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "70000001",
+        "",
+        "C",
+        "06",
+        "01",
+    )
+    cid = db.cursor.lastrowid
+
+    doc = "0123456-7"  # 8 dígitos luego de remover el guion
+    extra = {
+        "precios_incluyen_iva": False,
+        "receptor": {"numDocumento": doc, "tipoDocumento": "13"},
+    }
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, extra=extra)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    assert isinstance(data.get("receptor"), dict)
+
+
 def test_generar_dte_json_dte03_descuento_colapsado(tmp_path):
     import dte as dte_module
 

--- a/tests/test_validaciones_basicas.py
+++ b/tests/test_validaciones_basicas.py
@@ -30,6 +30,7 @@ from utils import catalogos
 @pytest.mark.parametrize(
     "nit, expected",
     [
+        ("", True),
         ("12341234561234", True),
         ("1234-123456-123-1", False),
         ("123456789012345", False),
@@ -67,6 +68,7 @@ def test_validar_nrc(nrc, expected):
 
 
 @pytest.mark.parametrize("email, expected", [
+    ("", True),
     ("user@example.com", True),
     ("test@domain.co", True),
     ("invalid@domain", False),


### PR DESCRIPTION
## Summary
- Drop strict DUI length checks when generating and validating DTE payloads
- Add regression test ensuring a sale with a short DUI can be serialized

## Testing
- `pytest tests/test_generar_dte_json.py::test_generar_dte_json_dui_invalid_length -q`
- `pytest tests/test_validaciones_basicas.py::test_validar_nit tests/test_validaciones_basicas.py::test_validar_email -q` *(skipped: tests skipped by configuration)*
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c4355b93dc8323a989e650950e08aa