### PR TITLE
Use San Salvador Centro as default address fallback

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -686,7 +686,7 @@ def _build_receptor_direccion(src: dict) -> dict:
 
 DEFAULT_ADDRESS = {
     "departamento": "06",
-    "municipio": "01",
+    "municipio": "23",
     "complemento": "San Salvador",
 }
 
@@ -750,8 +750,11 @@ def norm_receptor(
     dep = d.get("departamento")
     mun = d.get("municipio")
 
+    is_cf = tipo == "37" and num == "CONSUMIDOR"
+    fallback_addr = es_ticket or is_cf
+
     if dep is None or mun is None:
-        if es_ticket:
+        if fallback_addr:
             warnings.warn(
                 "Dirección incompleta; usando dirección por defecto",
                 UserWarning,
@@ -769,7 +772,7 @@ def norm_receptor(
                 dep, mun, strict=strict_geo
             )
         except GeoValidationError as e:
-            if es_ticket:
+            if fallback_addr:
                 warnings.warn(f"{e}; usando dirección por defecto", UserWarning)
                 dep = DEFAULT_ADDRESS["departamento"]
                 mun = DEFAULT_ADDRESS["municipio"]
@@ -777,7 +780,7 @@ def norm_receptor(
                 raise
 
     if not comp or len(comp) < 5:
-        comp = DEFAULT_ADDRESS["complemento"] if es_ticket else None
+        comp = DEFAULT_ADDRESS["complemento"] if fallback_addr else None
 
     r["direccion"] = {
         "departamento": dep,

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -242,7 +242,7 @@ def test_generar_dte_json_usa_cod_estable_punto(tmp_path):
         "",
         "C",
         "06",
-        "01",
+        "23",
         codActividad="99999",
     )
     cliente_id = db.cursor.lastrowid
@@ -1100,7 +1100,7 @@ def test_generar_dte_json_receptor_extra_preserva_direccion(tmp_path):
         "",
         "Calle",
         "06",
-        "01",
+        "23",
     )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta(
@@ -1117,7 +1117,7 @@ def test_generar_dte_json_receptor_extra_preserva_direccion(tmp_path):
     data = generar_dte_json(db, venta_id)
     direccion = data["receptor"]["direccion"]
     assert direccion["departamento"] == "06"
-    assert direccion["municipio"] == "01"
+    assert direccion["municipio"] == "23"
     assert direccion["complemento"] == "Calle"
 
 

--- a/tests/test_generar_nota_remision_json.py
+++ b/tests/test_generar_nota_remision_json.py
@@ -23,8 +23,8 @@ def test_generar_nota_remision_json_from_dte(db_conn):
             "telefono": "70000001",
             "correo": "cliente@example.com",
             "direccion": {
-                "departamento": "05",
-                "municipio": "01",
+                "departamento": "06",
+                "municipio": "23",
                 "complemento": "San Salvador",
             },
         },

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -33,7 +33,7 @@ def _stub_datos_negocio(monkeypatch):
         "tipoContribuyente": "PN",
         "telefono": "22223333",
         "correo": "demo@example.com",
-        "direccion": {"departamento": "01", "municipio": "01", "complemento": ""},
+        "direccion": {"departamento": "06", "municipio": "23", "complemento": ""},
     }
     monkeypatch.setattr(svfe_config, "load_datos_negocio", lambda: fake)
     monkeypatch.setattr(dte_module, "_load_datos_negocio", lambda: fake)

--- a/tests/test_geo_validation.py
+++ b/tests/test_geo_validation.py
@@ -30,12 +30,12 @@ def test_norm_receptor_ticket_fallback():
     assert res["direccion"]["complemento"] == "abcdef"
 
 
-def test_norm_receptor_missing_geo_keeps_none():
+def test_norm_receptor_cf_missing_geo_uses_default():
     r = {"direccion": {"complemento": "abc"}}
     res = norm_receptor(r)
     assert res["direccion"] == {
-        "departamento": None,
-        "municipio": None,
-        "complemento": None,
+        "departamento": DEFAULT_ADDRESS["departamento"],
+        "municipio": DEFAULT_ADDRESS["municipio"],
+        "complemento": DEFAULT_ADDRESS["complemento"],
     }
 

--- a/tests/test_nd_pipeline.py
+++ b/tests/test_nd_pipeline.py
@@ -41,7 +41,7 @@ def test_nd_minimum_pipeline():
         "correo": "demo@example.com",
         "direccion": {
             "departamento": "06",
-            "municipio": "01",
+            "municipio": "23",
             "complemento": "Calle X",
         },
     }
