### PR TITLE
Track DTE states and show sent documents

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -663,7 +663,7 @@ class FacturacionTab(QWidget):
                     "_parsed_fecha": fdate,
                     "cliente": cliente.get("nombre", "") if cliente else "",
                     "total": venta["total"],
-                    "estado": venta["estado"],
+                    "estado": "",
                     "tipo": rec["tipo"],
                 }
             )
@@ -688,10 +688,10 @@ class FacturacionTab(QWidget):
         tipo = self.tipo_filter.currentText()
 
         rows = self._scan_documents()
-        envio_estado = {}
-        if getattr(self, "sent_filter_cb", None) and self.sent_filter_cb.isChecked():
-            for env in self.manager.db.listar_dtes():
-                envio_estado[env.get("venta_id")] = env.get("estado")
+        envio_estado = {
+            env.get("venta_id"): env.get("estado")
+            for env in self.manager.db.listar_dtes()
+        }
         for r in list(rows):
             fdate = r.get("_parsed_fecha")
             if self.date_filter_cb.isChecked():
@@ -708,15 +708,12 @@ class FacturacionTab(QWidget):
             if search and search not in r.get("name", "").lower() and search not in cliente.lower():
                 rows.remove(r)
                 continue
-            if getattr(self, "sent_filter_cb", None) and self.sent_filter_cb.isChecked():
-                if r.get("row_type") not in ("venta", "ticket"):
-                    rows.remove(r)
-                    continue
-                estado = envio_estado.get(r.get("id"))
-                if not estado:
-                    rows.remove(r)
-                    continue
+            estado = envio_estado.get(r.get("id"))
+            if estado:
                 r["estado"] = estado
+            if getattr(self, "sent_filter_cb", None) and self.sent_filter_cb.isChecked() and not r.get("estado"):
+                rows.remove(r)
+                continue
 
         rows.sort(
             key=lambda r: (
@@ -753,7 +750,8 @@ class FacturacionTab(QWidget):
         self._update_send_btn()
 
     def _scan_documents(self):
-        result = []
+        result = self._get_invoices_from_db()
+        seen = {r.get("name") for r in result}
         folders = [
             CF_DIR,
             CREDITO_DIR,
@@ -786,6 +784,8 @@ class FacturacionTab(QWidget):
                     if ext.lower() not in (".pdf", ".json"):
                         continue
                     if not DOC_PATTERN.match(base):
+                        continue
+                    if base in seen:
                         continue
                     entry = files.setdefault(base, {"tipo": tipo})
                     entry.setdefault(ext.lower(), os.path.join(root, fname))

--- a/tests/test_dte_filter_status.py
+++ b/tests/test_dte_filter_status.py
@@ -1,0 +1,70 @@
+import os
+from types import SimpleNamespace
+import json
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+import facturacion_tab
+from db import DB
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+
+def _make_invoice(dir_path, base):
+    (dir_path / f"{base}.pdf").write_text("pdf")
+    # minimal json to satisfy scanner
+    js = {"identificacion": {"numeroControl": base, "tipoDte": "01", "fecEmi": "2024-01-01"},
+          "receptor": {"nombre": "Cliente"},
+          "resumen": {"totalPagar": 1}}
+    (dir_path / f"{base}.json").write_text(json.dumps(js))
+
+
+def test_sent_filter_shows_accepted_and_rejected(qt_app, tmp_path, monkeypatch):
+    inv_dir = tmp_path / "facturas_consumidor_final"
+    inv_dir.mkdir()
+    bases = [
+        "20240101_Test_1_ConsumidorFinal",
+        "20240102_Test_2_ConsumidorFinal",
+        "20240103_Test_3_ConsumidorFinal",
+    ]
+    for b in bases:
+        _make_invoice(inv_dir, b)
+
+    db = DB(":memory:")
+    db.cursor.execute("INSERT INTO clientes (id, nombre) VALUES (1, 'Alice')")
+    db.conn.commit()
+    ventas = []
+    for idx, b in enumerate(bases, start=1):
+        v = db.add_venta("2024-01-0{}".format(idx), idx * 10, cliente_id=1)
+        db.add_factura_pdf(v, "ConsumidorFinal", str(inv_dir / f"{b}.pdf"))
+        ventas.append(v)
+    db.registrar_envio_dte(ventas[0], "normal", "Aceptado", "S", "{}")
+    db.registrar_envio_dte(ventas[1], "normal", "Rechazado", "", "error")
+
+    manager = SimpleNamespace(db=db, _clientes=[{"id": 1, "nombre": "Alice"}])
+
+    # patch directories so scanner only sees our temp dir
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_DEBITO_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_CREDITO_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_REMISION_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    tab = facturacion_tab.FacturacionTab(manager)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 3
+    estados = {tab.table.item(r, 4).text() for r in range(tab.table.rowCount())}
+    assert "Aceptado" in estados
+    assert "Rechazado" in estados
+
+    tab.sent_filter_cb.setChecked(True)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 2
+    estados = {tab.table.item(r, 4).text() for r in range(tab.table.rowCount())}
+    assert estados == {"Aceptado", "Rechazado"}


### PR DESCRIPTION
## Summary
- associate scanned documents with their sales to classify as venta or ticket
- fill invoice status using listar_dtes and filter by state rather than row type
- add regression test for sent DTE filter displaying accepted and rejected documents

## Testing
- `pytest tests/test_facturacion_tab_loading.py tests/test_dte_filter_status.py tests/test_facturacion_tickets.py tests/test_orphan_dirs.py tests/test_note_signs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44a6236748323ac41cc8ab0d83716