### PR TITLE
Move pending DTEs into final directories after transmission

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -38,6 +38,7 @@ from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 from utils.fecha import fecha_emision_hoy_str, TZ_EL_SALVADOR
 from svfe import config as svfe_config
 from pathlib import Path
+import shutil
 import jsonpatch
 from paths import DATOS_NEGOCIO_PATH
 from xml.etree.ElementTree import Element, SubElement
@@ -50,6 +51,7 @@ CONFIG_NEGOCIO_PATH = os.path.join(os.path.dirname(__file__), "config_negocio.js
 DEFAULT_RECEPCION_URL = "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"
 DEFAULT_EVENTO_URL = "https://apitest.dtes.mh.gob.sv/fesv/contingencia"
 PATCHES_DIR = Path(__file__).resolve().parent / "schema_patches"
+PENDIENTES_DIR = "dtes_pendientes"
 
 SCHEMAS_DIR = Path(__file__).resolve().parent / "svfe-json-schemas"
 FC_SCHEMA_PATH = SCHEMAS_DIR / "fe-fc-v1.json"
@@ -4096,17 +4098,18 @@ def _write_json(path: str, data):
         save_file(path, stable_stringify(data, indent=2))
 
 
-def _dte_base_dir(dte_data: dict, fallido: bool = False) -> str:
+def _dte_base_dir(dte_data: dict, fallido: bool = False, root: str | None = None) -> str:
     """Return destination directory for ``dte_data`` grouped by tipoDte.
 
     The ``fallido`` flag controls whether the DTE should be stored under the
     accepted directory (``dtes/``) or the rejected one (``dte_fallidos/``).
+    ``root`` can be used to override the base directory.
     """
 
     ident = dte_data.get("identificacion", {})
     tipo = str(ident.get("tipoDte", "")).zfill(2)
-    root = "dte_fallidos" if fallido else "dtes"
-    base = os.path.join(os.path.dirname(__file__), root)
+    root_dir = root or ("dte_fallidos" if fallido else "dtes")
+    base = os.path.join(os.path.dirname(__file__), root_dir)
     mapping = {
         "01": "fcf",  # Factura consumidor final
         "03": "ccf",  # Comprobante de crédito fiscal
@@ -4142,6 +4145,28 @@ def _save_signed_dte(dte_data: dict, jws_token: str, fallido: bool = False) -> N
         pass
 
 
+def _finalize_pendiente(json_path: str, dte_data: dict, jws_token: str, estado: str) -> str:
+    """Move pending DTE directory to final location and attach JWS.
+
+    Returns the new ``documento.json`` path."""
+    try:
+        version_dir = os.path.dirname(json_path)
+        pend_root = os.path.join(os.path.dirname(__file__), PENDIENTES_DIR)
+        rel = os.path.relpath(version_dir, pend_root)
+        dest_root = "dte_fallidos" if estado == "Rechazado" else "dtes"
+        dest_dir = os.path.join(os.path.dirname(__file__), dest_root, rel)
+        os.makedirs(os.path.dirname(dest_dir), exist_ok=True)
+        shutil.move(version_dir, dest_dir)
+        jws_name = versioned_dte.add_jws(dest_dir, jws_token, origen="auto")
+        sobre = construir_sobre_recepcion(jws_token, dte_data)
+        if sobre.get("estado") != "Error":
+            sobre_path = os.path.join(dest_dir, jws_name.replace(".jws", "_sobre_hacienda.json"))
+            _write_json(sobre_path, sobre)
+        return os.path.join(dest_dir, "documento.json")
+    except Exception:
+        return json_path
+
+
 class DTEValidationError(Exception):
     """Error de validación que incluye lista de errores y ruta del JSON."""
 
@@ -4154,7 +4179,7 @@ class DTEValidationError(Exception):
 def save_dte_json(dte_data: dict) -> str:
     """Guarda ``dte_data`` en estructura versionada y devuelve la ruta."""
     try:
-        base_dir = _dte_base_dir(dte_data)
+        base_dir = _dte_base_dir(dte_data, root=PENDIENTES_DIR)
         version_dir, _ = versioned_dte.ensure_version(dte_data, base_dir)
         return os.path.join(version_dir, "documento.json")
     except Exception:
@@ -4821,6 +4846,15 @@ def _enviar_documento(
     """
     config = _load_dte_api_config()
 
+    pend_json_path = None
+    try:
+        row = db.cursor.execute("SELECT extra FROM ventas WHERE id=?", (doc_id,)).fetchone()
+        if row and row[0]:
+            extra = json.loads(row[0])
+            pend_json_path = extra.get("dteJsonPath")
+    except Exception:
+        pass
+
     if not data.get("resumen", {}).get("totalLetras"):
         raise ValueError("El total en letras es obligatorio")
 
@@ -4860,10 +4894,17 @@ def _enviar_documento(
     signed = jws_token or jws.sign_json(data)
 
     if modo == "contingencia":
-        try:
-            _save_signed_dte(data, signed, fallido=False)
-        except Exception:
-            pass
+        if pend_json_path:
+            try:
+                final_path = _finalize_pendiente(pend_json_path, data, signed, "Pendiente")
+                db.update_venta_extra(doc_id, {"dteJsonPath": final_path})
+            except Exception:
+                pass
+        else:
+            try:
+                _save_signed_dte(data, signed, fallido=False)
+            except Exception:
+                pass
         db.registrar_envio_dte(
             doc_id,
             modo,
@@ -4910,10 +4951,17 @@ def _enviar_documento(
         sello,
         json.dumps(respuesta, ensure_ascii=False),
     )
-    try:
-        _save_signed_dte(data, signed, fallido=(estado == "Rechazado"))
-    except Exception:
-        pass
+    if pend_json_path:
+        try:
+            final_path = _finalize_pendiente(pend_json_path, data, signed, estado)
+            db.update_venta_extra(doc_id, {"dteJsonPath": final_path})
+        except Exception:
+            pass
+    else:
+        try:
+            _save_signed_dte(data, signed, fallido=(estado == "Rechazado"))
+        except Exception:
+            pass
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)
     res = {"estado": estado, "sello": sello}


### PR DESCRIPTION
## Summary
- add `PENDIENTES_DIR` constant and save pending DTE JSONs there
- move DTE directory from pending to `dtes`/`dte_fallidos` once sent and store final path
- update sales extra info with the final DTE path for later lookups

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_68c6f0af3268832396d36bed5d9b88a0