### PR TITLE
Show Hacienda error message

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -28,6 +28,7 @@ from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent, QSize
 from PyQt5.QtGui import QPixmap, QDesktopServices
 import os
 import re
+import logging
 
 from ticket_pdf import generar_ticket_personalizado
 from factura_sv import (
@@ -60,6 +61,8 @@ from dialogs.invoice_detail_dialog import InvoiceDetailDialog
 from decimal import Decimal
 from utils.monto import iva_item
 from utils.catalogos import TRIBUTO_IVA
+
+logger = logging.getLogger(__name__)
 
 # Directory where debit notes will be stored
 NOTAS_DEBITO_DIR = os.path.join(os.path.dirname(__file__), "notas_debito")
@@ -1055,12 +1058,16 @@ class FacturacionTab(QWidget):
                             "Documento enviado y recibido correctamente",
                         )
                     else:
+                        detalle = resp.get("detalle")
+                        if detalle:
+                            logger.debug("Detalle de respuesta de Hacienda: %s", detalle)
+                        mensaje = resp.get("errores") or (
+                            detalle.get("descripcionMsg") if isinstance(detalle, dict) else None
+                        )
                         QMessageBox.critical(
                             self,
                             "Enviar a Hacienda",
-                            resp.get("errores")
-                            or resp.get("detalle")
-                            or "Fallo al enviar",
+                            mensaje or "Fallo al enviar",
                         )
                 except dte.DTEValidationError as exc:
                     QMessageBox.critical(
@@ -1095,12 +1102,16 @@ class FacturacionTab(QWidget):
                             "Documento enviado y recibido correctamente",
                         )
                     else:
+                        detalle = resp.get("detalle")
+                        if detalle:
+                            logger.debug("Detalle de respuesta de Hacienda: %s", detalle)
+                        mensaje = resp.get("errores") or (
+                            detalle.get("descripcionMsg") if isinstance(detalle, dict) else None
+                        )
                         QMessageBox.critical(
                             self,
                             "Enviar a Hacienda",
-                            resp.get("errores")
-                            or resp.get("detalle")
-                            or "Fallo al enviar",
+                            mensaje or "Fallo al enviar",
                         )
                 except dte.DTEValidationError as exc:
                     QMessageBox.critical(

--- a/tests/test_connection_error_message.py
+++ b/tests/test_connection_error_message.py
@@ -107,3 +107,67 @@ def test_send_selected_invoice_no_connection(monkeypatch, qt_app):
         captured["msg"]
         == "No hay conexión a Internet. Active la conexión antes de reenviar."
     )
+
+
+def test_send_selected_invoice_shows_detalle(monkeypatch, qt_app):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    tab = _make_tab(db, cid)
+
+    monkeypatch.setattr(
+        tab, "_selected_entry", lambda: {"row_type": "venta", "id": venta_id}
+    )
+    monkeypatch.setattr(
+        tab,
+        "_selected_factura",
+        lambda: {"venta_id": venta_id, "json": "", "control": "X"},
+    )
+
+    class DummyCheck:
+        def __init__(self):
+            self._checked = False
+
+        def setChecked(self, v):
+            self._checked = v
+
+        def isChecked(self):
+            return self._checked
+
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+            self.hacienda_cb.setChecked(True)
+
+        def exec_(self):
+            self.email_cb.setChecked(False)
+            return QDialog.Accepted
+
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    def fake_transmitir(db_, vid, tipo_dte="01", modo="normal"):
+        return {
+            "estado": "Rechazado",
+            "detalle": {
+                "descripcionMsg": "[identificacion.codigoGeneracion] YA EXISTE UN REGISTRO CON ESE VALOR"
+            },
+        }
+
+    monkeypatch.setattr(facturacion_tab, "transmitir_dte", fake_transmitir)
+
+    captured = {}
+
+    def fake_critical(parent, title, msg):
+        captured["title"] = title
+        captured["msg"] = msg
+
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", fake_critical)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", lambda *a, **k: None)
+
+    tab.send_selected_invoice()
+
+    assert (
+        captured["msg"]
+        == "[identificacion.codigoGeneracion] YA EXISTE UN REGISTRO CON ESE VALOR"
+    )


### PR DESCRIPTION
## Summary
- Improve send_selected_invoice to surface Hacienda error descriptions and log response details
- Cover Hacienda error handling with tests

## Testing
- `pytest tests/test_connection_error_message.py::test_send_selected_invoice_no_connection -q`
- `pytest tests/test_connection_error_message.py::test_send_selected_invoice_shows_detalle -q`


------
https://chatgpt.com/codex/tasks/task_e_68c728daa6048323a94a5bd6af20fc85