### PR TITLE
Clean up old DTE versions and block retransmission

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4156,6 +4156,19 @@ def _finalize_pendiente(json_path: str, dte_data: dict, jws_token: str, estado: 
         dest_dir = os.path.join(os.path.dirname(__file__), dest_root, rel)
         os.makedirs(os.path.dirname(dest_dir), exist_ok=True)
         shutil.move(version_dir, dest_dir)
+        try:
+            codigo_dir = os.path.dirname(dest_dir)
+            for name in os.listdir(codigo_dir):
+                path = os.path.join(codigo_dir, name)
+                if path != dest_dir and os.path.isdir(path):
+                    shutil.rmtree(path, ignore_errors=True)
+        except Exception:
+            pass
+        try:
+            pend_codigo_dir = os.path.dirname(version_dir)
+            shutil.rmtree(pend_codigo_dir, ignore_errors=True)
+        except Exception:
+            pass
         jws_name = versioned_dte.add_jws(dest_dir, jws_token, origen="auto")
         sobre = construir_sobre_recepcion(jws_token, dte_data)
         if sobre.get("estado") != "Error":
@@ -4535,17 +4548,26 @@ def transmitir_dte(
         except Exception:
             extra = {}
     json_path = extra.get("dteJsonPath") or extra.get("dte_json_path")
-    if json_path and os.path.exists(json_path):
-        try:
-            with open(json_path, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-        except Exception:
-            data = None
+    if json_path:
+        path_obj = Path(json_path)
+        if PENDIENTES_DIR not in path_obj.parts:
+            raise ValueError("El DTE ya fue enviado")
+        if path_obj.exists():
+            try:
+                with open(path_obj, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except Exception:
+                data = None
     if data is None:
         codigo = extra.get("codigoGeneracion") or extra.get("codigo_generacion")
         if codigo:
-            base_dir = Path(__file__).resolve().parent / "dtes"
-            matches = list(base_dir.glob(f"*/{codigo}/*/documento.json"))
+            base_root = Path(__file__).resolve().parent
+            for root_name in ("dtes", "dte_fallidos"):
+                matches = list((base_root / root_name).glob(f"*/{codigo}/*/documento.json"))
+                if matches:
+                    raise ValueError("El DTE ya fue enviado")
+            pend_dir = base_root / PENDIENTES_DIR
+            matches = list(pend_dir.glob(f"*/{codigo}/*/documento.json"))
             if matches:
                 json_path = str(matches[-1])
                 try:

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -4,9 +4,11 @@ import dte
 import json
 from datetime import datetime
 from pathlib import Path
+import os
 import pytest
 import auth
 from tests.conftest import make_jws
+from utils import versioned_dte
 
 
 def create_sale(db):
@@ -394,3 +396,44 @@ def test_listar_dtes():
     rows = db.listar_dtes(today, today, "Transmitido")
     assert len(rows) == 1
     assert rows[0]["estado"] == "Transmitido"
+
+
+def test_finalize_pendiente_cleans_versions(monkeypatch, tmp_path):
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
+    codigo = "CGTEST"
+    data1 = {"identificacion": {"tipoDte": "01", "codigoGeneracion": codigo, "numeroControl": "1"}}
+    data2 = {"identificacion": {"tipoDte": "01", "codigoGeneracion": codigo, "numeroControl": "2"}}
+    path1 = dte.save_dte_json(data1)
+    path2 = dte.save_dte_json(data2)
+    base_dest = dte._dte_base_dir(data1)
+    versioned_dte.ensure_version(data1, base_dir=base_dest)
+    final_path = dte._finalize_pendiente(path2, data2, "TOK", "Aceptado")
+    codigo_dir = os.path.dirname(os.path.dirname(final_path))
+    assert os.listdir(codigo_dir) == [os.path.basename(os.path.dirname(final_path))]
+    assert not os.path.exists(os.path.dirname(os.path.dirname(path1)))
+
+
+def test_transmitir_dte_blocks_when_json_in_final_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
+    db = DB(":memory:")
+    venta = create_sale(db)
+    codigo = "CGTEST2"
+    data = {"identificacion": {"tipoDte": "01", "codigoGeneracion": codigo}}
+    pend_path = dte.save_dte_json(data)
+    final_path = dte._finalize_pendiente(pend_path, data, "TOK", "Rechazado")
+    db.update_venta_extra(venta, {"dteJsonPath": final_path, "codigoGeneracion": codigo})
+    with pytest.raises(ValueError):
+        transmitir_dte(db, venta)
+
+
+def test_transmitir_dte_blocks_if_final_json_exists_without_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
+    db = DB(":memory:")
+    venta = create_sale(db)
+    codigo = "CGTEST3"
+    data = {"identificacion": {"tipoDte": "01", "codigoGeneracion": codigo}}
+    base_dest = dte._dte_base_dir(data)
+    versioned_dte.ensure_version(data, base_dir=base_dest)
+    db.update_venta_extra(venta, {"codigoGeneracion": codigo})
+    with pytest.raises(ValueError):
+        transmitir_dte(db, venta)


### PR DESCRIPTION
## Summary
- Remove previous DTE versions when finalizing pending documents
- Prevent retransmission if a DTE JSON exists in final directories and reuse pending versions for retries
- Add regression tests for directory cleanup and retransmission guard

## Testing
- `pytest tests/test_dte_transmision.py::test_finalize_pendiente_cleans_versions -q`
- `pytest tests/test_dte_transmision.py::test_transmitir_dte_blocks_when_json_in_final_dir -q`
- `pytest tests/test_dte_transmision.py::test_transmitir_dte_blocks_if_final_json_exists_without_path -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68c6ff1a90fc8323a351aafbb1848e99