### PR TITLE
Handle invalid stock values during import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -556,6 +556,11 @@ class InventoryManager:
                         old_vend_id,
                     )
                 dist = Distribuidor_id_map.get(p.get("Distribuidor_id"))
+                stock = p.get("stock")
+                try:
+                    stock = float(stock) if stock is not None else 0
+                except (TypeError, ValueError):
+                    stock = 0
                 self.db.add_producto(
                     p.get("nombre", ""),
                     p.get("codigo", ""),
@@ -565,7 +570,7 @@ class InventoryManager:
                     p.get("precio_compra", 0),
                     p.get("precio_venta_minorista", 0),
                     p.get("precio_venta_mayorista", 0),
-                    p.get("stock", 0),
+                    stock,
                     commit=False,
                 )
                 new_id = self.db.cursor.lastrowid  # Usa el ID real insertado, no busques por nombre
@@ -1050,12 +1055,21 @@ class ProductTableModel(QAbstractTableModel):
                 precio = row.get("precio_venta_minorista", 0) or 0
                 return f"${precio:.2f}"
             elif col == 3:
-                return row.get("stock", 0)
+                stock = row.get("stock")
+                try:
+                    stock = float(stock) if stock is not None else 0
+                except (TypeError, ValueError):
+                    stock = 0
+                return stock
             # Si agregas comisión:
             # elif col == 4:
             #     return f"{row.get('comision_base', 0)}%"  # O el campo que corresponda
         elif role == Qt.BackgroundRole and col == 3:
-            stock = row.get("stock", 0)
+            stock = row.get("stock")
+            try:
+                stock = float(stock) if stock is not None else 0
+            except (TypeError, ValueError):
+                stock = 0
             if stock < 5:
                 return QColor("red")
             elif stock < 10:

--- a/inventory_validator.py
+++ b/inventory_validator.py
@@ -87,6 +87,18 @@ def validate_inventory_json(data: dict) -> List[Issue]:
             issues.append({"path": f"productos[{i}].nombre", "severity": "error", "message": "Campo requerido"})
         if "precio_venta_minorista" not in p:
             issues.append({"path": f"productos[{i}].precio_venta_minorista", "severity": "error", "message": "Campo requerido"})
+        stock = p.get("stock")
+        if stock is not None:
+            try:
+                stock_val = float(stock)
+                if stock_val < 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                issues.append({
+                    "path": f"productos[{i}].stock",
+                    "severity": "error",
+                    "message": "stock debe ser un número no negativo",
+                })
 
     vendedor_ids = {v.get("id") for v in vendedores if isinstance(v, dict)}
     cliente_ids = {c.get("id") for c in clientes if isinstance(c, dict)}

--- a/tests/test_inventory_import_validation.py
+++ b/tests/test_inventory_import_validation.py
@@ -71,6 +71,16 @@ def test_invalid_producto_id(tmp_path):
     assert not manager.db.get_productos()
 
 
+def test_non_numeric_stock(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    data["productos"][0]["stock"] = "invalid"
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = manager.importar_inventario_json(str(path), dry_run=True, strict=False)
+    assert any(issue["path"] == "productos[0].stock" for issue in summary["errors"])
+
+
 def test_missing_section_is_error(tmp_path):
     manager = im.InventoryManager(MemoryDB())
     data = make_valid_data()


### PR DESCRIPTION
## Summary
- sanitize stock values when importing inventory JSON
- handle malformed stock values in the product table model
- validate and test that stock must be numeric

## Testing
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7928421b48323bc77dabf9b49517a