### PR TITLE
Persist DTE reception seal

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,3 +355,10 @@ generar_ticket_personalizado(
     dte_data=data["dte_data"],
 )
 ```
+
+### Anulación de documentos
+
+Cada DTE transmitido recibe un `selloRecibido` por parte del Ministerio de
+Hacienda. Este sello debe almacenarse y conservarse en el campo `extra` de la
+venta correspondiente, ya que es un requisito indispensable para solicitar la
+anulación del documento en el futuro.

--- a/dte.py
+++ b/dte.py
@@ -5038,7 +5038,10 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str | None = None) -> dict:
         token = sign_json(data)
         jws_token = token.rstrip("\n")
         save_file(jws_path, jws_token, add_final_newline=False)
-    return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
+    resp = _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
+    if resp.get("sello"):
+        db.update_venta_extra(nota_id, {"selloRecibido": resp["sello"]})
+    return resp
 
 
 def enviar_nota_debito(db: DB, nota_id: int, modo: str | None = None) -> dict:
@@ -5081,7 +5084,10 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str | None = None) -> dict:
         token = sign_json(data)
         jws_token = token.rstrip("\n")
         save_file(jws_path, jws_token, add_final_newline=False)
-    return _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
+    resp = _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
+    if resp.get("sello"):
+        db.update_venta_extra(nota_id, {"selloRecibido": resp["sello"]})
+    return resp
 
 
 def enviar_nota_remision(db: DB, nota_id: int, modo: str | None = None) -> dict:
@@ -5101,7 +5107,10 @@ def enviar_nota_remision(db: DB, nota_id: int, modo: str | None = None) -> dict:
     #     json_path = save_dte_json(data)
     #     errors = _format_validation_errors(exc)
     #     raise DTEValidationError(errors, json_path) from exc
-    return _enviar_documento(db, nota_id, data, modo)
+    resp = _enviar_documento(db, nota_id, data, modo)
+    if resp.get("sello"):
+        db.update_venta_extra(nota_id, {"selloRecibido": resp["sello"]})
+    return resp
 
 
 def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:

--- a/tests/test_sello_persistencia.py
+++ b/tests/test_sello_persistencia.py
@@ -1,0 +1,108 @@
+import json
+from db import DB
+from dte import (
+    transmitir_dte,
+    enviar_factura,
+    enviar_nota_credito,
+    enviar_nota_debito,
+    enviar_nota_remision,
+)
+import dte
+import nota_remision
+import utils.docs
+import utils.jws
+
+
+def create_sale(db: DB):
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "X", None, vid, None, 0, 0, 0, 1)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id
+
+
+def _stub_enviar_documento(db_obj, doc_id, data, modo, jws_token=None):
+    return {"estado": "Transmitido", "sello": "SELLO"}
+
+
+def _assert_sello_guardado(db: DB, venta_id: int):
+    row = db.cursor.execute("SELECT extra FROM ventas WHERE id=?", (venta_id,)).fetchone()
+    assert row and row["extra"]
+    extra = json.loads(row["extra"])
+    assert extra["selloRecibido"] == "SELLO"
+
+
+def test_transmitir_dte_guarda_sello(monkeypatch):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    monkeypatch.setattr(dte, "generar_dte_json", lambda db_obj, vid: {})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
+    monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
+    res = transmitir_dte(db, venta_id)
+    assert res["sello"] == "SELLO"
+    _assert_sello_guardado(db, venta_id)
+
+
+def test_enviar_factura_guarda_sello(monkeypatch):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    monkeypatch.setattr(dte, "generar_dte_json", lambda db_obj, vid: {})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
+    monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
+    res = enviar_factura(db, venta_id)
+    assert res["sello"] == "SELLO"
+    _assert_sello_guardado(db, venta_id)
+
+
+def test_enviar_nota_credito_guarda_sello(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    nota_id = db.add_nota(venta_id, "credito", "2024-01-02", 10, "motivo")
+    monkeypatch.setattr(dte, "generar_nota_credito_json", lambda db_obj, nid: {"identificacion": {"fecEmi": "2024-01-02", "numeroControl": "1"}, "receptor": {"nombre": "Cliente"}, "resumen": {"totalLetras": "X"}})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
+    monkeypatch.setattr(utils.docs, "get_dte_document_paths", lambda *a, **k: (None, tmp_path / "nc.json"))
+    monkeypatch.setattr(utils.jws, "sign_json", lambda data: "TOKEN")
+    monkeypatch.setattr(dte, "save_file", lambda *a, **k: None)
+    monkeypatch.setattr(dte, "stable_stringify", lambda data, indent=2: json.dumps(data))
+    monkeypatch.setattr(dte.os.path, "exists", lambda p: False)
+    monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
+    res = enviar_nota_credito(db, nota_id)
+    assert res["sello"] == "SELLO"
+    _assert_sello_guardado(db, nota_id)
+
+
+def test_enviar_nota_debito_guarda_sello(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    nota_id = db.add_nota(venta_id, "debito", "2024-01-02", 10, "motivo")
+    monkeypatch.setattr(dte, "generar_nota_debito_json", lambda db_obj, nid: {"identificacion": {"fecEmi": "2024-01-02", "numeroControl": "1"}, "receptor": {"nombre": "Cliente"}, "resumen": {"totalLetras": "X"}})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
+    monkeypatch.setattr(utils.docs, "get_dte_document_paths", lambda *a, **k: (None, tmp_path / "nd.json"))
+    monkeypatch.setattr(utils.jws, "sign_json", lambda data: "TOKEN")
+    monkeypatch.setattr(dte, "save_file", lambda *a, **k: None)
+    monkeypatch.setattr(dte, "stable_stringify", lambda data, indent=2: json.dumps(data))
+    monkeypatch.setattr(dte.os.path, "exists", lambda p: False)
+    monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
+    res = enviar_nota_debito(db, nota_id)
+    assert res["sello"] == "SELLO"
+    _assert_sello_guardado(db, nota_id)
+
+
+def test_enviar_nota_remision_guarda_sello(monkeypatch):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    nota_id = db.add_nota(venta_id, "remision", "2024-01-02", 10, "motivo")
+    monkeypatch.setattr(nota_remision, "generar_nota_remision_desde_db", lambda db_obj, nid: {"resumen": {"totalLetras": "X"}})
+    monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
+    monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
+    monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
+    res = enviar_nota_remision(db, nota_id)
+    assert res["sello"] == "SELLO"
+    _assert_sello_guardado(db, nota_id)
+


### PR DESCRIPTION
## Summary
- store `selloRecibido` in sale metadata after sending credit, debit and remision notes
- add unit tests covering seal persistence for each document type
- document the need to keep `selloRecibido` for future cancellations

## Testing
- `pytest tests/test_sello_persistencia.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7903516f4832398d04e134e2a88bd