### PR TITLE
Show Hacienda error messages when sending invoices

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1060,9 +1060,11 @@ class FacturacionTab(QWidget):
                     else:
                         detalle = resp.get("detalle")
                         if detalle:
-                            logger.debug("Detalle de respuesta de Hacienda: %s", detalle)
-                        mensaje = resp.get("errores") or (
-                            detalle.get("descripcionMsg") if isinstance(detalle, dict) else None
+                            logger.debug(
+                                "Detalle de respuesta de Hacienda: %s", detalle
+                            )
+                        mensaje = resp.get("errores") or resp.get("detalle", {}).get(
+                            "descripcionMsg"
                         )
                         QMessageBox.critical(
                             self,
@@ -1103,9 +1105,11 @@ class FacturacionTab(QWidget):
                     else:
                         detalle = resp.get("detalle")
                         if detalle:
-                            logger.debug("Detalle de respuesta de Hacienda: %s", detalle)
-                        mensaje = resp.get("errores") or (
-                            detalle.get("descripcionMsg") if isinstance(detalle, dict) else None
+                            logger.debug(
+                                "Detalle de respuesta de Hacienda: %s", detalle
+                            )
+                        mensaje = resp.get("errores") or resp.get("detalle", {}).get(
+                            "descripcionMsg"
                         )
                         QMessageBox.critical(
                             self,


### PR DESCRIPTION
## Summary
- Display Hacienda's error details in the send invoice dialog
- Log full Hacienda response details for diagnostics

## Testing
- `pytest tests/test_connection_error_message.py::test_send_selected_invoice_shows_detalle -q`
- `pytest` *(fails: ImportError: cannot import name 'DEFAULT_ADDRESS' from 'dte'; ImportError: cannot import name 'generar_evento_anulacion' from 'dte'; ImportError: cannot import name 'norm_receptor' from 'dte'; ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68c74f7253888323952d64a0820a6385