### PR TITLE
Allow notes without linked sales

### DIFF
--- a/db.py
+++ b/db.py
@@ -209,6 +209,90 @@ class DB:
         finally:
             self.cursor.execute("PRAGMA foreign_keys=on")
 
+    def migrate_dte_envios_fk(self):
+        """Drop ``ventas`` foreign key from ``dte_envios`` if present."""
+        self.cursor.execute("PRAGMA foreign_key_list(dte_envios)")
+        fk_exists = any(
+            row[2] == "ventas" and row[3] == "venta_id" for row in self.cursor.fetchall()
+        )
+        if not fk_exists:
+            return
+        logger.info("Migrating 'dte_envios' table to remove venta_id foreign key")
+        self.cursor.execute("PRAGMA foreign_keys=off")
+        try:
+            self.cursor.execute(
+                """
+                CREATE TABLE dte_envios_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    venta_id INTEGER,
+                    modo TEXT,
+                    estado TEXT,
+                    sello TEXT,
+                    fecha_hora TEXT,
+                    respuesta TEXT,
+                    codigo_lote TEXT,
+                    codigo_generacion TEXT,
+                    numero_control TEXT
+                )
+                """
+            )
+            self.cursor.execute(
+                """
+                INSERT INTO dte_envios_new (
+                    id, venta_id, modo, estado, sello, fecha_hora,
+                    respuesta, codigo_lote, codigo_generacion, numero_control
+                )
+                SELECT
+                    id, venta_id, modo, estado, sello, fecha_hora,
+                    respuesta, codigo_lote, codigo_generacion, numero_control
+                FROM dte_envios
+                """
+            )
+            self.cursor.execute("DROP TABLE dte_envios")
+            self.cursor.execute("ALTER TABLE dte_envios_new RENAME TO dte_envios")
+            self.conn.commit()
+        finally:
+            self.cursor.execute("PRAGMA foreign_keys=on")
+
+    def migrate_notas_fk(self):
+        """Drop ``ventas`` foreign key from ``notas`` if present."""
+        self.cursor.execute("PRAGMA foreign_key_list(notas)")
+        fk_exists = any(
+            row[2] == "ventas" and row[3] == "venta_id" for row in self.cursor.fetchall()
+        )
+        if not fk_exists:
+            return
+        logger.info("Migrating 'notas' table to remove venta_id foreign key")
+        self.cursor.execute("PRAGMA foreign_keys=off")
+        try:
+            self.cursor.execute(
+                """
+                CREATE TABLE notas_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    venta_id INTEGER,
+                    tipo TEXT,
+                    fecha TEXT,
+                    monto REAL,
+                    motivo TEXT,
+                    detalles TEXT
+                )
+                """
+            )
+            self.cursor.execute(
+                """
+                INSERT INTO notas_new (
+                    id, venta_id, tipo, fecha, monto, motivo, detalles
+                )
+                SELECT id, venta_id, tipo, fecha, monto, motivo, detalles
+                FROM notas
+                """
+            )
+            self.cursor.execute("DROP TABLE notas")
+            self.cursor.execute("ALTER TABLE notas_new RENAME TO notas")
+            self.conn.commit()
+        finally:
+            self.cursor.execute("PRAGMA foreign_keys=on")
+
     def setup(self):
         # Create tables if they don't exist without dropping existing data
         self.cursor.execute("""
@@ -358,9 +442,7 @@ class DB:
                 fecha TEXT,
                 monto REAL,
                 motivo TEXT,
-                detalles TEXT,
-                FOREIGN KEY (venta_id) REFERENCES ventas(id)
-
+                detalles TEXT
             )
         """)
         self.ensure_column("notas", "detalles", "TEXT")
@@ -496,9 +578,7 @@ class DB:
                 estado TEXT,
                 sello TEXT,
                 fecha_hora TEXT,
-                respuesta TEXT,
-
-                FOREIGN KEY (venta_id) REFERENCES ventas(id)
+                respuesta TEXT
             )
             """
         )
@@ -601,6 +681,8 @@ class DB:
         )
         self.migrate_ventas_cliente_fk()
         self.migrate_detalles_venta_vendedor_fk()
+        self.migrate_dte_envios_fk()
+        self.migrate_notas_fk()
         self.conn.commit()
 
         # Verifica que la columna estado exista en ventas
@@ -2101,10 +2183,10 @@ class DB:
             raise ValueError("tipo debe ser 'credito', 'debito' o 'remision'")
 
         if venta_id is not None:
-            row = self.cursor.execute("SELECT total FROM ventas WHERE id=?", (venta_id,)).fetchone()
-            if row is None:
-                raise ValueError("La venta indicada no existe")
-            if tipo == "credito":
+            row = self.cursor.execute(
+                "SELECT total FROM ventas WHERE id=?", (venta_id,)
+            ).fetchone()
+            if row is not None and tipo == "credito":
                 total_facturado = Decimal(str(row["total"]))
                 sum_row = self.cursor.execute(
                     "SELECT COALESCE(SUM(monto),0) AS total FROM notas WHERE venta_id=? AND tipo='credito'",
@@ -2114,7 +2196,9 @@ class DB:
                 monto_dec = Decimal(str(monto))
                 saldo = total_facturado - total_creditos
                 if monto_dec > saldo:
-                    raise ValueError("El monto de la nota excede el saldo restante de la venta")
+                    raise ValueError(
+                        "El monto de la nota excede el saldo restante de la venta"
+                    )
 
         detalles_json = json.dumps(detalles) if detalles is not None else None
         self.cursor.execute(

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -806,6 +806,7 @@ class FacturacionTab(QWidget):
         venta_id=None,
         numero_control=None,
         codigo_generacion=None,
+        doc_tipo=None,
     ):
         """Determine ``estado`` and ``envio`` for an invoice.
 
