### PR TITLE
Persist DTE identifiers

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1938,6 +1938,10 @@ def generar_dte_json(
 
     ``kwargs`` se acepta para compatibilidad con parámetros obsoletos.
     """
+    # Asegurar columnas necesarias para identificar la venta
+    db.ensure_column("ventas", "codigo_generacion", "TEXT")
+    db.ensure_column("ventas", "numero_control", "TEXT")
+    db.ensure_column("ventas", "correlativo", "INTEGER")
     row = db.cursor.execute("SELECT * FROM ventas WHERE id=?", (venta_id,)).fetchone()
     if not row:
         raise ValueError("Venta no encontrada")
@@ -1991,9 +1995,26 @@ def generar_dte_json(
     cod_punto = (cod_punto_raw or punto_pref.rjust(4, "0"))[-4:].zfill(4)
     suc = _norm3(cod_estable)
     pto = _norm3(cod_punto)
-    # Generar identificadores con formatos oficiales
-    codigo_generacion = str(uuid.uuid4()).upper()
-    numero_control, correlativo = generar_numero_control(db, tipo_dte, suc, pto)
+    # Usar identificadores existentes o generar nuevos si faltan
+    codigo_generacion = venta.get("codigo_generacion")
+    numero_control = venta.get("numero_control")
+    correlativo = venta.get("correlativo")
+    generated = False
+    if not codigo_generacion:
+        codigo_generacion = str(uuid.uuid4()).upper()
+        generated = True
+    if not numero_control or not correlativo:
+        numero_control, correlativo = generar_numero_control(db, tipo_dte, suc, pto)
+        generated = True
+    if generated:
+        db.cursor.execute(
+            "UPDATE ventas SET codigo_generacion=?, numero_control=?, correlativo=? WHERE id=?",
+            (codigo_generacion, numero_control, correlativo, venta_id),
+        )
+        db.conn.commit()
+        venta["codigo_generacion"] = codigo_generacion
+        venta["numero_control"] = numero_control
+        venta["correlativo"] = correlativo
 
 
     now = datetime.now(TZ_EL_SALVADOR)

--- a/tests/test_dte_correlativo.py
+++ b/tests/test_dte_correlativo.py
@@ -42,7 +42,7 @@ def _setup_db():
         "",
         "C",
         "06",
-        "01",
+        "20",
     )
     cid = db.cursor.lastrowid
     venta_id = db.add_venta(
@@ -52,18 +52,15 @@ def _setup_db():
     return db, venta_id
 
 
-def test_correlativo_incrementa_secuencialmente(tmp_path):
+def test_identificadores_reutilizados(tmp_path):
     _setup_datos_negocio(tmp_path)
     db, venta_id = _setup_db()
 
     dte1 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
     dte2 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
-    dte3 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
 
-    n1 = dte1["identificacion"]["numeroControl"]
-    n2 = dte2["identificacion"]["numeroControl"]
-    n3 = dte3["identificacion"]["numeroControl"]
+    ident1 = dte1["identificacion"]
+    ident2 = dte2["identificacion"]
 
-    assert n1.endswith("000000000000001")
-    assert n2.endswith("000000000000002")
-    assert n3.endswith("000000000000003")
+    assert ident1["numeroControl"] == ident2["numeroControl"]
+    assert ident1["codigoGeneracion"] == ident2["codigoGeneracion"]


### PR DESCRIPTION
## Summary
- reuse persisted codigo_generacion, numero_control y correlativo al generar DTE JSON
- create identifiers and store them in ventas when missing
- update tests to expect identifier reuse

## Testing
- `pytest tests/test_dte_correlativo.py::test_identificadores_reutilizados -q`
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c71923311c8323977ac2684d4e505b