### PR TITLE
Add TIPO_INVALIDACION catalog constant

### DIFF
--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -560,6 +560,8 @@ CONDICION_OPERACION = {int(k): v for k, v in _CATS["CAT-016"].items()}
 
 FORMA_PAGO = _CATS["CAT-017"]
 
+TIPO_INVALIDACION = {int(k): v for k, v in _CATS["CAT-024"].items()}
+
 # Catálogos geográficos
 CAT_DEPTOS = _CATS["CAT-012"]
 


### PR DESCRIPTION
## Summary
- add TIPO_INVALIDACION constant from catalog CAT-024 with integer keys

## Testing
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b11504ec8323baca206cb644a422