### PR TITLE
Remove MH acceptance requirements for NDE origin

### DIFF
--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -22,8 +22,6 @@ from dte import (
     generar_dte_json,
     sanitize_dte_payload,
     d4,
-    _origen_aceptado_en_mh,
-    normalize_uuid_v4_upper,
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
@@ -82,57 +80,6 @@ def generar_nde_desde_dte(
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
     origen_ident = dte_origen.get("identificacion", {})
-    # Intenta inyectar ``selloRecibido`` desde ventas.extra o dte_envios
-    extra = dte_origen.get("extra", {}) or {}
-    if isinstance(extra, str):
-        try:
-            extra = json.loads(extra)
-        except Exception:
-            extra = {}
-    sello = (
-        extra.get("selloRecibido")
-        or extra.get("sello_recibido")
-        or dte_origen.get("selloRecibido")
-    )
-    if not sello:
-        uuid = (str(origen_ident.get("codigoGeneracion") or "").upper())
-        numc = str(origen_ident.get("numeroControl") or "")
-        try:
-            row = db.cursor.execute(
-                """
-                SELECT TRIM(sello) AS sello
-                  FROM dte_envios
-                 WHERE UPPER(codigo_generacion)=? OR numero_control=?
-                 ORDER BY id DESC LIMIT 1
-                """,
-                (uuid, numc),
-            ).fetchone()
-            if row and row["sello"]:
-                sello = row["sello"]
-        except Exception:
-            db.ensure_column("dte_envios", "respuesta", "TEXT")
-            row = db.cursor.execute(
-                """
-                SELECT TRIM(sello) AS sello
-                  FROM dte_envios
-                 WHERE (respuesta LIKE ? OR respuesta LIKE ?)
-                 ORDER BY id DESC LIMIT 1
-                """,
-                (f"%{uuid}%", f"%{numc}%"),
-            ).fetchone()
-            if row and row["sello"]:
-                sello = row["sello"]
-    if sello:
-        dte_origen["selloRecibido"] = sello
-    sello = dte_origen.get("selloRecibido") or extra.get("selloRecibido")
-    if not sello:
-        raise ValueError(
-            "La factura base no tiene selloRecibido. No puedes referenciarla todavía."
-        )
-    if not _origen_aceptado_en_mh(db, origen_ident):
-        raise ValueError(
-            "El documento relacionado aún no está registrado en MH. Transmítelo y espera acuse antes de emitir la nota."
-        )
 
     cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
@@ -151,15 +98,11 @@ def generar_nde_desde_dte(
         "tipoMoneda": "USD",
     }
 
-    tipo_origen = origen_ident.get("tipoDte")
-    tipo_rel = "07" if tipo_origen == "07" else "03"
     doc_rel = [
         {
-            "tipoDocumento": tipo_rel,
+            "tipoDocumento": origen_ident.get("tipoDte"),
             "tipoGeneracion": 2,
-            "numeroDocumento": normalize_uuid_v4_upper(
-                str(origen_ident.get("codigoGeneracion") or "").upper()
-            ),
+            "numeroDocumento": origen_ident.get("codigoGeneracion"),
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]

--- a/tests/test_iva_conversion_prorrateo.py
+++ b/tests/test_iva_conversion_prorrateo.py
@@ -45,7 +45,7 @@ def test_prorrateo_porcentaje(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("0.1"))
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     assert data["resumen"]["montoTotalOperacion"] == 10.0
 

--- a/tests/test_nce_detalles_total.py
+++ b/tests/test_nce_detalles_total.py
@@ -55,7 +55,7 @@ def test_nce_monto_total_por_detalles(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     resumen = nce["resumen"]
     expected_iva = (Decimal("10") * Decimal("0.13")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
@@ -88,7 +88,7 @@ def test_nce_detalles_monto_un_dolar(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles, monto=Decimal("1"))
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     resumen = nce["resumen"]
     iva = resumen["tributos"][0]["valor"] if resumen["tributos"] else Decimal("0")

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -44,7 +44,7 @@ def test_generar_nota_credito_json_ticket(tmp_path, monkeypatch):
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     assert data["cuerpoDocumento"][0]["precioUni"] > 0
     assert "totalPagar" not in data["resumen"]
@@ -83,7 +83,7 @@ def test_generar_nota_credito_json_factura(tmp_path, monkeypatch):
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     assert "-" not in data["receptor"].get("nit", "")
 
@@ -110,7 +110,7 @@ def test_nota_credito_total_nueve(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"))
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     assert data["resumen"]["montoTotalOperacion"] == 9.0
 
@@ -147,7 +147,7 @@ def test_nota_credito_precio_uni(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles)
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     item = data["cuerpoDocumento"][0]
     assert item["precioUni"] == Decimal("7.9600")

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -83,7 +83,7 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     assert doc_rel["fechaEmision"]
     assert (
         doc_rel["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     assert doc_rel["numeroDocumento"] != data["identificacion"].get("numeroControl")
     assert "-" not in data["emisor"].get("nit", "")

--- a/tests/test_nota_detalles.py
+++ b/tests/test_nota_detalles.py
@@ -52,7 +52,7 @@ def test_generar_nce_detalles(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles, motivo="Dev")
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     item = data["cuerpoDocumento"][0]
     assert item["ventaGravada"] == 10
@@ -82,7 +82,7 @@ def test_generar_nce_detalles_tributos(monkeypatch):
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), detalles=detalles)
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     expected_iva = Decimal("10") * Decimal("0.13")
     assert data["resumen"]["tributos"][0]["valor"] == expected_iva
@@ -111,7 +111,7 @@ def test_generar_nce_detalles_monto_total(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     resumen = nce["resumen"]
     expected_iva = Decimal("10") * Decimal("0.13")
@@ -151,7 +151,7 @@ def test_generar_nota_debito_detalles(monkeypatch):
     assert doc_rel["tipoDocumento"] == "01"
     assert (
         doc_rel["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
 
 

--- a/tests/test_notas_precio_uni.py
+++ b/tests/test_notas_precio_uni.py
@@ -86,12 +86,12 @@ def test_notas_precio_uni_cuatro_decimales(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, None, detalles=detalles)
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
     nde = generar_nde_desde_dte(db, dte_origen, detalles, None, "Ajuste")
     assert (
         nde["documentoRelacionado"][0]["numeroDocumento"]
-        == dte_origen["identificacion"]["codigoGeneracion"].upper()
+        == dte_origen["identificacion"]["codigoGeneracion"]
     )
 
     expected_subtotal = sum(

--- a/tests/test_ticket_nitless.py
+++ b/tests/test_ticket_nitless.py
@@ -70,7 +70,7 @@ def test_recalcular_ticket_sin_nit_generar_nota(monkeypatch):
     assert nce["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert (
         nce["documentoRelacionado"][0]["numeroDocumento"]
-        == data["identificacion"]["codigoGeneracion"].upper()
+        == data["identificacion"]["codigoGeneracion"]
     )
     assert "nit" not in nce["receptor"]
 


### PR DESCRIPTION
## Summary
- drop the selloRecibido injection and MH acceptance guard when generating notas de débito
- rebuild the related document payload with the origin DTE identifiers
- update debit and credit note tests to assert the raw codigoGeneracion values
- align the nota de débito related document payload accessors with the nota de crédito implementation

## Testing
- pytest tests/test_nota_documento_relacionado.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c8929a922083238e0cd6e61c409647