### PR TITLE
Skip geo validation for missing address in norm_receptor

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -749,17 +749,36 @@ def norm_receptor(
     comp = (d.get("complemento") or "").strip()
     dep = d.get("departamento")
     mun = d.get("municipio")
-    try:
-        dep, mun = validar_dep_muni_por_catalogo(dep, mun, strict=strict_geo)
-    except GeoValidationError as e:
+
+    if dep is None or mun is None:
         if es_ticket:
-            warnings.warn(f"{e}; usando dirección por defecto", UserWarning)
+            warnings.warn(
+                "Dirección incompleta; usando dirección por defecto",
+                UserWarning,
+            )
             dep = DEFAULT_ADDRESS["departamento"]
             mun = DEFAULT_ADDRESS["municipio"]
         else:
-            raise
-    if len(comp) < 5:
-        comp = DEFAULT_ADDRESS["complemento"]
+            if dep is not None or mun is not None:
+                warnings.warn(
+                    "Dirección incompleta; validación omitida", UserWarning
+                )
+    else:
+        try:
+            dep, mun = validar_dep_muni_por_catalogo(
+                dep, mun, strict=strict_geo
+            )
+        except GeoValidationError as e:
+            if es_ticket:
+                warnings.warn(f"{e}; usando dirección por defecto", UserWarning)
+                dep = DEFAULT_ADDRESS["departamento"]
+                mun = DEFAULT_ADDRESS["municipio"]
+            else:
+                raise
+
+    if not comp or len(comp) < 5:
+        comp = DEFAULT_ADDRESS["complemento"] if es_ticket else None
+
     r["direccion"] = {
         "departamento": dep,
         "municipio": mun,

--- a/tests/test_geo_validation.py
+++ b/tests/test_geo_validation.py
@@ -29,3 +29,13 @@ def test_norm_receptor_ticket_fallback():
     assert res["direccion"]["municipio"] == DEFAULT_ADDRESS["municipio"]
     assert res["direccion"]["complemento"] == "abcdef"
 
+
+def test_norm_receptor_missing_geo_keeps_none():
+    r = {"direccion": {"complemento": "abc"}}
+    res = norm_receptor(r)
+    assert res["direccion"] == {
+        "departamento": None,
+        "municipio": None,
+        "complemento": None,
+    }
+


### PR DESCRIPTION
## Summary
- Skip departamento/municipio validation when either is missing
- Only use DEFAULT_ADDRESS for tickets, keeping `None` for other docs
- Test norm_receptor with absent geo data

## Testing
- `pytest tests/test_geo_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47354bb5c832398837022cf1d4e9e