### PR TITLE
Enable distributor removal from main window

### DIFF
--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -387,6 +387,13 @@ class MainWindow(QMainWindow):
         btn_edit_dist.clicked.connect(self._editar_Distribuidor)
         dist_layout.addWidget(btn_edit_dist)
 
+        btn_delete_dist = QPushButton("Eliminar Distribuidor")
+        btn_delete_dist.setMinimumHeight(24)
+        btn_delete_dist.setMaximumHeight(28)
+        btn_delete_dist.setStyleSheet("font-size:11px;")
+        btn_delete_dist.clicked.connect(self._eliminar_Distribuidor)
+        dist_layout.addWidget(btn_delete_dist)
+
         vend_dist_layout.addLayout(dist_layout)
 
         vend_dist_tab.setLayout(vend_dist_layout)
@@ -1376,6 +1383,45 @@ class MainWindow(QMainWindow):
 
         dialog = DistribuidorInfoDialog(Distribuidor, self)
         dialog.exec_()
+
+    def _eliminar_Distribuidor(self):
+        selected_items = self.Distribuidores_tree.selectedItems()
+        if not selected_items:
+            QMessageBox.warning(
+                self, "Eliminar Distribuidor", "Seleccione un Distribuidor para eliminar."
+            )
+            return
+        item = selected_items[0]
+        if item.parent() is not None:
+            QMessageBox.warning(
+                self, "Eliminar Distribuidor", "Seleccione un Distribuidor para eliminar."
+            )
+            return
+        dist_id = item.data(0, Qt.UserRole)
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar Distribuidor",
+            f"¿Eliminar Distribuidor '{item.text(0)}'?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+        try:
+            self.manager.db.delete_Distribuidor(dist_id)
+        except ValueError:
+            QMessageBox.warning(
+                self,
+                "Eliminar Distribuidor",
+                "No se puede eliminar el Distribuidor porque tiene registros asociados.",
+            )
+            return
+        self.manager.refresh_data()
+        self.compras_tab.refresh_filters()
+        self._actualizar_arbol_Distribuidores()
+        self._actualizar_arbol_vendedores()
+        QMessageBox.information(
+            self, "Distribuidor", "Distribuidor eliminado correctamente."
+        )
 
     def _actualizar_tabla_clientes(self):
         search = self.cliente_search.text()


### PR DESCRIPTION
## Summary
- Add 'Eliminar Distribuidor' button to distributor panel
- Implement `_eliminar_Distribuidor` with confirmation, association checks, and data refresh

## Testing
- `pytest tests/test_delete_cascade.py`


------
https://chatgpt.com/codex/tasks/task_e_68c809d5cd1c8323984b88b426bf8a71