### PR TITLE
feat: add invoice deletion

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -537,7 +537,7 @@ class FacturacionTab(QWidget):
 
         self.btn_enviar.clicked.connect(self.send_selected_invoice)
         self.btn_abrir_pdf.clicked.connect(self.open_pdf)
-        self.btn_eliminar.clicked.connect(self.delete_files)
+        self.btn_eliminar.clicked.connect(self.delete_invoice)
 
     def _toggle_date_filter(self, checked):
         self.quick_range.setEnabled(checked)
@@ -1670,79 +1670,84 @@ class FacturacionTab(QWidget):
             QMessageBox.critical(self, "Nota", str(exc))
         self.load_invoices()
 
-    def delete_files(self):
-        """Elimina PDF y JSON asociados a la venta seleccionada."""
+    def delete_invoice(self):
+        """Elimina una venta junto con archivos y correlativos asociados."""
         data = self._selected_entry()
-        if not data:
+        if not data or data.get("row_type") not in {"venta", "ticket"}:
             QMessageBox.warning(self, "Eliminar", "Seleccione una venta")
             return
-        # Collect base paths for associated files
-        base_paths = set()
-        pdf_path = None
-        ticket_path = None
-        row_type = data.get("row_type")
-        if row_type in ("venta", "ticket"):
-            venta_id = data.get("id")
-            if row_type == "venta":
-                pdf_path = self.manager.db.get_factura_pdf(venta_id)
-                if pdf_path:
-                    base_paths.add(os.path.splitext(pdf_path)[0])
-            ticket_path = self.manager.db.get_ticket_pdf(venta_id)
-            if ticket_path:
-                base_paths.add(os.path.splitext(ticket_path)[0])
-                json_path = data.get("json") or os.path.splitext(ticket_path)[0] + ".json"
-                base_paths.add(os.path.splitext(json_path)[0])
-        else:
-            for p in [data.get("pdf"), data.get("json")]:
-                if p:
-                    base_paths.add(os.path.splitext(p)[0])
+        venta_id = data.get("id")
 
-        # Build list of files to remove for all relevant extensions
-        paths = []
-        for base in base_paths:
-            for ext in (".pdf", ".json", ".jws"):
-                candidate = base + ext
-                if os.path.exists(candidate):
-                    paths.append(candidate)
-        if not paths:
-            if row_type in ("venta", "ticket"):
-                confirm = QMessageBox.question(
-                    self,
-                    "Eliminar",
-                    "No se encontraron archivos. ¿Eliminar registros?",
-                    QMessageBox.Yes | QMessageBox.No,
-                )
-                if confirm == QMessageBox.Yes:
-                    if row_type == "venta" and pdf_path:
-                        self.manager.db.delete_factura_pdf(venta_id)
-                    if ticket_path:
-                        self.manager.db.delete_ticket_pdf(venta_id)
-                    QMessageBox.information(self, "Eliminar", "Registros eliminados")
-                    self.load_invoices()
-                else:
-                    QMessageBox.information(self, "Eliminar", "No se eliminaron registros")
-            else:
-                QMessageBox.information(self, "Eliminar", "No se encontraron archivos")
-            return
         confirm = QMessageBox.question(
             self,
             "Eliminar",
-            "¿Eliminar archivos?",
+            "¿Eliminar venta y archivos asociados?",
             QMessageBox.Yes | QMessageBox.No,
         )
         if confirm != QMessageBox.Yes:
             return
-        for p in paths:
+
+        pdf_path = self.manager.db.get_factura_pdf(venta_id)
+        ticket_path = self.manager.db.get_ticket_pdf(venta_id)
+        dte_json_path = data.get("json")
+        if not dte_json_path and pdf_path:
+            dte_json_path = os.path.splitext(pdf_path)[0] + ".json"
+        if not dte_json_path:
             try:
