### PR TITLE
Persist email defaults and mark Hacienda by default

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -102,6 +102,8 @@ class SendOptionsDialog(QDialog):
         layout = QVBoxLayout(self)
         self.email_cb = QCheckBox("Enviar por correo")
         self.hacienda_cb = QCheckBox("Enviar a Hacienda")
+        self.email_cb.setChecked(True)
+        self.hacienda_cb.setChecked(True)
         layout.addWidget(self.email_cb)
         layout.addWidget(self.hacienda_cb)
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -959,6 +961,7 @@ class FacturacionTab(QWidget):
 
         dialog = SendOptionsDialog(self)
         dialog.email_cb.setChecked(True)
+        dialog.hacienda_cb.setChecked(True)
         if dialog.exec_() != QDialog.Accepted:
             return
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -571,6 +571,9 @@ class SalesTab(QWidget):
         if not venta or int(venta.get("id", 0)) != venta_id:
             QMessageBox.warning(self, "Guardar factura", "No se encontró la venta seleccionada.")
             return
+        self.email_subject = self.email_subject_edit.text()
+        self.email_body = self.email_body_edit.toPlainText()
+        self._save_email_config()
         if self._is_ticket_sale(venta):
             file_path = self._generate_ticket_pdf(venta_id)
             doc_type = "Ticket"
@@ -661,6 +664,9 @@ class SalesTab(QWidget):
             "subject": self.email_subject_edit.text(),
             "body": self.email_body_edit.toPlainText(),
         }
+        self.email_subject = dte_meta["subject"]
+        self.email_body = dte_meta["body"]
+        self._save_email_config()
 
         if self._is_ticket_sale(venta):
             doc_type = "ticket"

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from PyQt5.QtWidgets import QTableWidgetItem, QMessageBox
 
+import sales_tab
 from sales_tab import SalesTab
 
 warnings.filterwarnings(
@@ -126,6 +127,54 @@ def test_send_email_builds_message_and_marks_status(
         pdf.name,
         json_path.name,
     }
+
+
+def test_send_email_persists_defaults(
+    qt_app,
+    pdf_json_files,
+    monkeypatch,
+    venta_factory,
+    cliente_factory,
+    producto_factory,
+    tmp_path,
+):
+    pdf, json_path = pdf_json_files
+    venta = venta_factory()
+    cliente = cliente_factory(id=venta["cliente_id"])
+    producto = producto_factory()
+    db, tab = _setup_tab(venta, cliente, producto, monkeypatch)
+    db.factura_path = str(pdf)
+
+    data_path = tmp_path / "datos.json"
+    monkeypatch.setattr(sales_tab, "DATOS_NEGOCIO_PATH", str(data_path))
+
+    tab.sales_table.selectRow(0)
+    tab.email_subject_edit.setText("Hola")
+    tab.email_body_edit.setText("Adios")
+
+    monkeypatch.setattr(
+        SalesTab,
+        "_check_smtp_credentials",
+        lambda self: {"server": "s", "port": 25, "user": "u", "password": "p"},
+    )
+    monkeypatch.setattr(
+        "utils.email_sender.EmailSender.send",
+        lambda self: self.finished.emit(True, "ok"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "utils.email_sender.EmailSender.start", lambda self: self.send()
+    )
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: None)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+
+    tab.send_email()
+    qt_app.processEvents()
+
+    data = json.loads(data_path.read_text())
+    assert data["default_email_subject"] == "Hola"
+    assert data["default_email_body"] == "Adios"
 
 
 def test_save_invoice_generates_files_and_registers(


### PR DESCRIPTION
## Summary
- persist email subject and body when saving or sending invoices
- default both "Enviar por correo" and "Enviar a Hacienda" options in billing
- add test covering email default persistence

## Testing
- `pytest tests/test_sales_tab_email.py::test_send_email_persists_defaults -q`
- `pytest tests/test_connection_error_message.py::test_send_selected_invoice_no_connection -q`
- `pytest tests/test_orphan_send.py::test_send_orphan_invoice -q` *(fails: attachment mismatch due to existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c466d6341c832383e41849b5e33272