### PR TITLE
Reuse DTE identifiers across regenerations

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1884,17 +1884,40 @@ def generar_dte_json(
     cod_punto = (cod_punto_raw or punto_pref.rjust(4, "0"))[-4:].zfill(4)
     suc = _norm3(cod_estable)
     pto = _norm3(cod_punto)
-    # Generar identificadores con formatos oficiales
-    codigo_generacion = kwargs.get("codigo_generacion") or str(uuid.uuid4()).upper()
-    numero_control_kw = kwargs.get("numero_control")
-    correlativo_kw = kwargs.get("correlativo")
-    if numero_control_kw is not None and correlativo_kw is not None:
-        if not isinstance(correlativo_kw, int) or correlativo_kw <= 0:
-            raise ValueError("correlativo inválido")
-        numero_control = str(numero_control_kw)
-        correlativo = correlativo_kw
-    else:
+
+    # Reutilizar identificadores existentes si están almacenados
+    codigo_generacion = (
+        extra.get("codigoGeneracion")
+        or extra.get("codigo_generacion")
+        or kwargs.get("codigo_generacion")
+    )
+    numero_control = (
+        extra.get("numeroControl")
+        or extra.get("numero_control")
+        or kwargs.get("numero_control")
+    )
+    correlativo = extra.get("correlativo")
+    if correlativo is None:
+        correlativo = kwargs.get("correlativo")
+
+    if codigo_generacion is None:
+        codigo_generacion = str(uuid.uuid4()).upper()
+    if numero_control is None or correlativo is None:
         numero_control, correlativo = generar_numero_control(db, tipo_dte, suc, pto)
+
+    # Persistir identificadores para reutilización futura
+    if tipo_dte in ("01", "03"):
+        try:
+            db.update_venta_extra(
+                venta_id,
+                {
+                    "codigoGeneracion": codigo_generacion,
+                    "numeroControl": numero_control,
+                    "correlativo": correlativo,
+                },
+            )
+        except Exception:
+            pass
 
 
     now = datetime.now(TZ_EL_SALVADOR)

--- a/tests/test_dte_correlativo.py
+++ b/tests/test_dte_correlativo.py
@@ -60,15 +60,7 @@ def test_identificadores_reutilizados(tmp_path):
 
     dte1 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
     ident1 = dte1["identificacion"]
-    correlativo = int(ident1["numeroControl"].split("-")[-1])
-    dte2 = dte_module.generar_dte_json(
-        db,
-        venta_id,
-        tipo_dte="01",
-        numero_control=ident1["numeroControl"],
-        codigo_generacion=ident1["codigoGeneracion"],
-        correlativo=correlativo,
-    )
+    dte2 = dte_module.generar_dte_json(db, venta_id, tipo_dte="01")
     ident2 = dte2["identificacion"]
 
     assert ident1["numeroControl"] == ident2["numeroControl"]

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 import logging
+from datetime import datetime
 
 import dte
 from factura_sv import generar_factura_electronica_pdf
@@ -274,18 +275,56 @@ def generate_invoice_pdf(manager, venta_id):
     doc_key = "CreditoFiscal" if credito_info else "ConsumidorFinal"
     cliente_nombre = cliente.get("nombre") if cliente else ""
 
-    cabecera = generar_cabecera_dte_data(
-        tipo_modelo,
-        tipo_operacion,
-        "03" if credito_info else "01",
-        manager.db,
-        tipo_contingencia=tipo_contingencia,
-        motivo_contin=motivo_contin,
-        ambiente=ambiente,
-    )
-    codigo_generacion = cabecera["codigo_generacion"]
-    numero_control = cabecera["numero_control"]
-    fecha_generacion = cabecera["fecha_generacion"]
+    # Reutilizar códigos existentes si están presentes en ``extra``
+    codigo_generacion = extra.get("codigoGeneracion")
+    numero_control = extra.get("numeroControl")
+    correlativo = extra.get("correlativo")
+    fecha_generacion = extra.get("fechaGeneracion")
+    if codigo_generacion and numero_control and correlativo:
+        cabecera = {
+            "codigo_generacion": codigo_generacion,
+            "numero_control": numero_control,
+            "correlativo": correlativo,
+            "sello_recepcion": None,
+            "tipo_modelo": tipo_modelo,
+            "tipo_operacion": tipo_operacion,
+            "tipo_contingencia": tipo_contingencia,
+            "motivo_contin": motivo_contin,
+            "fecha_generacion": fecha_generacion
+            or datetime.now().strftime("%d/%m/%Y, %I:%M %p"),
+            "ambiente": ambiente,
+        }
+    else:
+        cabecera = generar_cabecera_dte_data(
+            tipo_modelo,
+            tipo_operacion,
+            "03" if credito_info else "01",
+            manager.db,
+            tipo_contingencia=tipo_contingencia,
+            motivo_contin=motivo_contin,
+            ambiente=ambiente,
+        )
+        codigo_generacion = cabecera["codigo_generacion"]
+        numero_control = cabecera["numero_control"]
+        correlativo = cabecera.get("correlativo")
+        fecha_generacion = cabecera["fecha_generacion"]
+        try:
+            manager.db.update_venta_extra(
+                venta_id,
+                {
+                    "codigoGeneracion": codigo_generacion,
+                    "numeroControl": numero_control,
+                    "correlativo": correlativo,
+                    "fechaGeneracion": fecha_generacion,
+                },
+            )
+        except Exception:
+            pass
+        extra["codigoGeneracion"] = codigo_generacion
+        extra["numeroControl"] = numero_control
+        extra["correlativo"] = correlativo
+        extra["fechaGeneracion"] = fecha_generacion
+
     sello_recepcion = sello_recepcion or cabecera["sello_recepcion"]
     venta_data["sello_recepcion"] = sello_recepcion
     tipo_modelo = cabecera["tipo_modelo"]


### PR DESCRIPTION
## Summary
- reuse stored codigoGeneracion, numeroControl and correlativo when generating DTE JSON
- persist identifiers after first creation to ensure subsequent generations match
- ensure invoice PDF generation reuses existing identifiers instead of generating new ones

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_dte_correlativo.py::test_identificadores_reutilizados -q`


------
https://chatgpt.com/codex/tasks/task_e_68c765df1b608323a74c71404ce67a69