### PR TITLE
Ensure DTE transmissions honor requested document type

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4645,12 +4645,46 @@ def transmitir_dte(
     if modo is None:
         modo = get_default_modo_transmision()
 
-    if tipo_dte == "03":
+    tipo_dte = str(tipo_dte)
+    venta_extra = {}
+    extra_es_ticket = False
+    if hasattr(db, "get_venta_by_id"):
+        try:
+            venta_row = db.get_venta_by_id(venta_id)
+        except Exception:
+            venta_row = None
+        row_data = venta_row if isinstance(venta_row, dict) else None
+        if row_data is None and venta_row is not None:
+            try:
+                row_data = dict(venta_row)
+            except Exception:
+                row_data = None
+        if isinstance(row_data, dict):
+            raw_extra = row_data.get("extra")
+            if isinstance(raw_extra, str) and raw_extra:
+                try:
+                    venta_extra = json.loads(raw_extra)
+                except Exception:
+                    venta_extra = {}
+            elif isinstance(raw_extra, dict):
+                venta_extra = raw_extra
+    extra_es_ticket = bool(venta_extra.get("es_ticket"))
+
+    if tipo_dte == "01" and extra_es_ticket:
         data = generar_ticket_json(db, venta_id)
     else:
-        data = generar_dte_json(db, venta_id)
-        if data.get("identificacion", {}).get("tipoDte") == "01":
-            recalcular_totales(data, incluir_iva=True)
+        extra_kwargs = {}
+        if extra_es_ticket and tipo_dte != "01":
+            extra_kwargs["extra"] = {"es_ticket": False}
+        data = generar_dte_json(db, venta_id, tipo_dte=tipo_dte, **extra_kwargs)
+
+    final_tipo = str(data.get("identificacion", {}).get("tipoDte") or "")
+    if final_tipo != tipo_dte:
+        raise ValueError(
+            f"tipoDte generado {final_tipo or 'desconocido'} no coincide con solicitado {tipo_dte}"
+        )
+    if final_tipo == "01":
+        recalcular_totales(data, incluir_iva=True)
 
     data = apply_schema_patch(data)
     schema = catalogos.get_dte_schema(tipo_dte)

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -49,7 +49,7 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
     monkeypatch.setattr("dte.validate_dte_json", lambda data, db=None: None)
     monkeypatch.setattr(
         "dte.generar_dte_json",
-        lambda db_obj, vid: {
+        lambda db_obj, vid, **kwargs: {
             "receptor": {"nombre": "Cliente"},
             "cuerpoDocumento": [{"cantidad": 1, "precioUni": 10}],
             "resumen": {
@@ -178,7 +178,7 @@ def test_no_envia_si_validacion_falla(monkeypatch):
 
     monkeypatch.setattr(
         "dte.generar_dte_json",
-        lambda db_obj, vid: {"identificacion": {"tipoDte": "01"}},
+        lambda db_obj, vid, **kwargs: {"identificacion": {"tipoDte": "01"}},
     )
 
     with pytest.raises(DTEValidationError):
@@ -186,6 +186,58 @@ def test_no_envia_si_validacion_falla(monkeypatch):
 
     assert sent == []
     assert sign_calls["count"] == 0
+
+
+def test_transmitir_dte_tipo03_preserves_tipo(monkeypatch, tmp_path):
+    db = DB(":memory:")
+    venta = create_sale(db)
+
+    captured = {}
+
+    def fake_generar(db_obj, vid, tipo_dte="01", **kwargs):
+        captured["requested_tipo"] = tipo_dte
+        return {
+            "identificacion": {
+                "tipoDte": "03",
+                "version": 1,
+                "ambiente": "00",
+                "codigoGeneracion": "00000000-0000-4000-8000-000000000003",
+                "numeroControl": "DTE-03-S001P001-000000000000123",
+            },
+            "resumen": {
+                "totalLetras": "DIEZ",
+                "totalPagar": 10,
+                "condicionOperacion": 1,
+                "pagos": None,
+            },
+            "cuerpoDocumento": [],
+        }
+
+    def fail_ticket(*args, **kwargs):
+        raise AssertionError("generar_ticket_json no debe invocarse")
+
+    def fake_enviar_documento(db_obj, doc_id, data, modo, jws_token=None):
+        dest = tmp_path / data["identificacion"]["tipoDte"]
+        dest.mkdir(parents=True, exist_ok=True)
+        path = dest / "documento.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        captured["path"] = path
+        return {"estado": "Transmitido"}
+
+    monkeypatch.setattr("dte.generar_dte_json", fake_generar)
+    monkeypatch.setattr("dte.generar_ticket_json", fail_ticket)
+    monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
+    monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda _: {})
+    monkeypatch.setattr("dte._enviar_documento", fake_enviar_documento)
+
+    resp = dte.transmitir_dte(db, venta, tipo_dte="03")
+
+    assert resp["estado"] == "Transmitido"
+    assert captured.get("requested_tipo") == "03"
+    path = captured.get("path")
+    assert path and path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["identificacion"]["tipoDte"] == "03"
 
 
 def test_enviar_nota_credito(monkeypatch, tmp_path):
@@ -573,7 +625,7 @@ def test_enviar_factura_default_contingencia(monkeypatch):
     monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
     monkeypatch.setattr(
         "dte.generar_dte_json",
-        lambda db_obj, vid: {"resumen": {"totalLetras": "X"}},
+        lambda db_obj, vid, **kwargs: {"resumen": {"totalLetras": "X"}},
     )
     monkeypatch.setattr("dte.apply_schema_patch", lambda data: data)
     monkeypatch.setattr("dte.catalogos.get_dte_schema", lambda t: {})

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -73,7 +73,7 @@ def test_transmision_exitosa(monkeypatch, tmp_path):
     monkeypatch.setattr("dte.validate_dte_json", lambda d, db=None: None)
     monkeypatch.setattr(
         "dte.generar_dte_json",
-        lambda db_obj, vid: {
+        lambda db_obj, vid, **kwargs: {
             "receptor": {
                 "nombre": "Cliente",
                 "tipoDocumento": "36",

--- a/tests/test_sello_persistencia.py
+++ b/tests/test_sello_persistencia.py
@@ -38,7 +38,11 @@ def _assert_sello_guardado(db: DB, venta_id: int):
 def test_transmitir_dte_guarda_sello(monkeypatch):
     db = DB(":memory:")
     venta_id = create_sale(db)
-    monkeypatch.setattr(dte, "generar_dte_json", lambda db_obj, vid: {})
+    monkeypatch.setattr(
+        dte,
+        "generar_dte_json",
+        lambda db_obj, vid, **kwargs: {"identificacion": {"tipoDte": "01"}},
+    )
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
@@ -50,7 +54,11 @@ def test_transmitir_dte_guarda_sello(monkeypatch):
 def test_enviar_factura_guarda_sello(monkeypatch):
     db = DB(":memory:")
     venta_id = create_sale(db)
-    monkeypatch.setattr(dte, "generar_dte_json", lambda db_obj, vid: {})
+    monkeypatch.setattr(
+        dte,
+        "generar_dte_json",
+        lambda db_obj, vid, **kwargs: {"identificacion": {"tipoDte": "01"}},
+    )
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
@@ -122,7 +130,7 @@ def test_sello_recibido_actualiza_envio_y_extra(monkeypatch):
         "resumen": {"totalLetras": "X"},
     }
 
-    monkeypatch.setattr(dte, "generar_dte_json", lambda db_obj, vid: minimo)
+    monkeypatch.setattr(dte, "generar_dte_json", lambda db_obj, vid, **kwargs: minimo)
     monkeypatch.setattr(dte, "apply_schema_patch", lambda d: d)
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte.jws, "sign_json", lambda data: make_jws(data))


### PR DESCRIPTION
## Summary
- ensure `transmitir_dte` inspects sale extras, calls the generic generator for the requested document code, and validates the generated tipoDte
- add a regression test for transmitting tipo 03 documents and adjust ticket-related stubs to accept arbitrary keyword arguments
- update other transmission tests to accommodate the stricter generation logic and provide minimal identificacion data

## Testing
- pytest tests/test_envio_documentos.py::test_transmitir_dte_tipo03_preserves_tipo
- pytest tests/test_envio_documentos.py::test_enviar_factura_rechazo_y_reenvio
- pytest tests/test_envio_documentos.py::test_enviar_factura_default_contingencia
- pytest tests/test_envio_hacienda.py::test_transmision_exitosa
- pytest tests/test_sello_persistencia.py::test_transmitir_dte_guarda_sello


------
https://chatgpt.com/codex/tasks/task_e_68c8c40b07ac83238241cbf0e1c1dbd8