### PR TITLE
Fix related document numbering for electronic notes

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -16,6 +16,7 @@ from decimal import Decimal, ROUND_HALF_UP
 import copy
 import json
 import os
+import re
 from typing import Optional
 
 from db import DB
@@ -35,6 +36,48 @@ Decimal_0 = Decimal("0")
 Decimal_1 = Decimal("1")
 Q4 = Decimal("0.0001")
 IVA = Decimal("0.13")
+
+
+def _is_uuid(s: str) -> bool:
+    return bool(
+        re.fullmatch(r"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}", s.upper())
+    )
+
+
+def _is_nc(s: str) -> bool:
+    return str(s).startswith("DTE-")
+
+
+def _build_documento_relacionado(origen_ident: dict) -> tuple[list[dict], str]:
+    uuid_rel = str(origen_ident.get("codigoGeneracion", "")).upper()
+    nc_rel = origen_ident.get("numeroControl")
+    fec_rel = origen_ident.get("fecEmi")
+    tipo_generacion = origen_ident.get("tipoGeneracion")
+    numero_conf = origen_ident.get("numeroDocumento")
+    if tipo_generacion is None and numero_conf:
+        if _is_uuid(str(numero_conf)):
+            tipo_generacion = 2
+        elif _is_nc(str(numero_conf)):
+            tipo_generacion = 1
+        else:
+            raise ValueError("numeroDocumento inválido para documentoRelacionado")
+    if tipo_generacion is None:
+        tipo_generacion = 2
+    if tipo_generacion == 2:
+        numero_rel = uuid_rel
+    elif tipo_generacion == 1:
+        numero_rel = nc_rel
+    else:
+        raise ValueError("tipoGeneracion inválido para documentoRelacionado")
+    doc_rel = [
+        {
+            "tipoDocumento": origen_ident.get("tipoDte"),
+            "tipoGeneracion": tipo_generacion,
+            "numeroDocumento": numero_rel,
+            "fechaEmision": fec_rel,
+        }
+    ]
+    return doc_rel, numero_rel
 
 
 def _pct_label(ratio: Decimal) -> str:
@@ -160,14 +203,7 @@ def generar_nce_desde_dte(
     }
 
     origen_ident = dte_origen.get("identificacion", {})
-    doc_rel = [
-        {
-            "tipoDocumento": origen_ident.get("tipoDte"),
-            "tipoGeneracion": 2,
-            "numeroDocumento": origen_ident.get("numeroControl"),
-            "fechaEmision": origen_ident.get("fecEmi"),
-        }
-    ]
+    doc_rel, numero_rel = _build_documento_relacionado(origen_ident)
 
     emisor = dte_origen.get("emisor")
     receptor = copy.deepcopy(dte_origen.get("receptor", {}))
@@ -193,7 +229,7 @@ def generar_nce_desde_dte(
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
-    uuid_origen = origen_ident.get("codigoGeneracion", "")
+    uuid_origen = str(origen_ident.get("codigoGeneracion", "")).upper()
     tipo_doc_desc = catalogos.DTE_TIPOS.get(origen_ident.get("tipoDte", ""), "documento")
     extra_desc = f": {motivo}" if motivo else ""
 
@@ -249,7 +285,7 @@ def generar_nce_desde_dte(
                     "ventaExenta": exenta,
                     "ventaNoSuj": nosuj,
                     "tributos": [TRIBUTO_IVA] if grav > 0 else [],
-                    "numeroDocumento": uuid_origen,
+                    "numeroDocumento": numero_rel,
                     "codTributo": None,
                 }
             )
@@ -338,7 +374,7 @@ def generar_nce_desde_dte(
                         "ventaExenta": 0.0,
                         "ventaNoSuj": 0.0,
                         "tributos": [TRIBUTO_IVA],
-                        "numeroDocumento": uuid_origen,
+                        "numeroDocumento": numero_rel,
                         "codTributo": None,
                     }
                 )
@@ -365,7 +401,7 @@ def generar_nce_desde_dte(
                         "ventaExenta": 0.0,
                         "ventaNoSuj": 0.0,
                         "tributos": [TRIBUTO_IVA],
-                        "numeroDocumento": uuid_origen,
+                        "numeroDocumento": numero_rel,
                         "codTributo": None,
                     }
                 )
