### PR TITLE
feat: add invoice cancellation dialog and event

### DIFF
--- a/dialogs/anular_factura_dialog.py
+++ b/dialogs/anular_factura_dialog.py
@@ -1,0 +1,127 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QComboBox,
+    QLineEdit,
+    QDialogButtonBox,
+    QMessageBox,
+)
+
+DOC_TYPES = [
+    ("NIT", "36"),
+    ("DUI", "13"),
+    ("Carnet de residente", "02"),
+    ("Pasaporte", "03"),
+    ("Otro", "37"),
+]
+
+class AnularFacturaDialog(QDialog):
+    """Formulario para capturar datos de anulación."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Anular factura")
+        layout = QVBoxLayout(self)
+
+        # Tipo de anulación
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Tipo de anulación:"))
+        self.tipo_cb = QComboBox()
+        for text, val in [
+            ("1", 1),
+            ("2", 2),
+            ("3", 3),
+        ]:
+            self.tipo_cb.addItem(text, val)
+        row.addWidget(self.tipo_cb)
+        layout.addLayout(row)
+
+        # Motivo
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Motivo:"))
+        self.motivo_edit = QLineEdit()
+        row.addWidget(self.motivo_edit)
+        layout.addLayout(row)
+
+        # Responsable
+        layout.addWidget(QLabel("Responsable"))
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Nombre:"))
+        self.nom_resp = QLineEdit()
+        row.addWidget(self.nom_resp)
+        layout.addLayout(row)
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Tipo doc:"))
+        self.tdoc_resp = QComboBox()
+        for text, val in DOC_TYPES:
+            self.tdoc_resp.addItem(text, val)
+        row.addWidget(self.tdoc_resp)
+        row.addWidget(QLabel("Número:"))
+        self.ndoc_resp = QLineEdit()
+        row.addWidget(self.ndoc_resp)
+        layout.addLayout(row)
+
+        # Solicitante
+        layout.addWidget(QLabel("Solicitante"))
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Nombre:"))
+        self.nom_sol = QLineEdit()
+        row.addWidget(self.nom_sol)
+        layout.addLayout(row)
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Tipo doc:"))
+        self.tdoc_sol = QComboBox()
+        for text, val in DOC_TYPES:
+            self.tdoc_sol.addItem(text, val)
+        row.addWidget(self.tdoc_sol)
+        row.addWidget(QLabel("Número:"))
+        self.ndoc_sol = QLineEdit()
+        row.addWidget(self.ndoc_sol)
+        layout.addLayout(row)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self._on_accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _on_accept(self):
+        if not self._validate():
+            return
+        self.accept()
+
+    def _validate(self) -> bool:
+        motivo = self.motivo_edit.text().strip()
+        if len(motivo) < 5 or len(motivo) > 250:
+            QMessageBox.warning(self, "Anulación", "Motivo inválido")
+            return False
+        for name, line in [
+            ("Responsable", self.nom_resp),
+            ("Solicitante", self.nom_sol),
+        ]:
+            val = line.text().strip()
+            if len(val) < 5 or len(val) > 100:
+                QMessageBox.warning(self, "Anulación", f"Nombre de {name} inválido")
+                return False
+        for name, line in [
+            ("Documento responsable", self.ndoc_resp),
+            ("Documento solicitante", self.ndoc_sol),
+        ]:
+            val = line.text().strip()
+            if len(val) < 3 or len(val) > 20:
+                QMessageBox.warning(self, "Anulación", f"Número de {name} inválido")
+                return False
+        return True
+
+    def get_data(self) -> dict:
+        return {
+            "tipoAnulacion": self.tipo_cb.currentData(),
+            "motivoAnulacion": self.motivo_edit.text().strip(),
+            "nombreResponsable": self.nom_resp.text().strip(),
+            "tipDocResponsable": self.tdoc_resp.currentData(),
+            "numDocResponsable": self.ndoc_resp.text().strip(),
+            "nombreSolicita": self.nom_sol.text().strip(),
+            "tipDocSolicita": self.tdoc_sol.currentData(),
+            "numDocSolicita": self.ndoc_sol.text().strip(),
+        }

--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -8,17 +8,36 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QHeaderView,
     QAbstractItemView,
+    QMessageBox,
 )
 from PyQt5.QtCore import Qt
 
 from utils.catalogos import TRIBUTO_IVA
+from .anular_factura_dialog import AnularFacturaDialog
+import dte
 
 
 class InvoiceDetailDialog(QDialog):
-    """Simple read-only dialog showing invoice items and totals."""
+    """Simple read-only dialog showing invoice items and totals.
 
