### PR TITLE
Ensure receptor nit and nombreComercial preserved in notes

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
+import copy
 import json
 from typing import Optional
 
@@ -156,9 +157,19 @@ def generar_nce_desde_dte(
     ]
 
     emisor = dte_origen.get("emisor")
-    receptor = dte_origen.get("receptor")
+    receptor = copy.deepcopy(dte_origen.get("receptor", {}))
+    receptor.setdefault("nit", "")
+    receptor.setdefault("nombreComercial", "")
+    if not receptor["nit"]:
+        receptor["nit"] = "000000000"
+    if not receptor["nombreComercial"]:
+        receptor["nombreComercial"] = receptor.get("nombre", "")
     limpiar_documentos(emisor)
     limpiar_documentos(receptor)
+    receptor["nit"] = str(receptor.get("nit", ""))
+    receptor["nombreComercial"] = str(
+        receptor.get("nombreComercial", "")
+    )
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -107,10 +107,18 @@ def generar_nde_desde_dte(
 
     emisor = copy.deepcopy(dte_origen.get("emisor", {}))
     receptor = copy.deepcopy(dte_origen.get("receptor", {}))
-    receptor.setdefault("nombreComercial", None)
-    receptor.setdefault("nit", None)
+    receptor.setdefault("nit", "")
+    receptor.setdefault("nombreComercial", "")
+    if not receptor["nit"]:
+        receptor["nit"] = "000000000"
+    if not receptor["nombreComercial"]:
+        receptor["nombreComercial"] = receptor.get("nombre", "")
     limpiar_documentos(emisor)
     limpiar_documentos(receptor)
+    receptor["nit"] = str(receptor.get("nit", ""))
+    receptor["nombreComercial"] = str(
+        receptor.get("nombreComercial", "")
+    )
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []


### PR DESCRIPTION
## Summary
- Clone receptor in credit and debit note generation to avoid mutating source DTE
- Ensure `nit` and `nombreComercial` exist as strings with business defaults before payload sanitization

## Testing
- `pytest` *(fails: 52 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c4741ebf58832397f6fb87fed487a4