### PR TITLE
Preserve selloRecibido when generating DTEs

### DIFF
--- a/db.py
+++ b/db.py
@@ -2162,15 +2162,32 @@ class DB:
         sello,
         respuesta_json="",
         codigo_lote=None,
+        codigo_generacion=None,
+        numero_control=None,
     ):
-        """Guarda un registro del estado de transmisión de un DTE."""
+        """Guarda un registro del estado de transmisión de un DTE.
+
+        Siempre asegura las columnas ``codigo_generacion`` y ``numero_control`` y
+        almacena ``codigo_generacion`` en mayúsculas cuando se provee.
+        """
+
         self.ensure_column("dte_envios", "respuesta", "TEXT")
         self.ensure_column("dte_envios", "codigo_lote", "TEXT")
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
+        self.ensure_column("dte_envios", "numero_control", "TEXT")
+
+        # Normaliza valores
+        codigo_generacion = (codigo_generacion or "").upper() or None
+        numero_control = numero_control or None
+
         fecha_hora = datetime.now().isoformat()
         self.cursor.execute(
             """
-            INSERT INTO dte_envios (venta_id, modo, estado, sello, fecha_hora, respuesta, codigo_lote)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO dte_envios (
+                venta_id, modo, estado, sello, fecha_hora,
+                respuesta, codigo_lote, codigo_generacion, numero_control
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 venta_id,
@@ -2180,6 +2197,8 @@ class DB:
                 fecha_hora,
                 respuesta_json,
                 codigo_lote,
+                codigo_generacion,
+                numero_control,
             ),
         )
         self.conn.commit()

--- a/dte.py
+++ b/dte.py
@@ -2753,6 +2753,13 @@ def generar_dte_json(
         result.pop("receptor", None)
     result.pop("extra", None)
     final = json.loads(stable_stringify(result), parse_float=Decimal)
+    # Conservar el sello de recepción para operaciones posteriores (p.ej.,
+    # anulaciones o notas).  ``extra`` se elimina del DTE final, pero si ahí se
+    # encontraba ``selloRecibido`` lo exponemos en la raíz para que sea
+    # accesible por los generadores de notas.
+    sello = extra.get("selloRecibido") or extra.get("sello_recibido")
+    if sello:
+        final["selloRecibido"] = sello
     try:
         for idx, det in enumerate(detalles):
             if idx >= len(final.get("cuerpoDocumento", [])):
@@ -4739,7 +4746,14 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(None, "orphan", "Rechazado", "")
+        db.registrar_envio_dte(
+            None,
+            "orphan",
+            "Rechazado",
+            "",
+            codigo_generacion=ident.get("codigoGeneracion"),
+            numero_control=ident.get("numeroControl"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -4748,6 +4762,8 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
         estado,
         sello,
         json.dumps(respuesta, ensure_ascii=False),
+        codigo_generacion=ident.get("codigoGeneracion"),
+        numero_control=ident.get("numeroControl"),
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)
@@ -4817,6 +4833,7 @@ def enviar_lote_dtes(pendientes, db: DB | None = None):
                 {
                     "venta_id": venta_id,
                     "codigoGeneracion": ident.get("codigoGeneracion"),
+                    "numeroControl": ident.get("numeroControl"),
                     "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
                     "documento": firmado,
                 }
@@ -4859,6 +4876,8 @@ def enviar_lote_dtes(pendientes, db: DB | None = None):
                 "",
                 json.dumps(data_resp, ensure_ascii=False),
                 codigo_lote=codigo_lote,
+                codigo_generacion=d["codigoGeneracion"],
+                numero_control=d.get("numeroControl"),
             )
         resultados.append(data_resp)
 
@@ -4980,6 +4999,8 @@ def _enviar_documento(
             "Pendiente",
             "",
             json.dumps({"jws": signed}, ensure_ascii=False),
+            codigo_generacion=ident.get("codigoGeneracion"),
+            numero_control=ident.get("numeroControl"),
         )
         return {"estado": "Pendiente"}
 
@@ -5015,7 +5036,14 @@ def _enviar_documento(
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(doc_id, modo, "Rechazado", "")
+        db.registrar_envio_dte(
+            doc_id,
+            modo,
+            "Rechazado",
+            "",
+            codigo_generacion=p_cod,
+            numero_control=pident.get("numeroControl"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -5024,6 +5052,8 @@ def _enviar_documento(
         estado,
         sello,
         json.dumps(respuesta, ensure_ascii=False),
+        codigo_generacion=p_cod,
+        numero_control=pident.get("numeroControl"),
     )
     try:
         _save_signed_dte(data, signed, fallido=(estado == "Rechazado"))
@@ -5183,6 +5213,7 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     url = f"{pu.scheme}://{pu.netloc}/fesv/contingencia"
     signed = jws.sign_json(data)
     token = auth.get_token()
+    ident = data.get("identificacion") or data.get("identificador") or {}
 
     try:
         respuesta = _post_evento(url, token, signed, data)
@@ -5195,7 +5226,14 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
         )
         detalle = respuesta.get("detalle")
     except Exception:
-        db.registrar_envio_dte(evento_id, "evento", "Rechazado", "")
+        db.registrar_envio_dte(
+            evento_id,
+            "evento",
+            "Rechazado",
+            "",
+            codigo_generacion=ident.get("codigoGeneracion"),
+            numero_control=ident.get("numeroControl"),
+        )
         raise
 
     db.registrar_envio_dte(
@@ -5204,6 +5242,8 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
         estado,
         sello,
         json.dumps(respuesta, ensure_ascii=False),
+        codigo_generacion=ident.get("codigoGeneracion"),
+        numero_control=ident.get("numeroControl"),
     )
     if estado == "Rechazado":
         respuesta["errores"] = _parse_error_response(respuesta)

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -129,7 +129,49 @@ def generar_nce_desde_dte(
             raise ValueError("El porcentaje a acreditar debe ser mayor que cero")
 
     origen_ident = dte_origen.get("identificacion", {})
-    sello = dte_origen.get("selloRecibido") or dte_origen.get("extra", {}).get("selloRecibido")
+    # Intenta inyectar ``selloRecibido`` desde ventas.extra o dte_envios
+    extra = dte_origen.get("extra", {}) or {}
+    if isinstance(extra, str):
+        try:
+            extra = json.loads(extra)
+        except Exception:
+            extra = {}
+    sello = (
+        extra.get("selloRecibido")
+        or extra.get("sello_recibido")
+        or dte_origen.get("selloRecibido")
+    )
+    if not sello:
+        uuid = (str(origen_ident.get("codigoGeneracion") or "").upper())
+        numc = str(origen_ident.get("numeroControl") or "")
+        try:
+            row = db.cursor.execute(
+                """
+                SELECT TRIM(sello) AS sello
+                  FROM dte_envios
+                 WHERE UPPER(codigo_generacion)=? OR numero_control=?
+                 ORDER BY id DESC LIMIT 1
+                """,
+                (uuid, numc),
+            ).fetchone()
+            if row and row["sello"]:
+                sello = row["sello"]
+        except Exception:
+            db.ensure_column("dte_envios", "respuesta", "TEXT")
+            row = db.cursor.execute(
+                """
+                SELECT TRIM(sello) AS sello
+                  FROM dte_envios
+                 WHERE (respuesta LIKE ? OR respuesta LIKE ?)
+                 ORDER BY id DESC LIMIT 1
+                """,
+                (f"%{uuid}%", f"%{numc}%"),
+            ).fetchone()
+            if row and row["sello"]:
+                sello = row["sello"]
+    if sello:
+        dte_origen["selloRecibido"] = sello
+    sello = dte_origen.get("selloRecibido") or extra.get("selloRecibido")
     if not sello:
         raise ValueError(
             "La factura base no tiene selloRecibido. No puedes referenciarla todavía."

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -78,7 +78,49 @@ def generar_nde_desde_dte(
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
     origen_ident = dte_origen.get("identificacion", {})
-    sello = dte_origen.get("selloRecibido") or dte_origen.get("extra", {}).get("selloRecibido")
+    # Intenta inyectar ``selloRecibido`` desde ventas.extra o dte_envios
+    extra = dte_origen.get("extra", {}) or {}
+    if isinstance(extra, str):
+        try:
+            extra = json.loads(extra)
+        except Exception:
+            extra = {}
+    sello = (
+        extra.get("selloRecibido")
+        or extra.get("sello_recibido")
+        or dte_origen.get("selloRecibido")
+    )
+    if not sello:
+        uuid = (str(origen_ident.get("codigoGeneracion") or "").upper())
+        numc = str(origen_ident.get("numeroControl") or "")
+        try:
+            row = db.cursor.execute(
+                """
+                SELECT TRIM(sello) AS sello
+                  FROM dte_envios
+                 WHERE UPPER(codigo_generacion)=? OR numero_control=?
+                 ORDER BY id DESC LIMIT 1
+                """,
+                (uuid, numc),
+            ).fetchone()
+            if row and row["sello"]:
+                sello = row["sello"]
+        except Exception:
+            db.ensure_column("dte_envios", "respuesta", "TEXT")
+            row = db.cursor.execute(
+                """
+                SELECT TRIM(sello) AS sello
+                  FROM dte_envios
+                 WHERE (respuesta LIKE ? OR respuesta LIKE ?)
+                 ORDER BY id DESC LIMIT 1
+                """,
+                (f"%{uuid}%", f"%{numc}%"),
+            ).fetchone()
+            if row and row["sello"]:
+                sello = row["sello"]
+    if sello:
+        dte_origen["selloRecibido"] = sello
+    sello = dte_origen.get("selloRecibido") or extra.get("selloRecibido")
     if not sello:
         raise ValueError(
             "La factura base no tiene selloRecibido. No puedes referenciarla todavía."

--- a/tests/test_envio_correo.py
+++ b/tests/test_envio_correo.py
@@ -53,9 +53,24 @@ class FakeDB:
     def get_factura_pdf(self, vid):
         return self.factura_path
 
-    def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json=""):
+    def registrar_envio_dte(
+        self,
+        venta_id,
+        modo,
+        estado,
+        sello,
+        respuesta_json="",
+        codigo_lote=None,
+        codigo_generacion=None,
+        numero_control=None,
+    ):
         self.envios.append(
-            {"venta_id": venta_id, "modo": modo, "estado": estado, "sello": sello}
+            {
+                "venta_id": venta_id,
+                "modo": modo,
+                "estado": estado,
+                "sello": sello,
+            }
         )
 
 

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -80,13 +80,14 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
                 "version": 2,
                 "ambiente": "00",
                 "codigoGeneracion": "ABC",
+                "numeroControl": "DTE-01-S001P001-000000000000123",
             },
         },
     )
 
     responses = [
         {"estado": "Rechazado", "descripcionMsg": "Error", "observaciones": ["campo"]},
-        {"estado": "Transmitido", "sello": "ABC"},
+        {"estado": "PROCESADO", "sello": "ABC"},
     ]
 
     calls = []
@@ -127,9 +128,22 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
 
     caplog.clear()
     res = enviar_factura(db, venta)
-    assert res["estado"] == "Transmitido"
+    assert res["estado"] == "PROCESADO"
     row = db.cursor.execute("SELECT count(*) c FROM dte_envios WHERE venta_id=?", (venta,)).fetchone()
     assert row["c"] == 2
+
+    # Verifica que se hayan almacenado los campos clave
+    row = db.cursor.execute(
+        """
+        SELECT codigo_generacion, numero_control, estado, sello
+          FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1
+        """,
+        (venta,),
+    ).fetchone()
+    assert row["codigo_generacion"] == "ABC"
+    assert row["numero_control"] == "DTE-01-S001P001-000000000000123"
+    assert row["estado"] == "PROCESADO"
+    assert row["sello"] == "ABC"
 
     assert sign_calls["count"] == 2
     assert len(calls) == 2

--- a/tests/test_envio_registra_campos.py
+++ b/tests/test_envio_registra_campos.py
@@ -1,0 +1,22 @@
+from db import DB
+
+
+def test_registrar_envio_dte_guarda_campos():
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 10)
+    db.registrar_envio_dte(
+        venta_id,
+        "normal",
+        "Procesado",
+        "SELLO",
+        codigo_generacion="abc",
+        numero_control="DTE-01-S001P001-000000000000001",
+    )
+    row = db.cursor.execute(
+        "SELECT codigo_generacion, numero_control, estado, sello FROM dte_envios WHERE venta_id=?",
+        (venta_id,),
+    ).fetchone()
+    assert row["codigo_generacion"] == "ABC"
+    assert row["numero_control"] == "DTE-01-S001P001-000000000000001"
+    assert row["estado"] == "Procesado"
+    assert row["sello"] == "SELLO"

--- a/tests/test_lote_dte.py
+++ b/tests/test_lote_dte.py
@@ -40,7 +40,17 @@ def test_enviar_lote_dtes_envia_lote_y_registra_codigo(monkeypatch):
         def __init__(self):
             self.reg = []
 
-        def registrar_envio_dte(self, venta_id, modo, estado, sello, respuesta_json="", codigo_lote=None):
+        def registrar_envio_dte(
+            self,
+            venta_id,
+            modo,
+            estado,
+            sello,
+            respuesta_json="",
+            codigo_lote=None,
+            codigo_generacion=None,
+            numero_control=None,
+        ):
             self.reg.append((venta_id, modo, estado, codigo_lote))
 
     db = DummyDB()

--- a/tests/test_nota_inyecta_sello.py
+++ b/tests/test_nota_inyecta_sello.py
@@ -1,0 +1,51 @@
+from decimal import Decimal
+
+from db import DB
+from nota_credito_electronica import generar_nce_desde_dte
+from nota_debito_electronica import generar_nde_desde_dte
+
+
+def _insert_envio(db: DB, uuid: str, numc: str, sello: str):
+    db.ensure_column("dte_envios", "respuesta", "TEXT")
+    db.cursor.execute(
+        "INSERT INTO dte_envios (venta_id, estado, sello, respuesta) VALUES (?,?,?,?)",
+        (None, "Procesado", sello, f"{uuid} {numc}"),
+    )
+    db.conn.commit()
+
+
+def test_nce_inyecta_sello_desde_envio():
+    db = DB(":memory:")
+    _insert_envio(db, "UUID", "NC", "SELLO")
+    dte_origen = {
+        "identificacion": {
+            "codigoGeneracion": "uuid",
+            "numeroControl": "NC",
+            "tipoDte": "01",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {},
+        "resumen": {},
+    }
+    generar_nce_desde_dte(db, dte_origen, Decimal("1"))
+    assert dte_origen["selloRecibido"] == "SELLO"
+
+
+def test_nde_inyecta_sello_desde_envio():
+    db = DB(":memory:")
+    _insert_envio(db, "UUID", "NC", "SELLO")
+    dte_origen = {
+        "identificacion": {
+            "codigoGeneracion": "uuid",
+            "numeroControl": "NC",
+            "tipoDte": "01",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {},
+        "resumen": {},
+    }
+    detalles = [{"ventas_gravadas": 1, "precio_unitario": 1, "descripcion": "x"}]
+    generar_nde_desde_dte(db, dte_origen, detalles, None)
+    assert dte_origen["selloRecibido"] == "SELLO"

--- a/tests/test_sello_persistencia.py
+++ b/tests/test_sello_persistencia.py
@@ -150,3 +150,31 @@ def test_sello_recibido_actualiza_envio_y_extra(monkeypatch):
     extra = json.loads(extra_row["extra"])
     assert extra["selloRecibido"] == "SR"
 
+
+def test_generar_dte_json_exposes_sello(monkeypatch):
+    db = DB(":memory:")
+    venta_id = create_sale(db)
+    db.update_venta_extra(venta_id, {"selloRecibido": "ABC", "es_ticket": True})
+    datos = {
+        "nombre": "X",
+        "nit": "06140010912506",
+        "nrc": "123456-7",
+        "cod_giro": "123456",
+        "dte_api": {"prefijo_control": "DTE-01-S001P001"},
+    }
+    monkeypatch.setattr(dte, "_load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        dte.svfe_config,
+        "load_datos_negocio",
+        lambda: {
+            "direccion": {
+                "departamento": "01",
+                "municipio": "001",
+                "complemento": "X",
+            }
+        },
+    )
+    monkeypatch.setattr(dte, "validate_dte_json", lambda *a, **k: None)
+    data = dte.generar_dte_json(db, venta_id, tipo_dte="01")
+    assert data["selloRecibido"] == "ABC"
+


### PR DESCRIPTION
## Summary
- keep stored `selloRecibido` in generated DTE JSON so later notes can reference it
- add regression test verifying `generar_dte_json` exposes the reception seal
- inject the reception seal from database when building credit or debit notes
- test seal reinjection for credit and debit notes
- record `codigo_generacion` and `numero_control` when logging DTE transmissions
- verify transmission records keep identifiers uppercased

## Testing
- `pytest tests/test_envio_registra_campos.py::test_registrar_envio_dte_guarda_campos -q`
- `pytest tests/test_nota_inyecta_sello.py::test_nce_inyecta_sello_desde_envio -q`
- `pytest tests/test_nota_inyecta_sello.py::test_nde_inyecta_sello_desde_envio -q`
- `pytest tests/test_sello_persistencia.py::test_generar_dte_json_exposes_sello -q`
- `pytest tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio -q`
- `pytest tests/test_lote_dte.py::test_enviar_lote_dtes_envia_lote_y_registra_codigo -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80170dda48323a76b4dec95c14f9b