### PR TITLE
Adjust credito fiscal discount base calculations

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -2305,28 +2305,32 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         if vendedor_idx > 0:
             vendedor_id = self.vendedores_trabajadores[vendedor_idx - 1]["id"]
 
-        sumas = 0
-        descuentos = 0
-        ventas_exentas = 0
-        ventas_no_sujetas = 0
-        total = 0
-        iva = 0
+        sumas = Decimal("0")
+        descuentos = Decimal("0")
+        ventas_exentas = Decimal("0")
+        ventas_no_sujetas = Decimal("0")
+        iva = Decimal("0")
+        q8 = Decimal("0.00000001")
 
         for item in self.venta_items:
             tipo_fiscal = item.get("tipo_fiscal", "").lower()
-            base = item["subtotal_con_descuento"]
+            base = Decimal(str(item.get("subtotal_con_descuento", 0)))
             if item.get("iva_tipo") == "desglosado":
-                base = item.get("subtotal", base)
+                base = Decimal(str(item.get("subtotal", base)))
 
             if tipo_fiscal == "venta gravada":
-                sumas += item["subtotal"]
-                descuentos += item.get("descuento_monto", 0)
-                iva += item.get("iva", 0)
+                sumas += Decimal(str(item.get("subtotal", 0)))
+                descuento_monto = Decimal(str(item.get("descuento_monto", 0)))
+                descuento_base = (descuento_monto / IVA_FACTOR).quantize(q8)
+                descuentos += descuento_base
+                iva += Decimal(str(item.get("iva", 0)))
             elif tipo_fiscal == "venta exenta":
                 ventas_exentas += base
             elif tipo_fiscal == "venta no sujeta":
                 ventas_no_sujetas += base
-            total += item.get("total", 0)
+
+        subtotal = (sumas - descuentos) + iva
+        total = subtotal + ventas_exentas + ventas_no_sujetas
 
         return {
             "cliente": self.selected_cliente if self.selected_cliente else {},
@@ -2349,13 +2353,13 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
             "documento_venta_a_cuenta": self.venta_documento_edit.text(),
             "fecha_remision_anterior": self.fecha_remision_anterior.date().toString("yyyy-MM-dd"),
             "fecha_remision": self.fecha_remision.date().toString("yyyy-MM-dd"),
-            "sumas": sumas,
-            "descuentos": descuentos,
-            "iva": iva,
-            "subtotal": (sumas - descuentos) + iva,
-            "ventas_exentas": ventas_exentas,
-            "ventas_no_sujetas": ventas_no_sujetas,
-            "total": (sumas - descuentos) + iva + ventas_exentas + ventas_no_sujetas,
+            "sumas": float(sumas.quantize(q8)),
+            "descuentos": float(descuentos.quantize(q8)),
+            "iva": float(iva.quantize(q8)),
+            "subtotal": float(subtotal.quantize(q8)),
+            "ventas_exentas": float(ventas_exentas.quantize(q8)),
+            "ventas_no_sujetas": float(ventas_no_sujetas.quantize(q8)),
+            "total": float(total.quantize(q8)),
             "fecha": QDate.currentDate().toString("yyyy-MM-dd"),
             "Distribuidor_id": (
                 self.Distribuidor_combo.currentIndex()

--- a/tests/test_credito_fiscal_dialog_iva.py
+++ b/tests/test_credito_fiscal_dialog_iva.py
@@ -9,7 +9,10 @@ from PyQt5.QtWidgets import (
     QRadioButton,
     QListWidget,
     QTableWidget,
+    QLineEdit,
+    QDateEdit,
 )
+from PyQt5.QtCore import QDate
 from dialogs import RegisterCreditoFiscalDialog
 
 
@@ -30,6 +33,10 @@ def build_dialog(qty=5, price=1.00):
     dialog.precio_total_spin = QDoubleSpinBox()
     dialog.precio_total_spin.setDecimals(2)
     dialog.precio_total_spin.setValue(qty * price)
+    dialog.tipo_minorista = QRadioButton()
+    dialog.tipo_minorista.setChecked(True)
+    dialog.tipo_mayorista_unit = QRadioButton()
+    dialog.tipo_mayorista_unit.setChecked(False)
     dialog.tipo_mayorista_total = QRadioButton()
     dialog.tipo_mayorista_total.setChecked(False)
     dialog.descuento_spin = QDoubleSpinBox()
@@ -58,6 +65,23 @@ def build_dialog(qty=5, price=1.00):
     dialog.venta_items = []
     dialog.table = QTableWidget(0, 6)
     dialog.total_label = QLabel()
+    dialog.vendedor_combo = QComboBox()
+    dialog.vendedor_combo.addItem("Sin vendedor")
+    dialog.vendedores_trabajadores = []
+    dialog.selected_cliente = {"id": 1, "nombre": "Cliente"}
+    dialog.iva_agregado_radio = QRadioButton()
+    dialog.nrc_edit = QLineEdit()
+    dialog.nit_edit = QLineEdit()
+    dialog.giro_edit = QLineEdit()
+    dialog.email_edit = QLineEdit()
+    dialog.no_remision_edit = QLineEdit()
+    dialog.orden_no_edit = QLineEdit()
+    dialog.condicion_pago_combo = QComboBox()
+    dialog.venta_a_cuenta_de_edit = QLineEdit()
+    dialog.venta_documento_edit = QLineEdit()
+    dialog.fecha_remision_anterior = QDateEdit(QDate.currentDate())
+    dialog.fecha_remision = QDateEdit(QDate.currentDate())
+    dialog.Distribuidor_combo = QComboBox()
     return dialog
 
 
@@ -139,3 +163,18 @@ def test_totals_precision_edge_cases(qt_app, qty, price, expected):
     RegisterCreditoFiscalDialog._agregar_a_venta(dialog)
     item = dialog.venta_items[0]
     assert pytest.approx(item["total"], rel=1e-6) == expected
+
+
+def test_get_data_credito_fiscal_discount_total(qt_app):
+    dialog = build_dialog(qty=1, price=15.00)
+    dialog.descuento_spin.setValue(10)
+    dialog.descuento_tipo_combo.setCurrentIndex(0)
+    RegisterCreditoFiscalDialog._recalcular_totales(dialog)
+    RegisterCreditoFiscalDialog._agregar_a_venta(dialog)
+
+    data = RegisterCreditoFiscalDialog.get_data(dialog)
+
+    assert len(dialog.venta_items) == 1
+    assert data["total"] == pytest.approx(13.5)
+    assert f"{data['total']:.2f}" == "13.50"
+    assert data["descuentos"] == pytest.approx(1.32743363)


### PR DESCRIPTION
## Summary
- convert credit fiscal discount and totals to work from base amounts in `RegisterCreditoFiscalDialog.get_data`
- update the dialog test harness and add coverage for a 10% discount on $15 yielding a $13.50 total

## Testing
- pytest tests/test_credito_fiscal_dialog_iva.py

------
https://chatgpt.com/codex/tasks/task_e_68c890575e9883238927345174c53657