### PR TITLE
Pass DTE identifiers to note PDFs

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1639,12 +1639,19 @@ class FacturacionTab(QWidget):
             nota_json["identificacion"].get("numeroControl"),
             doc_type,
         )
+        identificacion = nota_json.get("identificacion", {}) or {}
+        codigo_gen = identificacion.get("codigoGeneracion")
+        num_ctrl = identificacion.get("numeroControl")
+        fec_emision = identificacion.get("fecEmi") or identificacion.get("fechaEmi")
         pdf_func(
             venta_data,
             detalles_pdf,
             cliente or {},
             distribuidor or {},
             archivo=str(pdf_path),
+            codigo_generacion=codigo_gen,
+            numero_control=num_ctrl,
+            fecha_generacion=fec_emision,
         )
 
         # Mostrar previsualización del PDF generado


### PR DESCRIPTION
## Summary
- Pass codigo de generacion, numero de control y fecha de emision a las funciones de PDF de notas
- Confirm that nota credito/debito generators accept extra kwargs

## Testing
- `python - <<'PY'
import os
from factura_sv import generar_nota_credito_pdf
venta={}
detalles=[]
cliente={}
distribuidor={}
try:
    generar_nota_credito_pdf(venta, detalles, cliente, distribuidor, archivo="/tmp/test_nota.pdf", codigo_generacion="abc", numero_control="123", fecha_generacion="01/01/2024")
    print("PDF generated", os.path.exists("/tmp/test_nota.pdf"))
except Exception as e:
    print("Error", e)
PY`
- `python - <<'PY'
import os
from factura_sv import generar_nota_debito_pdf
venta={}
detalles=[]
cliente={}
distribuidor={}
try:
    generar_nota_debito_pdf(venta, detalles, cliente, distribuidor, archivo="/tmp/test_nota_debito.pdf", codigo_generacion="xyz", numero_control="456", fecha_generacion="02/02/2024")
    print("Debit PDF", os.path.exists("/tmp/test_nota_debito.pdf"))
except Exception as e:
    print("Error", e)
PY`
- `pytest` *(fails: ImportError: cannot import name 'generar_evento_anulacion' from 'dte'; ImportError: cannot import name 'norm_receptor' from 'dte')*


------
https://chatgpt.com/codex/tasks/task_e_68c773a98cb48323ab5581b2c5c016b2