### PR TITLE
Enable auto-fill for invoice cancellation fields

### DIFF
--- a/dialogs/anular_factura_dialog.py
+++ b/dialogs/anular_factura_dialog.py
@@ -20,7 +20,7 @@ DOC_TYPES = [
 class AnularFacturaDialog(QDialog):
     """Formulario para capturar datos de anulación."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, responsable: dict | None = None, solicitante: dict | None = None):
         super().__init__(parent)
         self.setWindowTitle("Anular factura")
         layout = QVBoxLayout(self)
@@ -80,6 +80,25 @@ class AnularFacturaDialog(QDialog):
         self.ndoc_sol = QLineEdit()
         row.addWidget(self.ndoc_sol)
         layout.addLayout(row)
+
+        def _prefill(data: dict | None, name_edit: QLineEdit, combo: QComboBox, doc_edit: QLineEdit):
+            if not data:
+                return
+            name_edit.setText(data.get("nombre", ""))
+            doc = data.get("dui")
+            doc_type = "13" if doc else None
+            if not doc:
+                doc = data.get("nit")
+                doc_type = "36" if doc else doc_type
+            if doc_type:
+                idx = combo.findData(doc_type)
+                if idx >= 0:
+                    combo.setCurrentIndex(idx)
+            if doc:
+                doc_edit.setText(doc)
+
+        _prefill(responsable, self.nom_resp, self.tdoc_resp, self.ndoc_resp)
+        _prefill(solicitante, self.nom_sol, self.tdoc_sol, self.ndoc_sol)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self._on_accept)

--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -102,7 +102,9 @@ class InvoiceDetailDialog(QDialog):
         layout.addWidget(buttons)
 
     def _anular(self):
-        dlg = AnularFacturaDialog(self)
+        negocio = dte._load_datos_negocio()
+        receptor = self.factura.get("receptor", {})
+        dlg = AnularFacturaDialog(self, responsable=negocio, solicitante=receptor)
         if dlg.exec_() != QDialog.Accepted:
             return
         form = dlg.get_data()

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1096,7 +1096,7 @@ class FacturacionTab(QWidget):
         dlg = InvoiceDetailDialog(
             items,
             resumen,
-            venta_id=factura.get("id"),
+            venta_id=factura.get("venta_id"),
             numero_control=ident.get("numeroControl"),
             factura=data,
             parent=self,

--- a/tests/test_anular_factura_autofill.py
+++ b/tests/test_anular_factura_autofill.py
@@ -1,0 +1,38 @@
+import dte
+from dialogs.anular_factura_dialog import AnularFacturaDialog
+from dialogs.invoice_detail_dialog import InvoiceDetailDialog
+from PyQt5.QtWidgets import QDialog
+
+
+def test_anular_dialog_prefills_fields(qt_app):
+    resp = {"nombre": "Negocio", "nit": "1234"}
+    sol = {"nombre": "Cliente", "dui": "5678"}
+    dlg = AnularFacturaDialog(responsable=resp, solicitante=sol)
+    assert dlg.nom_resp.text() == "Negocio"
+    assert dlg.ndoc_resp.text() == "1234"
+    assert dlg.tdoc_resp.currentData() == "36"
+    assert dlg.nom_sol.text() == "Cliente"
+    assert dlg.ndoc_sol.text() == "5678"
+    assert dlg.tdoc_sol.currentData() == "13"
+    dlg.nom_resp.setText("Otro")
+    assert dlg.nom_resp.text() == "Otro"
+
+
+def test_invoice_detail_uses_negocio_and_cliente(monkeypatch, qt_app):
+    negocio = {"nombre": "Dueño", "nit": "1111"}
+    factura = {"receptor": {"nombre": "Comprador", "nit": "2222"}}
+    monkeypatch.setattr(dte, "_load_datos_negocio", lambda: negocio)
+    captured = {}
+
+    class FakeDialog:
+        def __init__(self, parent=None, responsable=None, solicitante=None):
+            captured["responsable"] = responsable
+            captured["solicitante"] = solicitante
+        def exec_(self):
+            return QDialog.Rejected
+
+    monkeypatch.setattr("dialogs.invoice_detail_dialog.AnularFacturaDialog", FakeDialog)
+    dlg = InvoiceDetailDialog([], {}, venta_id=1, numero_control="1", factura=factura)
+    dlg._anular()
+    assert captured["responsable"]["nombre"] == "Dueño"
+    assert captured["solicitante"]["nombre"] == "Comprador"

--- a/tests/test_facturacion_tab_anular_button.py
+++ b/tests/test_facturacion_tab_anular_button.py
@@ -1,0 +1,79 @@
+import os
+import json
+from types import SimpleNamespace
+
+import pytest
+from PyQt5.QtWidgets import QApplication, QDialogButtonBox
+
+import facturacion_tab
+from db import DB
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QApplication.instance() or QApplication([])
+
+
+def _create_sale(db):
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "C1", None, vid, None, 0, 10, 10, 1)
+    pid = db.cursor.lastrowid
+    db.add_cliente("C", "", "", "", "", "", "c@x.com", "", "", "")
+    cid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, vendedor_id=vid)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id, cid
+
+
+def test_double_click_shows_anular_button(qt_app, tmp_path, monkeypatch):
+    invoice_dir = tmp_path / "invoices"
+    invoice_dir.mkdir()
+    for name in [
+        "CF_DIR",
+        "CREDITO_DIR",
+        "TICKETS_DIR",
+        "NOTAS_DEBITO_DIR",
+        "NOTAS_CREDITO_DIR",
+        "NOTAS_REMISION_DIR",
+    ]:
+        monkeypatch.setattr(facturacion_tab, name, str(invoice_dir))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    manager = SimpleNamespace(db=db, _clientes=[{"id": cid, "nombre": "C"}], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(manager)
+
+    data = {
+        "cuerpoDocumento": [],
+        "resumen": {},
+        "identificacion": {"numeroControl": "NC123"},
+    }
+    json_path = tmp_path / "factura.json"
+    json_path.write_text(json.dumps(data))
+
+    monkeypatch.setattr(
+        tab,
+        "_selected_factura",
+        lambda: {"venta_id": venta_id, "json": str(json_path), "control": "NC123"},
+    )
+
+    created = []
+    OrigDialog = facturacion_tab.InvoiceDetailDialog
+
+    class RecordingDialog(OrigDialog):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+        def exec_(self):
+            return 0
+
+    monkeypatch.setattr(facturacion_tab, "InvoiceDetailDialog", RecordingDialog)
+
+    tab.mostrar_detalle_factura()
+
+    assert created, "dialog should be created"
+    buttons = created[0].findChild(QDialogButtonBox)
+    assert any(b.text() == "Anular factura" for b in buttons.buttons())


### PR DESCRIPTION
## Summary
- Prefill "Responsable" and "Solicitante" fields in the cancellation dialog using business and client data
- Pass negocio and receptor information when opening the cancellation dialog
- Add tests covering auto-filled fields and dialog integration

## Testing
- `pytest tests/test_facturacion_tab_actions.py tests/test_facturacion_tab_anular_button.py tests/test_evento_anulacion.py tests/test_anular_factura_autofill.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c465ead9e48323894eec59bc8aa2ce