### PR TITLE
Validate origin DTE before issuing notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -67,6 +67,35 @@ DTE_VERSIONES = {
 }
 
 
+def _origen_aceptado_en_mh(db: DB, ident: dict) -> bool:
+    """Check if the origin document has an accepted record in ``dte_envios``.
+
+    Se considera aceptado cuando existe un registro cuya ``estado`` sea
+    "Recibido", "Procesado" o "Aceptado" y posea un ``sello`` no vacío.
+    La coincidencia se realiza buscando el ``codigoGeneracion`` o el
+    ``numeroControl`` dentro del JSON almacenado en ``dte_envios.respuesta``.
+    """
+
+    uuid = str(ident.get("codigoGeneracion") or "").upper()
+    numc = str(ident.get("numeroControl") or "")
+    if not uuid and not numc:
+        return False
+    db.ensure_column("dte_envios", "respuesta", "TEXT")
+    row = db.cursor.execute(
+        """
+        SELECT estado, TRIM(sello) AS sello
+          FROM dte_envios
+         WHERE (respuesta LIKE ? OR respuesta LIKE ?)
+         ORDER BY id DESC LIMIT 1
+        """,
+        (f"%{uuid}%", f"%{numc}%"),
+    ).fetchone()
+    if not row:
+        return False
+    estado = str(row["estado"] or "").lower()
+    return bool(estado in {"recibido", "procesado", "aceptado"} and row["sello"])
+
+
 def _strip_additional_properties(value, schema):
     """Remove keys not defined in ``schema`` when ``additionalProperties`` is ``false``."""
     if "$ref" in schema:

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -24,6 +24,7 @@ from dte import (
     DTE_VERSIONES,
     generar_cabecera_dte_data,
     sanitize_dte_payload,
+    _origen_aceptado_en_mh,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -123,16 +124,13 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     dte_path = extra.get("dteJsonPath")
     if not dte_path or not os.path.exists(dte_path):
         raise ValueError("DTE base no encontrado")
-
-    estado_row = db.cursor.execute(
-        "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
-        (venta_id,),
-    ).fetchone()
-    if not estado_row or estado_row["estado"] != "Aceptado":
-        raise ValueError("El DTE base no fue aceptado")
-
     with open(dte_path, "r", encoding="utf-8") as fh:
         dte_origen = json.load(fh)
+
+    if not _origen_aceptado_en_mh(db, dte_origen.get("identificacion", {})):
+        raise ValueError(
+            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
+        )
 
     detalles = None
     if nota.get("detalles"):
@@ -181,6 +179,15 @@ def generar_nce_desde_dte(
     monto: Decimal | None = None,
 ) -> dict:
     """Genera la estructura JSON de una NCE."""
+    sello = dte_origen.get("selloRecibido") or dte_origen.get("extra", {}).get("selloRecibido")
+    if not sello:
+        raise ValueError(
+            "La factura base no tiene selloRecibido. No puedes referenciarla todavía."
+        )
+    if not _origen_aceptado_en_mh(db, dte_origen.get("identificacion", {})):
+        raise ValueError(
+            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
+        )
     if detalles is None:
         if ratio is None or ratio <= Decimal_0:
             raise ValueError("El porcentaje a acreditar debe ser mayor que cero")

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -22,6 +22,7 @@ from dte import (
     generar_cabecera_dte_data,
     sanitize_dte_payload,
     d4,
+    _origen_aceptado_en_mh,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -97,16 +98,13 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     dte_path = extra.get("dteJsonPath")
     if not dte_path or not os.path.exists(dte_path):
         raise ValueError("DTE base no encontrado")
-
-    estado_row = db.cursor.execute(
-        "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
-        (venta_id,),
-    ).fetchone()
-    if not estado_row or estado_row["estado"] != "Aceptado":
-        raise ValueError("El DTE base no fue aceptado")
-
     with open(dte_path, "r", encoding="utf-8") as fh:
         dte_origen = json.load(fh)
+
+    if not _origen_aceptado_en_mh(db, dte_origen.get("identificacion", {})):
+        raise ValueError(
+            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
+        )
 
     detalles = None
     if nota.get("detalles"):
@@ -135,6 +133,15 @@ def generar_nde_desde_dte(
     ambiente: str = "00",
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
+    sello = dte_origen.get("selloRecibido") or dte_origen.get("extra", {}).get("selloRecibido")
+    if not sello:
+        raise ValueError(
+            "La factura base no tiene selloRecibido. No puedes referenciarla todavía."
+        )
+    if not _origen_aceptado_en_mh(db, dte_origen.get("identificacion", {})):
+        raise ValueError(
+            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
+        )
     cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
     identificacion = {

--- a/tests/test_nota_origen_validations.py
+++ b/tests/test_nota_origen_validations.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+import pytest
+from db import DB
+from nota_credito_electronica import generar_nce_desde_dte
+
+
+def test_nce_requires_sello():
+    db = DB(":memory:")
+    dte_origen = {
+        "identificacion": {
+            "codigoGeneracion": "UUID",
+            "numeroControl": "NC",
+            "tipoDte": "01",
+            "fecEmi": "2024-01-01",
+        }
+    }
+    with pytest.raises(ValueError):
+        generar_nce_desde_dte(db, dte_origen, Decimal("1"))
+
+
+def test_nce_requires_db_record():
+    db = DB(":memory:")
+    dte_origen = {
+        "identificacion": {
+            "codigoGeneracion": "UUID",
+            "numeroControl": "NC",
+            "tipoDte": "01",
+            "fecEmi": "2024-01-01",
+        },
+        "selloRecibido": "SELLO",
+    }
+    with pytest.raises(ValueError):
+        generar_nce_desde_dte(db, dte_origen, Decimal("1"))


### PR DESCRIPTION
## Summary
- ensure related documents exist in MH before generating credit/debit notes
- guard note generation when base invoice lacks `selloRecibido`
- add regression tests for missing seal or MH record

## Testing
- `pytest tests/test_nota_origen_validations.py`
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c7faf49b188323a742ca70cefc1a04