### PR TITLE
Remove vendor-to-worker sync

### DIFF
--- a/db.py
+++ b/db.py
@@ -209,24 +209,6 @@ class DB:
         finally:
             self.cursor.execute("PRAGMA foreign_keys=on")
 
-    def ensure_vendedores_trabajadores(self):
-        """Ensure every vendedor has a corresponding trabajador entry."""
-        self.cursor.execute("SELECT id, codigo, nombre, dui FROM vendedores")
-        for vend in self.cursor.fetchall():
-            self.cursor.execute(
-                "SELECT 1 FROM trabajadores WHERE id=?", (vend["id"],)
-            )
-            if self.cursor.fetchone():
-                continue
-            self.cursor.execute(
-                """
-                INSERT INTO trabajadores (id, codigo, nombre, dui, es_vendedor)
-                VALUES (?, ?, ?, ?, 1)
-                """,
-                (vend["id"], vend["codigo"], vend["nombre"], vend["dui"]),
-            )
-        self.conn.commit()
-
     def setup(self):
         # Create tables if they don't exist without dropping existing data
         self.cursor.execute("""
@@ -617,7 +599,6 @@ class DB:
         self.cursor.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_distribuidores_nombre ON Distribuidores(nombre)"
         )
-        self.ensure_vendedores_trabajadores()
         self.migrate_ventas_cliente_fk()
         self.migrate_detalles_venta_vendedor_fk()
         self.conn.commit()

--- a/tests/test_trabajador_vendedor_independencia.py
+++ b/tests/test_trabajador_vendedor_independencia.py
@@ -1,0 +1,17 @@
+from db import DB
+
+
+def test_add_trabajador_es_vendedor_no_crea_vendedor(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_trabajador({"codigo": "T1", "nombre": "Juan", "es_vendedor": True})
+    db.cursor.execute("SELECT COUNT(*) FROM vendedores")
+    assert db.cursor.fetchone()[0] == 0
+
+
+def test_update_trabajador_es_vendedor_no_crea_vendedor(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_trabajador({"codigo": "T1", "nombre": "Ana"})
+    tid = db.get_trabajadores()[0]["id"]
+    db.update_trabajador(tid, {"codigo": "T1", "nombre": "Ana", "es_vendedor": True})
+    db.cursor.execute("SELECT COUNT(*) FROM vendedores")
+    assert db.cursor.fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- drop `ensure_vendedores_trabajadores` and related call
- add tests ensuring workers marked as vendors don't populate `vendedores`

## Testing
- `pytest tests/test_trabajador_vendedor_independencia.py tests/test_delete_trabajador_sales.py -q`
- `pytest tests/test_estado_cuenta_dialog.py::test_dialog_uses_trabajadores_for_vendedores -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b13eff148323b22391ae86708ca1