@@ -385,7 +421,7 @@ def generar_nce_desde_dte(
                         "ventaExenta": total_exenta,
                         "ventaNoSuj": 0.0,
                         "tributos": [],
-                        "numeroDocumento": uuid_origen,
+                        "numeroDocumento": numero_rel,
                         "codTributo": None,
                     }
                 )
@@ -405,7 +441,7 @@ def generar_nce_desde_dte(
                         "ventaExenta": 0.0,
                         "ventaNoSuj": total_nosuj,
                         "tributos": [],
-                        "numeroDocumento": uuid_origen,
+                        "numeroDocumento": numero_rel,
                         "codTributo": None,
                     }
                 )

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -13,6 +13,7 @@ from decimal import Decimal, ROUND_HALF_UP
 import copy
 import json
 import os
+import re
 from typing import Optional
 
 from db import DB
@@ -27,6 +28,48 @@ from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
 from utils.sanitize import limpiar_documentos
+
+
+def _is_uuid(s: str) -> bool:
+    return bool(
+        re.fullmatch(r"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}", s.upper())
+    )
+
+
+def _is_nc(s: str) -> bool:
+    return str(s).startswith("DTE-")
+
+
+def _build_documento_relacionado(origen_ident: dict) -> tuple[list[dict], str]:
+    uuid_rel = str(origen_ident.get("codigoGeneracion", "")).upper()
+    nc_rel = origen_ident.get("numeroControl")
+    fec_rel = origen_ident.get("fecEmi")
+    tipo_generacion = origen_ident.get("tipoGeneracion")
+    numero_conf = origen_ident.get("numeroDocumento")
+    if tipo_generacion is None and numero_conf:
+        if _is_uuid(str(numero_conf)):
+            tipo_generacion = 2
+        elif _is_nc(str(numero_conf)):
+            tipo_generacion = 1
+        else:
+            raise ValueError("numeroDocumento inválido para documentoRelacionado")
+    if tipo_generacion is None:
+        tipo_generacion = 2
+    if tipo_generacion == 2:
+        numero_rel = uuid_rel
+    elif tipo_generacion == 1:
+        numero_rel = nc_rel
+    else:
+        raise ValueError("tipoGeneracion inválido para documentoRelacionado")
+    doc_rel = [
+        {
+            "tipoDocumento": origen_ident.get("tipoDte"),
+            "tipoGeneracion": tipo_generacion,
+            "numeroDocumento": numero_rel,
+            "fechaEmision": fec_rel,
+        }
+    ]
+    return doc_rel, numero_rel
 
 
 def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
@@ -110,16 +153,7 @@ def generar_nde_desde_dte(
     }
 
     origen_ident = dte_origen.get("identificacion", {})
-    tipo_origen = origen_ident.get("tipoDte")
-    tipo_rel = "07" if tipo_origen == "07" else "03"
-    doc_rel = [
-        {
-            "tipoDocumento": tipo_rel,
-            "tipoGeneracion": 2,
-            "numeroDocumento": origen_ident.get("numeroControl"),
-            "fechaEmision": origen_ident.get("fecEmi"),
-        }
-    ]
+    doc_rel, numero_rel = _build_documento_relacionado(origen_ident)
 
     emisor = copy.deepcopy(dte_origen.get("emisor", {}))
     receptor = copy.deepcopy(dte_origen.get("receptor", {}))
@@ -145,7 +179,7 @@ def generar_nde_desde_dte(
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
-    uuid_origen = origen_ident.get("codigoGeneracion", "")
+    uuid_origen = str(origen_ident.get("codigoGeneracion", "")).upper()
     tipo_doc_desc = catalogos.DTE_TIPOS.get(origen_ident.get("tipoDte", ""), "documento")
     extra_desc = f": {motivo}" if motivo else ""
 
@@ -183,7 +217,7 @@ def generar_nde_desde_dte(
                     "ventaExenta": d4(exenta),
                     "ventaNoSuj": d4(nosuj),
                     "tributos": [TRIBUTO_IVA] if grav > 0 else [],
-                    "numeroDocumento": uuid_origen,
+                    "numeroDocumento": numero_rel,
                     "codTributo": None,
                 }
             )
@@ -241,7 +275,7 @@ def generar_nde_desde_dte(
                     "ventaExenta": 0.0,
                     "ventaNoSuj": 0.0,
                     "tributos": [TRIBUTO_IVA],
-                    "numeroDocumento": uuid_origen,
+                    "numeroDocumento": numero_rel,
                     "codTributo": None,
                 }
             )
