### PR TITLE
Normalize related note document UUID

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -23,6 +23,7 @@ from dte import (
     generar_dte_json,
     sanitize_dte_payload,
     _origen_aceptado_en_mh,
+    normalize_uuid_v4_upper,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -202,7 +203,9 @@ def generar_nce_desde_dte(
         {
             "tipoDocumento": origen_ident.get("tipoDte"),
             "tipoGeneracion": 2,
-            "numeroDocumento": str(origen_ident.get("codigoGeneracion") or "").upper(),
+            "numeroDocumento": normalize_uuid_v4_upper(
+                str(origen_ident.get("codigoGeneracion") or "").upper()
+            ),
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -22,6 +22,7 @@ from dte import (
     sanitize_dte_payload,
     d4,
     _origen_aceptado_en_mh,
+    normalize_uuid_v4_upper,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -153,7 +154,9 @@ def generar_nde_desde_dte(
         {
             "tipoDocumento": tipo_rel,
             "tipoGeneracion": 2,
-            "numeroDocumento": str(origen_ident.get("codigoGeneracion") or "").upper(),
+            "numeroDocumento": normalize_uuid_v4_upper(
+                str(origen_ident.get("codigoGeneracion") or "").upper()
+            ),
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]

--- a/tests/test_nota_documento_relacionado.py
+++ b/tests/test_nota_documento_relacionado.py
@@ -1,0 +1,40 @@
+import json
+from decimal import Decimal
+
+from db import DB
+import nota_credito_electronica as nce_mod
+import nota_debito_electronica as nde_mod
+from nota_credito_electronica import generar_nce_desde_dte
+from nota_debito_electronica import generar_nde_desde_dte
+
+
+def _patch_module(monkeypatch, module):
+    dummy_header = {
+        "numero_control": "NC",
+        "codigo_generacion": "12345678-1234-4234-8234-1234567890AB",
+        "tipo_modelo": 1,
+        "tipo_operacion": 1,
+        "tipo_contingencia": None,
+        "motivo_contin": None,
+    }
+    monkeypatch.setattr(module, "generar_cabecera_dte_data", lambda *a, **k: dummy_header)
+    monkeypatch.setattr(module, "_origen_aceptado_en_mh", lambda db, ident: True)
+    monkeypatch.setattr(module, "sanitize_dte_payload", lambda data, schema: data)
+    monkeypatch.setattr(module.catalogos, "get_dte_schema", lambda *a, **k: {})
+
+
+def test_documento_relacionado_usa_uuid(monkeypatch):
+    db = DB(":memory:")
+    _patch_module(monkeypatch, nce_mod)
+    _patch_module(monkeypatch, nde_mod)
+    with open("tests/goldens/ccf.json") as f:
+        dte_origen = json.load(f)
+    dte_origen["selloRecibido"] = "SELLO"
+    uuid = dte_origen["identificacion"]["codigoGeneracion"].upper()
+
+    nce = generar_nce_desde_dte(db, dte_origen, Decimal("1"))
+    assert nce["documentoRelacionado"][0]["numeroDocumento"] == uuid
+
+    detalles = [{"descripcion": "Prod", "precio_unitario": 1, "ventas_gravadas": 1}]
+    nde = generar_nde_desde_dte(db, dte_origen, detalles, None)
+    assert nde["documentoRelacionado"][0]["numeroDocumento"] == uuid


### PR DESCRIPTION
## Summary
- ensure credit and debit notes derive `documentoRelacionado.numeroDocumento` from the origin `codigoGeneracion` using `normalize_uuid_v4_upper`
- add regression test verifying notes embed the originating UUID

## Testing
- `pytest tests/test_nota_documento_relacionado.py -q`
- `pytest tests/test_iva_conversion_prorrateo.py tests/test_nce_detalles_total.py tests/test_nota_inyecta_sello.py -q` *(fails: base document lacks `selloRecibido` or uses invalid UUID placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ca64704832394725a3822af10ea