@@ -56,8 +56,8 @@ def test_nd_minimum_pipeline():
         "telefono": "70000001",
         "correo": "cliente@example.com",
         "direccion": {
-            "departamento": "05",
-            "municipio": "01",
+            "departamento": "06",
+            "municipio": "23",
             "complemento": "San Salvador",
         },
     }

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -25,8 +25,8 @@ def _sample_receptor():
         "telefono": "70000001",
         "correo": "cliente@example.com",
         "direccion": {
-            "departamento": "05",
-            "municipio": "01",
+            "departamento": "06",
+            "municipio": "23",
             "complemento": "San Salvador",
         },
     }
@@ -130,8 +130,8 @@ def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
             "telefono": "70000001",
             "correo": "cliente@example.com",
             "direccion": {
-                "departamento": "05",
-                "municipio": "01",
+                "departamento": "06",
+                "municipio": "23",
                 "complemento": "San Salvador",
             },
         },
@@ -300,8 +300,8 @@ def test_receptor_dui_sin_nrc(monkeypatch):
         "telefono": "70000001",
         "correo": "cliente@example.com",
         "direccion": {
-            "departamento": "05",
-            "municipio": "01",
+            "departamento": "06",
+            "municipio": "23",
             "complemento": "San Salvador",
         },
     }
@@ -336,8 +336,8 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
         "telefono": "70000001",
         "correo": "cliente@example.com",
         "direccion": {
-            "departamento": "05",
-            "municipio": "01",
+            "departamento": "06",
+            "municipio": "23",
             "complemento": "San Salvador",
         },
     }

--- a/tests/test_nr_pipeline.py
+++ b/tests/test_nr_pipeline.py
@@ -45,7 +45,7 @@ def test_nr_minimum_pipeline():
         "codPuntoVentaMH": "0001",
         "direccion": {
             "departamento": "06",
-            "municipio": "01",
+            "municipio": "23",
             "complemento": "Calle X",
         },
     }
@@ -62,8 +62,8 @@ def test_nr_minimum_pipeline():
         "numDocumento": "12345678901234",
         "tipoDocumento": "36",
         "direccion": {
-            "departamento": "05",
-            "municipio": "01",
+            "departamento": "06",
+            "municipio": "23",
             "complemento": "San Salvador",
         },
     }

--- a/tickets/20250912_63_Ticket.json
+++ b/tickets/20250912_63_Ticket.json
@@ -64,7 +64,7 @@
     "direccion": {
       "complemento": "San Salvador",
       "departamento": "06",
-      "municipio": "01"
+      "municipio": "23"
     },
     "nombre": "CONSUMIDOR FINAL",
     "nrc": null,

--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -567,7 +567,6 @@ CAT_DEPTOS = _CATS["CAT-012"]
 # Cada código está asociado a un departamento según CAT-013.
 CAT_MUNI44 = {
     "00": {"dep": "00", "name": "OTRO"},
-    "01": {"dep": "06", "name": "SAN SALVADOR CENTRO"},
     "10": {"dep": "06", "name": "SAN SALVADOR SUR"},
     "13": {"dep": "01", "name": "AHUACHAPAN NORTE"},
     # La Libertad (dep = 05)


### PR DESCRIPTION
## Summary
- update default fallback address to department 06, municipality 23 (San Salvador Centro)
- fall back to that address for tickets and consumer-final clients lacking location data
- align sample catalog and tests with updated municipality codes

## Testing
- `pytest` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c478d91db88323aae8a2b9350f6105