@@ -261,7 +295,7 @@ def generar_nde_desde_dte(
                     "ventaExenta": total_exenta,
                     "ventaNoSuj": 0.0,
                     "tributos": [],
-                    "numeroDocumento": uuid_origen,
+                    "numeroDocumento": numero_rel,
                     "codTributo": None,
                 }
             )
@@ -281,7 +315,7 @@ def generar_nde_desde_dte(
                     "ventaExenta": 0.0,
                     "ventaNoSuj": total_nosuj,
                     "tributos": [],
-                    "numeroDocumento": uuid_origen,
+                    "numeroDocumento": numero_rel,
                     "codTributo": None,
                 }
             )

--- a/tests/test_iva_conversion_prorrateo.py
+++ b/tests/test_iva_conversion_prorrateo.py
@@ -45,7 +45,7 @@ def test_prorrateo_porcentaje(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("0.1"))
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     assert data["resumen"]["montoTotalOperacion"] == 10.0
 

--- a/tests/test_nce_detalles_total.py
+++ b/tests/test_nce_detalles_total.py
@@ -55,7 +55,7 @@ def test_nce_monto_total_por_detalles(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     resumen = nce["resumen"]
     expected_iva = (Decimal("10") * Decimal("0.13")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
@@ -88,7 +88,7 @@ def test_nce_detalles_monto_un_dolar(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles, monto=Decimal("1"))
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     resumen = nce["resumen"]
     iva = resumen["tributos"][0]["valor"] if resumen["tributos"] else Decimal("0")

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -44,7 +44,7 @@ def test_generar_nota_credito_json_ticket(tmp_path, monkeypatch):
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     assert data["cuerpoDocumento"][0]["precioUni"] > 0
     assert "totalPagar" not in data["resumen"]
@@ -83,7 +83,7 @@ def test_generar_nota_credito_json_factura(tmp_path, monkeypatch):
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     assert "-" not in data["receptor"].get("nit", "")
 
@@ -110,7 +110,7 @@ def test_nota_credito_total_nueve(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"))
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     assert data["resumen"]["montoTotalOperacion"] == 9.0
 
@@ -147,7 +147,7 @@ def test_nota_credito_precio_uni(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles)
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     item = data["cuerpoDocumento"][0]
     assert item["precioUni"] == Decimal("7.9600")

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -83,7 +83,7 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     assert doc_rel["fechaEmision"]
     assert (
         doc_rel["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     assert doc_rel["numeroDocumento"] != data["identificacion"].get("numeroControl")
     assert "-" not in data["emisor"].get("nit", "")

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -52,7 +52,7 @@ def test_generar_nce_detalles(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles, motivo="Dev")
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 10
@@ -82,7 +82,7 @@ def test_generar_nce_detalles_tributos(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles)
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     expected_iva = Decimal("10") * Decimal("0.13")
     assert data["resumen"]["tributos"][0]["valor"] == expected_iva
@@ -111,7 +111,7 @@ def test_generar_nce_detalles_monto_total(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     resumen = nce["resumen"]
     expected_iva = Decimal("10") * Decimal("0.13")
@@ -151,7 +151,7 @@ def test_generar_nota_debito_detalles(monkeypatch):
     assert doc_rel["tipoDocumento"] == "01"
     assert (
         doc_rel["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
 
 

--- a/tests/test_notas_precio_uni.py
+++ b/tests/test_notas_precio_uni.py
@@ -86,12 +86,12 @@ def test_notas_precio_uni_cuatro_decimales(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
     nde = generar_nde_desde_dte(db, dte_origen, detalles, None, "Ajuste")
     assert (
         nde["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["numeroControl"]
+        == dte_origen["identificacion"]["codigoGeneracion"].upper()
     )
 
     expected_subtotal = sum(

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -70,7 +70,7 @@ def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
     assert nce["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == data["identificacion"]["numeroControl"]
+        == data["identificacion"]["codigoGeneracion"].upper()
     )
     assert "nit" not in nce["receptor"]
 


### PR DESCRIPTION
## Summary
- normalize documentoRelacionado for credit and debit notes
- align note item identifiers with related document
- revert remisión note changes to keep existing behavior

## Testing
- `apt-get update`
- `apt-get install -y libgl1`
- `pytest` *(fails: ImportError: cannot import name 'norm_receptor'; ModuleNotFoundError: cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b377ebb083239bf83fffc0ec4cd9