### PR TITLE
Handle sello in dte_envios response for DTE annulment

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1331,11 +1331,24 @@ class FacturacionTab(QWidget):
         sello = data.get("selloRecibido") or extra.get("selloRecibido")
         if not sello and venta_id:
             row = self.manager.db.cursor.execute(
-                "SELECT sello FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+                "SELECT sello, respuesta FROM dte_envios WHERE venta_id=? AND TRIM(sello)<>'' ORDER BY id DESC LIMIT 1",
                 (venta_id,),
             ).fetchone()
-            if row and row["sello"]:
+            if not row:
+                row = self.manager.db.cursor.execute(
+                    "SELECT sello, respuesta FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+                    (venta_id,),
+                ).fetchone()
+            if row:
                 sello = row["sello"]
+                if not sello:
+                    resp = row["respuesta"]
+                    if resp:
+                        try:
+                            resp_json = json.loads(resp)
+                            sello = resp_json.get("selloRecibido") or resp_json.get("sello")
+                        except Exception:
+                            pass
         ident = data.get("identificacion", {})
         if not (ident.get("codigoGeneracion") and ident.get("numeroControl") and sello):
             QMessageBox.critical(

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -1,5 +1,6 @@
 import uuid
 from types import SimpleNamespace
+import json
 
 from PyQt5.QtWidgets import QDialog, QWidget
 
@@ -99,6 +100,78 @@ def test_anular_dte_uses_sello_from_db(qt_app, db_conn, monkeypatch):
     venta_id = _create_sale(db_conn)
     sello = "S" * 40
     db_conn.registrar_envio_dte(venta_id, "test", "aceptado", sello)
+
+    factura = {"venta_id": venta_id}
+    data = {
+        "identificacion": {
+            "codigoGeneracion": "CG123",
+            "numeroControl": "NC123",
+        },
+        "receptor": {},
+    }
+
+    class DummyTab(QWidget):
+        def __init__(self, db):
+            super().__init__()
+            self.manager = SimpleNamespace(db=db)
+
+        def refresh_and_reload(self):
+            pass
+
+    dummy = DummyTab(db_conn)
+
+    monkeypatch.setattr(
+        facturacion_tab.dte,
+        "_load_datos_negocio",
+        lambda: {"nombre": "Empresa", "nit": "06141404100016"},
+    )
+
+    class DummyDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec_(self):
+            return QDialog.Rejected
+
+        def get_data(self):
+            return {}
+
+    monkeypatch.setattr(facturacion_tab, "AnularDteDialog", DummyDialog)
+
+    called = []
+
+    def fake_critical(*args, **kwargs):
+        called.append((args, kwargs))
+
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", fake_critical)
+
+    facturacion_tab.FacturacionTab._anular_dte(dummy, factura, data)
+
+    assert not called
+    assert data["selloRecibido"] == sello
+
+
+def test_anular_dte_uses_sello_from_respuesta(qt_app, db_conn, monkeypatch):
+    def _create_sale(db):
+        db.add_vendedor("V1")
+        vid = db.cursor.lastrowid
+        db.add_producto("P1", "C1", None, vid, None, 0, 10, 10, 1)
+        pid = db.cursor.lastrowid
+        db.add_cliente("C", "", "", "", "", "", "c@x.com", "", "", "")
+        cid = db.cursor.lastrowid
+        venta_id = db.add_venta("2024-01-01", 10, cliente_id=cid, vendedor_id=vid)
+        db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+        return venta_id
+
+    venta_id = _create_sale(db_conn)
+    sello = "R" * 40
+    db_conn.registrar_envio_dte(
+        venta_id,
+        "test",
+        "aceptado",
+        "",
+        json.dumps({"selloRecibido": sello}),
+    )
 
     factura = {"venta_id": venta_id}
     data = {


### PR DESCRIPTION
## Summary
- Retrieve `respuesta` when looking up previous DTE transmissions
- Parse JSON `respuesta` when `sello` column is empty to get `selloRecibido`
- Add regression test for sello stored only in `dte_envios.respuesta`

## Testing
- `pytest tests/test_evento_anulacion.py::test_anular_dte_uses_sello_from_db tests/test_evento_anulacion.py::test_anular_dte_uses_sello_from_respuesta -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a9a57ea8832382328a4cf45c2130