### PR TITLE
Corrige estados de facturación y envío

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -668,7 +668,9 @@ class FacturacionTab(QWidget):
                         cliente_nombre = ""
                 total = venta.get("total")
                 row_type = "ticket" if self._is_ticket_sale(venta) else "venta"
-                if not (pdf_exists and json_exists):
+                if pdf_exists and json_exists:
+                    estado = "Completa"
+                else:
                     estado = "Incompleta"
             else:
                 estado = "Sin venta"
@@ -688,9 +690,11 @@ class FacturacionTab(QWidget):
                 elif est == "error":
                     envio = "Error"
                 elif est in {"transmitido", "recibido", "procesado"}:
-                    envio = "Pendiente"
+                    envio = "Enviado"
                 else:
                     envio = "Pendiente"
+            else:
+                envio = "Pendiente de envío"
 
             row = {
                 "row_type": row_type,


### PR DESCRIPTION
## Resumen
- Marca facturas como completas solo cuando la venta tiene PDF y JSON
- Muestra "Enviado" para transmisiones y "Pendiente de envío" si no hay registro

## Testing
- `pytest` *(errores: falta generar_evento_anulacion y norm_receptor)*

------
https://chatgpt.com/codex/tasks/task_e_68c773c9d914832382b306220195e4ae