### PR TITLE
Preserve envio state for orphan invoices

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -915,6 +915,8 @@ class FacturacionTab(QWidget):
             row_type = "venta"
             cliente_nombre = ""
             total = None
+            numero_control = None
+            codigo_generacion = None
             if venta:
                 getter = getattr(self.manager.db, "get_cliente", None)
                 if venta.get("cliente_id") and getter:
@@ -927,6 +929,16 @@ class FacturacionTab(QWidget):
                 row_type = "ticket" if self._is_ticket_sale(venta) else "venta"
             else:
                 row_type = "orphan"
+                if json_path and os.path.exists(json_path):
+                    try:
+                        with open(json_path, "r", encoding="utf-8") as fh:
+                            data = json.load(fh)
+                        ident = data.get("identificacion", {})
+                        numero_control = ident.get("numeroControl")
+                        codigo_generacion = ident.get("codigoGeneracion")
+                    except Exception:
+                        numero_control = None
+                        codigo_generacion = None
 
             estado, envio = self._detectar_estado_factura(
                 venta,
@@ -934,6 +946,8 @@ class FacturacionTab(QWidget):
                 json_path,
                 cur,
                 venta_id=rec["venta_id"],
+                numero_control=numero_control,
+                codigo_generacion=codigo_generacion,
             )
 
             row = {

--- a/tests/test_stale_invoice_records.py
+++ b/tests/test_stale_invoice_records.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pytest
 from PyQt5.QtWidgets import QApplication
 from types import SimpleNamespace
@@ -26,3 +27,32 @@ def test_missing_invoice_records_removed(qt_app, tmp_path):
     assert rows[0]["estado"] == "Incompleta"
     count = db.cursor.execute("SELECT COUNT(*) FROM facturas_pdf").fetchone()[0]
     assert count == 1
+
+
+def test_orphan_invoice_envio_state_from_json(qt_app, tmp_path):
+    db = DB(":memory:")
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_text("pdf")
+    data = {
+        "identificacion": {
+            "numeroControl": "NC-1",
+            "codigoGeneracion": "CG-1",
+        }
+    }
+    json_path = tmp_path / "doc.json"
+    json_path.write_text(json.dumps(data))
+    db.add_factura_pdf(None, "CF", str(pdf_path))
+    resp = json.dumps(
+        {
+            "numeroControl": "NC-1",
+            "codigoGeneracion": "CG-1",
+        }
+    )
+    db.registrar_envio_dte(None, "normal", "Aceptado", "", resp)
+
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+
+    rows = tab._get_invoices_from_db()
+    assert len(rows) == 1
+    assert rows[0]["envio"] == "Aceptado"


### PR DESCRIPTION
### Summary
- parse control codes from JSON for invoices without linked sales and forward to status detection
- ensure JSON read errors don't break invoice loading
- add regression test covering envio state for orphan invoices

### Testing
- `pytest` *(fails: libGL.so.1 missing and Qt aborts despite installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c8006ee38c832380fb2090a31c055d