-    def __init__(self, items: List[Dict], resumen: Dict, parent=None):
+    When ``venta_id`` and ``numero_control`` are provided an additional
+    button allows the user to start the invoice cancellation flow.
+    """
+
+    def __init__(
+        self,
+        items: List[Dict],
+        resumen: Dict,
+        venta_id: int | None = None,
+        numero_control: str | None = None,
+        factura: Dict | None = None,
+        parent=None,
+    ):
         super().__init__(parent)
+        self.venta_id = venta_id
+        self.numero_control = numero_control
+        self.factura = factura or {}
+        self.anulacion_result = None
         self.setWindowTitle("Detalle de factura")
         layout = QVBoxLayout(self)
 
@@ -74,5 +93,40 @@ class InvoiceDetailDialog(QDialog):
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok)
         buttons.button(QDialogButtonBox.Ok).setText("Cerrar")
+        if self.venta_id and self.numero_control:
+            anular_btn = buttons.addButton(
+                "Anular factura", QDialogButtonBox.ActionRole
+            )
+            anular_btn.clicked.connect(self._anular)
         buttons.accepted.connect(self.accept)
         layout.addWidget(buttons)
+
+    def _anular(self):
+        dlg = AnularFacturaDialog(self)
+        if dlg.exec_() != QDialog.Accepted:
+            return
+        form = dlg.get_data()
+        parent = self.parent()
+        db = getattr(getattr(parent, "manager", None), "db", None)
+        if not db:
+            QMessageBox.warning(self, "Anulación", "Base de datos no disponible")
+            return
+        row = db.cursor.execute(
+            "SELECT sello FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+            (self.venta_id,),
+        ).fetchone()
+        sello = row["sello"] if row and row["sello"] else None
+        if not sello:
+            QMessageBox.warning(
+                self, "Anulación", "No se encontró sello de recepción"
+            )
+            return
+        try:
+            evento = dte.generar_evento_anulacion(self.factura, form, sello)
+            res = dte.enviar_evento_anulacion(db, self.venta_id, evento)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            QMessageBox.warning(self, "Anulación", str(exc))
+            return
+        QMessageBox.information(self, "Anulación", res.get("estado", ""))
+        self.anulacion_result = res
+        self.accept()

--- a/dte.py
+++ b/dte.py
@@ -3985,6 +3985,102 @@ def generar_evento_contingencia(
 
     return evento
 
+
+def generar_evento_anulacion(
+    factura: dict, motivo: dict, sello_recibido: str, ambiente: str | None = None
+) -> dict:
+    """Construye el JSON para un evento de anulación.
+
+    ``factura`` debe contener al menos las claves ``identificacion``,
+    ``emisor``, ``receptor`` y ``resumen``.
+    """
+
+    if not sello_recibido:
+        raise ValueError("selloRecibido requerido")
+
+    ident = factura.get("identificacion", {})
+    emisor_src = factura.get("emisor", {})
+    receptor = factura.get("receptor", {})
+    resumen = factura.get("resumen", {})
+
+    if ambiente not in ("00", "01"):
+        ambiente = ident.get("ambiente", "00")
+
+    now = datetime.now(TZ_EL_SALVADOR)
+    identificacion = {
+        "version": 2,
+        "ambiente": ambiente,
+        "codigoGeneracion": str(uuid.uuid4()).upper(),
+        "fecAnula": fecha_emision_hoy_str(now),
+        "horAnula": now.strftime("%H:%M:%S"),
+    }
+
+    emisor = {
+        "nit": emisor_src.get("nit"),
+        "nombre": emisor_src.get("nombre"),
+        "tipoEstablecimiento": emisor_src.get("tipoEstablecimiento"),
+        "telefono": emisor_src.get("telefono"),
+        "correo": emisor_src.get("correo"),
+        "codEstable": emisor_src.get("codEstable"),
+        "codPuntoVenta": emisor_src.get("codPuntoVenta"),
+        "nomEstablecimiento": emisor_src.get("nombreComercial"),
+    }
+
+    tribs = resumen.get("tributos") or []
+    monto_iva = float(
+        next((t.get("valor", 0) for t in tribs if t.get("codigo") == TRIBUTO_IVA), 0)
+    )
+
+    tipo_doc = receptor.get("tipoDocumento")
+    num_doc = receptor.get("numDocumento")
+    if not tipo_doc:
+        if receptor.get("nit"):
+            tipo_doc = "36"
+            num_doc = receptor.get("nit")
+        elif receptor.get("dui"):
+            tipo_doc = "13"
+            num_doc = receptor.get("dui")
+        else:
+            tipo_doc = "37"
+
+    documento = {
+        "tipoDte": ident.get("tipoDte"),
+        "codigoGeneracion": ident.get("codigoGeneracion"),
+        "selloRecibido": sello_recibido,
+        "numeroControl": ident.get("numeroControl"),
+        "fecEmi": ident.get("fecEmi"),
+        "montoIva": round(monto_iva, 2),
+        "codigoGeneracionR": None,
+        "tipoDocumento": tipo_doc,
+        "numDocumento": num_doc,
+        "nombre": receptor.get("nombre"),
+    }
+    if receptor.get("telefono"):
+        documento["telefono"] = receptor.get("telefono")
+    if receptor.get("correo"):
+        documento["correo"] = receptor.get("correo")
+
+    evento = {
+        "identificacion": identificacion,
+        "emisor": emisor,
+        "documento": documento,
+        "motivo": motivo,
+    }
+
+    schema_path = SCHEMAS_DIR / "anulacion-schema-v2.json"
+    try:
+        with open(schema_path, "r", encoding="utf-8") as fh:
+            schema = json.load(fh)
+        from jsonschema import validate
+
+        validate(evento, schema)
+    except ValidationError as exc:  # pragma: no cover - best effort
+        raise ValueError(exc.message) from exc
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+    return evento
+
 def _normalize_recepcion_url(raw: str) -> str:
     """Normaliza y valida ``raw`` como URL de recepción de Hacienda.
 

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1092,8 +1092,18 @@ class FacturacionTab(QWidget):
             return
         items = data.get("cuerpoDocumento") or []
         resumen = data.get("resumen") or {}
