### PR TITLE
Add inventory import validation with migration and dry-run

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -12,6 +12,16 @@ from utils.stable_json import DecimalEncoder
 from utils.line_totals import compute_line_totals
 from utils.monto import d8
 
+try:  # Prefer shared app version if available
+    from dte import APP_VERSION
+except Exception:  # pragma: no cover - fallback when dte isn't importable
+    APP_VERSION = "unknown"
+
+from inventory_validator import (
+    validate_inventory_json,
+    migrate_inventory_json,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -205,6 +215,15 @@ class InventoryManager:
             except Exception:
                 logger.exception("Failed to parse %s", DATOS_NEGOCIO_PATH)
 
+        def write_kv(key, value):
+            nonlocal first_section
+            if not first_section:
+                f.write(",\n")
+            json.dump(key, f)
+            f.write(":")
+            json.dump(value, f, ensure_ascii=False, cls=DecimalEncoder)
+            first_section = False
+
         def write_array(key, iterator):
             nonlocal first_section
             if not first_section:
@@ -230,6 +249,9 @@ class InventoryManager:
             with open(filename, "w", encoding="utf-8") as f:
                 first_section = True
                 f.write("{")
+                write_kv("schemaVersion", 1)
+                write_kv("generatedAt", datetime.utcnow().isoformat())
+                write_kv("appVersion", APP_VERSION)
                 write_array("productos", self._products)
                 write_array("vendedores", (dict(v) for v in self._vendedores))
                 write_array("Distribuidores", (dict(v) for v in self._Distribuidores))
@@ -322,7 +344,7 @@ class InventoryManager:
                 f"No se pudo exportar inventario a {filename}: {e}"
             ) from e
 
-    def importar_inventario_json(self, filename):
+    def importar_inventario_json(self, filename, *, dry_run: bool = False, strict: bool = True):
         with open(filename, "r", encoding="utf-8") as f:
             try:
                 data = json.load(f)
@@ -330,6 +352,46 @@ class InventoryManager:
                 raise InventoryManagerError(
                     f"No se pudo importar inventario desde {filename}: JSON malformado en línea {e.lineno}, columna {e.colno}"
                 ) from e
+
+        data, migrations_applied = migrate_inventory_json(data)
+        issues = validate_inventory_json(data)
+        errors = [i for i in issues if i["severity"] == "error"]
+        warnings = [i for i in issues if i["severity"] == "warning"]
+
+        if strict and errors:
+            sample = "; ".join(f"{i['path']}: {i['message']}" for i in errors[:20])
+            raise ValueError(
+                f"Se encontraron {len(errors)} errores al importar {filename}: {sample}"
+            )
+
+        if dry_run:
+            return {
+                "errors": errors,
+                "warnings": warnings,
+                "migrations_applied": migrations_applied,
+            }
+
+        log_dir = os.path.join("logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(
+            log_dir, f"import_inventory_{datetime.now():%Y%m%d_%H%M%S}.log"
+        )
+        handler = logging.FileHandler(log_path, encoding="utf-8")
+        logger.addHandler(handler)
+        try:
+            self._importar_inventario_json_legacy(data)
+        except Exception as e:
+            logger.exception("Error al importar inventario desde %s", filename)
+            raise InventoryManagerError(
+                f"No se pudo importar inventario desde {filename}: {e}"
+            ) from e
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+        return data
+
+    def _importar_inventario_json_legacy(self, data):
         # Limpia tablas hijas primero para evitar violaciones de clave foránea
         self.db.conn.execute("BEGIN")
         try:
@@ -390,7 +452,7 @@ class InventoryManager:
         self.db.conn.execute("BEGIN")
         try:
             # --- Distribuidores primero ---
