### PR TITLE
Adjust product table column widths in factura PDF

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -416,7 +416,7 @@ def generar_factura_electronica_pdf(
 
     tabla = Table(
         tabla_data,
-        colWidths=[44, 180, 60, 50, 60, 60, 70],
+        colWidths=[44, 150, 90, 50, 60, 60, 70],
         repeatRows=1,
     )
     tabla.setStyle(TableStyle([


### PR DESCRIPTION
## Summary
- tweak product table widths to shift "Precio Unitario" away from vertical line

## Testing
- `python - <<'PY'
from factura_sv import generar_factura_electronica_pdf
import uuid
venta = {'sumas':10,'descuentos':0,'subtotal':10,'iva':1.3,'total':11.3,'ventas_exentas':0,'ventas_no_sujetas':0,'total_letras':'ONCE CON 30/100 DOLARES'}
detalles = [{'cantidad':1,'descripcion':'Prod','precio_unitario':10,'ventas_no_sujetas':0,'ventas_exentas':0,'ventas_gravadas':10}]
generar_factura_electronica_pdf(venta,detalles,{}, {}, 'Crédito Fiscal', archivo='factura_test.pdf', datos_negocio={}, codigo_generacion=str(uuid.uuid4()), numero_control=uuid.uuid4().hex[:8].upper(), fecha_generacion='01/01/2024', sello_recepcion='SELLO')
print('generated')
PY`
- `pytest tests/test_factura_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_68c782359e9c8323a2b69128bdfa5800