### PR TITLE
Corrige sincronización de numeroControl con correlativo

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2931,12 +2931,15 @@ def validate_dte_json(
         else None
     )
     if correlativo is not None:
-        if numero_control and not re.fullmatch(regex_nc, numero_control):
-            ident["numeroControl"] = recon
-        elif numero_control and numero_control != recon:
-            raise ValueError("numeroControl no coincide con correlativo suministrado")
-        else:
-            ident["numeroControl"] = recon
+        if numero_control and numero_control != recon:
+            # Reemplazar cualquier numeroControl inconsistente con el correlativo
+            logger.warning(
+                "numeroControl %s no coincide con correlativo %s; se reemplaza con %s",
+                numero_control,
+                correlativo,
+                recon,
+            )
+        ident["numeroControl"] = recon
     elif not (isinstance(numero_control, str) and re.fullmatch(regex_nc, numero_control)):
         ident["numeroControl"], correlativo = generar_numero_control(db, tipo, suc, pto)
     numero_control = ident.get("numeroControl")

--- a/tests/test_dte_correlativo.py
+++ b/tests/test_dte_correlativo.py
@@ -95,8 +95,8 @@ def test_validate_dte_json_correlativo_desincronizado(tmp_path):
     ident = dte["identificacion"]
     corr = int(ident["numeroControl"].split("-")[-1])
     ident["numeroControl"] = dte_module._format_numero_control("01", "001", "001", corr + 1)
-    with pytest.raises(ValueError):
-        dte_module.validate_dte_json(dte, db=db, correlativo=corr)
+    dte_module.validate_dte_json(dte, db=db, correlativo=corr)
+    assert ident["numeroControl"] == dte_module._format_numero_control("01", "001", "001", corr)
 
 
 def test_validate_dte_json_corrige_numero_control_invalido(tmp_path):


### PR DESCRIPTION
## Summary
- Corrige la validación de `numeroControl` reemplazándolo si no coincide con el correlativo
- Ajusta la prueba que verifica la sincronización del correlativo

## Testing
- `pytest tests/test_dte_correlativo.py::test_validate_dte_json_correlativo_desincronizado -q --no-cov`
- `pytest -q` *(falla: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c786d88b1c8323908783e0473955ac