### PR TITLE
Propagate DTE error details

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4379,6 +4379,14 @@ def _post_dte(
             "http_status": resp.status_code,
             "detalle": detalle,
         }
+        if isinstance(data, dict):
+            detalle_info = data.get("detalle") if isinstance(data.get("detalle"), dict) else data
+            for key in ("descripcionMsg", "observaciones"):
+                if key in detalle_info:
+                    result[key] = detalle_info[key]
+            err = _parse_error_response(result)
+            if err:
+                result["errores"] = err
         print(json.dumps(result, ensure_ascii=False))
         return result
 
@@ -4614,6 +4622,8 @@ def enviar_dte_a_hacienda(jws_token: str) -> dict:
     )
     if estado:
         respuesta["estado"] = estado
+    if respuesta.get("estado") == "Rechazado":
+        respuesta["errores"] = _parse_error_response(respuesta)
     return respuesta
 
 
@@ -4715,18 +4725,25 @@ def consultar_estado_lote(codigo_lote: str) -> dict:
 
 def _parse_error_response(respuesta: dict) -> str:
     """Construye un mensaje de error a partir de ``descripcionMsg`` y ``observaciones``."""
-    partes = []
-    desc = respuesta.get("descripcionMsg")
-    if desc:
-        partes.append(str(desc))
-    obs = respuesta.get("observaciones")
-    if isinstance(obs, dict):
-        for k, v in obs.items():
-            partes.append(f"{k}: {v}")
-    elif isinstance(obs, list):
-        partes.extend(str(o) for o in obs)
-    elif obs:
-        partes.append(str(obs))
+
+    def _agregar_partes(origen, partes):
+        desc = origen.get("descripcionMsg")
+        if desc:
+            partes.append(str(desc))
+        obs = origen.get("observaciones")
+        if isinstance(obs, dict):
+            for k, v in obs.items():
+                partes.append(f"{k}: {v}")
+        elif isinstance(obs, list):
+            partes.extend(str(o) for o in obs)
+        elif obs:
+            partes.append(str(obs))
+
+    partes: list[str] = []
+    _agregar_partes(respuesta, partes)
+    detalle = respuesta.get("detalle", {})
+    if isinstance(detalle, dict):
+        _agregar_partes(detalle, partes)
     mensaje = "; ".join(partes)
     if mensaje:
         logger.error(mensaje)
@@ -5007,6 +5024,8 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     res = {"estado": estado, "sello": sello}
     if detalle:
         res["detalle"] = detalle
+    if respuesta.get("errores"):
+        res["errores"] = respuesta["errores"]
     return res
 
 

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -1,0 +1,56 @@
+import dte
+import auth
+from dte import _post_dte, enviar_dte_a_hacienda
+from db import DB
+from tests.conftest import make_jws
+
+
+def test_post_dte_populates_error_fields(monkeypatch):
+    meta = {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "CG"}
+    token = make_jws({"identificacion": meta})
+    monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda doc, data: {})
+
+    def fake_post(url, headers=None, json=None, timeout=20):
+        class R:
+            status_code = 400
+            text = ""
+
+            def json(self):
+                return {"detalle": {"descripcionMsg": "Bad", "observaciones": {"foo": "bar"}}}
+
+        return R()
+
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    resp = _post_dte(dte.DEFAULT_RECEPCION_URL, "TOKEN", token, meta)
+    assert resp["http_status"] == 400
+    assert resp["descripcionMsg"] == "Bad"
+    assert resp["observaciones"] == {"foo": "bar"}
+    assert resp["errores"] == "Bad; foo: bar"
+
+
+def test_enviar_dte_a_hacienda_returns_errores(monkeypatch):
+    jws_token = make_jws({"identificacion": {"tipoDte": "01", "codigoGeneracion": "1", "ambiente": "00", "version": 1}})
+
+    def fake_post_dte(url, token, jws, meta):
+        return {"estado": "Rechazado", "descripcionMsg": "Mal", "observaciones": {"a": "b"}}
+
+    monkeypatch.setattr(dte, "_post_dte", fake_post_dte)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": dte.DEFAULT_RECEPCION_URL})
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    resp = enviar_dte_a_hacienda(jws_token)
+    assert resp["errores"] == "Mal; a: b"
+
+
+def test_enviar_evento_propagates_errores(monkeypatch):
+    db = DB(":memory:")
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": dte.DEFAULT_RECEPCION_URL})
+    monkeypatch.setattr(dte.jws, "sign_json", lambda data: "TOKEN")
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+
+    def fake_post_evento(url, token, evento, evento_data):
+        return {"estado": "Rechazado", "descripcionMsg": "Oops", "observaciones": {"x": "y"}}
+
+    monkeypatch.setattr(dte, "_post_evento", fake_post_evento)
+    monkeypatch.setattr(db, "registrar_envio_dte", lambda *a, **k: None)
+    res = dte.enviar_evento_contingencia(db, 1, {"id": 1})
+    assert res["errores"] == "Oops; x: y"


### PR DESCRIPTION
## Summary
- surface `descripcionMsg` and `observaciones` from nested error details when `_post_dte` receives an HTTP error
- parse nested `detalle` structures for error messages
- ensure DTE send helpers return formatted `errores`

## Testing
- `pytest`
- `pytest tests/test_error_propagation.py`

------
https://chatgpt.com/codex/tasks/task_e_68c74f72873c8323add6d37cf4a21f07