### PR TITLE
Default missing client address to San Salvador

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -674,9 +674,13 @@ def _build_receptor_direccion(src: dict) -> dict:
     dep_code = dep_code or dep_inferred
     if dep_code is None or muni_code is None:
         warnings.warn(
-            "Información de dirección incompleta; la factura se generará con campos nulos",
+            "Información de dirección incompleta; usando dirección por defecto",
             UserWarning,
         )
+        dep_code = DEFAULT_ADDRESS["departamento"]
+        muni_code = DEFAULT_ADDRESS["municipio"]
+        if not complemento or len(complemento) < 5:
+            complemento = DEFAULT_ADDRESS["complemento"]
 
     return {
         "departamento": dep_code,
@@ -751,21 +755,16 @@ def norm_receptor(
     mun = d.get("municipio")
 
     is_cf = tipo == "37" and num == "CONSUMIDOR"
-    fallback_addr = es_ticket or is_cf
+    missing_addr = dep is None or mun is None
+    fallback_addr = es_ticket or is_cf or missing_addr
 
-    if dep is None or mun is None:
-        if fallback_addr:
-            warnings.warn(
-                "Dirección incompleta; usando dirección por defecto",
-                UserWarning,
-            )
-            dep = DEFAULT_ADDRESS["departamento"]
-            mun = DEFAULT_ADDRESS["municipio"]
-        else:
-            if dep is not None or mun is not None:
-                warnings.warn(
-                    "Dirección incompleta; validación omitida", UserWarning
-                )
+    if missing_addr:
+        warnings.warn(
+            "Dirección incompleta; usando dirección por defecto",
+            UserWarning,
+        )
+        dep = DEFAULT_ADDRESS["departamento"]
+        mun = DEFAULT_ADDRESS["municipio"]
     else:
         try:
             dep, mun = validar_dep_muni_por_catalogo(

--- a/tests/test_doc_utils.py
+++ b/tests/test_doc_utils.py
@@ -1,5 +1,6 @@
 import os
 from utils import docs
+from dte import DEFAULT_ADDRESS
 
 
 def test_generate_document_name():
@@ -33,3 +34,9 @@ def test_build_invoice_json_preserves_address():
     assert rec.get('nrc') == '123456-7'
     assert rec.get('telefono') == '2222-3333'
     assert rec.get('correo') == 'ariel@example.com'
+
+
+def test_build_invoice_json_uses_default_address():
+    cliente = {'nombre': 'Ariel', 'direccion': 'abc'}
+    data = docs.build_invoice_json({'fecha': '2024-01-01'}, cliente, [])
+    assert data.get('receptor', {}).get('direccion') == DEFAULT_ADDRESS

--- a/tests/test_geo_validation.py
+++ b/tests/test_geo_validation.py
@@ -39,3 +39,13 @@ def test_norm_receptor_cf_missing_geo_uses_default():
         "complemento": DEFAULT_ADDRESS["complemento"],
     }
 
+
+def test_norm_receptor_missing_geo_uses_default():
+    r = {"nit": "06142501751015", "direccion": {"complemento": "abc"}}
+    res = norm_receptor(r)
+    assert res["direccion"] == {
+        "departamento": DEFAULT_ADDRESS["departamento"],
+        "municipio": DEFAULT_ADDRESS["municipio"],
+        "complemento": DEFAULT_ADDRESS["complemento"],
+    }
+


### PR DESCRIPTION
## Summary
- Use San Salvador as fallback department/municipality when client geo data is missing
- Apply same default in invoice JSON builder
- Add tests for default address behavior

## Testing
- `pytest` *(fails: libGL.so.1 missing, 51 errors)*
- `pytest tests/test_geo_validation.py::test_norm_receptor_missing_geo_uses_default -q --disable-warnings --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c6e47639e88323ba545bad605dd874