### PR TITLE
Use DB seal when annulling DTE

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1329,6 +1329,13 @@ class FacturacionTab(QWidget):
                 except Exception:
                     extra = {}
         sello = data.get("selloRecibido") or extra.get("selloRecibido")
+        if not sello and venta_id:
+            row = self.manager.db.cursor.execute(
+                "SELECT sello FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+                (venta_id,),
+            ).fetchone()
+            if row and row["sello"]:
+                sello = row["sello"]
         ident = data.get("identificacion", {})
         if not (ident.get("codigoGeneracion") and ident.get("numeroControl") and sello):
             QMessageBox.critical(

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -1,8 +1,12 @@
 import uuid
+from types import SimpleNamespace
+
+from PyQt5.QtWidgets import QDialog, QWidget
 
 from dialogs.anular_factura_dialog import AnularFacturaDialog
-from dte import generar_evento_anulacion
 from utils.catalogos import TRIBUTO_IVA
+import facturacion_tab
+import anulacion
 
 
 def _sample_factura():
@@ -38,7 +42,7 @@ def _sample_factura():
     }
 
 
-def test_generar_evento_anulacion(qt_app):
+def test_generar_evento_anulacion(qt_app, monkeypatch):
     factura = _sample_factura()
     dlg = AnularFacturaDialog()
     dlg.tipo_cb.setCurrentIndex(1)
@@ -51,8 +55,96 @@ def test_generar_evento_anulacion(qt_app):
     dlg.ndoc_sol.setText("987654321")
     form = dlg.get_data()
     sello = "A" * 40
-    evento = generar_evento_anulacion(factura, form, sello)
+
+    monkeypatch.setattr(
+        anulacion,
+        "_load_datos_negocio",
+        lambda: {
+            "nit": "06141404100016",
+            "nombre": "Empresa SA",
+            "telefono": "22223333",
+            "correo": "info@empresa.com",
+            "tipoEstablecimiento": "01",
+            "nombreComercial": "Empresa",
+            "codEstableMH": "0001",
+            "codEstable": "0001",
+            "codPuntoVentaMH": "0001",
+            "codPuntoVenta": "0001",
+        },
+    )
+    evento = anulacion.build_invalidacion_json(
+        {**factura, "selloRecibido": sello}, form, ambiente="00"
+    )
     assert evento["motivo"]["nombreResponsable"] == "Responsable Uno"
     assert evento["motivo"]["numDocSolicita"] == "987654321"
     assert evento["documento"]["selloRecibido"] == sello
-    assert evento["documento"]["numeroControl"] == factura["identificacion"]["numeroControl"]
+    assert (
+        evento["documento"]["numeroControl"]
+        == factura["identificacion"]["numeroControl"]
+    )
+
+
+def test_anular_dte_uses_sello_from_db(qt_app, db_conn, monkeypatch):
+    def _create_sale(db):
+        db.add_vendedor("V1")
+        vid = db.cursor.lastrowid
+        db.add_producto("P1", "C1", None, vid, None, 0, 10, 10, 1)
+        pid = db.cursor.lastrowid
+        db.add_cliente("C", "", "", "", "", "", "c@x.com", "", "", "")
+        cid = db.cursor.lastrowid
+        venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, vendedor_id=vid)
+        db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+        return venta_id
+
+    venta_id = _create_sale(db_conn)
+    sello = "S" * 40
+    db_conn.registrar_envio_dte(venta_id, "test", "aceptado", sello)
+
+    factura = {"venta_id": venta_id}
+    data = {
+        "identificacion": {
+            "codigoGeneracion": "CG123",
+            "numeroControl": "NC123",
+        },
+        "receptor": {},
+    }
+
+    class DummyTab(QWidget):
+        def __init__(self, db):
+            super().__init__()
+            self.manager = SimpleNamespace(db=db)
+
+        def refresh_and_reload(self):
+            pass
+
+    dummy = DummyTab(db_conn)
+
+    monkeypatch.setattr(
+        facturacion_tab.dte,
+        "_load_datos_negocio",
+        lambda: {"nombre": "Empresa", "nit": "06141404100016"},
+    )
+
+    class DummyDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec_(self):
+            return QDialog.Rejected
+
+        def get_data(self):
+            return {}
+
+    monkeypatch.setattr(facturacion_tab, "AnularDteDialog", DummyDialog)
+
+    called = []
+
+    def fake_critical(*args, **kwargs):
+        called.append((args, kwargs))
+
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", fake_critical)
+
+    facturacion_tab.FacturacionTab._anular_dte(dummy, factura, data)
+
+    assert not called
+    assert data["selloRecibido"] == sello


### PR DESCRIPTION
## Summary
- recover `selloRecibido` from `dte_envios` when missing in invoice and sale data
- exercise DTE annulment when seal only exists in `dte_envios`

## Testing
- `pytest tests/test_evento_anulacion.py -q --disable-warnings --override-ini=addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68c78cc2241c8323819110a553ae92a3