### PR TITLE
Allow ventas without vendedor assignment

### DIFF
--- a/inventory_validator.py
+++ b/inventory_validator.py
@@ -111,7 +111,7 @@ def validate_inventory_json(data: dict) -> List[Issue]:
         if vid is not None:
             venta_ids.add(vid)
         vend_id = v.get("vendedor_id")
-        if vend_id not in vendedor_ids:
+        if vend_id is not None and vend_id not in vendedor_ids:
             issues.append({
                 "path": f"ventas[{i}].vendedor_id",
                 "severity": "error",

--- a/tests/test_inventory_import_validation.py
+++ b/tests/test_inventory_import_validation.py
@@ -99,3 +99,13 @@ def test_migration_applied(tmp_path):
     summary = manager.importar_inventario_json(str(path), dry_run=True)
     assert not summary["errors"]
     assert any("Distribuidores" in m for m in summary["migrations_applied"])
+
+
+def test_vendedor_id_optional(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    data["ventas"][0]["vendedor_id"] = None
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = manager.importar_inventario_json(str(path), dry_run=True, strict=False)
+    assert not any(issue["path"] == "ventas[0].vendedor_id" for issue in summary["errors"])


### PR DESCRIPTION
## Summary
- allow inventory validation to accept ventas without a vendedor assignment
- add a regression test covering ventas with vendedor_id set to null during import

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d3b8b5f08323aae3777c4f55caa2