### PR TITLE
Usar catálogos para tipos de anulación y documentos

### DIFF
--- a/dialogs/anular_factura_dialog.py
+++ b/dialogs/anular_factura_dialog.py
@@ -14,14 +14,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtCore import Qt, QTimer, QEvent
 import dte
 from db import DB
-
-DOC_TYPES = [
-    ("NIT", "36"),
-    ("DUI", "13"),
-    ("Carnet de residente", "02"),
-    ("Pasaporte", "03"),
-    ("Otro", "37"),
-]
+from utils.catalogos import TIPO_INVALIDACION, TIPO_DOC_REC
 
 class AnularFacturaDialog(QDialog):
     """Formulario para capturar datos de anulación."""
@@ -42,12 +35,8 @@ class AnularFacturaDialog(QDialog):
         row = QHBoxLayout()
         row.addWidget(QLabel("Tipo de anulación:"))
         self.tipo_cb = QComboBox()
-        for text, val in [
-            ("1", 1),
-            ("2", 2),
-            ("3", 3),
-        ]:
-            self.tipo_cb.addItem(text, val)
+        for code, desc in sorted(TIPO_INVALIDACION.items()):
+            self.tipo_cb.addItem(f"{code} - {desc}", str(code))
         row.addWidget(self.tipo_cb)
         layout.addLayout(row)
 
@@ -79,8 +68,8 @@ class AnularFacturaDialog(QDialog):
         row = QHBoxLayout()
         row.addWidget(QLabel("Tipo doc:"))
         self.tdoc_resp = QComboBox()
-        for text, val in DOC_TYPES:
-            self.tdoc_resp.addItem(text, val)
+        for code, desc in sorted(TIPO_DOC_REC.items()):
+            self.tdoc_resp.addItem(f"{code} - {desc}", code)
         row.addWidget(self.tdoc_resp)
         row.addWidget(QLabel("Número:"))
         self.ndoc_resp = QLineEdit()
@@ -106,8 +95,8 @@ class AnularFacturaDialog(QDialog):
         row = QHBoxLayout()
         row.addWidget(QLabel("Tipo doc:"))
         self.tdoc_sol = QComboBox()
-        for text, val in DOC_TYPES:
-            self.tdoc_sol.addItem(text, val)
+        for code, desc in sorted(TIPO_DOC_REC.items()):
+            self.tdoc_sol.addItem(f"{code} - {desc}", code)
         row.addWidget(self.tdoc_sol)
         row.addWidget(QLabel("Número:"))
         self.ndoc_sol = QLineEdit()

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -64,7 +64,7 @@ from dialogs.nota_detalle_dialog import NotaDetalleDialog
 from dialogs.invoice_detail_dialog import InvoiceDetailDialog
 from decimal import Decimal
 from utils.monto import iva_item
-from utils.catalogos import TRIBUTO_IVA
+from utils.catalogos import TRIBUTO_IVA, TIPO_INVALIDACION, TIPO_DOC_REC
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +126,8 @@ class AnularDteDialog(QDialog):
         layout = QFormLayout(self)
 
         self.tipo_cb = QComboBox()
-        self.tipo_cb.addItems(["1", "2", "3"])
+        for code, desc in sorted(TIPO_INVALIDACION.items()):
+            self.tipo_cb.addItem(f"{code} - {desc}", str(code))
         layout.addRow("Tipo anulación", self.tipo_cb)
 
         self.motivo_edit = QLineEdit()
@@ -134,9 +135,10 @@ class AnularDteDialog(QDialog):
 
         self.nombre_resp = QLineEdit((responsable or {}).get("nombre", ""))
         self.tipdoc_resp = QComboBox()
-        self.tipdoc_resp.addItems(["36", "13", "02", "03", "37"])
+        for code, desc in sorted(TIPO_DOC_REC.items()):
+            self.tipdoc_resp.addItem(f"{code} - {desc}", code)
         if responsable and responsable.get("tipDoc"):
-            idx = self.tipdoc_resp.findText(responsable.get("tipDoc"))
+            idx = self.tipdoc_resp.findData(responsable.get("tipDoc"))
             if idx >= 0:
                 self.tipdoc_resp.setCurrentIndex(idx)
         self.numdoc_resp = QLineEdit((responsable or {}).get("numDoc", ""))
@@ -146,9 +148,10 @@ class AnularDteDialog(QDialog):
 
         self.nombre_sol = QLineEdit((solicitante or {}).get("nombre", ""))
         self.tipdoc_sol = QComboBox()
-        self.tipdoc_sol.addItems(["36", "13", "02", "03", "37"])
+        for code, desc in sorted(TIPO_DOC_REC.items()):
+            self.tipdoc_sol.addItem(f"{code} - {desc}", code)
         if solicitante and solicitante.get("tipDoc"):
-            idx = self.tipdoc_sol.findText(solicitante.get("tipDoc"))
+            idx = self.tipdoc_sol.findData(solicitante.get("tipDoc"))
             if idx >= 0:
                 self.tipdoc_sol.setCurrentIndex(idx)
         self.numdoc_sol = QLineEdit((solicitante or {}).get("numDoc", ""))
@@ -163,13 +166,13 @@ class AnularDteDialog(QDialog):
 
     def get_data(self):
         return {
-            "tipoAnulacion": self.tipo_cb.currentText(),
+            "tipoAnulacion": self.tipo_cb.currentData(),
             "motivoAnulacion": self.motivo_edit.text().strip(),
             "nombreResponsable": self.nombre_resp.text().strip(),
-            "tipDocResponsable": self.tipdoc_resp.currentText(),
+            "tipDocResponsable": self.tipdoc_resp.currentData(),
             "numDocResponsable": self.numdoc_resp.text().strip(),
             "nombreSolicita": self.nombre_sol.text().strip(),
-            "tipDocSolicita": self.tipdoc_sol.currentText(),
+            "tipDocSolicita": self.tipdoc_sol.currentData(),
             "numDocSolicita": self.numdoc_sol.text().strip(),
         }
 

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -46,13 +46,13 @@ def _sample_factura():
 def test_generar_evento_anulacion(qt_app, monkeypatch):
     factura = _sample_factura()
     dlg = AnularFacturaDialog()
-    dlg.tipo_cb.setCurrentIndex(1)
+    dlg.tipo_cb.setCurrentIndex(dlg.tipo_cb.findData("2"))
     dlg.motivo_edit.setText("Error en factura")
     dlg.nom_resp.setText("Responsable Uno")
-    dlg.tdoc_resp.setCurrentIndex(0)
+    dlg.tdoc_resp.setCurrentIndex(dlg.tdoc_resp.findData("36"))
     dlg.ndoc_resp.setText("123456789")
     dlg.nom_sol.setText("Solicita Dos")
-    dlg.tdoc_sol.setCurrentIndex(1)
+    dlg.tdoc_sol.setCurrentIndex(dlg.tdoc_sol.findData("13"))
     dlg.ndoc_sol.setText("987654321")
     form = dlg.get_data()
     sello = "A" * 40


### PR DESCRIPTION
## Summary
- Poblar combos de tipo de anulación y documentos con catálogos oficiales
- Enviar solo los códigos en datos de anulación
- Ajustar pruebas para seleccionar valores por código

## Testing
- `pytest -q` *(falla: cannot import name 'norm_receptor' from 'dte')*
- `pytest tests/test_evento_anulacion.py tests/test_anular_factura_autofill.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b1c870ec832388debb838a7cca14