### PR TITLE
Evita reenvío de DTE ya transmitidos

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4871,6 +4871,19 @@ def _enviar_documento(
 
     Si ``jws_token`` se proporciona, se reutiliza en lugar de firmar nuevamente.
     """
+    SUCCESS_STATES = {"Transmitido", "Recibido", "Procesado", "Aceptado"}
+    if doc_id is not None:
+        row = db.cursor.execute(
+            """
+            SELECT estado FROM dte_envios
+            WHERE venta_id=? AND estado IN (?, ?, ?, ?)
+            ORDER BY id DESC LIMIT 1
+            """,
+            (doc_id, *SUCCESS_STATES),
+        ).fetchone()
+        if row:
+            raise ValueError("DTE ya enviado")
+
     config = _load_dte_api_config()
 
     if not data.get("resumen", {}).get("totalLetras"):

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -729,24 +729,66 @@ class FacturacionTab(QWidget):
         try:
             if cur is not None:
                 if venta_id is not None:
-                    env_row = cur.execute(
-                        "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
-                        (venta_id,),
+                    success = cur.execute(
+                        """
+                        SELECT estado FROM dte_envios
+                        WHERE venta_id=? AND estado IN (?, ?, ?, ?)
+                        ORDER BY id DESC LIMIT 1
+                        """,
+                        (
+                            venta_id,
+                            "Transmitido",
+                            "Recibido",
+                            "Procesado",
+                            "Aceptado",
+                        ),
                     ).fetchone()
+                    if success:
+                        env_row = success
+                    else:
+                        env_row = cur.execute(
+                            "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+                            (venta_id,),
+                        ).fetchone()
                 elif codigo_generacion or numero_control:
-                    query = (
+                    query_success = (
+                        "SELECT estado FROM dte_envios WHERE venta_id IS NULL AND respuesta LIKE ? AND estado IN (?, ?, ?, ?) ORDER BY id DESC LIMIT 1"
+                    )
+                    query_latest = (
                         "SELECT estado FROM dte_envios WHERE venta_id IS NULL AND respuesta LIKE ? ORDER BY id DESC LIMIT 1"
                     )
                     if codigo_generacion:
                         env_row = cur.execute(
-                            query,
-                            (f"%{codigo_generacion}%",),
+                            query_success,
+                            (
+                                f"%{codigo_generacion}%",
+                                "Transmitido",
+                                "Recibido",
+                                "Procesado",
+                                "Aceptado",
+                            ),
                         ).fetchone()
+                        if not env_row:
+                            env_row = cur.execute(
+                                query_latest,
+                                (f"%{codigo_generacion}%",),
+                            ).fetchone()
                     if not env_row and numero_control:
                         env_row = cur.execute(
-                            query,
-                            (f"%{numero_control}%",),
+                            query_success,
+                            (
+                                f"%{numero_control}%",
+                                "Transmitido",
+                                "Recibido",
+                                "Procesado",
+                                "Aceptado",
+                            ),
                         ).fetchone()
+                        if not env_row:
+                            env_row = cur.execute(
+                                query_latest,
+                                (f"%{numero_control}%",),
+                            ).fetchone()
         except Exception:
             env_row = None
         if env_row:

--- a/tests/test_dte_resend_block.py
+++ b/tests/test_dte_resend_block.py
@@ -1,0 +1,66 @@
+import os
+
+import pytest
+
+import auth
+import dte
+from db import DB
+
+
+def create_sale(db: DB) -> int:
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("P1", "X", None, vid, None, 0, 0, 0, 1)
+    pid = db.cursor.lastrowid
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    return venta_id
+
+
+def test_enviar_documento_rechaza_reenvio_exitoso(monkeypatch):
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(venta, "normal", "Procesado", "S")
+
+    called = {"sign": 0, "post": 0}
+
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+
+    def fake_sign(data):  # pragma: no cover - should not be called
+        called["sign"] += 1
+        return "token"
+
+    def fake_post(url, token, signed, meta):  # pragma: no cover - should not be called
+        called["post"] += 1
+        return {"estado": "Procesado"}
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+
+    data = {
+        "identificacion": {"tipoDte": "01", "codigoGeneracion": "A"},
+        "resumen": {"totalLetras": "X"},
+    }
+    with pytest.raises(ValueError):
+        dte._enviar_documento(db, venta, data, "normal")
+
+    assert called["sign"] == 0
+    assert called["post"] == 0
+
+
+def test_detectar_estado_factura_prioriza_exitosos(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from facturacion_tab import FacturacionTab
+
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(venta, "normal", "Transmitido", "S")
+    db.registrar_envio_dte(venta, "normal", "Rechazado", "")
+
+    _, envio = FacturacionTab._detectar_estado_factura(
+        {}, cur=db.cursor, venta_id=venta
+    )
+    assert envio == "Enviado"
+


### PR DESCRIPTION
## Summary
- Bloquea reenvíos de DTE cuando ya existe un envío exitoso registrado
- Prioriza estados de envío exitosos al mostrar facturas en la interfaz
- Agrega pruebas que verifican el bloqueo de reenvío y la detección de estados

## Testing
- `pytest tests/test_dte_resend_block.py tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c7fb1a28a88323af7c033bd7479f98