### PR TITLE
Remove foreign key constraint from dte_envios

### DIFF
--- a/db.py
+++ b/db.py
@@ -496,9 +496,7 @@ class DB:
                 estado TEXT,
                 sello TEXT,
                 fecha_hora TEXT,
-                respuesta TEXT,
-
-                FOREIGN KEY (venta_id) REFERENCES ventas(id)
+                respuesta TEXT
             )
             """
         )

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -806,6 +806,7 @@ class FacturacionTab(QWidget):
         venta_id=None,
         numero_control=None,
         codigo_generacion=None,
+        doc_tipo=None,
     ):
         """Determine ``estado`` and ``envio`` for an invoice.
 
@@ -817,10 +818,16 @@ class FacturacionTab(QWidget):
         pdf_exists = bool(pdf_path and os.path.exists(pdf_path))
         json_exists = bool(json_path and os.path.exists(json_path))
 
+        tipo_lower = str(doc_tipo or "").strip().lower()
+        is_nota = tipo_lower.startswith("nota")
+
         if venta:
             estado = "Completa" if pdf_exists and json_exists else "Incompleta"
         else:
-            estado = "Sin venta" if pdf_exists and json_exists else "Incompleta"
+            if is_nota:
+                estado = "Incompleta"
+            else:
+                estado = "Sin venta" if pdf_exists and json_exists else "Incompleta"
 
         envio = "Pendiente de envío"
         env_row = None
@@ -911,7 +918,14 @@ class FacturacionTab(QWidget):
         records = cur.fetchall()
         rows = []
         for rec in records:
-            venta = self.manager.db.get_venta_by_id(rec["venta_id"])
+            try:
+                doc_tipo = rec["tipo"]
+            except (KeyError, IndexError):
+                doc_tipo = None
+            tipo_lower = str(doc_tipo or "").strip().lower()
+            venta = None
+            if rec["venta_id"] is not None and not tipo_lower.startswith("nota"):
+                venta = self.manager.db.get_venta_by_id(rec["venta_id"])
             ruta = rec["ruta"]
             json_path = os.path.splitext(ruta)[0] + ".json" if ruta else None
 
@@ -960,6 +974,7 @@ class FacturacionTab(QWidget):
                 venta_id=rec["venta_id"],
                 numero_control=numero_control,
                 codigo_generacion=codigo_generacion,
+                doc_tipo=doc_tipo,
             )
 
             row = {
@@ -973,7 +988,7 @@ class FacturacionTab(QWidget):
                 "total": total,
                 "estado": estado,
                 "envio": envio,
-                "tipo": rec["tipo"],
+                "tipo": doc_tipo,
             }
             if row_type == "orphan":
                 row["pdf"] = ruta
@@ -1127,6 +1142,7 @@ class FacturacionTab(QWidget):
                 pdf,
                 js,
                 cur,
+                doc_tipo=tipo,
             )
             numero = base
             fecha = ""
@@ -1179,6 +1195,7 @@ class FacturacionTab(QWidget):
                         cur,
                         numero_control=numero,
                         codigo_generacion=codigo_gen,
+                        doc_tipo=tipo,
                     )
                 except Exception:
                     estado = "Incompleta"

--- a/schema_patches/remove_dte_envios_fk.sql
+++ b/schema_patches/remove_dte_envios_fk.sql
@@ -1,0 +1,31 @@
+-- Rebuilds ``dte_envios`` without enforcing ``venta_id`` as a foreign key.
+--
+-- Older installations created the table with ``FOREIGN KEY (venta_id)
+-- REFERENCES ventas(id)``, which prevents storing transmission records for
+-- notas and otros documentos que no están registrados en ``ventas``.  The
+-- migration recreates the table without that constraint while preserving the
+-- existing rows.
+BEGIN TRANSACTION;
+CREATE TABLE dte_envios_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    venta_id INTEGER,
+    modo TEXT,
+    estado TEXT,
+    sello TEXT,
+    fecha_hora TEXT,
+    respuesta TEXT,
+    codigo_lote TEXT,
+    codigo_generacion TEXT,
+    numero_control TEXT
+);
+INSERT INTO dte_envios_new (
+    id, venta_id, modo, estado, sello, fecha_hora,
+    respuesta, codigo_lote, codigo_generacion, numero_control
+)
+SELECT
+    id, venta_id, modo, estado, sello, fecha_hora,
+    respuesta, codigo_lote, codigo_generacion, numero_control
+FROM dte_envios;
+DROP TABLE dte_envios;
+ALTER TABLE dte_envios_new RENAME TO dte_envios;
+COMMIT;


### PR DESCRIPTION
## Summary
- remove the ventas foreign key from the dte_envios table definition and add a schema patch that rebuilds the table without the constraint
- adjust the Facturacion tab to treat dte_envios.venta_id as a generic document identifier, marking notas as incompletas when their referenced factura is missing

## Testing
- pytest tests/test_envio_documentos.py::test_enviar_nota_credito -q
- pytest tests/test_facturacion_tab_loading.py -q *(fails: missing libGL.so.1 in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8963e9d588323852cd4e2aec557c6