### PR TITLE
Use stable invoice identifiers

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -58,6 +58,7 @@ from paths import DATOS_NEGOCIO_PATH
 import tempfile
 import subprocess
 import shutil
+import hashlib
 import dte
 import anulacion
 from dialogs.nota_detalle_dialog import NotaDetalleDialog
@@ -938,7 +939,8 @@ class FacturacionTab(QWidget):
 
             row = {
                 "row_type": row_type,
-                "id": rec["venta_id"],
+                "id": rec["id"],
+                "venta_id": rec["venta_id"],
                 "name": os.path.splitext(os.path.basename(ruta or ""))[0],
                 "fecha": fecha_str,
                 "_parsed_fecha": fdate,
@@ -1159,6 +1161,10 @@ class FacturacionTab(QWidget):
             result.append(
                 {
                     "row_type": "orphan",
+                    "id": hashlib.sha1(
+                        os.path.abspath(js or pdf or "").encode("utf-8")
+                    ).hexdigest(),
+                    "venta_id": None,
                     "name": numero,
                     "codigo": codigo,
                     "pdf": pdf,
@@ -1199,7 +1205,7 @@ class FacturacionTab(QWidget):
             return None
         rtype = data.get("row_type")
         if rtype == "venta":
-            venta_id = data.get("id")
+            venta_id = data.get("venta_id")
             pdf_path = self.manager.db.get_factura_pdf(venta_id)
             if not pdf_path:
                 return None
@@ -1222,7 +1228,7 @@ class FacturacionTab(QWidget):
             if not pdf_path or not os.path.exists(pdf_path):
                 return None
             return {
-                "venta_id": data.get("id"),
+                "venta_id": data.get("venta_id"),
                 "json": json_path,
                 "control": data.get("name"),
             }
@@ -1285,7 +1291,7 @@ class FacturacionTab(QWidget):
             if rtype == "venta" and factura:
                 self._send_invoice_email(factura.get("venta_id"))
             elif rtype == "ticket":
-                self._send_ticket_email(entry.get("id"))
+                self._send_ticket_email(entry.get("venta_id"))
             elif rtype == "orphan" and factura:
                 self._send_orphan_email(entry)
         if dialog.hacienda_cb.isChecked():
@@ -1336,7 +1342,7 @@ class FacturacionTab(QWidget):
             else:
                 try:
                     resp = transmitir_dte(
-                        self.manager.db, entry.get("id")
+                        self.manager.db, entry.get("venta_id")
                     )  # tickets también se transmiten con tipo "01"
                     if resp.get("http_status") in {401, 403}:
                         QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
@@ -1388,12 +1394,12 @@ class FacturacionTab(QWidget):
         pdf_path = None
         rtype = entry.get("row_type")
         if rtype == "venta":
-            venta_id = entry.get("id")
+            venta_id = entry.get("venta_id")
             pdf_path = self.manager.db.get_factura_pdf(venta_id)
             if not pdf_path or not os.path.exists(pdf_path):
                 pdf_path = self._generate_invoice_pdf(venta_id)
         elif rtype == "ticket":
-            venta_id = entry.get("id")
+            venta_id = entry.get("venta_id")
             pdf_path = self.manager.db.get_ticket_pdf(venta_id)
             if not pdf_path or not os.path.exists(pdf_path):
                 pdf_path = self._generate_ticket_pdf(venta_id)
@@ -1648,7 +1654,7 @@ class FacturacionTab(QWidget):
         entry = self._selected_entry()
         if not entry or entry.get("row_type") not in ("venta", "ticket"):
             raise ValueError("No sale selected")
-        venta_id = entry.get("id")
+        venta_id = entry.get("venta_id")
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
         detalles = self.manager.db.get_detalles_venta(venta_id)
         extra = {}
@@ -2030,7 +2036,7 @@ class FacturacionTab(QWidget):
         if not data or data.get("row_type") not in {"venta", "ticket"}:
             QMessageBox.warning(self, "Eliminar", "Seleccione una venta")
             return
-        venta_id = data.get("id")
+        venta_id = data.get("venta_id")
 
         confirm = QMessageBox.question(
             self,
@@ -2118,7 +2124,7 @@ class FacturacionTab(QWidget):
             self._clear_preview_files()
             return
         if data.get("row_type") in ("venta", "ticket"):
-            self._update_preview(data.get("id"))
+            self._update_preview(data.get("venta_id"))
         else:
             pdf = data.get("pdf")
             if pdf and os.path.exists(pdf):


### PR DESCRIPTION
## Summary
- use `facturas_pdf.id` as the primary identifier for invoices and store `venta_id` separately
- assign stable hash-based identifiers to orphaned invoice files
- ensure invoice selection compares these new identifiers when reloading

## Testing
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c8007512e48323b7328fb97a984c16