### PR TITLE
Handle empty string addresses in norm_receptor

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -757,7 +757,7 @@ def norm_receptor(
     mun = d.get("municipio")
 
     is_cf = tipo == "37" and num == "CONSUMIDOR"
-    missing_addr = dep is None or mun is None
+    missing_addr = not dep or not mun
     fallback_addr = es_ticket or is_cf or missing_addr
 
     if missing_addr:


### PR DESCRIPTION
## Summary
- Treat empty department or municipality values as missing in `norm_receptor`

## Testing
- `python -m pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c70fd08ac08323b1c4e2292d6a2c41