### PR TITLE
refactor: streamline DTE artifacts

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4207,23 +4207,19 @@ def _dte_base_dir(dte_data: dict, fallido: bool = False, root: str | None = None
 
 
 def _save_signed_dte(dte_data: dict, jws_token: str, fallido: bool = False) -> None:
-    """Guarda el JSON y JWS usando estructura versionada por hash."""
+    """Guarda únicamente el JSON original y el estado final del DTE."""
     try:
         base_dir = _dte_base_dir(dte_data, fallido=fallido)
         version_dir, _ = versioned_dte.ensure_version(dte_data, base_dir)
-        jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
         sobre = construir_sobre_recepcion(jws_token, dte_data)
         if sobre.get("estado") != "Error":
-            sobre_path = os.path.join(
-                version_dir, jws_name.replace(".jws", "_sobre_hacienda.json")
-            )
-            _write_json(sobre_path, sobre)
+            versioned_dte.save_estado(version_dir, sobre)
     except Exception:
         pass
 
 
 def _finalize_pendiente(json_path: str, dte_data: dict, jws_token: str, estado: str) -> str:
-    """Move pending DTE directory to final location promoting existing JWS."""
+    """Move pending DTE directory to final location keeping only JSON files."""
     try:
         version_dir = os.path.dirname(json_path)
         pend_root = os.path.join(os.path.dirname(__file__), PENDIENTES_DIR)
@@ -4245,15 +4241,13 @@ def _finalize_pendiente(json_path: str, dte_data: dict, jws_token: str, estado: 
             shutil.rmtree(pend_codigo_dir, ignore_errors=True)
         except Exception:
             pass
-        try:
-            meta_path = os.path.join(dest_dir, "metadata.json")
-            with open(meta_path, "r", encoding="utf-8") as fh:
-                meta = json.load(fh)
-            firmas = meta.get("firmas", [])
-            if firmas:
-                versioned_dte.promote(dest_dir, firmas[-1]["archivo"])
-        except Exception:
-            pass
+        # Remove any leftover files besides JSON
+        for name in os.listdir(dest_dir):
+            if not name.endswith('.json'):
+                try:
+                    os.remove(os.path.join(dest_dir, name))
+                except Exception:
+                    pass
         return os.path.join(dest_dir, "documento.json")
     except Exception:
         return json_path
@@ -4621,7 +4615,6 @@ def transmitir_dte(
         modo = get_default_modo_transmision()
 
     data = None
-    jws_token = None
     extra = {}
     row = db.cursor.execute("SELECT extra FROM ventas WHERE id=?", (venta_id,)).fetchone()
     if row and row[0]:
@@ -4638,17 +4631,8 @@ def transmitir_dte(
             try:
                 with open(path_obj, "r", encoding="utf-8") as fh:
                     data = json.load(fh)
-                meta_path = path_obj.with_name("metadata.json")
-                with open(meta_path, "r", encoding="utf-8") as fh:
-                    meta = json.load(fh)
-                firmas = meta.get("firmas", [])
-                if firmas:
-                    jws_path = path_obj.with_name(firmas[-1]["archivo"])
-                    with open(jws_path, "r", encoding="utf-8") as fh:
-                        jws_token = fh.read()
             except Exception:
                 data = None
-                jws_token = None
 
     row = db.cursor.execute(
         "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
@@ -4658,7 +4642,7 @@ def transmitir_dte(
     if row and str(row["estado"]).lower() in success:
         raise ValueError("El DTE ya fue enviado")
 
-    if data is None or jws_token is None:
+    if data is None:
         raise ValueError("DTE no preparado para envío")
     data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema(tipo_dte)
@@ -4670,6 +4654,7 @@ def transmitir_dte(
     #     json_path = save_dte_json(data)
     #     errors = _format_validation_errors(exc)
     #     raise DTEValidationError(errors, json_path) from exc
+    jws_token = jws.sign_json(data)
     resp = _enviar_documento(db, venta_id, data, modo, jws_token=jws_token)
     if resp.get("sello"):
         db.update_venta_extra(venta_id, {"selloRecibido": resp["sello"]})
@@ -4969,7 +4954,7 @@ def _enviar_documento(
         logger.error("ERROR: DTE inválido: %s", exc)
         raise ValueError(f"DTE inválido: {exc}") from exc
 
-    signed = jws_token or jws.sign_json(data)
+    signed = jws.sign_json(data)
 
     if modo == "contingencia":
         if pend_json_path:
@@ -5099,19 +5084,8 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str | None = None) -> dict:
         ident.get("numeroControl"),
         "NotaCredito",
     )
-    jws_path = os.path.splitext(json_path)[0] + ".jws"
-    jws_token = None
-    if os.path.exists(jws_path):
-        try:
-            with open(jws_path, "r", encoding="utf-8") as fh:
-                jws_token = fh.read()
-        except Exception:
-            jws_token = None
-    if jws_token is None:
-        save_file(json_path, stable_stringify(data, indent=2))
-        token = sign_json(data)
-        jws_token = token.rstrip("\n")
-        save_file(jws_path, jws_token, add_final_newline=False)
+    save_file(json_path, stable_stringify(data, indent=2))
+    jws_token = sign_json(data).rstrip("\n")
     return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
 
 
@@ -5142,19 +5116,8 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str | None = None) -> dict:
         ident.get("numeroControl"),
         "NotaDebito",
     )
-    jws_path = os.path.splitext(json_path)[0] + ".jws"
-    jws_token = None
-    if os.path.exists(jws_path):
-        try:
-            with open(jws_path, "r", encoding="utf-8") as fh:
-                jws_token = fh.read()
-        except Exception:
-            jws_token = None
-    if jws_token is None:
-        save_file(json_path, stable_stringify(data, indent=2))
-        token = sign_json(data)
-        jws_token = token.rstrip("\n")
-        save_file(jws_path, jws_token, add_final_newline=False)
+    save_file(json_path, stable_stringify(data, indent=2))
+    jws_token = sign_json(data).rstrip("\n")
     return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
 
 

--- a/tests/test_dte_transmision.py
+++ b/tests/test_dte_transmision.py
@@ -8,7 +8,6 @@ import os
 import pytest
 import auth
 from tests.conftest import make_jws
-from utils import versioned_dte
 
 
 def create_sale(db):
@@ -28,8 +27,6 @@ def test_transmitir_dte_contingencia(monkeypatch, tmp_path):
     data = {"identificacion": {"tipoDte": "01", "codigoGeneracion": "ABC"}, "resumen": {"totalLetras": "X"}}
     pend_path = dte.save_dte_json(data)
     version_dir = os.path.dirname(pend_path)
-    token = make_jws(data)
-    versioned_dte.add_jws(version_dir, token)
     db.update_venta_extra(venta, {"dteJsonPath": pend_path})
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
@@ -51,8 +48,6 @@ def test_transmitir_dte_default_contingencia(monkeypatch, tmp_path):
     data = {"identificacion": {"tipoDte": "01", "codigoGeneracion": "DEF"}, "resumen": {"totalLetras": "X"}}
     pend_path = dte.save_dte_json(data)
     version_dir = os.path.dirname(pend_path)
-    token = make_jws(data)
-    versioned_dte.add_jws(version_dir, token)
     db.update_venta_extra(venta, {"dteJsonPath": pend_path})
     monkeypatch.setattr(dte, "get_default_modo_transmision", lambda: "contingencia")
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
@@ -92,17 +87,16 @@ def test_transmitir_dte_normal(monkeypatch, tmp_path):
     }
     pend_path = dte.save_dte_json(data)
     version_dir = os.path.dirname(pend_path)
-    token = make_jws(data)
-    versioned_dte.add_jws(version_dir, token)
     db.update_venta_extra(venta, {"dteJsonPath": pend_path})
+    token = make_jws(data)
     token_calls = {"count": 0}
-    def fake_get_token():
+    def fake_sign_json(payload):
         token_calls["count"] += 1
-        return "Bearer JWT"
-    monkeypatch.setattr(auth, "get_token", fake_get_token)
+        return token
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign_json)
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer JWT")
     monkeypatch.setattr(auth, "get_last_auth_host", lambda: "apitest.dtes.mh.gob.sv")
     monkeypatch.setattr("dte.validate_dte_json", lambda data, db=None: None)
-    monkeypatch.setattr("utils.jws.sign_json", lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not sign")))
     calls = []
     def fake_post(url, json=None, headers=None, timeout=20):
         calls.append((url, headers, json))

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -338,10 +338,6 @@ def test_enviar_nota_credito_reuses_jws(monkeypatch, tmp_path):
         data["identificacion"]["numeroControl"],
         "NotaCredito",
     )
-    jws_path = os.path.splitext(json_path)[0] + ".jws"
-    token = make_jws(data)
-    with open(jws_path, "w", encoding="utf-8") as fh:
-        fh.write(token)
 
     captured = {}
 
@@ -376,8 +372,8 @@ def test_enviar_nota_credito_reuses_jws(monkeypatch, tmp_path):
 
     res = enviar_nota_credito(db, nota_id)
     assert res["estado"] == "Transmitido"
-    assert captured["token"] == token
-    assert sign_calls["count"] == 0
+    assert captured["token"] == "SIGNED"
+    assert sign_calls["count"] == 1
 
 
 def test_post_dte_packs_jws_in_json_body(monkeypatch):

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -156,9 +156,9 @@ def test_generate_invoice_pdf_saves_sobre(tmp_path, monkeypatch):
     pend_root = tmp_path / dte.PENDIENTES_DIR
     documento = next(pend_root.rglob("documento.json"))
     version_dir = documento.parent
-    assert (version_dir / "documento.pdf").exists()
-    assert any(f.name.endswith(".jws") for f in version_dir.iterdir())
-    assert any(f.name.endswith("_sobre_hacienda.json") for f in version_dir.iterdir())
+    assert not (version_dir / "documento.pdf").exists()
+    assert not any(f.name.endswith(".jws") for f in version_dir.iterdir())
+    assert (version_dir / "estado.json").exists()
 
 
 def test_generate_invoice_pdf_propagates_error(monkeypatch):

--- a/tests/test_jws_no_newline.py
+++ b/tests/test_jws_no_newline.py
@@ -1,9 +1,8 @@
-from pathlib import Path
 from utils.jws import sign_and_save
 
 
-def test_sign_and_save_writes_jws_without_newline(monkeypatch, tmp_path):
-    """Ensure sign_and_save writes JWS files without a trailing newline."""
+def test_sign_and_save_returns_token_without_creating_jws(monkeypatch, tmp_path):
+    """`sign_and_save` should not create a `.jws` file on disk."""
     payload = {"identificacion": {"version": 1, "tipoDte": "01"}}
 
     def fake_sign_json(*args, **kwargs):
@@ -12,8 +11,8 @@ def test_sign_and_save_writes_jws_without_newline(monkeypatch, tmp_path):
     monkeypatch.setattr("utils.jws.sign_json", fake_sign_json)
 
     json_path = tmp_path / "payload.json"
-    jws_path = Path(sign_and_save(payload, str(json_path)))
+    path, token = sign_and_save(payload, str(json_path), return_token=True)
 
-    content = jws_path.read_bytes()
-    assert content == b"TOKEN"
-    assert not content.endswith(b"\n"), "JWS file should not end with a newline"
+    assert token == "TOKEN"
+    assert path == str(json_path)
+    assert not (tmp_path / "payload.jws").exists()

--- a/tests/test_versioned_dte.py
+++ b/tests/test_versioned_dte.py
@@ -1,10 +1,6 @@
-import json
 import os
-import jwt
-import pytest
 
 from utils import versioned_dte
-from utils.stable_json import stable_stringify
 
 
 def _sample_dte():
@@ -17,47 +13,12 @@ def _sample_dte():
     }
 
 
-def test_store_and_promote(tmp_path):
+def test_store_and_save_estado(tmp_path):
     data = _sample_dte()
     version_dir, json_hash = versioned_dte.ensure_version(data, base_dir=tmp_path)
-    token = jwt.encode(data, "secret", algorithm="HS256")
-    jws_name = versioned_dte.add_jws(version_dir, token, origen="manual")
-
-    meta_path = os.path.join(version_dir, "metadata.json")
-    meta = json.load(open(meta_path))
-    assert meta["hashJson"] == json_hash
-    assert meta["firmas"][0]["archivo"] == jws_name
-    assert meta["firmas"][0]["estado"] == "borrador"
-
-    versioned_dte.promote(version_dir, jws_name)
-    meta = json.load(open(meta_path))
-    assert meta["estado"] == "lista"
-    assert meta["firmas"][0]["estado"] == "lista"
-
-
-def test_verify_detects_mismatch(tmp_path):
-    data = _sample_dte()
-    version_dir, _ = versioned_dte.ensure_version(data, base_dir=tmp_path)
-    good_token = jwt.encode(data, "secret", algorithm="HS256")
-    good_name = versioned_dte.add_jws(version_dir, good_token)
-
-    # Verification passes for matching token
-    versioned_dte.verify(version_dir, good_name)
-
-    bad_payload = _sample_dte()
-    bad_payload["identificacion"]["codigoGeneracion"] = "11111111-1111-4111-8111-111111111111"
-    bad_token = jwt.encode(bad_payload, "secret", algorithm="HS256")
-    bad_name = versioned_dte.add_jws(version_dir, bad_token)
-
-    with pytest.raises(ValueError):
-        versioned_dte.verify(version_dir, bad_name)
-
-    # Tamper with JSON after signing
-    json_path = os.path.join(version_dir, "documento.json")
-    obj = json.load(open(json_path))
-    obj["nuevo"] = "cambio"
-    from utils.stable_json import save_file
-
-    save_file(json_path, stable_stringify(obj, indent=2))
-    with pytest.raises(ValueError):
-        versioned_dte.verify(version_dir, good_name)
+    assert os.path.exists(os.path.join(version_dir, "documento.json"))
+    assert json_hash
+    state = {"estado": "Aceptado"}
+    name = versioned_dte.save_estado(version_dir, state)
+    assert name == "aceptado.json"
+    assert os.path.exists(os.path.join(version_dir, name))

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -2,7 +2,6 @@ import json
 import os
 import uuid
 import logging
-import shutil
 
 import dte
 from factura_sv import generar_factura_electronica_pdf
@@ -388,19 +387,11 @@ def generate_invoice_pdf(manager, venta_id):
     try:
         pend_json_path = dte.save_dte_json(json_data)
         version_dir = os.path.dirname(pend_json_path)
-        try:
-            shutil.copy(file_path, os.path.join(version_dir, "documento.pdf"))
-        except Exception:
-            pass
         if jws_token:
             try:
-                jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
                 sobre = dte.construir_sobre_recepcion(jws_token, json_data)
                 if sobre.get("estado") != "Error":
-                    sobre_path = os.path.join(
-                        version_dir, jws_name.replace(".jws", "_sobre_hacienda.json")
-                    )
-                    dte._write_json(sobre_path, sobre)
+                    versioned_dte.save_estado(version_dir, sobre)
             except Exception:
                 pass
         try:
@@ -493,19 +484,11 @@ def generate_ticket_pdf(manager, venta_id):
     try:
         pend_json_path = dte.save_dte_json(ticket_json)
         version_dir = os.path.dirname(pend_json_path)
-        try:
-            shutil.copy(filename, os.path.join(version_dir, "documento.pdf"))
-        except Exception:
-            pass
         if jws_token:
             try:
-                jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
                 sobre = dte.construir_sobre_recepcion(jws_token, ticket_json)
                 if sobre.get("estado") != "Error":
-                    sobre_path = os.path.join(
-                        version_dir, jws_name.replace(".jws", "_sobre_hacienda.json")
-                    )
-                    dte._write_json(sobre_path, sobre)
+                    versioned_dte.save_estado(version_dir, sobre)
             except Exception:
                 pass
         try:

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -164,17 +164,15 @@ def sign_and_save(
     url: str | None = None,
     return_token: bool = False,
 ):
-    """Sign ``payload`` and store both JSON and JWS files.
+    """Sign ``payload`` and store only the JSON representation.
 
-    The JSON written to ``json_path`` uses a stable alphabetical key order
-    and indentation for readability.  The external signer receives the
-    compact representation without indentation ensuring both outputs are
-    derived from the same serialized string.
+    The previous implementation also persisted the JWS token to disk.  To
+    comply with the new requirement of keeping only the original JSON and
+    the final state, the JWS token is now generated in memory and returned
+    to the caller when needed but **no** ``.jws`` file is written.
 
     When ``return_token`` is ``True`` the function returns a tuple
-    ``(jws_path, token)``; otherwise only the path to the created JWS file
-    is returned.  Existing callers maintain their behaviour without
-    modification.
+    ``(json_path, token)``; otherwise only ``json_path`` is returned.
     """
     json_pretty = stable_stringify(payload, indent=2)
     payload_compact = stable_stringify(payload)
@@ -199,8 +197,6 @@ def sign_and_save(
         # Allows tests to patch ``sign_json`` with a simplified signature
         token = sign_json(payload)
     token = token.rstrip("\n")
-    jws_path = os.path.splitext(json_path)[0] + ".jws"
-    save_file(jws_path, token, add_final_newline=False)
     if return_token:
-        return jws_path, token
-    return jws_path
+        return json_path, token
+    return json_path

--- a/utils/versioned_dte.py
+++ b/utils/versioned_dte.py
@@ -19,107 +19,50 @@ def decode_jws_payload(token: str) -> dict:
     return json.loads(data.decode("utf-8"))
 
 
-def _version_dir(base: str, codigo: str, json_hash: str, timestamp: str) -> str:
-    return os.path.join(base, codigo, f"{timestamp}-{json_hash}")
-
-
 def ensure_version(dte_json: dict, base_dir: str | None = None) -> tuple[str, str]:
-    """Ensure a directory for the given ``dte_json`` version exists.
+    """Ensure a directory for the given ``dte_json`` exists.
 
-    Returns a tuple ``(version_dir, hashJson)``.
+    Previously this module created versioned subdirectories with metadata and
+    stored JWS signatures.  To reduce the number of generated files we now
+    keep a single directory per ``codigoGeneracion`` containing only the
+    original JSON and, eventually, the final state.
     """
     ident = dte_json.get("identificacion", {})
     codigo = ident.get("codigoGeneracion") or "SIN-CODIGO"
     json_hash = hash_json(dte_json)
-    base_dir = os.path.abspath(base_dir or os.path.join(os.path.dirname(__file__), "..", "dtes"))
-    codigo_dir = os.path.join(base_dir, codigo)
-    os.makedirs(codigo_dir, exist_ok=True)
-    for name in os.listdir(codigo_dir):
-        if name.endswith(f"-{json_hash}"):
-            return os.path.join(codigo_dir, name), json_hash
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    version_dir = _version_dir(base_dir, codigo, json_hash, timestamp)
+    base_dir = os.path.abspath(
+        base_dir or os.path.join(os.path.dirname(__file__), "..", "dtes")
+    )
+    version_dir = os.path.join(base_dir, codigo)
     os.makedirs(version_dir, exist_ok=True)
-    save_file(os.path.join(version_dir, "documento.json"), stable_stringify(dte_json, indent=2))
-    meta = {
-        "codigoGeneracion": codigo,
-        "hashJson": json_hash,
-        "timestamp": timestamp,
-        "estado": "borrador",
-        "firmas": [],
-    }
-    save_file(os.path.join(version_dir, "metadata.json"), stable_stringify(meta, indent=2))
+    save_file(
+        os.path.join(version_dir, "documento.json"),
+        stable_stringify(dte_json, indent=2),
+    )
     return version_dir, json_hash
 
 
-def add_jws(version_dir: str, token: str, origen: str = "manual", estado: str = "borrador") -> str:
-    """Store ``token`` under ``version_dir`` registering metadata."""
-    ts = datetime.now().strftime("%Y%m%d%H%M%S")
-    jws_filename = f"documento-{ts}.jws"
-    save_file(os.path.join(version_dir, jws_filename), token, add_final_newline=False)
-    meta_path = os.path.join(version_dir, "metadata.json")
-    try:
-        with open(meta_path, "r", encoding="utf-8") as fh:
-            meta = json.load(fh)
-    except Exception:
-        meta = {"firmas": []}
-    meta.setdefault("firmas", []).append(
-        {
-            "archivo": jws_filename,
-            "fechaFirma": ts,
-            "origen": origen,
-            "estado": estado,
-        }
-    )
-    save_file(meta_path, stable_stringify(meta, indent=2))
-    return jws_filename
+def save_estado(version_dir: str, data: dict) -> str:
+    """Store ``data`` representing the final state of the DTE.
 
-
-def promote(version_dir: str, jws_filename: str) -> None:
-    """Mark the pair as ready for sending."""
-    meta_path = os.path.join(version_dir, "metadata.json")
-    with open(meta_path, "r", encoding="utf-8") as fh:
-        meta = json.load(fh)
-    meta["estado"] = "lista"
-    for firma in meta.get("firmas", []):
-        if firma.get("archivo") == jws_filename:
-            firma["estado"] = "lista"
-    save_file(meta_path, stable_stringify(meta, indent=2))
-
-
-def verify(version_dir: str, jws_filename: str) -> None:
-    """Validate that ``jws_filename`` matches the stored JSON version."""
-    json_path = os.path.join(version_dir, "documento.json")
-    with open(json_path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    meta_path = os.path.join(version_dir, "metadata.json")
-    try:
-        with open(meta_path, "r", encoding="utf-8") as fh:
-            meta = json.load(fh)
-    except Exception:
-        meta = {}
-    if meta.get("hashJson") != hash_json(data):
-        raise ValueError(
-            "La firma no corresponde a la versión actual del documento. Vuelva a firmar o seleccione una firma compatible."
-        )
-    jws_path = os.path.join(version_dir, jws_filename)
-    with open(jws_path, "r", encoding="utf-8") as fh:
-        token = fh.read()
-    payload = decode_jws_payload(token)
-    ident_payload = payload.get("identificacion") or payload.get("identificador") or payload
-    ident_json = data.get("identificacion") or data.get("identificador") or data
-    for key in ("codigoGeneracion", "tipoDte", "version"):
-        if str(ident_payload.get(key)) != str(ident_json.get(key)):
-            raise ValueError(
-                "La firma no corresponde a la versión actual del documento. Vuelva a firmar o seleccione una firma compatible."
-            )
+    The file name is chosen based on ``data['estado']`` when available
+    (``aceptado.json`` or ``rechazado.json``); otherwise ``estado.json`` is
+    used.  The chosen file name is returned.
+    """
+    estado = str(data.get("estado", "")).lower()
+    if estado == "aceptado":
+        name = "aceptado.json"
+    elif estado == "rechazado":
+        name = "rechazado.json"
+    else:
+        name = "estado.json"
+    save_file(os.path.join(version_dir, name), stable_stringify(data, indent=2))
+    return name
 
 
 __all__ = [
     "ensure_version",
-    "add_jws",
-    "promote",
-    "verify",
+    "save_estado",
     "decode_jws_payload",
     "hash_json",
 ]


### PR DESCRIPTION
## Summary
- avoid persisting JWS signatures to disk and only store JSON data
- keep final DTE state as a single JSON file per document
- update tests for new artifact layout

## Testing
- `pytest` *(fails: tests require additional environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c73826941883239effa314be99de65