-                os.remove(p)
-            except OSError:
-                pass
-        if row_type in ("venta", "ticket"):
-            if row_type == "venta" and pdf_path:
-                self.manager.db.delete_factura_pdf(venta_id)
-            if ticket_path:
-                self.manager.db.delete_ticket_pdf(venta_id)
-        QMessageBox.information(self, "Eliminar", "Archivos eliminados")
+                resp = self.manager.db.consultar_envio_dte(venta_id)
+                dte_json_path = resp.get("json") or resp.get("path") or resp.get("ruta")
+            except Exception:
+                dte_json_path = None
+
+        self.manager.db.delete_venta(venta_id)
+
+        numero_control = None
+        if dte_json_path and os.path.exists(dte_json_path):
+            try:
+                with open(dte_json_path, "r", encoding="utf-8") as fh:
+                    jdata = json.load(fh)
+                ident = jdata.get("identificacion") or jdata.get("identificador") or {}
+                numero_control = ident.get("numeroControl")
+            except Exception:
+                numero_control = None
+            base_dir = os.path.dirname(__file__)
+            abs_json = os.path.normpath(dte_json_path)
+            for root in ("dtes", "dte_fallidos", "dtes_pendientes"):
+                root_dir = os.path.normpath(os.path.join(base_dir, root))
+                if abs_json.startswith(root_dir + os.sep):
+                    try:
+                        shutil.rmtree(os.path.dirname(abs_json))
+                    except OSError:
+                        pass
+                    break
+
+        if numero_control:
+            m = re.match(r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$", numero_control)
+            if m:
+                tipo, suc, punto, corr = m.groups()
+                try:
+                    corr_int = int(corr)
+                    if (
+                        self.manager.db.get_dte_correlativo(tipo, suc, punto)
+                        == corr_int
+                    ):
+                        self.manager.db.set_dte_correlativo(
+                            tipo, suc, punto, corr_int - 1
+                        )
+                except Exception:
+                    pass
+
+        for base in filter(None, [pdf_path, ticket_path]):
+            root = os.path.splitext(base)[0]
+            for ext in (".pdf", ".json", ".jws"):
+                candidate = root + ext
+                if os.path.exists(candidate):
+                    try:
+                        os.remove(candidate)
+                    except OSError:
+                        pass
+
+        QMessageBox.information(self, "Eliminar", "Venta eliminada")
         self.load_invoices()
 
     # ------------------------------------------------------------------

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -136,26 +136,50 @@ def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     assert captured_post["args"] == ("http://example.com", "TOKEN", "SIGNED")
 
 
-def test_delete_files_removes(qt_app, tmp_path, monkeypatch):
+def test_delete_invoice_removes_all(qt_app, tmp_path, monkeypatch):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)
+
     pdf = tmp_path / "f.pdf"
     pdf.write_text("p")
     js = pdf.with_suffix(".json")
-    js.write_text("{}")
+    js.write_text(
+        json.dumps({"identificacion": {"numeroControl": "DTE-01-S001P001-000000000000005"}})
+    )
     jws = pdf.with_suffix(".jws")
     jws.write_text("TOKEN")
     db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf))
-    tab = _make_tab(db, cid)
-    monkeypatch.setattr(
-        tab, "_selected_entry", lambda: {"row_type": "venta", "id": venta_id}
+
+    base_dte = Path(facturacion_tab.__file__).with_name("dtes")
+    dte_dir = base_dte / "tmp_test" / "abc"
+    dte_dir.mkdir(parents=True, exist_ok=True)
+    dte_json = dte_dir / "documento.json"
+    dte_json.write_text(
+        json.dumps({"identificacion": {"numeroControl": "DTE-01-S001P001-000000000000005"}})
     )
 
-    monkeypatch.setattr(facturacion_tab.QMessageBox, "question", lambda *a, **k: facturacion_tab.QMessageBox.Yes)
+    db.set_dte_correlativo("01", "001", "001", 5)
+    monkeypatch.setattr(facturacion_tab.FacturacionTab, "load_invoices", lambda self: None)
+    tab = _make_tab(db, cid)
+    monkeypatch.setattr(
+        tab,
+        "_selected_entry",
+        lambda: {"row_type": "venta", "id": venta_id, "json": str(dte_json)},
+    )
+
+    monkeypatch.setattr(
+        facturacion_tab.QMessageBox,
+        "question",
+        lambda *a, **k: facturacion_tab.QMessageBox.Yes,
+    )
     monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", lambda *a, **k: None)
     monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
 
-    tab.delete_files()
+    tab.delete_invoice()
+
     assert not pdf.exists()
     assert not js.exists()
     assert not jws.exists()
+    assert not dte_dir.exists()
+    assert db.get_venta_by_id(venta_id) is None
+    assert db.get_dte_correlativo("01", "001", "001") == 4


### PR DESCRIPTION
## Summary
- replace file deletion button with full `delete_invoice` workflow
- cascade sale removal, cleanup DTE dirs and correlativo
- test invoice deletion removes files and decrements correlativo

## Testing
- `pytest --no-cov tests/test_facturacion_tab_actions.py::test_delete_invoice_removes_all -q`


------
https://chatgpt.com/codex/tasks/task_e_68c763cad96883239611765a2ef3e287