### PR TITLE
Log origin DTE details when generating notes

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 import json
+import logging
 from typing import Optional
 
 from db import DB
@@ -29,6 +30,9 @@ from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
 from utils.sanitize import limpiar_documentos
+
+
+logger = logging.getLogger(__name__)
 
 
 Decimal_0 = Decimal("0")
@@ -439,6 +443,14 @@ def generar_nce_desde_dte(
         "apendice": None,
     }
 
+    logger.info(
+        "NCE relaciona tipo=%s gen=%s num=%s fec=%s sello=%s",
+        doc_rel[0].get("tipoDocumento"),
+        origen_ident.get("codigoGeneracion"),
+        origen_ident.get("numeroControl"),
+        origen_ident.get("fecEmi"),
+        dte_origen.get("selloRecibido"),
+    )
     schema = catalogos.get_dte_schema("05")
     return sanitize_dte_payload(data, schema)
 

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 import copy
 import json
+import logging
 from typing import Optional
 
 from db import DB
@@ -29,6 +30,8 @@ from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
 from utils.sanitize import limpiar_documentos
 
+
+logger = logging.getLogger(__name__)
 
 def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
     """Genera una NDE basada en la nota registrada en ``notas``."""
@@ -354,6 +357,14 @@ def generar_nde_desde_dte(
         "apendice": None,
     }
 
+    logger.info(
+        "NDE relaciona tipo=%s gen=%s num=%s fec=%s sello=%s",
+        doc_rel[0].get("tipoDocumento"),
+        origen_ident.get("codigoGeneracion"),
+        origen_ident.get("numeroControl"),
+        origen_ident.get("fecEmi"),
+        dte_origen.get("selloRecibido"),
+    )
     schema = catalogos.get_dte_schema("06")
     return sanitize_dte_payload(data, schema)
 


### PR DESCRIPTION
## Summary
- log related document details when building credit notes
- log related document details when building debit notes

## Testing
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c81cab5ba483239b67862138486792