### PR TITLE
Persist DTE version on creation and reuse for sending

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4166,9 +4166,7 @@ def _save_signed_dte(dte_data: dict, jws_token: str, fallido: bool = False) -> N
 
 
 def _finalize_pendiente(json_path: str, dte_data: dict, jws_token: str, estado: str) -> str:
-    """Move pending DTE directory to final location and attach JWS.
-
-    Returns the new ``documento.json`` path."""
+    """Move pending DTE directory to final location promoting existing JWS."""
     try:
         version_dir = os.path.dirname(json_path)
         pend_root = os.path.join(os.path.dirname(__file__), PENDIENTES_DIR)
@@ -4190,11 +4188,15 @@ def _finalize_pendiente(json_path: str, dte_data: dict, jws_token: str, estado: 
             shutil.rmtree(pend_codigo_dir, ignore_errors=True)
         except Exception:
             pass
-        jws_name = versioned_dte.add_jws(dest_dir, jws_token, origen="auto")
-        sobre = construir_sobre_recepcion(jws_token, dte_data)
-        if sobre.get("estado") != "Error":
-            sobre_path = os.path.join(dest_dir, jws_name.replace(".jws", "_sobre_hacienda.json"))
-            _write_json(sobre_path, sobre)
+        try:
+            meta_path = os.path.join(dest_dir, "metadata.json")
+            with open(meta_path, "r", encoding="utf-8") as fh:
+                meta = json.load(fh)
+            firmas = meta.get("firmas", [])
+            if firmas:
+                versioned_dte.promote(dest_dir, firmas[-1]["archivo"])
+        except Exception:
+            pass
         return os.path.join(dest_dir, "documento.json")
     except Exception:
         return json_path
@@ -4561,6 +4563,7 @@ def transmitir_dte(
         modo = get_default_modo_transmision()
 
     data = None
+    jws_token = None
     extra = {}
     row = db.cursor.execute("SELECT extra FROM ventas WHERE id=?", (venta_id,)).fetchone()
     if row and row[0]:
@@ -4577,26 +4580,17 @@ def transmitir_dte(
             try:
                 with open(path_obj, "r", encoding="utf-8") as fh:
                     data = json.load(fh)
+                meta_path = path_obj.with_name("metadata.json")
+                with open(meta_path, "r", encoding="utf-8") as fh:
+                    meta = json.load(fh)
+                firmas = meta.get("firmas", [])
+                if firmas:
+                    jws_path = path_obj.with_name(firmas[-1]["archivo"])
+                    with open(jws_path, "r", encoding="utf-8") as fh:
+                        jws_token = fh.read()
             except Exception:
                 data = None
-    if data is None:
-        codigo = extra.get("codigoGeneracion") or extra.get("codigo_generacion")
-        if codigo:
-            base_root = Path(__file__).resolve().parent
-            for root_name in ("dtes", "dte_fallidos"):
-                matches = list((base_root / root_name).glob(f"*/{codigo}/*/documento.json"))
-                if matches:
-                    raise ValueError("El DTE ya fue enviado")
-            pend_dir = base_root / PENDIENTES_DIR
-            matches = list(pend_dir.glob(f"*/{codigo}/*/documento.json"))
-            if matches:
-                json_path = str(matches[-1])
-                try:
-                    with open(matches[-1], "r", encoding="utf-8") as fh:
-                        data = json.load(fh)
-                    db.update_venta_extra(venta_id, {"dteJsonPath": json_path})
-                except Exception:
-                    data = None
+                jws_token = None
 
     row = db.cursor.execute(
         "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
@@ -4606,25 +4600,9 @@ def transmitir_dte(
     if row and str(row["estado"]).lower() in success:
         raise ValueError("El DTE ya fue enviado")
 
-    if data is None:
-        if tipo_dte == "03":
-            data = generar_ticket_json(db, venta_id)
-        else:
-            data = generar_dte_json(db, venta_id)
-            if data.get("identificacion", {}).get("tipoDte") == "01":
-                recalcular_totales(data, incluir_iva=True)
-        data = apply_schema_patch(data)
-        json_path = save_dte_json(data)
-        ident = data.get("identificacion", {})
-        updates = {}
-        if ident.get("codigoGeneracion"):
-            updates["codigoGeneracion"] = ident["codigoGeneracion"]
-        if json_path:
-            updates["dteJsonPath"] = json_path
-        if updates:
-            db.update_venta_extra(venta_id, updates)
-    else:
-        data = apply_schema_patch(data)
+    if data is None or jws_token is None:
+        raise ValueError("DTE no preparado para envío")
+    data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema(tipo_dte)
     # La validación de esquema se omite para permitir la transmisión sin
     # interrupciones por inconsistencias.
@@ -4634,7 +4612,7 @@ def transmitir_dte(
     #     json_path = save_dte_json(data)
     #     errors = _format_validation_errors(exc)
     #     raise DTEValidationError(errors, json_path) from exc
-    resp = _enviar_documento(db, venta_id, data, modo)
+    resp = _enviar_documento(db, venta_id, data, modo, jws_token=jws_token)
     if resp.get("sello"):
         db.update_venta_extra(venta_id, {"selloRecibido": resp["sello"]})
     return resp

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -24,14 +24,18 @@ def create_sale(db):
 def test_transmitir_dte_contingencia(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
-    monkeypatch.setattr(dte, "generar_dte_json", lambda *a, **k: {"resumen": {"totalLetras": "X"}})
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
+    data = {"identificacion": {"tipoDte": "01", "codigoGeneracion": "ABC"}, "resumen": {"totalLetras": "X"}}
+    pend_path = dte.save_dte_json(data)
+    version_dir = os.path.dirname(pend_path)
+    token = make_jws(data)
+    versioned_dte.add_jws(version_dir, token)
+    db.update_venta_extra(venta, {"dteJsonPath": pend_path})
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
-    monkeypatch.setattr(dte, "_save_signed_dte", lambda *a, **k: None)
     monkeypatch.setattr(auth, "get_token", lambda: "T")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
-    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
     res = transmitir_dte(db, venta, modo="contingencia")
     assert res["estado"] == "Pendiente"
     row = db.cursor.execute(
@@ -40,24 +44,26 @@ def test_transmitir_dte_contingencia(monkeypatch, tmp_path):
     assert row["estado"] == "Pendiente"
 
 
-def test_transmitir_dte_default_contingencia(monkeypatch):
+def test_transmitir_dte_default_contingencia(monkeypatch, tmp_path):
     db = DB(":memory:")
     venta = create_sale(db)
-
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
+    data = {"identificacion": {"tipoDte": "01", "codigoGeneracion": "DEF"}, "resumen": {"totalLetras": "X"}}
+    pend_path = dte.save_dte_json(data)
+    version_dir = os.path.dirname(pend_path)
+    token = make_jws(data)
+    versioned_dte.add_jws(version_dir, token)
+    db.update_venta_extra(venta, {"dteJsonPath": pend_path})
     monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
-    monkeypatch.setattr(dte, "generar_dte_json", lambda *a, **k: {"resumen": {"totalLetras": "X"}})
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
-    monkeypatch.setattr(dte, "_save_signed_dte", lambda *a, **k: None)
     monkeypatch.setattr(auth, "get_token", lambda: "T")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
     monkeypatch.setattr(
         "dte.requests.post",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not post")),
     )
-    monkeypatch.setattr("utils.jws.sign_json", lambda d: make_jws(d))
-
     res = transmitir_dte(db, venta)
     assert res["estado"] == "Pendiente"
     row = db.cursor.execute(
@@ -67,105 +73,55 @@ def test_transmitir_dte_default_contingencia(monkeypatch):
     assert row["modo"] == "contingencia"
 
 
+
 def test_transmitir_dte_normal(monkeypatch, tmp_path):
     ambiente = "pruebas"
     db = DB(":memory:")
     venta = create_sale(db)
-
-    sign_calls = {"count": 0, "tokens": []}
-
-    def fake_sign(data):
-        sign_calls["count"] += 1
-        token = make_jws(data)
-        sign_calls["tokens"].append(token)
-        return token
-
-    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
-
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
+    data = {
+        "receptor": {"nombre": "Cliente"},
+        "cuerpoDocumento": [{"cantidad": 1, "precioUni": 10}],
+        "resumen": {"totalGravada": 10, "totalPagar": 10, "totalLetras": "DIEZ"},
+        "identificacion": {
+            "tipoDte": "01",
+            "version": 2,
+            "ambiente": "00",
+            "codigoGeneracion": "ABC",
+        },
+    }
+    pend_path = dte.save_dte_json(data)
+    version_dir = os.path.dirname(pend_path)
+    token = make_jws(data)
+    versioned_dte.add_jws(version_dir, token)
+    db.update_venta_extra(venta, {"dteJsonPath": pend_path})
     token_calls = {"count": 0}
-
     def fake_get_token():
         token_calls["count"] += 1
         return "Bearer JWT"
-
     monkeypatch.setattr(auth, "get_token", fake_get_token)
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "apitest.dtes.mh.gob.sv")
     monkeypatch.setattr("dte.validate_dte_json", lambda data, db=None: None)
-    monkeypatch.setattr(
-        "dte.generar_dte_json",
-        lambda db_obj, vid: {
-            "receptor": {
-                "nombre": "Cliente",
-                "tipoDocumento": "36",
-                "numDocumento": "06149876543210",
-                "nrc": None,
-                "codActividad": None,
-                "descActividad": None,
-                "direccion": None,
-                "telefono": None,
-                "correo": None,
-            },
-            "cuerpoDocumento": [{"cantidad": 1, "precioUni": 10}],
-                "resumen": {
-                    "totalNoSuj": 0,
-                    "totalExenta": 0,
-                    "totalGravada": 10,
-                    "subTotalVentas": 10,
-                    "descuNoSuj": 0,
-                    "descuExenta": 0,
-                    "descuGravada": 0,
-                    "porcentajeDescuento": 0,
-                    "totalDescu": 0,
-                    "tributos": [],
-                    "subTotal": 10,
-                    "ivaRete1": 0,
-                    "reteRenta": 0,
-                    "montoTotalOperacion": 10,
-                    "totalNoGravado": 0,
-                    "totalPagar": 10,
-                    "totalLetras": "DIEZ",
-                    "saldoFavor": 0,
-                    "condicionOperacion": 1,
-                    "pagos": None,
-                    "numPagoElectronico": None,
-            },
-            "identificacion": {
-                "tipoDte": "01",
-                "version": 2,
-                "ambiente": "00",
-                "codigoGeneracion": "ABC",
-            },
-        },
-    )
-
+    monkeypatch.setattr("utils.jws.sign_json", lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not sign")))
     calls = []
-
     def fake_post(url, json=None, headers=None, timeout=20):
         calls.append((url, headers, json))
-
         class R:
             status_code = 200
-
             def json(self):
                 return {"estado": "Transmitido", "sello": "ABC123"}
-
             def raise_for_status(self):
                 pass
-
         return R()
-
     monkeypatch.setattr("dte.requests.post", fake_post)
-
     datos = {"dte_api": {"url": dte.DEFAULT_RECEPCION_URL, "ambiente": ambiente}}
     cfg_path = tmp_path / "datos_negocio.json"
     with open(cfg_path, "w", encoding="utf-8") as fh:
         json.dump(datos, fh)
     monkeypatch.setattr("dte.DATOS_NEGOCIO_PATH", str(cfg_path))
-
     res = transmitir_dte(db, venta)
     assert res["estado"] == "Transmitido"
     assert token_calls["count"] == 1
-    assert sign_calls["count"] == 1
     assert len(calls) == 1
     url, headers, body = calls[0]
     assert url == dte.DEFAULT_RECEPCION_URL
@@ -173,13 +129,12 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
     assert headers["Content-Type"] == "application/json"
     assert headers["Accept"] == "application/json"
     assert headers["User-Agent"] == "Vertex-DTE/1.0"
-    assert body["documento"] in sign_calls["tokens"]
+    assert body["documento"] == token
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta,)
     ).fetchone()
     assert row["estado"] == "Transmitido"
     assert row["sello"] == "ABC123"
-
 
 def test_post_dte_normalizes_bearer(monkeypatch):
     captured = {}

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -149,36 +149,16 @@ def test_generate_invoice_pdf_saves_sobre(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
     monkeypatch.setattr("utils.jws.sign_json", lambda *a, **k: "TOKEN")
     monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda *a, **k: {"estado": "OK"})
-
-    created = {}
-
-    def fake_save(dte_data, jws_token):
-        fecha = dte_data.get("identificacion", {}).get("fecEmi") or dte.fecha_emision_hoy_str()
-        year = str(fecha)[:4]
-        base_dir = tmp_path / "dtes" / year
-        os.makedirs(base_dir, exist_ok=True)
-        nombre = dte_data.get("identificacion", {}).get("numeroControl") or uuid.uuid4().hex
-        json_dest = base_dir / f"{nombre}.json"
-        dte._write_json(str(json_dest), dte_data)
-        jws_dest = base_dir / f"{nombre}.jws"
-        dte._write_json(str(jws_dest), jws_token)
-        sobre = dte.construir_sobre_recepcion(jws_token, dte_data)
-        if sobre.get("estado") != "Error":
-            sobre_dest = base_dir / f"{nombre}_sobre_hacienda.json"
-            dte._write_json(str(sobre_dest), sobre)
-        created["dir"] = base_dir
-
-    monkeypatch.setattr(dte, "_save_signed_dte", fake_save)
+    monkeypatch.setattr(dte, "__file__", str(tmp_path / "dte.py"))
 
     generate_invoice_pdf(man, 1)
 
-    base_dir = created["dir"]
-    files = list(base_dir.iterdir())
-    sobre = [f for f in files if f.name.endswith("_sobre_hacienda.json")]
-    assert sobre, "sobre no creado"
-    base = sobre[0].name.replace("_sobre_hacienda.json", "")
-    assert (base_dir / f"{base}.json").exists()
-    assert (base_dir / f"{base}.jws").exists()
+    pend_root = tmp_path / dte.PENDIENTES_DIR
+    documento = next(pend_root.rglob("documento.json"))
+    version_dir = documento.parent
+    assert (version_dir / "documento.pdf").exists()
+    assert any(f.name.endswith(".jws") for f in version_dir.iterdir())
+    assert any(f.name.endswith("_sobre_hacienda.json") for f in version_dir.iterdir())
 
 
 def test_generate_invoice_pdf_propagates_error(monkeypatch):

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 import logging
+import shutil
 
 import dte
 from factura_sv import generar_factura_electronica_pdf
@@ -10,6 +11,7 @@ from dte import generar_ticket_json, generar_dte_json, d4
 from utils.monto import D, d2, monto_a_texto_sv, iva_item, to_base_iva
 from utils.docs import get_document_paths, build_invoice_json
 from utils.jws import sign_and_save
+from utils import versioned_dte
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 from utils.sanitize import limpiar_documentos
 
@@ -358,12 +360,31 @@ def generate_invoice_pdf(manager, venta_id):
     except ValueError as exc:
         logger.error("ERROR: DTE inválido: %s", exc)
         raise ValueError(f"DTE inválido: {exc}") from exc
+    jws_token = None
     try:
-        jws_path = sign_and_save(json_data, json_path)
+        _, jws_token = sign_and_save(json_data, json_path, return_token=True)
+    except Exception:
+        pass
+    try:
+        pend_json_path = dte.save_dte_json(json_data)
+        version_dir = os.path.dirname(pend_json_path)
         try:
-            with open(jws_path, "r", encoding="utf-8") as fh:
-                jws_token = fh.read()
-            dte._save_signed_dte(json_data, jws_token)
+            shutil.copy(file_path, os.path.join(version_dir, "documento.pdf"))
+        except Exception:
+            pass
+        if jws_token:
+            try:
+                jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
+                sobre = dte.construir_sobre_recepcion(jws_token, json_data)
+                if sobre.get("estado") != "Error":
+                    sobre_path = os.path.join(
+                        version_dir, jws_name.replace(".jws", "_sobre_hacienda.json")
+                    )
+                    dte._write_json(sobre_path, sobre)
+            except Exception:
+                pass
+        try:
+            manager.db.update_venta_extra(venta_id, {"dteJsonPath": pend_json_path})
         except Exception:
             pass
     except Exception:
@@ -444,8 +465,33 @@ def generate_ticket_pdf(manager, venta_id):
     except ValueError as exc:
         logger.error("ERROR: DTE inválido: %s", exc)
         raise ValueError(f"DTE inválido: {exc}") from exc
+    jws_token = None
     try:
-        sign_and_save(ticket_json, json_path)
+        _, jws_token = sign_and_save(ticket_json, json_path, return_token=True)
+    except Exception:
+        pass
+    try:
+        pend_json_path = dte.save_dte_json(ticket_json)
+        version_dir = os.path.dirname(pend_json_path)
+        try:
+            shutil.copy(filename, os.path.join(version_dir, "documento.pdf"))
+        except Exception:
+            pass
+        if jws_token:
+            try:
+                jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
+                sobre = dte.construir_sobre_recepcion(jws_token, ticket_json)
+                if sobre.get("estado") != "Error":
+                    sobre_path = os.path.join(
+                        version_dir, jws_name.replace(".jws", "_sobre_hacienda.json")
+                    )
+                    dte._write_json(sobre_path, sobre)
+            except Exception:
+                pass
+        try:
+            manager.db.update_venta_extra(venta_id, {"dteJsonPath": pend_json_path})
+        except Exception:
+            pass
     except Exception:
         pass
     dte_data = dict(extra)


### PR DESCRIPTION
## Summary
- persist initial DTE JSON, JWS, PDF and envelope under versioned directory when generating documents
- reuse saved DTE version and signature when transmitting instead of rebuilding
- streamline tests for new DTE persistence workflow

## Testing
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c71b6279448323be55928a99ae201e