### PR TITLE
Transmit tickets with code 01

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4492,8 +4492,9 @@ def transmitir_dte(
 ) -> dict:
     """Genera y transmite un DTE reutilizando ``_enviar_documento``.
 
-    ``tipo_dte`` permite especificar el código del documento a transmitir,
-    usando ``"01"`` para facturas y ``"03"`` para tickets.
+    ``tipo_dte`` permite especificar el código del documento a transmitir.
+    Actualmente tanto los tickets como las facturas a consumidor final se
+    envían con el código ``"01"``.
     """
 
     if modo is None:

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1085,7 +1085,7 @@ class FacturacionTab(QWidget):
                 try:
                     resp = transmitir_dte(
                         self.manager.db, entry.get("id")
-                    )
+                    )  # tickets también se transmiten con tipo "01"
                     if resp.get("http_status") in {401, 403}:
                         QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
                         return


### PR DESCRIPTION
## Summary
- Clarify that tickets are transmitted using the same DTE code as consumer invoices ("01")
- Note in UI flow that Hacienda submissions rely on default type "01"

## Testing
- `pytest -q` *(fails: cannot import generar_evento_anulacion, norm_receptor)*

------
https://chatgpt.com/codex/tasks/task_e_68c754e2eae88323afefe3f86ffd8f68