### PR TITLE
Ensure origin DTE accepted before issuing credit/debit notes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -72,24 +72,40 @@ def _origen_aceptado_en_mh(db: DB, ident: dict) -> bool:
 
     Se considera aceptado cuando existe un registro cuya ``estado`` sea
     "Recibido", "Procesado" o "Aceptado" y posea un ``sello`` no vacío.
-    La coincidencia se realiza buscando el ``codigoGeneracion`` o el
-    ``numeroControl`` dentro del JSON almacenado en ``dte_envios.respuesta``.
+    La consulta intenta primero usar columnas explícitas (``codigo_generacion`` y
+    ``numero_control``) y, si estas no existen, recurre a buscar dentro del JSON
+    ``respuesta``.
     """
 
     uuid = str(ident.get("codigoGeneracion") or "").upper()
     numc = str(ident.get("numeroControl") or "")
     if not uuid and not numc:
         return False
-    db.ensure_column("dte_envios", "respuesta", "TEXT")
-    row = db.cursor.execute(
-        """
-        SELECT estado, TRIM(sello) AS sello
-          FROM dte_envios
-         WHERE (respuesta LIKE ? OR respuesta LIKE ?)
-         ORDER BY id DESC LIMIT 1
-        """,
-        (f"%{uuid}%", f"%{numc}%"),
-    ).fetchone()
+
+    row = None
+    try:
+        row = db.cursor.execute(
+            """
+            SELECT estado, TRIM(sello) AS sello
+              FROM dte_envios
+             WHERE UPPER(codigo_generacion)=? OR numero_control=?
+             ORDER BY id DESC LIMIT 1
+            """,
+            (uuid, numc),
+        ).fetchone()
+    except Exception:
+        # fall back to searching within ``respuesta`` if explicit columns are missing
+        db.ensure_column("dte_envios", "respuesta", "TEXT")
+        row = db.cursor.execute(
+            """
+            SELECT estado, TRIM(sello) AS sello
+              FROM dte_envios
+             WHERE (respuesta LIKE ? OR respuesta LIKE ?)
+             ORDER BY id DESC LIMIT 1
+            """,
+            (f"%{uuid}%", f"%{numc}%"),
+        ).fetchone()
+
     if not row:
         return False
     estado = str(row["estado"] or "").lower()

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -22,6 +22,7 @@ from dte import (
     generar_cabecera_dte_data,
     generar_dte_json,
     sanitize_dte_payload,
+    _origen_aceptado_en_mh,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -127,6 +128,17 @@ def generar_nce_desde_dte(
         if ratio is None or ratio <= Decimal_0:
             raise ValueError("El porcentaje a acreditar debe ser mayor que cero")
 
+    origen_ident = dte_origen.get("identificacion", {})
+    sello = dte_origen.get("selloRecibido") or dte_origen.get("extra", {}).get("selloRecibido")
+    if not sello:
+        raise ValueError(
+            "La factura base no tiene selloRecibido. No puedes referenciarla todavía."
+        )
+    if not _origen_aceptado_en_mh(db, origen_ident):
+        raise ValueError(
+            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
+        )
+
     cabecera = generar_cabecera_dte_data(1, 1, "05", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
     identificacion = {
@@ -144,12 +156,11 @@ def generar_nce_desde_dte(
         "tipoMoneda": "USD",
     }
 
-    origen_ident = dte_origen.get("identificacion", {})
     doc_rel = [
         {
             "tipoDocumento": origen_ident.get("tipoDte"),
             "tipoGeneracion": 2,
-            "numeroDocumento": origen_ident.get("codigoGeneracion"),
+            "numeroDocumento": str(origen_ident.get("codigoGeneracion") or "").upper(),
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -21,6 +21,7 @@ from dte import (
     generar_dte_json,
     sanitize_dte_payload,
     d4,
+    _origen_aceptado_en_mh,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -76,6 +77,17 @@ def generar_nde_desde_dte(
     ambiente: str = "00",
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
+    origen_ident = dte_origen.get("identificacion", {})
+    sello = dte_origen.get("selloRecibido") or dte_origen.get("extra", {}).get("selloRecibido")
+    if not sello:
+        raise ValueError(
+            "La factura base no tiene selloRecibido. No puedes referenciarla todavía."
+        )
+    if not _origen_aceptado_en_mh(db, origen_ident):
+        raise ValueError(
+            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
+        )
+
     cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
     identificacion = {
@@ -93,14 +105,13 @@ def generar_nde_desde_dte(
         "tipoMoneda": "USD",
     }
 
-    origen_ident = dte_origen.get("identificacion", {})
     tipo_origen = origen_ident.get("tipoDte")
     tipo_rel = "07" if tipo_origen == "07" else "03"
     doc_rel = [
         {
             "tipoDocumento": tipo_rel,
             "tipoGeneracion": 2,
-            "numeroDocumento": origen_ident.get("codigoGeneracion"),
+            "numeroDocumento": str(origen_ident.get("codigoGeneracion") or "").upper(),
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]


### PR DESCRIPTION
## Summary
- validate that original document has a receipt (`selloRecibido`) and is accepted by MH before generating credit/debit notes
- normalize related document UUID formatting to uppercase
- prefer explicit `dte_envios` columns to verify origin acceptance, falling back to JSON search when absent

## Testing
- `pytest tests/test_nota_origen_validations.py -q --disable-warnings --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c8000a46288323bc224b153c5b92a3