-        dlg = InvoiceDetailDialog(items, resumen, self)
+        ident = data.get("identificacion") or {}
+        dlg = InvoiceDetailDialog(
+            items,
+            resumen,
+            venta_id=factura.get("id"),
+            numero_control=ident.get("numeroControl"),
+            factura=data,
+            parent=self,
+        )
         dlg.exec_()
+        if getattr(dlg, "anulacion_result", None):
+            self.refresh_and_reload()
 
     def _send_invoice_email(self, venta_id):
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -1,0 +1,58 @@
+import uuid
+
+from dialogs.anular_factura_dialog import AnularFacturaDialog
+from dte import generar_evento_anulacion
+from utils.catalogos import TRIBUTO_IVA
+
+
+def _sample_factura():
+    ident = {
+        "ambiente": "00",
+        "tipoDte": "01",
+        "codigoGeneracion": str(uuid.uuid4()).upper(),
+        "numeroControl": "DTE-01-S001P001-000000000000001",
+        "fecEmi": "2024-01-01",
+    }
+    emisor = {
+        "nit": "06141404100016",
+        "nombre": "Empresa SA",
+        "tipoEstablecimiento": "01",
+        "telefono": "22223333",
+        "correo": "info@empresa.com",
+        "codEstable": "0001",
+        "codPuntoVenta": "0001",
+        "nombreComercial": "Empresa",
+    }
+    receptor = {
+        "nombre": "Cliente",
+        "nit": "06141404100016",
+    }
+    resumen = {
+        "tributos": [{"codigo": TRIBUTO_IVA, "valor": "1.30"}]
+    }
+    return {
+        "identificacion": ident,
+        "emisor": emisor,
+        "receptor": receptor,
+        "resumen": resumen,
+    }
+
+
+def test_generar_evento_anulacion(qt_app):
+    factura = _sample_factura()
+    dlg = AnularFacturaDialog()
+    dlg.tipo_cb.setCurrentIndex(1)
+    dlg.motivo_edit.setText("Error en factura")
+    dlg.nom_resp.setText("Responsable Uno")
+    dlg.tdoc_resp.setCurrentIndex(0)
+    dlg.ndoc_resp.setText("123456789")
+    dlg.nom_sol.setText("Solicita Dos")
+    dlg.tdoc_sol.setCurrentIndex(1)
+    dlg.ndoc_sol.setText("987654321")
+    form = dlg.get_data()
+    sello = "A" * 40
+    evento = generar_evento_anulacion(factura, form, sello)
+    assert evento["motivo"]["nombreResponsable"] == "Responsable Uno"
+    assert evento["motivo"]["numDocSolicita"] == "987654321"
+    assert evento["documento"]["selloRecibido"] == sello
+    assert evento["documento"]["numeroControl"] == factura["identificacion"]["numeroControl"]


### PR DESCRIPTION
## Summary
- add `AnularFacturaDialog` and extend invoice detail dialog with cancel option
- generate and submit annulment events
- cover event generation with GUI-driven test

## Testing
- `pytest tests/test_evento_anulacion.py tests/test_envio_documentos.py::test_enviar_evento_anulacion -q`

------
https://chatgpt.com/codex/tasks/task_e_68c453e178188323972bb489ab476cf5