### PR TITLE
Verify persisted DTE JSON hash after saving

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -15,7 +15,7 @@ from db import DB
 import requests
 from utils import jws
 from utils import versioned_dte
-from utils.stable_json import stable_stringify, save_file
+from utils.stable_json import stable_stringify, save_file, hash_json
 import auth
 from jsonschema import ValidationError, RefResolver
 from utils import catalogos
@@ -4223,9 +4223,13 @@ def _dte_base_dir(
 
 def _save_signed_dte(dte_data: dict, jws_token: str, fallido: bool = False) -> None:
     """Guarda el JSON y JWS usando estructura versionada por hash."""
+    expected_hash = hash_json(dte_data)
+    version_dir = ""
+    json_path = ""
     try:
         base_dir = _dte_base_dir(dte_data, fallido=fallido)
         version_dir, _ = versioned_dte.ensure_version(dte_data, base_dir)
+        json_path = os.path.join(version_dir, "documento.json")
         jws_name = versioned_dte.add_jws(version_dir, jws_token, origen="auto")
         sobre = construir_sobre_recepcion(jws_token, dte_data)
         if sobre.get("estado") != "Error":
@@ -4235,6 +4239,18 @@ def _save_signed_dte(dte_data: dict, jws_token: str, fallido: bool = False) -> N
             _write_json(sobre_path, sobre)
     except Exception:
         pass
+    else:
+        with open(json_path, "r", encoding="utf-8") as fh:
+            persisted_data = json.load(fh)
+        actual_hash = hash_json(persisted_data)
+        if actual_hash != expected_hash:
+            logger.error(
+                "El JSON guardado difiere del payload firmado: esperado %s, obtenido %s (ruta: %s)",
+                expected_hash,
+                actual_hash,
+                json_path,
+            )
+            raise RuntimeError("El JSON guardado difiere del payload firmado")
 
 
 class DTEValidationError(Exception):

--- a/tests/test_sello_persistencia.py
+++ b/tests/test_sello_persistencia.py
@@ -11,6 +11,7 @@ import dte
 import nota_remision
 import utils.docs
 import utils.jws
+from utils import versioned_dte
 from tests.conftest import make_jws
 
 
@@ -33,6 +34,49 @@ def _assert_sello_guardado(db: DB, venta_id: int):
     assert row and row["extra"]
     extra = json.loads(row["extra"])
     assert extra["selloRecibido"] == "SELLO"
+
+
+def test_save_signed_dte_persists_stable_json(monkeypatch, tmp_path):
+    data = {
+        "identificacion": {
+            "codigoGeneracion": "00000000-0000-4000-8000-000000000123",
+            "tipoDte": "01",
+            "version": 1,
+            "ambiente": "00",
+        },
+        "resumen": {"totalLetras": "X"},
+    }
+
+    monkeypatch.setattr(
+        dte,
+        "_dte_base_dir",
+        lambda *a, **k: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        dte.versioned_dte,
+        "add_jws",
+        lambda *a, **k: "documento.jws",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        dte,
+        "construir_sobre_recepcion",
+        lambda *a, **k: {"estado": "Error"},
+    )
+
+    calls: list[dict] = []
+
+    def tracking_hash(value):
+        calls.append(value)
+        return versioned_dte.hash_json(value)
+
+    monkeypatch.setattr(dte, "hash_json", tracking_hash)
+
+    dte._save_signed_dte(data, "TOKEN")
+
+    assert len(calls) >= 2
+    assert calls[0] is data
+    assert calls[1] == data
 
 
 def test_transmitir_dte_guarda_sello(monkeypatch):


### PR DESCRIPTION
## Summary
- compute the expected JSON hash before persisting a signed DTE and verify the stored file matches after reopening it
- log and raise an error when the persisted payload differs to prevent transmission
- add a unit test covering the save-and-reload hash comparison

## Testing
- pytest tests/test_sello_persistencia.py

------
https://chatgpt.com/codex/tasks/task_e_68c8bdf268308323891a34c4865fa59f