### PR TITLE
Asignar ubicación por defecto a clientes

### DIFF
--- a/db.py
+++ b/db.py
@@ -1357,6 +1357,15 @@ class DB:
     ):
         if codigo is None:
             codigo = self.get_next_cliente_codigo()
+        if (
+            not departamento
+            or not getattr(departamento, "strip", lambda: "")()
+            or not municipio
+            or not getattr(municipio, "strip", lambda: "")()
+        ):
+            departamento = "06"
+            municipio = "23"
+            direccion = direccion or "San Salvador"
         nit = nit.strip() if isinstance(nit, str) else nit
         nit = nit or None
         if self.nit_exists(nit):
@@ -1417,6 +1426,15 @@ class DB:
         codActividad=None,
         nombreComercial=None,
     ):
+        if (
+            not departamento
+            or not getattr(departamento, "strip", lambda: "")()
+            or not municipio
+            or not getattr(municipio, "strip", lambda: "")()
+        ):
+            departamento = "06"
+            municipio = "23"
+            direccion = direccion or "San Salvador"
         nit = nit.strip() if isinstance(nit, str) else nit
         nit = nit or None
         if self.nit_exists(nit, exclude_id=id):

--- a/tests/test_cliente_default_address.py
+++ b/tests/test_cliente_default_address.py
@@ -1,0 +1,44 @@
+from db import DB
+
+
+def test_add_cliente_defaults_to_san_salvador(tmp_path):
+    db = DB(tmp_path / "test.db")
+    db.add_cliente("Juan", "", "", "", "", "", "", "", None, None)
+    row = db.cursor.execute(
+        "SELECT direccion, departamento, municipio FROM clientes WHERE nombre=?",
+        ("Juan",),
+    ).fetchone()
+    assert row["direccion"] == "San Salvador"
+    assert row["departamento"] == "06"
+    assert row["municipio"] == "23"
+
+
+def test_update_cliente_defaults_to_san_salvador(tmp_path):
+    db = DB(tmp_path / "test.db")
+    db.add_cliente("Ana", "", "", "", "", "", "", "Calle 1", "01", "02")
+    row = db.cursor.execute(
+        "SELECT id, codigo FROM clientes WHERE nombre=?",
+        ("Ana",),
+    ).fetchone()
+    cliente_id, codigo = row["id"], row["codigo"]
+    db.update_cliente(
+        cliente_id,
+        codigo,
+        "Ana",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        None,
+        None,
+    )
+    row = db.cursor.execute(
+        "SELECT direccion, departamento, municipio FROM clientes WHERE id=?",
+        (cliente_id,),
+    ).fetchone()
+    assert row["direccion"] == "San Salvador"
+    assert row["departamento"] == "06"
+    assert row["municipio"] == "23"


### PR DESCRIPTION
## Resumen
- Definir valores por defecto de departamento, municipio y dirección al crear o actualizar clientes sin estos datos.
- Añadir pruebas que validan que los nuevos clientes heredan "San Salvador" con códigos de ubicación por defecto.

## Pruebas
- `pytest --no-cov tests/test_cliente_default_address.py tests/test_cliente_nit_unique.py tests/test_cliente_dui.py tests/test_estado_cuenta_clientes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70c2743088323a1db208e332d91f5