-            for v in data.get("Distribuidores", []):
+            for v in data.get("distribuidores", []):
                 self.db.add_Distribuidor_detallado(v, commit=False)
                 self.db.cursor.execute(
                     "SELECT id FROM Distribuidores WHERE nombre=? ORDER BY id DESC LIMIT 1",

--- a/inventory_validator.py
+++ b/inventory_validator.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import TypedDict, List, Tuple, Any, Set
+
+
+class Issue(TypedDict):
+    path: str
+    severity: str
+    message: str
+
+
+def migrate_inventory_json(data: dict) -> tuple[dict, list[str]]:
+    """Return migrated copy of *data* and list of applied migrations."""
+    migrations: Set[str] = set()
+    # Normalize root key for distributors
+    if "Distribuidores" in data and "distribuidores" not in data:
+        data["distribuidores"] = data.pop("Distribuidores")
+        migrations.add("rename Distribuidores -> distribuidores")
+    # Rename seller_id -> vendedor_id in ventas and detalles_venta
+    for venta in data.get("ventas", []):
+        if isinstance(venta, dict) and "seller_id" in venta and "vendedor_id" not in venta:
+            venta["vendedor_id"] = venta.pop("seller_id")
+            migrations.add("rename ventas[].seller_id -> vendedor_id")
+    for det in data.get("detalles_venta", []):
+        if isinstance(det, dict) and "seller_id" in det and "vendedor_id" not in det:
+            det["vendedor_id"] = det.pop("seller_id")
+            migrations.add("rename detalles_venta[].seller_id -> vendedor_id")
+    return data, sorted(migrations)
+
+
+def validate_inventory_json(data: dict) -> List[Issue]:
+    issues: List[Issue] = []
+
+    required_sections = [
+        "productos",
+        "vendedores",
+        "distribuidores",
+        "clientes",
+        "ventas",
+        "detalles_venta",
+    ]
+
+    for section in required_sections:
+        if section not in data:
+            issues.append(
+                {
+                    "path": section,
+                    "severity": "error",
+                    "message": f"Falta sección {section}[]",
+                }
+            )
+        elif not isinstance(data.get(section), list):
+            issues.append(
+                {
+                    "path": section,
+                    "severity": "error",
+                    "message": f"{section} debe ser una lista",
+                }
+            )
+
+    productos = data.get("productos", []) if isinstance(data.get("productos"), list) else []
+    vendedores = data.get("vendedores", []) if isinstance(data.get("vendedores"), list) else []
+    distribuidores = data.get("distribuidores", []) if isinstance(data.get("distribuidores"), list) else []
+    clientes = data.get("clientes", []) if isinstance(data.get("clientes"), list) else []
+    ventas = data.get("ventas", []) if isinstance(data.get("ventas"), list) else []
+    detalles = data.get("detalles_venta", []) if isinstance(data.get("detalles_venta"), list) else []
+
+    prod_ids: Set[int] = set()
+    prod_skus: Set[str] = set()
+    for i, p in enumerate(productos):
+        if not isinstance(p, dict):
+            issues.append({"path": f"productos[{i}]", "severity": "error", "message": "Debe ser objeto"})
+            continue
+        pid = p.get("id")
+        if pid is None:
+            issues.append({"path": f"productos[{i}].id", "severity": "error", "message": "Campo requerido"})
+        else:
+            if pid in prod_ids:
+                issues.append({"path": f"productos[{i}].id", "severity": "error", "message": "id duplicado"})
+            prod_ids.add(pid)
+        sku = p.get("sku")
+        if sku is not None:
+            if sku in prod_skus:
+                issues.append({"path": f"productos[{i}].sku", "severity": "error", "message": "sku duplicado"})
+            prod_skus.add(sku)
+        if "nombre" not in p:
+            issues.append({"path": f"productos[{i}].nombre", "severity": "error", "message": "Campo requerido"})
+        if "precio_venta_minorista" not in p:
+            issues.append({"path": f"productos[{i}].precio_venta_minorista", "severity": "error", "message": "Campo requerido"})
+
+    vendedor_ids = {v.get("id") for v in vendedores if isinstance(v, dict)}
+    cliente_ids = {c.get("id") for c in clientes if isinstance(c, dict)}
+    venta_ids: Set[int] = set()
+    for i, v in enumerate(ventas):
+        if not isinstance(v, dict):
+            issues.append({"path": f"ventas[{i}]", "severity": "error", "message": "Debe ser objeto"})
+            continue
+        vid = v.get("id")
+        if vid is not None:
+            venta_ids.add(vid)
+        vend_id = v.get("vendedor_id")
+        if vend_id not in vendedor_ids:
+            issues.append({
+                "path": f"ventas[{i}].vendedor_id",
+                "severity": "error",
+                "message": f"vendedor_id {vend_id} no existe",
+            })
+        cid = v.get("cliente_id")
+        if cid not in cliente_ids:
+            issues.append({
+                "path": f"ventas[{i}].cliente_id",
+                "severity": "error",
+                "message": f"cliente_id {cid} no existe",
+            })
+
+    for i, d in enumerate(detalles):
+        if not isinstance(d, dict):
+            issues.append({"path": f"detalles_venta[{i}]", "severity": "error", "message": "Debe ser objeto"})
+            continue
+        pid = d.get("producto_id")
+        if pid not in prod_ids:
+            issues.append({
+                "path": f"detalles_venta[{i}].producto_id",
+                "severity": "error",
+                "message": f"producto_id {pid} no existe en productos",
+            })
+        vid = d.get("venta_id")
+        if vid not in venta_ids:
+            issues.append({
+                "path": f"detalles_venta[{i}].venta_id",
+                "severity": "error",
+                "message": f"venta_id {vid} no existe en ventas",
+            })
+
+    return issues

--- a/tests/test_import_vendor_mapping.py
+++ b/tests/test_import_vendor_mapping.py
@@ -12,8 +12,39 @@ def test_import_maps_vendors(tmp_path):
     data = {
         "Distribuidores": [{"id": 1, "nombre": "D1"}],
         "vendedores": [{"id": 99, "nombre": "V1", "Distribuidor_id": 1, "codigo": "V001"}],
+        "productos": [
+            {
+                "id": 1,
+                "nombre": "P1",
+                "codigo": "P001",
+                "sku": "S1",
+                "vendedor_id": 99,
+                "Distribuidor_id": 1,
+                "precio_compra": 0,
+                "precio_venta_minorista": 0,
+                "precio_venta_mayorista": 0,
+                "stock": 0,
+            }
+        ],
         "clientes": [{"id": 2, "nombre": "C1", "codigo": "C001"}],
-        "ventas": [{"id": 5, "fecha": "2024-01-01", "total": 10, "cliente_id": 2, "Distribuidor_id": 1, "vendedor_id": 99}],
+        "ventas": [
+            {
+                "id": 5,
+                "fecha": "2024-01-01",
+                "total": 10,
+                "cliente_id": 2,
+                "Distribuidor_id": 1,
+                "vendedor_id": 99,
+            }
+        ],
+        "detalles_venta": [
+            {
+                "venta_id": 5,
+                "producto_id": 1,
+                "cantidad": 1,
+                "precio_unitario": 10,
+            }
+        ],
     }
     path = tmp_path / "inv.json"
     path.write_text(json.dumps(data))

--- a/tests/test_inventory_import_validation.py
+++ b/tests/test_inventory_import_validation.py
@@ -1,0 +1,91 @@
+import json
+import inventory_manager as im
+
+
+class MemoryDB(im.DB):
+    def __init__(self):
+        super().__init__(db_name=":memory:")
+
+
+def make_valid_data():
+    return {
+        "schemaVersion": 1,
+        "generatedAt": "2024-01-01T00:00:00",
+        "appVersion": "test",
+        "Distribuidores": [{"id": 1, "nombre": "D"}],
+        "vendedores": [{"id": 1, "nombre": "V", "Distribuidor_id": 1}],
+        "productos": [
+            {
+                "id": 1,
+                "nombre": "P",
+                "codigo": "P1",
+                "sku": "S1",
+                "vendedor_id": 1,
+                "Distribuidor_id": 1,
+                "precio_compra": 1,
+                "precio_venta_minorista": 2,
+                "precio_venta_mayorista": 2,
+                "stock": 0,
+            }
+        ],
+        "clientes": [{"id": 1, "nombre": "C"}],
+        "ventas": [
+            {
+                "id": 1,
+                "fecha": "2024-01-01",
+                "total": 2,
+                "cliente_id": 1,
+                "vendedor_id": 1,
+                "Distribuidor_id": 1,
+            }
+        ],
+        "detalles_venta": [
+            {
+                "venta_id": 1,
+                "producto_id": 1,
+                "cantidad": 1,
+                "precio_unitario": 2,
+            }
+        ],
+    }
+
+
+def test_happy_path_import(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    manager.importar_inventario_json(str(path))
+    assert manager.db.get_productos()
+
+
+def test_invalid_producto_id(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    data["detalles_venta"][0]["producto_id"] = 99
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = manager.importar_inventario_json(str(path), dry_run=True, strict=False)
+    assert len(summary["errors"]) == 1
+    assert summary["errors"][0]["path"] == "detalles_venta[0].producto_id"
+    assert not manager.db.get_productos()
+
+
+def test_missing_section_is_error(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    data.pop("productos")
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = manager.importar_inventario_json(str(path), dry_run=True, strict=False)
+    assert any(issue["path"] == "productos" and issue["severity"] == "error" for issue in summary["errors"])
+
+
+def test_migration_applied(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = manager.importar_inventario_json(str(path), dry_run=True)
+    assert not summary["errors"]
+    assert any("Distribuidores" in m for m in summary["migrations_applied"])


### PR DESCRIPTION
## Summary
- embed schema metadata during inventory export
- add inventory validator and migrator for structural and referential checks
- support transactional import with dry-run reporting
- treat missing inventory sections as errors during validation

## Testing
- `pytest tests/test_inventory_import_validation.py tests/test_import_malformed_json.py tests/test_import_vendor_mapping.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c77c5ef700832398bba207d8f5389d