### PR TITLE
Rename DTE state files to match original document name

### DIFF
--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -153,10 +153,11 @@ def test_delete_invoice_removes_all(qt_app, tmp_path, monkeypatch):
     base_dte = Path(facturacion_tab.__file__).with_name("dtes")
     dte_dir = base_dte / "tmp_test" / "abc"
     dte_dir.mkdir(parents=True, exist_ok=True)
-    dte_json = dte_dir / "documento.json"
+    dte_json = dte_dir / js.name
     dte_json.write_text(
         json.dumps({"identificacion": {"numeroControl": "DTE-01-S001P001-000000000000005"}})
     )
+    (dte_dir / f"{js.stem}_estado.json").write_text(json.dumps({"estado": "aceptado"}))
 
     db.set_dte_correlativo("01", "001", "001", 5)
     monkeypatch.setattr(facturacion_tab.FacturacionTab, "load_invoices", lambda self: None)

--- a/tests/test_invoice_json_save.py
+++ b/tests/test_invoice_json_save.py
@@ -154,11 +154,11 @@ def test_generate_invoice_pdf_saves_sobre(tmp_path, monkeypatch):
     generate_invoice_pdf(man, 1)
 
     pend_root = tmp_path / dte.PENDIENTES_DIR
-    documento = next(pend_root.rglob("documento.json"))
+    documento = next(pend_root.rglob(json_path.name))
     version_dir = documento.parent
-    assert not (version_dir / "documento.pdf").exists()
+    assert not (version_dir / f"{json_path.stem}.pdf").exists()
     assert not any(f.name.endswith(".jws") for f in version_dir.iterdir())
-    assert (version_dir / "estado.json").exists()
+    assert (version_dir / f"{json_path.stem}_estado.json").exists()
 
 
 def test_generate_invoice_pdf_propagates_error(monkeypatch):

--- a/tests/test_versioned_dte.py
+++ b/tests/test_versioned_dte.py
@@ -20,5 +20,5 @@ def test_store_and_save_estado(tmp_path):
     assert json_hash
     state = {"estado": "Aceptado"}
     name = versioned_dte.save_estado(version_dir, state)
-    assert name == "aceptado.json"
+    assert name == "documento_aceptado.json"
     assert os.path.exists(os.path.join(version_dir, name))

--- a/utils/versioned_dte.py
+++ b/utils/versioned_dte.py
@@ -43,19 +43,35 @@ def ensure_version(dte_json: dict, base_dir: str | None = None) -> tuple[str, st
 
 
 def save_estado(version_dir: str, data: dict) -> str:
-    """Store ``data`` representing the final state of the DTE.
+    """Store ``data`` representing the final state of the DTE."""
 
-    The file name is chosen based on ``data['estado']`` when available
-    (``aceptado.json`` or ``rechazado.json``); otherwise ``estado.json`` is
-    used.  The chosen file name is returned.
-    """
+    # Ensure the state file shares the same base name as the original JSON
+    # stored in ``version_dir``.  When the directory only contains
+    # ``documento.json`` this will default to ``documento``; otherwise the
+    # existing JSON filename (sans extension) is reused.
+    base_name = None
+    try:
+        for fname in os.listdir(version_dir):
+            if not fname.endswith(".json"):
+                continue
+            stem = os.path.splitext(fname)[0]
+            if stem.endswith("_estado") or stem.endswith("_aceptado") or stem.endswith("_rechazado"):
+                continue
+            base_name = stem
+            break
+    except OSError:  # pragma: no cover - best effort
+        base_name = None
+    if not base_name:
+        base_name = "documento"
+
     estado = str(data.get("estado", "")).lower()
     if estado == "aceptado":
-        name = "aceptado.json"
+        suffix = "aceptado"
     elif estado == "rechazado":
-        name = "rechazado.json"
+        suffix = "rechazado"
     else:
-        name = "estado.json"
+        suffix = "estado"
+    name = f"{base_name}_{suffix}.json"
     save_file(os.path.join(version_dir, name), stable_stringify(data, indent=2))
     return name
 


### PR DESCRIPTION
## Summary
- ensure DTE state JSON files reuse the base name of the original document
- adjust tests to check for the new `<name>_estado.json` pattern and cleanup

## Testing
- `pytest` *(fails: ImportError while importing test modules, 52 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c76d04e0ec8323adebe7aa96dab685