### PR TITLE
Require explicit DTE identifiers for PDF and JSON generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1932,6 +1932,9 @@ def generar_dte_json(
     motivo_contin: str | None = None,
     tipo_modelo: int | None = None,
     tipo_moneda: str = "USD",
+    codigo_generacion: str | None = None,
+    numero_control: str | None = None,
+    correlativo: int | None = None,
     **kwargs,
 ) -> dict:
     """Genera un diccionario DTE básico para una venta.
@@ -1996,17 +1999,22 @@ def generar_dte_json(
     suc = _norm3(cod_estable)
     pto = _norm3(cod_punto)
     # Usar identificadores existentes o generar nuevos si faltan
-    codigo_generacion = venta.get("codigo_generacion")
-    numero_control = venta.get("numero_control")
-    correlativo = venta.get("correlativo")
+    codigo_generacion = codigo_generacion or venta.get("codigo_generacion")
+    numero_control = numero_control or venta.get("numero_control")
+    correlativo = correlativo if correlativo is not None else venta.get("correlativo")
     generated = False
     if not codigo_generacion:
         codigo_generacion = str(uuid.uuid4()).upper()
         generated = True
-    if not numero_control or not correlativo:
+    if not numero_control or correlativo is None:
         numero_control, correlativo = generar_numero_control(db, tipo_dte, suc, pto)
         generated = True
-    if generated:
+    if (
+        generated
+        or venta.get("codigo_generacion") != codigo_generacion
+        or venta.get("numero_control") != numero_control
+        or venta.get("correlativo") != correlativo
+    ):
         db.cursor.execute(
             "UPDATE ventas SET codigo_generacion=?, numero_control=?, correlativo=? WHERE id=?",
             (codigo_generacion, numero_control, correlativo, venta_id),

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -9,8 +9,6 @@ from reportlab.lib.units import mm
 
 from utils.pdf_utils import draw_wrapped_text
 import utils.catalogos as catalogos
-from dte import generar_cabecera_dte_data
-from db import DB
 from urllib.parse import urlencode
 import json
 import os
@@ -96,20 +94,8 @@ def generar_factura_electronica_pdf(
     if not tipo_dte:
         tipo_dte = "01" if tipo_documento.upper() == "CONSUMIDOR FINAL" else "03"
 
-    if not codigo_generacion or not numero_control or not fecha_generacion:
-        cab = generar_cabecera_dte_data(
-            tipo_modelo,
-            tipo_operacion,
-            tipo_dte,
-            DB(),
-            tipo_contingencia=tipo_contingencia,
-            motivo_contin=motivo_contin,
-            ambiente=ambiente,
-        )
-        codigo_generacion = codigo_generacion or cab["codigo_generacion"]
-        numero_control = numero_control or cab["numero_control"]
-        fecha_generacion = fecha_generacion or cab["fecha_generacion"]
-        sello_recepcion = sello_recepcion or cab["sello_recepcion"]
+    if not codigo_generacion or not numero_control:
+        raise ValueError("codigo_generacion and numero_control are required")
 
     try:
         fecha_emision = datetime.strptime(

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -1,3 +1,4 @@
+import uuid
 import pytest
 import fitz
 from urllib.parse import urlparse, parse_qs
@@ -41,6 +42,10 @@ def _generate(tmp_path, tipo):
         tipo,
         archivo=str(out),
         datos_negocio={},
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion="SELLO",
     )
     return out
 
@@ -110,6 +115,10 @@ def test_total_letras_is_wrapped(tmp_path):
         'Crédito Fiscal',
         archivo=str(out),
         datos_negocio={},
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion="SELLO",
     )
     with fitz.open(out) as doc:
         text = ''.join(p.get_text() for p in doc)
@@ -162,6 +171,10 @@ def test_qr_url_matches_environment(tmp_path, monkeypatch):
             archivo=str(out),
             datos_negocio={},
             ambiente=env,
+            codigo_generacion=str(uuid.uuid4()),
+            numero_control=uuid.uuid4().hex[:8].upper(),
+            fecha_generacion="01/01/2024",
+            sello_recepcion="SELLO",
         )
         assert captured, 'QR value not generated'
         url = captured[0]
@@ -182,6 +195,10 @@ def test_contingencia_draws_message(tmp_path):
         archivo=str(out),
         datos_negocio={},
         tipo_operacion=2,
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion="SELLO",
     )
     with fitz.open(out) as doc:
         text = ''.join(p.get_text() for p in doc)
@@ -221,6 +238,10 @@ def test_direccion_includes_municipio(tmp_path, monkeypatch):
         'Crédito Fiscal',
         archivo=str(out),
         datos_negocio=datos_negocio,
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion="SELLO",
     )
     with fitz.open(out) as doc:
         lines = ''.join(p.get_text() for p in doc).splitlines()
@@ -241,6 +262,10 @@ def test_direccion_as_text(tmp_path):
         'Crédito Fiscal',
         archivo=str(out),
         datos_negocio={},
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion="SELLO",
     )
     assert out.exists()
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -6,7 +6,7 @@ import logging
 import dte
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado
-from dte import generar_ticket_json, generar_dte_json, d4
+from dte import generar_ticket_json, generar_dte_json, d4, generar_cabecera_dte_data
 from utils.monto import D, d2, monto_a_texto_sv, iva_item, to_base_iva
 from utils.docs import get_document_paths, build_invoice_json
 from utils.jws import sign_and_save
@@ -262,7 +262,6 @@ def generate_invoice_pdf(manager, venta_id):
     if ambiente not in ("00", "01"):
         amb_cfg = str(ambiente).lower()
         ambiente = "01" if amb_cfg.startswith("produc") else "00"
-    fecha_generacion = venta_data.get("fecha_generacion") or extra.get("fechaGeneracion", "")
 
     if tipo_operacion == 1 and not sello_recepcion:
         sello_recepcion = f"SELLO-{uuid.uuid4().hex[:8]}"
@@ -273,6 +272,26 @@ def generate_invoice_pdf(manager, venta_id):
     tipo_doc = "Crédito Fiscal" if credito_info else "Consumidor Final"
     doc_key = "CreditoFiscal" if credito_info else "ConsumidorFinal"
     cliente_nombre = cliente.get("nombre") if cliente else ""
+
+    cabecera = generar_cabecera_dte_data(
+        tipo_modelo,
+        tipo_operacion,
+        "03" if credito_info else "01",
+        manager.db,
+        tipo_contingencia=tipo_contingencia,
+        motivo_contin=motivo_contin,
+        ambiente=ambiente,
+    )
+    codigo_generacion = cabecera["codigo_generacion"]
+    numero_control = cabecera["numero_control"]
+    fecha_generacion = cabecera["fecha_generacion"]
+    sello_recepcion = sello_recepcion or cabecera["sello_recepcion"]
+    venta_data["sello_recepcion"] = sello_recepcion
+    tipo_modelo = cabecera["tipo_modelo"]
+    tipo_operacion = cabecera["tipo_operacion"]
+    tipo_contingencia = cabecera["tipo_contingencia"]
+    motivo_contin = cabecera["motivo_contin"]
+
     try:
         json_data = generar_dte_json(
             manager.db,
@@ -282,6 +301,10 @@ def generate_invoice_pdf(manager, venta_id):
             tipo_operacion=tipo_operacion,
             tipo_contingencia=tipo_contingencia,
             motivo_contin=motivo_contin,
+            codigo_generacion=codigo_generacion,
+            numero_control=numero_control,
+            correlativo=cabecera.get("correlativo"),
+            tipo_modelo=tipo_modelo,
         )
     except AttributeError as exc:
         logger.warning(
@@ -318,9 +341,6 @@ def generate_invoice_pdf(manager, venta_id):
         except Exception:
             venta_data["total_letras"] = ""
 
-    ident = json_data.get("identificacion", {})
-    codigo_generacion = ident.get("codigoGeneracion")
-    numero_control = ident.get("numeroControl")
     venta_data["codigo_generacion"] = codigo_generacion
     venta_data["numero_control"] = numero_control
 


### PR DESCRIPTION
## Summary
- require callers to provide `codigo_generacion` and `numero_control` to `generar_factura_electronica_pdf`
- generate DTE header once and reuse identifiers for JSON creation and PDF generation
- allow `generar_dte_json` to accept precomputed identifiers and update tests accordingly

## Testing
- `pytest tests/test_factura_pdf.py tests/test_factura_pdf_includes_iva_column.py`
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c71d77305c83238f043174126efa54