@@ -817,10 +818,16 @@ class FacturacionTab(QWidget):
         pdf_exists = bool(pdf_path and os.path.exists(pdf_path))
         json_exists = bool(json_path and os.path.exists(json_path))
 
+        tipo_lower = str(doc_tipo or "").strip().lower()
+        is_nota = tipo_lower.startswith("nota")
+
         if venta:
             estado = "Completa" if pdf_exists and json_exists else "Incompleta"
         else:
-            estado = "Sin venta" if pdf_exists and json_exists else "Incompleta"
+            if is_nota:
+                estado = "Incompleta"
+            else:
+                estado = "Sin venta" if pdf_exists and json_exists else "Incompleta"
 
         envio = "Pendiente de envío"
         env_row = None
@@ -911,7 +918,14 @@ class FacturacionTab(QWidget):
         records = cur.fetchall()
         rows = []
         for rec in records:
-            venta = self.manager.db.get_venta_by_id(rec["venta_id"])
+            try:
+                doc_tipo = rec["tipo"]
+            except (KeyError, IndexError):
+                doc_tipo = None
+            tipo_lower = str(doc_tipo or "").strip().lower()
+            venta = None
+            if rec["venta_id"] is not None and not tipo_lower.startswith("nota"):
+                venta = self.manager.db.get_venta_by_id(rec["venta_id"])
             ruta = rec["ruta"]
             json_path = os.path.splitext(ruta)[0] + ".json" if ruta else None
 
@@ -960,6 +974,7 @@ class FacturacionTab(QWidget):
                 venta_id=rec["venta_id"],
                 numero_control=numero_control,
                 codigo_generacion=codigo_generacion,
+                doc_tipo=doc_tipo,
             )
 
             row = {
@@ -973,7 +988,7 @@ class FacturacionTab(QWidget):
                 "total": total,
                 "estado": estado,
                 "envio": envio,
-                "tipo": rec["tipo"],
+                "tipo": doc_tipo,
             }
             if row_type == "orphan":
                 row["pdf"] = ruta
@@ -1127,6 +1142,7 @@ class FacturacionTab(QWidget):
                 pdf,
                 js,
                 cur,
+                doc_tipo=tipo,
             )
             numero = base
             fecha = ""
@@ -1179,6 +1195,7 @@ class FacturacionTab(QWidget):
                         cur,
                         numero_control=numero,
                         codigo_generacion=codigo_gen,
+                        doc_tipo=tipo,
                     )
                 except Exception:
                     estado = "Incompleta"

--- a/schema_patches/remove_dte_envios_fk.sql
+++ b/schema_patches/remove_dte_envios_fk.sql
@@ -1,0 +1,31 @@
+-- Rebuilds ``dte_envios`` without enforcing ``venta_id`` as a foreign key.
+--
+-- Older installations created the table with ``FOREIGN KEY (venta_id)
+-- REFERENCES ventas(id)``, which prevents storing transmission records for
+-- notas and otros documentos que no están registrados en ``ventas``.  The
+-- migration recreates the table without that constraint while preserving the
+-- existing rows.
+BEGIN TRANSACTION;
+CREATE TABLE dte_envios_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    venta_id INTEGER,
+    modo TEXT,
+    estado TEXT,
+    sello TEXT,
+    fecha_hora TEXT,
+    respuesta TEXT,
+    codigo_lote TEXT,
+    codigo_generacion TEXT,
+    numero_control TEXT
+);
+INSERT INTO dte_envios_new (
+    id, venta_id, modo, estado, sello, fecha_hora,
+    respuesta, codigo_lote, codigo_generacion, numero_control
+)
+SELECT
+    id, venta_id, modo, estado, sello, fecha_hora,
+    respuesta, codigo_lote, codigo_generacion, numero_control
+FROM dte_envios;
+DROP TABLE dte_envios;
+ALTER TABLE dte_envios_new RENAME TO dte_envios;
+COMMIT;

--- a/tests/test_notas.py
+++ b/tests/test_notas.py
@@ -37,8 +37,10 @@ def test_agregar_nota_remision():
 
 def test_agregar_nota_venta_inexistente():
     db = create_db()
-    with pytest.raises(ValueError):
-        db.agregar_nota("debito", 999, "2024-01-03", 10, "extra")
+    note_id = db.agregar_nota("debito", 999, "2024-01-03", 10, "extra")
+    assert isinstance(note_id, int)
+    notas = db.obtener_notas_por_venta(999)
+    assert notas and notas[0]["venta_id"] == 999
 
 
 def test_credito_no_supera_total():


### PR DESCRIPTION
## Summary
- drop `venta_id` foreign keys from `dte_envios` and `notas`, migrating existing tables
- permit registering notes even if the referenced sale is missing, while still enforcing credit limits
- update tests for the relaxed note restrictions

## Testing
- `pytest tests/test_notas.py::test_agregar_nota_venta_inexistente tests/test_envio_documentos.py::test_enviar_nota_credito -q --disable-warnings --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c8963e9d588323852cd4e2aec557c6