### PR TITLE
Enforce replacement DTE emitter and date checks

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -43,6 +43,26 @@ ACCEPTED_EVENT_STATE_ALIASES = {
     "aceptada": "aceptado",
 }
 
+ERROR_REEMPLAZO_TIPO_INDETERMINADO = (
+    "No se pudo determinar el tipo del DTE de reemplazo; verifica que exista el "
+    "documento.json o la respuesta almacenada."
+)
+ERROR_REEMPLAZO_NO_RECEPCION = (
+    "El DTE de reemplazo no existe o no ha sido recepcionado por MH."
+)
+ERROR_REEMPLAZO_DISTINTO = (
+    "El documento de reemplazo debe ser distinto al que se desea anular."
+)
+ERROR_REEMPLAZO_TIPO = (
+    "El DTE de reemplazo debe ser del mismo tipo que el documento a invalidar."
+)
+ERROR_REEMPLAZO_EMISOR = (
+    "El DTE de reemplazo debe pertenecer al mismo emisor que el documento a invalidar."
+)
+ERROR_REEMPLAZO_FECHA = (
+    "El DTE de reemplazo debe tener una fecha de emisión igual o posterior al documento a invalidar."
+)
+
 
 def _load_json_file(path: str | None) -> dict | None:
     if not path:
@@ -52,6 +72,29 @@ def _load_json_file(path: str | None) -> dict | None:
             return json.load(fh)
     except Exception:
         return None
+
+
+def normalize_ambiente(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    if text in {"00", "01"}:
+        return text
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if digits[:2] in {"00", "01"}:
+        return digits[:2]
+    lowered = text.lower()
+    if lowered.startswith("pru") or "prue" in lowered:
+        return "00"
+    if lowered.startswith("pro"):
+        return "01"
+    if text == "0":
+        return "00"
+    if text == "1":
+        return "01"
+    return text[:2]
 
 
 def _canonical_event_state(raw: str | None) -> str | None:
@@ -64,6 +107,18 @@ def _canonical_event_state(raw: str | None) -> str | None:
     if estado in ACCEPTED_EVENT_STATES:
         return estado
     return None
+
+
+def _normalize_documento_id(value: str | None) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().upper()
+    if not text:
+        return ""
+    digits = solo_digitos(text)
+    if digits:
+        return digits
+    return text
 
 
 def _load_dte_json_from_venta(db: DB, venta_id: int | None) -> dict | None:
@@ -114,19 +169,353 @@ def _load_dte_json_from_venta(db: DB, venta_id: int | None) -> dict | None:
     return None
 
 
-def _ensure_replacement_document(db: DB | None, codigo: str) -> str:
-    if db is None:
-        raise ValueError(
-            "No se pudo determinar el tipo del DTE de reemplazo; verifica que exista el documento.json o la respuesta almacenada."
+def _extract_metadata(source: dict | None) -> dict:
+    metadata = {
+        "tipo_dte": None,
+        "fecha_emision": None,
+        "ambiente": None,
+        "numero_control": None,
+        "emisor_nombre": None,
+        "emisor_documento": None,
+        "receptor_nombre": None,
+        "receptor_documento": None,
+        "total": None,
+    }
+    if not isinstance(source, dict):
+        return metadata
+
+    ident = source.get("identificacion")
+    if not isinstance(ident, dict):
+        ident = source.get("identificacionDocumento")
+    if isinstance(ident, dict):
+        tipo_val = ident.get("tipoDte") or ident.get("tipoDTE")
+        if tipo_val is not None:
+            metadata["tipo_dte"] = str(tipo_val).zfill(2)
+        fec = ident.get("fecEmi") or ident.get("fechaEmision") or ident.get("fecha")
+        if fec is not None:
+            metadata["fecha_emision"] = str(fec)[:10]
+        num_control = ident.get("numeroControl") or ident.get("numControl")
+        if num_control is not None:
+            metadata["numero_control"] = str(num_control).strip()
+        amb = ident.get("ambiente")
+        if amb is not None:
+            metadata["ambiente"] = normalize_ambiente(amb)
+
+    emisor = source.get("emisor")
+    if not isinstance(emisor, dict):
+        for key in ("emisorGenerador", "emisorResponsable", "sujetoGenerador", "transmitente"):
+            cand = source.get(key)
+            if isinstance(cand, dict):
+                emisor = cand
+                break
+    if isinstance(emisor, dict):
+        nombre_emisor = (
+            emisor.get("nombre")
+            or emisor.get("nombreComercial")
+            or emisor.get("razonSocial")
         )
-    db.ensure_column("dte_envios", "codigo_generacion", "TEXT")
-    db.ensure_column("dte_envios", "numero_control", "TEXT")
-    db.ensure_column("dte_envios", "respuesta", "TEXT")
+        if nombre_emisor:
+            metadata["emisor_nombre"] = str(nombre_emisor).strip()
+        doc_emisor = (
+            emisor.get("nit")
+            or emisor.get("numDocumento")
+            or emisor.get("nrc")
+            or emisor.get("dui")
+        )
+        if doc_emisor:
+            metadata["emisor_documento"] = str(doc_emisor).strip()
+
+    receptor = source.get("receptor")
+    if not isinstance(receptor, dict):
+        receptor = source.get("cliente")
+    if isinstance(receptor, dict):
+        nombre = receptor.get("nombre") or receptor.get("razonSocial")
+        if nombre:
+            metadata["receptor_nombre"] = str(nombre).strip()
+        doc = (
+            receptor.get("numDocumento")
+            or receptor.get("nit")
+            or receptor.get("dui")
+            or receptor.get("nrc")
+        )
+        if doc:
+            metadata["receptor_documento"] = str(doc).strip()
+
+    resumen = source.get("resumen")
+    if not isinstance(resumen, dict):
+        resumen = source.get("totales")
+    if isinstance(resumen, dict):
+        for key in (
+            "montoTotalOperacion",
+            "totalPagar",
+            "totalPagarSinRedondeo",
+            "totalGeneral",
+        ):
+            val = resumen.get(key)
+            if val is not None:
+                try:
+                    metadata["total"] = float(Decimal(str(val)))
+                except (InvalidOperation, TypeError, ValueError):
+                    continue
+                else:
+                    break
+
+    if metadata["ambiente"] is None:
+        amb = source.get("ambiente")
+        if amb is not None:
+            metadata["ambiente"] = normalize_ambiente(amb)
+
+    return metadata
+
+
+def _merge_metadata(primary: dict, secondary: dict) -> dict:
+    for key, value in secondary.items():
+        if key not in primary:
+            primary[key] = value
+            continue
+        if primary[key] in (None, "") and value not in (None, ""):
+            primary[key] = value
+    return primary
+
+
+def _parse_respuesta_documento(respuesta_raw: str | None) -> dict | None:
+    if not respuesta_raw:
+        return None
+    try:
+        data = json.loads(respuesta_raw)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    for key in ("documento", "dte", "acuseRecibido", "acuseRecepcion"):
+        doc = data.get(key)
+        if isinstance(doc, dict):
+            if key in {"acuseRecibido", "acuseRecepcion"}:
+                inner = doc.get("documento") or doc.get("dte")
+                if isinstance(inner, dict):
+                    return inner
+                continue
+            return doc
+        if isinstance(doc, str):
+            try:
+                parsed = json.loads(doc)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                return parsed
+    return None
+
+
+def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> list[dict]:
+    if db is None:
+        return []
+    filtros = filtros or {}
+    try:
+        db.ensure_column("dte_envios", "respuesta", "TEXT")
+        db.ensure_column("dte_envios", "codigo_generacion", "TEXT")
+        db.ensure_column("dte_envios", "numero_control", "TEXT")
+        db.ensure_column("dte_envios", "ambiente", "TEXT")
+        db.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dte_envios_codigo_generacion ON dte_envios(codigo_generacion)"
+        )
+        db.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dte_envios_fecha_hora ON dte_envios(fecha_hora)"
+        )
+        db.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dte_envios_estado ON dte_envios(estado)"
+        )
+        db.cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dte_envios_ambiente ON dte_envios(ambiente)"
+        )
+    except Exception:
+        pass
+
+    fecha_inicio = filtros.get("fecha_inicio")
+    fecha_fin = filtros.get("fecha_fin")
+    params: list = []
+    query = [
+        "SELECT id, venta_id, fecha_hora, modo, estado, TRIM(sello) AS sello,",
+        "       TRIM(codigo_generacion) AS codigo_generacion, numero_control,",
+        "       respuesta, ambiente",
+        "  FROM dte_envios",
+        " WHERE TRIM(COALESCE(codigo_generacion, '')) <> ''",
+    ]
+    if fecha_inicio:
+        query.append("   AND date(fecha_hora) >= date(?)")
+        params.append(fecha_inicio)
+    if fecha_fin:
+        query.append("   AND date(fecha_hora) <= date(?)")
+        params.append(fecha_fin)
+    query.append(" ORDER BY fecha_hora DESC, id DESC")
+
+    try:
+        rows = [dict(row) for row in db.cursor.execute("\n".join(query), params).fetchall()]
+    except Exception:
+        return []
+
+    exclude_uuid = str(filtros.get("exclude_uuid") or "").strip().upper()
+    ambiente_objetivo = normalize_ambiente(filtros.get("ambiente"))
+    tipo_objetivo = filtros.get("tipo_dte")
+    if tipo_objetivo is not None:
+        tipo_objetivo = str(tipo_objetivo).zfill(2)
+    receptor_docs_raw = filtros.get("receptor_documentos") or []
+    receptor_docs = {
+        _normalize_documento_id(val)
+        for val in receptor_docs_raw
+        if _normalize_documento_id(val)
+    }
+    recepcionado_only = bool(filtros.get("recepcionado", True))
+    mismo_receptor = bool(filtros.get("mismo_receptor", True))
+    search = str(filtros.get("search") or "").strip().upper()
+    limit = filtros.get("limit")
+    if isinstance(limit, int) and limit <= 0:
+        limit = None
+
+    results: list[dict] = []
+    for row in rows:
+        codigo = str(row.get("codigo_generacion") or "").strip().upper()
+        if not codigo or (exclude_uuid and codigo == exclude_uuid):
+            continue
+
+        sello = str(row.get("sello") or "").strip().upper()
+        sello_valido = bool(SELLO40_RE.fullmatch(sello))
+        estado_canonico = _canonical_event_state(row.get("estado"))
+
+        if recepcionado_only:
+            if estado_canonico not in ACCEPTED_EVENT_STATES or not sello_valido:
+                continue
+
+        venta_id = row.get("venta_id")
+        payload = _load_dte_json_from_venta(db, venta_id)
+        respuesta_doc = _parse_respuesta_documento(row.get("respuesta"))
+        metadata = _extract_metadata(payload)
+        metadata = _merge_metadata(metadata, _extract_metadata(respuesta_doc))
+
+        numero_control = metadata.get("numero_control") or row.get("numero_control")
+        ambiente_doc = metadata.get("ambiente") or normalize_ambiente(row.get("ambiente"))
+        if ambiente_objetivo and ambiente_doc:
+            if ambiente_doc != ambiente_objetivo:
+                continue
+        elif ambiente_objetivo:
+            continue
+
+        tipo_dte = metadata.get("tipo_dte")
+        tipo_indeterminado = False
+        if tipo_dte is None:
+            tipo_indeterminado = True
+        elif tipo_objetivo and tipo_dte != tipo_objetivo:
+            continue
+
+        receptor_doc = metadata.get("receptor_documento")
+        receptor_nombre = metadata.get("receptor_nombre")
+        receptor_norm = _normalize_documento_id(receptor_doc)
+        coincide_receptor = True
+        if receptor_docs:
+            coincide_receptor = receptor_norm in receptor_docs
+        if mismo_receptor and receptor_docs and not coincide_receptor:
+            continue
+
+        total = metadata.get("total")
+        fecha_emision = metadata.get("fecha_emision")
+        fecha_sort = None
+        if fecha_emision:
+            try:
+                fecha_sort = datetime.strptime(str(fecha_emision), "%Y-%m-%d")
+            except Exception:
+                fecha_sort = None
+        if fecha_sort is None:
+            raw_fecha = row.get("fecha_hora")
+            if raw_fecha:
+                try:
+                    fecha_sort = datetime.fromisoformat(raw_fecha)
+                except Exception:
+                    fecha_sort = None
+                else:
+                    if not fecha_emision:
+                        fecha_emision = str(raw_fecha)[:10]
+
+        if search:
+            campos = [
+                codigo,
+                str(numero_control or "").upper(),
+                str(receptor_nombre or "").upper(),
+                receptor_norm,
+            ]
+            if total is not None:
+                campos.append(f"{total:.2f}".upper())
+            if not any(search in campo for campo in campos if campo):
+                continue
+
+        estado_display = estado_canonico or (row.get("estado") or "").strip()
+        seleccionable = (
+            not tipo_indeterminado
+            and estado_canonico in ACCEPTED_EVENT_STATES
+            and sello_valido
+        )
+
+        candidato = {
+            "codigo_generacion": codigo,
+            "numero_control": str(numero_control or ""),
+            "estado": estado_display,
+            "estado_canonico": estado_canonico,
+            "con_sello": sello_valido,
+            "sello": sello,
+            "tipo_dte": tipo_dte,
+            "tipo_indeterminado": tipo_indeterminado,
+            "emisor_documento": metadata.get("emisor_documento"),
+            "emisor_nombre": metadata.get("emisor_nombre"),
+            "receptor_nombre": receptor_nombre,
+            "receptor_documento": receptor_doc,
+            "coincide_receptor": coincide_receptor,
+            "total": total,
+            "fecha_emision": fecha_emision,
+            "ambiente": ambiente_doc,
+            "venta_id": venta_id,
+            "seleccionable": seleccionable,
+            "_sort_key": (
+                fecha_sort or datetime.min,
+                {
+                    "aceptado": 3,
+                    "procesado": 2,
+                    "recibido": 1,
+                }.get(estado_canonico, 0),
+            ),
+        }
+        candidato["preselect"] = bool(
+            candidato["seleccionable"]
+            and candidato["coincide_receptor"]
+            and (tipo_objetivo is None or candidato.get("tipo_dte") == tipo_objetivo)
+        )
+
+        results.append(candidato)
+        if isinstance(limit, int) and len(results) >= limit:
+            break
+
+    results.sort(key=lambda item: item.get("_sort_key", (datetime.min, 0)), reverse=True)
+    for item in results:
+        item.pop("_sort_key", None)
+
+    return results
+
+
+def _ensure_replacement_document(db: DB | None, codigo: str) -> dict:
+    if db is None:
+        raise ValueError(ERROR_REEMPLAZO_TIPO_INDETERMINADO)
+
+    try:
+        db.ensure_column("dte_envios", "codigo_generacion", "TEXT")
+        db.ensure_column("dte_envios", "numero_control", "TEXT")
+        db.ensure_column("dte_envios", "respuesta", "TEXT")
+        db.ensure_column("dte_envios", "ambiente", "TEXT")
+    except Exception:
+        pass
+
+    codigo = (codigo or "").strip().upper()
     row = None
     try:
         row = db.cursor.execute(
             """
-            SELECT venta_id, estado, TRIM(sello) AS sello, respuesta, numero_control
+            SELECT venta_id, estado, TRIM(sello) AS sello, respuesta, numero_control, ambiente, fecha_hora
               FROM dte_envios
              WHERE UPPER(codigo_generacion)=?
              ORDER BY id DESC LIMIT 1
@@ -139,7 +528,7 @@ def _ensure_replacement_document(db: DB | None, codigo: str) -> str:
         try:
             row = db.cursor.execute(
                 """
-                SELECT venta_id, estado, TRIM(sello) AS sello, respuesta, numero_control
+                SELECT venta_id, estado, TRIM(sello) AS sello, respuesta, numero_control, ambiente, fecha_hora
                   FROM dte_envios
                  WHERE UPPER(respuesta) LIKE ?
                  ORDER BY id DESC LIMIT 1
@@ -149,61 +538,68 @@ def _ensure_replacement_document(db: DB | None, codigo: str) -> str:
         except Exception:
             row = None
     if row is None:
-        raise ValueError(
-            "El DTE de reemplazo no existe o no ha sido recepcionado por MH."
-        )
+        raise ValueError(ERROR_REEMPLAZO_NO_RECEPCION)
+
     row_dict = dict(row)
-    estado = _canonical_event_state(row_dict.get("estado"))
-    sello = str(row_dict.get("sello") or "").strip()
+    estado_canonico = _canonical_event_state(row_dict.get("estado"))
+    sello = str(row_dict.get("sello") or "").strip().upper()
     respuesta_raw = row_dict.get("respuesta")
-    if (not sello) and respuesta_raw:
+    if (not SELLO40_RE.fullmatch(sello)) and respuesta_raw:
         try:
             resp_json = json.loads(respuesta_raw)
         except Exception:
             resp_json = None
         else:
             if isinstance(resp_json, dict):
-                sello = (
+                sello_resp = (
                     str(
                         resp_json.get("selloRecibido")
                         or resp_json.get("selloRecepcion")
                         or resp_json.get("sello")
                         or ""
-                    ).strip()
+                    )
+                    .strip()
+                    .upper()
                 )
-    if not sello or estado is None:
-        raise ValueError(
-            "El DTE de reemplazo no existe o no ha sido recepcionado por MH."
-        )
+                if SELLO40_RE.fullmatch(sello_resp):
+                    sello = sello_resp
+    if not SELLO40_RE.fullmatch(sello) or estado_canonico not in ACCEPTED_EVENT_STATES:
+        raise ValueError(ERROR_REEMPLAZO_NO_RECEPCION)
+
     venta_id = row_dict.get("venta_id")
     payload = _load_dte_json_from_venta(db, venta_id)
-    tipo_dte = None
+    respuesta_doc = _parse_respuesta_documento(respuesta_raw)
+
+    metadata = _extract_metadata(None)
     if payload:
         ident = payload.get("identificacion") or {}
-        tipo_val = ident.get("tipoDte")
-        if tipo_val is not None:
-            tipo_dte = str(tipo_val).zfill(2)
-        cod_archivo = str(ident.get("codigoGeneracion") or "").upper()
-        if cod_archivo and cod_archivo != codigo:
-            tipo_dte = None
-    if tipo_dte is None and respuesta_raw:
-        try:
-            resp_json = json.loads(respuesta_raw)
-        except Exception:
-            resp_json = None
-        else:
-            if isinstance(resp_json, dict):
-                doc = resp_json.get("documento") or resp_json.get("dte")
-                if isinstance(doc, dict):
-                    ident = doc.get("identificacion") or {}
-                    tipo_val = ident.get("tipoDte")
-                    if tipo_val is not None:
-                        tipo_dte = str(tipo_val).zfill(2)
+        codigo_archivo = str(ident.get("codigoGeneracion") or "").strip().upper()
+        if not codigo_archivo or codigo_archivo == codigo:
+            metadata = _merge_metadata(metadata, _extract_metadata(payload))
+    if respuesta_doc:
+        metadata = _merge_metadata(metadata, _extract_metadata(respuesta_doc))
+
+    if metadata.get("ambiente") is None:
+        metadata["ambiente"] = normalize_ambiente(row_dict.get("ambiente"))
+    if not metadata.get("numero_control"):
+        metadata["numero_control"] = str(row_dict.get("numero_control") or "").strip()
+    if not metadata.get("fecha_emision"):
+        fecha_raw = row_dict.get("fecha_hora")
+        if fecha_raw:
+            metadata["fecha_emision"] = str(fecha_raw)[:10]
+
+    tipo_dte = metadata.get("tipo_dte")
     if tipo_dte is None:
-        raise ValueError(
-            "No se pudo determinar el tipo del DTE de reemplazo; verifica que exista el documento.json o la respuesta almacenada."
-        )
-    return tipo_dte
+        raise ValueError(ERROR_REEMPLAZO_TIPO_INDETERMINADO)
+
+    metadata.update(
+        {
+            "codigo_generacion": codigo,
+            "estado_canonico": estado_canonico,
+            "sello": sello,
+        }
+    )
+    return metadata
 
 
 def _post_invalidacion(
@@ -481,14 +877,43 @@ def build_invalidacion_json(
                 "El código de generación debe ser un UUID de 36 caracteres en mayúsculas con guiones."
             )
         if codigo_generacion_r == codigo_gen:
-            raise ValueError(
-                "El documento de reemplazo debe ser distinto al que se desea anular."
-            )
-        tipo_reemplazo = _ensure_replacement_document(db, codigo_generacion_r)
+            raise ValueError(ERROR_REEMPLAZO_DISTINTO)
+        reemplazo = _ensure_replacement_document(db, codigo_generacion_r)
+        tipo_reemplazo = reemplazo.get("tipo_dte")
         if tipo_reemplazo != tipo_dte_str:
-            raise ValueError(
-                "El DTE de reemplazo debe ser del mismo tipo que el documento a invalidar."
-            )
+            raise ValueError(ERROR_REEMPLAZO_TIPO)
+
+        emisor_original_doc = None
+        emisor_factura = factura.get("emisor") or {}
+        for key in ("nit", "numDocumento", "nrc", "dui"):
+            val = emisor_factura.get(key)
+            if val:
+                emisor_original_doc = str(val)
+                break
+        emisor_original_norm = _normalize_documento_id(emisor_original_doc)
+        emisor_reemplazo_norm = _normalize_documento_id(
+            reemplazo.get("emisor_documento")
+        )
+        if emisor_original_norm and emisor_reemplazo_norm:
+            if emisor_original_norm != emisor_reemplazo_norm:
+                raise ValueError(ERROR_REEMPLAZO_EMISOR)
+        elif emisor_original_norm:
+            raise ValueError(ERROR_REEMPLAZO_EMISOR)
+
+        fecha_reemplazo = reemplazo.get("fecha_emision")
+        if fecha_reemplazo:
+            try:
+                fecha_reemplazo_dt = datetime.strptime(str(fecha_reemplazo)[:10], "%Y-%m-%d")
+                fecha_original_dt = datetime.strptime(str(fec_emi), "%Y-%m-%d")
+            except Exception:
+                fecha_reemplazo_dt = None
+                fecha_original_dt = None
+            if (
+                fecha_reemplazo_dt is not None
+                and fecha_original_dt is not None
+                and fecha_reemplazo_dt < fecha_original_dt
+            ):
+                raise ValueError(ERROR_REEMPLAZO_FECHA)
 
     def _val_persona(nombre, tip, num, *, sujeto: str):
         nombre_val = (nombre or "").strip()

--- a/dialogs/anular_factura_dialog.py
+++ b/dialogs/anular_factura_dialog.py
@@ -16,6 +16,7 @@ import dte
 import anulacion
 from db import DB
 from utils.catalogos import TIPO_INVALIDACION, TIPO_DOC_REC
+from .seleccionar_dte_dialog import SeleccionarDteDialog
 
 class AnularFacturaDialog(QDialog):
     """Formulario para capturar datos de anulación."""
@@ -26,10 +27,38 @@ class AnularFacturaDialog(QDialog):
         responsable: dict | None = None,
         solicitante: dict | None = None,
         db: DB | None = None,
+        factura: dict | None = None,
     ):
         super().__init__(parent)
         self.setWindowTitle("Anular factura")
         self.db = db
+        self._factura = factura or {}
+        ident = self._factura.get("identificacion") or {}
+        tipo_val = ident.get("tipoDte")
+        self._original_tipo = str(tipo_val).zfill(2) if tipo_val is not None else None
+        codigo_val = ident.get("codigoGeneracion")
+        self._original_uuid = str(codigo_val or "").strip().upper() or None
+        self._original_ambiente = anulacion.normalize_ambiente(ident.get("ambiente"))
+        fecha_val = ident.get("fecEmi") or ident.get("fechaEmision") or ident.get("fecha")
+        self._original_fecha = str(fecha_val)[:10] if fecha_val else None
+        self._receptor_docs: set[str] = set()
+        receptor_data = (factura or {}).get("receptor") or {}
+        for key in ("numDocumento", "nit", "dui"):
+            val = receptor_data.get(key)
+            if val:
+                self._receptor_docs.add(str(val))
+        self._emisor_doc = None
+        emisor_data = (factura or {}).get("emisor") or {}
+        for key in ("nit", "numDocumento", "nrc", "dui"):
+            val = emisor_data.get(key)
+            if val:
+                self._emisor_doc = str(val)
+                break
+        if solicitante:
+            for key in ("numDoc", "numDocumento", "nit", "dui"):
+                val = solicitante.get(key)
+                if val:
+                    self._receptor_docs.add(str(val))
         layout = QVBoxLayout(self)
 
         # Tipo de anulación
@@ -52,9 +81,22 @@ class AnularFacturaDialog(QDialog):
         self.codigo_label = QLabel("Documento que reemplaza:")
         row.addWidget(self.codigo_label)
         self.codigo_edit = QLineEdit()
-        self.codigo_edit.setPlaceholderText("UUID del DTE corregido")
+        self.codigo_edit.setPlaceholderText("UUID del DTE corregido (36 caracteres)")
         row.addWidget(self.codigo_edit)
+        self.codigo_status = QLabel("")
+        self.codigo_status.setFixedWidth(18)
+        self.codigo_status.setAlignment(Qt.AlignCenter)
+        row.addWidget(self.codigo_status)
+        self.buscar_btn = QPushButton("Buscar…")
+        row.addWidget(self.buscar_btn)
         layout.addLayout(row)
+        self.codigo_hint = QLabel(
+            "Para tipo 1/3, selecciona el DTE corregido (mismo tipo) recepcionado por MH. "
+            "En tipo 2 deja vacío."
+        )
+        self.codigo_hint.setWordWrap(True)
+        self.codigo_hint.setStyleSheet("color: #555555; font-size: 11px;")
+        layout.addWidget(self.codigo_hint)
 
         # Responsable
         layout.addWidget(QLabel("Responsable"))
@@ -138,6 +180,11 @@ class AnularFacturaDialog(QDialog):
 
         self.negocio_btn.clicked.connect(self._usar_datos_negocio)
         self.tipo_cb.currentIndexChanged.connect(self._on_tipo_changed)
+        self.codigo_edit.textChanged.connect(self._update_codigo_status)
+        self.codigo_edit.editingFinished.connect(self._normalize_codigo)
+        self.buscar_btn.clicked.connect(self._abrir_selector)
+        self.buscar_btn.setEnabled(self.db is not None)
+        self._update_codigo_status()
         self._on_tipo_changed(self.tipo_cb.currentIndex())
 
         def _prefill(data: dict | None, name_edit: QLineEdit, combo: QComboBox, doc_edit: QLineEdit):
@@ -190,13 +237,23 @@ class AnularFacturaDialog(QDialog):
                     "Ingresa ese código en 'Documento que reemplaza'.",
                 )
                 return False
-            if not anulacion.UUID36_RE.fullmatch(codigo.upper()):
+            codigo_upper = codigo.upper()
+            if not anulacion.UUID36_RE.fullmatch(codigo_upper):
                 QMessageBox.warning(
                     self,
                     "Anulación",
                     "El código de generación debe ser un UUID de 36 caracteres en mayúsculas con guiones.",
                 )
                 return False
+            if self._original_uuid and codigo_upper == self._original_uuid:
+                QMessageBox.warning(
+                    self,
+                    "Anulación",
+                    anulacion.ERROR_REEMPLAZO_DISTINTO,
+                )
+                return False
+            if self.codigo_edit.text() != codigo_upper:
+                self.codigo_edit.setText(codigo_upper)
 
         for name, line in [
             ("Responsable", self.nom_resp),
@@ -221,8 +278,70 @@ class AnularFacturaDialog(QDialog):
         requiere = tipo in {"1", "3"}
         self.codigo_label.setVisible(requiere)
         self.codigo_edit.setVisible(requiere)
+        self.codigo_status.setVisible(requiere)
+        self.codigo_hint.setVisible(requiere)
+        self.buscar_btn.setVisible(requiere)
+        self.buscar_btn.setEnabled(requiere and self.db is not None and self._original_tipo is not None)
         if not requiere:
             self.codigo_edit.clear()
+        self._update_codigo_status()
+
+    def _normalize_codigo(self):
+        codigo = self.codigo_edit.text().strip().upper()
+        if codigo and self.codigo_edit.text() != codigo:
+            self.codigo_edit.blockSignals(True)
+            self.codigo_edit.setText(codigo)
+            self.codigo_edit.blockSignals(False)
+        self._update_codigo_status()
+
+    def _update_codigo_status(self):
+        if not self.codigo_edit.isVisible():
+            self.codigo_status.clear()
+            return
+        codigo = self.codigo_edit.text().strip().upper()
+        if not codigo:
+            self.codigo_status.setText("")
+            self.codigo_status.setStyleSheet("")
+            return
+        if self._original_uuid and codigo == self._original_uuid:
+            self.codigo_status.setText("!")
+            self.codigo_status.setStyleSheet("color: #d93025; font-weight: bold;")
+            return
+        if anulacion.UUID36_RE.fullmatch(codigo):
+            self.codigo_status.setText("✓")
+            self.codigo_status.setStyleSheet("color: #1e8e3e; font-weight: bold;")
+        else:
+            self.codigo_status.setText("•")
+            self.codigo_status.setStyleSheet("color: #999999; font-weight: bold;")
+
+    def _abrir_selector(self):
+        if self.db is None:
+            QMessageBox.warning(
+                self,
+                "Anulación",
+                "Base de datos no disponible para buscar DTEs.",
+            )
+            return
+        if not self._original_tipo:
+            QMessageBox.warning(
+                self,
+                "Anulación",
+                "No se pudo determinar el tipo del DTE original.",
+            )
+            return
+        dialog = SeleccionarDteDialog(
+            self.db,
+            tipo_dte=self._original_tipo,
+            ambiente=self._original_ambiente,
+            receptor_documentos=sorted(self._receptor_docs),
+            exclude_uuid=self._original_uuid,
+            emisor_documento=self._emisor_doc,
+            fecha_emision_original=self._original_fecha,
+            parent=self,
+        )
+        if dialog.exec_() == QDialog.Accepted and dialog.selected_uuid:
+            self.codigo_edit.setText(dialog.selected_uuid)
+            self._update_codigo_status()
 
     # --- Empleado search helpers -----------------------------------------------
 

--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -14,6 +14,7 @@ from PyQt5.QtCore import Qt
 
 from utils.catalogos import TRIBUTO_IVA
 from .anular_factura_dialog import AnularFacturaDialog
+import anulacion
 import dte
 
 
@@ -104,12 +105,21 @@ class InvoiceDetailDialog(QDialog):
     def _anular(self):
         negocio = dte._load_datos_negocio()
         receptor = self.factura.get("receptor", {})
-        dlg = AnularFacturaDialog(self, responsable=negocio, solicitante=receptor)
+        parent = self.parent()
+        db = getattr(getattr(parent, "manager", None), "db", None)
+        dlg = AnularFacturaDialog(
+            self,
+            responsable=negocio,
+            solicitante=receptor,
+            db=db,
+            factura=self.factura,
+        )
         if dlg.exec_() != QDialog.Accepted:
             return
         form = dlg.get_data()
-        parent = self.parent()
-        db = getattr(getattr(parent, "manager", None), "db", None)
+        if db is None:
+            parent = self.parent()
+            db = getattr(getattr(parent, "manager", None), "db", None)
         if not db:
             QMessageBox.warning(self, "Anulación", "Base de datos no disponible")
             return
@@ -124,8 +134,18 @@ class InvoiceDetailDialog(QDialog):
             )
             return
         try:
-            evento = dte.generar_evento_anulacion(self.factura, form, sello)
-            res = dte.enviar_evento_anulacion(db, self.venta_id, evento)
+            cfg = dte._load_dte_api_config()
+            ambiente_cfg = str(cfg.get("ambiente", ""))
+            amb = "01" if ambiente_cfg.lower().startswith("produc") else "00"
+            factura_payload = dict(self.factura)
+            factura_payload["selloRecibido"] = sello
+            evento = anulacion.build_invalidacion_json(
+                factura_payload,
+                form,
+                ambiente=amb,
+                db=db,
+            )
+            res = anulacion.enviar_invalidacion(db, evento)
         except Exception as exc:  # pragma: no cover - UI feedback
             QMessageBox.warning(self, "Anulación", str(exc))
             return

--- a/dialogs/seleccionar_dte_dialog.py
+++ b/dialogs/seleccionar_dte_dialog.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List
+
+from PyQt5.QtCore import QDate, QTimer, Qt
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QDateEdit,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+import anulacion
+from db import DB
+
+
+class SeleccionarDteDialog(QDialog):
+    """Modal dialog to browse DTE candidates received by the tax authority."""
+
+    HEADERS = [
+        "Fecha emisión",
+        "Tipo",
+        "Número de control",
+        "Código generación (UUID)",
+        "Receptor",
+        "Total",
+        "Estado",
+        "Con sello",
+    ]
+
+    def __init__(
+        self,
+        db: DB | None,
+        *,
+        tipo_dte: str | None,
+        ambiente: str | None,
+        receptor_documentos: Iterable[str] | None = None,
+        exclude_uuid: str | None = None,
+        emisor_documento: str | None = None,
+        fecha_emision_original: str | None = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.db = db
+        self.tipo_dte = str(tipo_dte).zfill(2) if tipo_dte else None
+        self.ambiente = anulacion.normalize_ambiente(ambiente)
+        docs = receptor_documentos or []
+        self.receptor_documentos: List[str] = [str(doc) for doc in docs if doc]
+        self.exclude_uuid = (exclude_uuid or "").strip().upper()
+        self.candidates: list[dict] = []
+        self.selected_uuid: str | None = None
+        self.emisor_documento_norm = anulacion._normalize_documento_id(emisor_documento)
+        self.original_fecha = (
+            str(fecha_emision_original)[:10]
+            if fecha_emision_original
+            else None
+        )
+
+        self.setWindowTitle("Seleccionar DTE corregido")
+        layout = QVBoxLayout(self)
+
+        info_parts = []
+        if self.tipo_dte:
+            info_parts.append(f"Tipo: {self.tipo_dte}")
+        if self.ambiente:
+            info_parts.append(f"Ambiente: {self.ambiente}")
+        if info_parts:
+            info_label = QLabel(" · ".join(info_parts))
+            info_label.setStyleSheet("color: #555555; font-size: 11px;")
+            layout.addWidget(info_label)
+
+        search_layout = QHBoxLayout()
+        search_label = QLabel("Buscar:")
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText(
+            "Código de generación, número de control, receptor o monto"
+        )
+        search_layout.addWidget(search_label)
+        search_layout.addWidget(self.search_edit)
+        layout.addLayout(search_layout)
+
+        filters_layout = QHBoxLayout()
+        self.recepcionado_cb = QCheckBox("Solo DTE recepcionados por MH")
+        self.recepcionado_cb.setChecked(True)
+        filters_layout.addWidget(self.recepcionado_cb)
+
+        self.mismo_receptor_cb = QCheckBox("Mismo receptor")
+        tiene_docs = bool(self.receptor_documentos)
+        self.mismo_receptor_cb.setChecked(tiene_docs)
+        self.mismo_receptor_cb.setEnabled(tiene_docs)
+        filters_layout.addWidget(self.mismo_receptor_cb)
+        filters_layout.addStretch(1)
+
+        filters_layout.addWidget(QLabel("Desde:"))
+        self.fecha_inicio = QDateEdit()
+        self.fecha_inicio.setCalendarPopup(True)
+        self.fecha_inicio.setDate(QDate.currentDate().addDays(-60))
+        filters_layout.addWidget(self.fecha_inicio)
+
+        filters_layout.addWidget(QLabel("Hasta:"))
+        self.fecha_fin = QDateEdit()
+        self.fecha_fin.setCalendarPopup(True)
+        self.fecha_fin.setDate(QDate.currentDate())
+        filters_layout.addWidget(self.fecha_fin)
+        layout.addLayout(filters_layout)
+
+        self.table = QTableWidget(0, len(self.HEADERS))
+        self.table.setHorizontalHeaderLabels(self.HEADERS)
+        header = self.table.horizontalHeader()
+        header.setStretchLastSection(True)
+        for idx in range(len(self.HEADERS)):
+            header.setSectionResizeMode(idx, QHeaderView.Stretch)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        layout.addWidget(self.table)
+
+        self.result_label = QLabel("")
+        self.result_label.setStyleSheet("color: #555555; font-size: 11px;")
+        layout.addWidget(self.result_label)
+
+        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.select_btn = self.button_box.button(QDialogButtonBox.Ok)
+        self.select_btn.setText("Seleccionar")
+        self.button_box.accepted.connect(self._select_current)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+        self.table.itemDoubleClicked.connect(lambda *_: self._select_current())
+        self.table.itemSelectionChanged.connect(self._update_button_state)
+
+        self.search_timer = QTimer(self)
+        self.search_timer.setInterval(250)
+        self.search_timer.setSingleShot(True)
+        self.search_edit.textChanged.connect(self.search_timer.start)
+        self.search_timer.timeout.connect(self._refresh)
+
+        self.recepcionado_cb.toggled.connect(self._refresh)
+        self.mismo_receptor_cb.toggled.connect(self._refresh)
+        self.fecha_inicio.dateChanged.connect(lambda *_: self._refresh())
+        self.fecha_fin.dateChanged.connect(lambda *_: self._refresh())
+
+        if self.db is None:
+            for widget in (
+                self.search_edit,
+                self.recepcionado_cb,
+                self.mismo_receptor_cb,
+                self.fecha_inicio,
+                self.fecha_fin,
+            ):
+                widget.setEnabled(False)
+
+        self._refresh()
+
+    def _current_candidate(self) -> dict | None:
+        row = self.table.currentRow()
+        if row < 0:
+            return None
+        item = self.table.item(row, 0)
+        if item is None:
+            return None
+        data = item.data(Qt.UserRole)
+        return data if isinstance(data, dict) else None
+
+    def _update_button_state(self) -> None:
+        self.select_btn.setEnabled(self._current_candidate() is not None)
+
+    def _refresh(self) -> None:
+        if self.db is None:
+            self.candidates = []
+            self._populate_table()
+            return
+
+        if self.fecha_inicio.date() > self.fecha_fin.date():
+            self.fecha_fin.setDate(self.fecha_inicio.date())
+
+        filtros = {
+            "tipo_dte": self.tipo_dte,
+            "ambiente": self.ambiente,
+            "exclude_uuid": self.exclude_uuid,
+            "recepcionado": self.recepcionado_cb.isChecked(),
+            "mismo_receptor": self.mismo_receptor_cb.isChecked(),
+            "receptor_documentos": self.receptor_documentos,
+            "fecha_inicio": self.fecha_inicio.date().toString("yyyy-MM-dd"),
+            "fecha_fin": self.fecha_fin.date().toString("yyyy-MM-dd"),
+            "search": self.search_edit.text(),
+        }
+        try:
+            self.candidates = anulacion.buscar_candidatos_reemplazo(self.db, filtros)
+        except Exception:
+            self.candidates = []
+        self._populate_table()
+
+    def _populate_table(self) -> None:
+        self.table.setRowCount(0)
+        preselect_row = -1
+        for idx, cand in enumerate(self.candidates):
+            self.table.insertRow(idx)
+            fecha = cand.get("fecha_emision") or ""
+            tipo = cand.get("tipo_dte") or "?"
+            numero_control = cand.get("numero_control") or ""
+            codigo = cand.get("codigo_generacion") or ""
+            receptor_nombre = cand.get("receptor_nombre") or ""
+            receptor_doc = cand.get("receptor_documento") or ""
+            if receptor_doc:
+                if receptor_nombre:
+                    receptor = f"{receptor_nombre}\n{receptor_doc}"
+                else:
+                    receptor = receptor_doc
+            else:
+                receptor = receptor_nombre
+            total = cand.get("total")
+            total_txt = f"{total:.2f}" if isinstance(total, (int, float)) else ""
+            estado = cand.get("estado") or ""
+            con_sello = "Sí" if cand.get("con_sello") else "No"
+
+            values = [
+                fecha,
+                tipo,
+                numero_control,
+                codigo,
+                receptor,
+                total_txt,
+                estado.capitalize() if estado else "",
+                con_sello,
+            ]
+            for col, value in enumerate(values):
+                item = QTableWidgetItem(value)
+                if col == 0:
+                    item.setData(Qt.UserRole, cand)
+                item.setTextAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+                self.table.setItem(idx, col, item)
+
+            if not cand.get("seleccionable", False):
+                for col in range(len(self.HEADERS)):
+                    cell = self.table.item(idx, col)
+                    if cell is not None:
+                        cell.setForeground(Qt.gray)
+
+            if cand.get("preselect") and preselect_row == -1:
+                preselect_row = idx
+
+        if self.candidates:
+            if preselect_row >= 0:
+                self.table.selectRow(preselect_row)
+            else:
+                self.table.selectRow(0)
+        self._update_button_state()
+        self.result_label.setText(f"{len(self.candidates)} resultado(s)")
+
+    def _select_current(self) -> None:
+        cand = self._current_candidate()
+        if not cand:
+            return
+        error = self._validate_candidate(cand)
+        if error:
+            QMessageBox.warning(self, "Seleccionar DTE", error)
+            return
+        self.selected_uuid = cand.get("codigo_generacion")
+        if self.selected_uuid:
+            self.selected_uuid = self.selected_uuid.upper()
+        self.accept()
+
+    def _validate_candidate(self, cand: dict) -> str | None:
+        codigo = (cand.get("codigo_generacion") or "").upper()
+        if self.exclude_uuid and codigo == self.exclude_uuid:
+            return anulacion.ERROR_REEMPLAZO_DISTINTO
+        if cand.get("tipo_indeterminado"):
+            return anulacion.ERROR_REEMPLAZO_TIPO_INDETERMINADO
+        if self.tipo_dte and cand.get("tipo_dte") != self.tipo_dte:
+            return anulacion.ERROR_REEMPLAZO_TIPO
+        if cand.get("estado_canonico") not in anulacion.ACCEPTED_EVENT_STATES or not cand.get(
+            "con_sello"
+        ):
+            return anulacion.ERROR_REEMPLAZO_NO_RECEPCION
+        if self.ambiente and cand.get("ambiente") and cand.get("ambiente") != self.ambiente:
+            return "El DTE seleccionado pertenece a un ambiente diferente."
+        if self.emisor_documento_norm:
+            cand_emisor = anulacion._normalize_documento_id(
+                cand.get("emisor_documento")
+            )
+            if not cand_emisor or cand_emisor != self.emisor_documento_norm:
+                return anulacion.ERROR_REEMPLAZO_EMISOR
+        if self.original_fecha and cand.get("fecha_emision"):
+            try:
+                cand_dt = datetime.strptime(str(cand.get("fecha_emision"))[:10], "%Y-%m-%d")
+                orig_dt = datetime.strptime(self.original_fecha[:10], "%Y-%m-%d")
+            except Exception:
+                cand_dt = None
+                orig_dt = None
+            if cand_dt is not None and orig_dt is not None and cand_dt < orig_dt:
+                return anulacion.ERROR_REEMPLAZO_FECHA
+        return None

--- a/tests/test_anular_factura_autofill.py
+++ b/tests/test_anular_factura_autofill.py
@@ -1,3 +1,5 @@
+import uuid
+
 import dte
 from db import DB
 from dialogs.anular_factura_dialog import AnularFacturaDialog
@@ -26,9 +28,9 @@ def test_invoice_detail_uses_negocio_and_cliente(monkeypatch, qt_app):
     captured = {}
 
     class FakeDialog:
-        def __init__(self, parent=None, responsable=None, solicitante=None):
-            captured["responsable"] = responsable
-            captured["solicitante"] = solicitante
+        def __init__(self, *args, **kwargs):
+            captured["responsable"] = kwargs.get("responsable")
+            captured["solicitante"] = kwargs.get("solicitante")
         def exec_(self):
             return QDialog.Rejected
 
@@ -37,6 +39,23 @@ def test_invoice_detail_uses_negocio_and_cliente(monkeypatch, qt_app):
     dlg._anular()
     assert captured["responsable"]["nombre"] == "Dueño"
     assert captured["solicitante"]["nombre"] == "Comprador"
+
+
+def test_anular_dialog_rejects_same_uuid(monkeypatch, qt_app):
+    codigo = str(uuid.uuid4()).upper()
+    factura = {"identificacion": {"tipoDte": "01", "codigoGeneracion": codigo}}
+    dlg = AnularFacturaDialog(factura=factura)
+    idx = dlg.tipo_cb.findData("1")
+    dlg.tipo_cb.setCurrentIndex(idx)
+    dlg.codigo_edit.setText(codigo)
+    warnings = []
+
+    def fake_warning(*args):
+        warnings.append(args)
+
+    monkeypatch.setattr("dialogs.anular_factura_dialog.QMessageBox.warning", fake_warning)
+    assert not dlg._validate()
+    assert warnings, "expected warning when selecting same UUID"
 
 
 def test_usar_datos_negocio_button(monkeypatch, qt_app):

--- a/tests/test_buscar_candidatos_reemplazo.py
+++ b/tests/test_buscar_candidatos_reemplazo.py
@@ -1,0 +1,142 @@
+import json
+import uuid
+
+import pytest
+
+import anulacion
+
+
+def _crear_factura(base_factory, *, tipo="01", ambiente="00", codigo=None, numero=None):
+    factura = base_factory()
+    factura["identificacion"]["tipoDte"] = tipo
+    factura["identificacion"]["ambiente"] = ambiente
+    factura["identificacion"]["codigoGeneracion"] = codigo or str(uuid.uuid4()).upper()
+    factura["identificacion"]["numeroControl"] = numero or "DTE-01-S001P001-000000000000001"
+    factura["resumen"]["montoTotalOperacion"] = "25.50"
+    return factura
+
+
+@pytest.mark.usefixtures("qt_app")
+def test_buscar_candidatos_reemplazo_filters(db_conn, tmp_path, dte_metadata_factory):
+    factura_a = _crear_factura(
+        dte_metadata_factory,
+        codigo=str(uuid.uuid4()).upper(),
+        numero="DTE-01-S001P001-000000000000111",
+    )
+    json_a = tmp_path / "candidato_a.json"
+    json_a.write_text(json.dumps(factura_a), encoding="utf-8")
+    extra = {
+        "codigoGeneracion": factura_a["identificacion"]["codigoGeneracion"],
+        "numeroControl": factura_a["identificacion"]["numeroControl"],
+        "dteJsonPath": str(json_a),
+        "selloRecibido": "Z" * 40,
+    }
+    venta_a = db_conn.add_venta("2024-02-01", 25.5, extra=extra)
+    db_conn.registrar_envio_dte(
+        venta_a,
+        "manual",
+        "Aceptada",
+        "Z" * 40,
+        respuesta_json=json.dumps({"documento": factura_a}),
+        codigo_generacion=factura_a["identificacion"]["codigoGeneracion"],
+        numero_control=factura_a["identificacion"]["numeroControl"],
+    )
+    row_a = db_conn.cursor.lastrowid
+    db_conn.ensure_column("dte_envios", "ambiente", "TEXT")
+    db_conn.cursor.execute(
+        "UPDATE dte_envios SET ambiente=? WHERE id=?",
+        (factura_a["identificacion"]["ambiente"], row_a),
+    )
+
+    codigo_b = str(uuid.uuid4()).upper()
+    respuesta_b = {
+        "documento": {
+            "identificacion": {"fecEmi": "2024-02-05"},
+            "receptor": factura_a["receptor"],
+        }
+    }
+    db_conn.registrar_envio_dte(
+        None,
+        "manual",
+        "Recibida",
+        "Y" * 40,
+        respuesta_json=json.dumps(respuesta_b),
+        codigo_generacion=codigo_b,
+        numero_control="DTE-01-S001P001-000000000000222",
+    )
+    row_b = db_conn.cursor.lastrowid
+    db_conn.cursor.execute(
+        "UPDATE dte_envios SET ambiente=? WHERE id=?",
+        (factura_a["identificacion"]["ambiente"], row_b),
+    )
+
+    factura_c = _crear_factura(
+        dte_metadata_factory,
+        tipo="03",
+        codigo=str(uuid.uuid4()).upper(),
+        numero="DTE-03-S001P001-000000000000333",
+    )
+    json_c = tmp_path / "candidato_c.json"
+    json_c.write_text(json.dumps(factura_c), encoding="utf-8")
+    extra_c = {
+        "codigoGeneracion": factura_c["identificacion"]["codigoGeneracion"],
+        "numeroControl": factura_c["identificacion"]["numeroControl"],
+        "dteJsonPath": str(json_c),
+        "selloRecibido": "X" * 40,
+    }
+    venta_c = db_conn.add_venta("2024-02-02", 10, extra=extra_c)
+    db_conn.registrar_envio_dte(
+        venta_c,
+        "manual",
+        "Aceptado",
+        "X" * 40,
+        respuesta_json=json.dumps({"documento": factura_c}),
+        codigo_generacion=factura_c["identificacion"]["codigoGeneracion"],
+        numero_control=factura_c["identificacion"]["numeroControl"],
+    )
+    row_c = db_conn.cursor.lastrowid
+    db_conn.cursor.execute(
+        "UPDATE dte_envios SET ambiente=? WHERE id=?",
+        (factura_c["identificacion"]["ambiente"], row_c),
+    )
+    db_conn.conn.commit()
+
+    receptor_doc = factura_a["receptor"]["numDocumento"]
+    filtros = {
+        "tipo_dte": "01",
+        "ambiente": factura_a["identificacion"]["ambiente"],
+        "exclude_uuid": "IGNORAR",
+        "recepcionado": True,
+        "mismo_receptor": True,
+        "receptor_documentos": [receptor_doc],
+    }
+    resultados = anulacion.buscar_candidatos_reemplazo(db_conn, filtros)
+    codigos = {r["codigo_generacion"] for r in resultados}
+
+    assert factura_a["identificacion"]["codigoGeneracion"] in codigos
+    assert codigo_b in codigos
+    assert factura_c["identificacion"]["codigoGeneracion"] not in codigos
+
+    datos = {item["codigo_generacion"]: item for item in resultados}
+    cand_a = datos[factura_a["identificacion"]["codigoGeneracion"]]
+    assert cand_a["tipo_dte"] == "01"
+    assert cand_a["seleccionable"] is True
+    assert cand_a["preselect"] is True
+    assert pytest.approx(cand_a["total"], rel=1e-6) == 25.5
+    assert cand_a["emisor_documento"] == factura_a["emisor"]["nit"]
+
+    cand_b = datos[codigo_b]
+    assert cand_b["tipo_indeterminado"] is True
+    assert cand_b["seleccionable"] is False
+
+    filtros_con_exclusion = dict(filtros)
+    filtros_con_exclusion["exclude_uuid"] = factura_a["identificacion"]["codigoGeneracion"]
+    excluidos = anulacion.buscar_candidatos_reemplazo(db_conn, filtros_con_exclusion)
+    codigos_excluidos = {r["codigo_generacion"] for r in excluidos}
+    assert factura_a["identificacion"]["codigoGeneracion"] not in codigos_excluidos
+    assert codigo_b in codigos_excluidos
+
+    filtros_busqueda = dict(filtros)
+    filtros_busqueda["search"] = receptor_doc
+    resultados_busqueda = anulacion.buscar_candidatos_reemplazo(db_conn, filtros_busqueda)
+    assert {r["codigo_generacion"] for r in resultados_busqueda} == codigos

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -186,6 +186,138 @@ def test_invalidacion_tipo3_requiere_codigo(monkeypatch, db_conn, tmp_path):
         )
 
 
+def _patch_negocio(monkeypatch):
+    monkeypatch.setattr(
+        anulacion,
+        "_load_datos_negocio",
+        lambda: {
+            "nit": "06141404100016",
+            "nombre": "Empresa SA",
+            "telefono": "22223333",
+            "correo": "info@empresa.com",
+            "tipoEstablecimiento": "01",
+            "nombreComercial": "Empresa",
+            "codEstableMH": "0001",
+            "codEstable": "0001",
+            "codPuntoVentaMH": "0001",
+            "codPuntoVenta": "0001",
+        },
+    )
+
+
+def _build_form(codigo):
+    return {
+        "tipoAnulacion": "3",
+        "motivoAnulacion": "Cliente solicita anulación",
+        "nombreResponsable": "Responsable Uno",
+        "tipDocResponsable": "13",
+        "numDocResponsable": "01234567-8",
+        "nombreSolicita": "Solicita Dos",
+        "tipDocSolicita": "36",
+        "numDocSolicita": "06141404100016",
+        "codigoGeneracionR": codigo,
+    }
+
+
+def test_invalidacion_rechaza_emisor_distinto(monkeypatch, db_conn, tmp_path):
+    factura = _sample_factura()
+    sello = "C" * 40
+    codigo_reemplazo = str(uuid.uuid4()).upper()
+    numero_control = "DTE-01-S001P001-000000000000888"
+    reemplazo = {
+        "identificacion": {
+            "tipoDte": factura["identificacion"]["tipoDte"],
+            "codigoGeneracion": codigo_reemplazo,
+            "numeroControl": numero_control,
+            "fecEmi": "2024-01-02",
+        },
+        "emisor": {
+            "nit": "06141404100017",
+            "nombre": "Otra Empresa",
+        },
+        "receptor": factura.get("receptor", {}),
+    }
+    json_path = tmp_path / "reemplazo_emisor.json"
+    json_path.write_text(json.dumps(reemplazo), encoding="utf-8")
+
+    extra = {
+        "codigoGeneracion": codigo_reemplazo,
+        "numeroControl": numero_control,
+        "dteJsonPath": str(json_path),
+        "selloRecibido": "Z" * 40,
+    }
+    venta_id = db_conn.add_venta("2024-01-02", 10, extra=extra)
+    db_conn.registrar_envio_dte(
+        venta_id,
+        "manual",
+        "Aceptado",
+        "Z" * 40,
+        respuesta_json=json.dumps({"documento": reemplazo}),
+        codigo_generacion=codigo_reemplazo,
+        numero_control=numero_control,
+    )
+
+    _patch_negocio(monkeypatch)
+    form = _build_form(codigo_reemplazo)
+
+    with pytest.raises(ValueError) as excinfo:
+        anulacion.build_invalidacion_json(
+            {**factura, "selloRecibido": sello},
+            form,
+            ambiente="00",
+            db=db_conn,
+        )
+    assert str(excinfo.value) == anulacion.ERROR_REEMPLAZO_EMISOR
+
+
+def test_invalidacion_rechaza_fecha_anterior(monkeypatch, db_conn, tmp_path):
+    factura = _sample_factura()
+    sello = "D" * 40
+    codigo_reemplazo = str(uuid.uuid4()).upper()
+    numero_control = "DTE-01-S001P001-000000000000889"
+    reemplazo = {
+        "identificacion": {
+            "tipoDte": factura["identificacion"]["tipoDte"],
+            "codigoGeneracion": codigo_reemplazo,
+            "numeroControl": numero_control,
+            "fecEmi": "2023-12-20",
+        },
+        "emisor": factura.get("emisor", {}),
+        "receptor": factura.get("receptor", {}),
+    }
+    json_path = tmp_path / "reemplazo_fecha.json"
+    json_path.write_text(json.dumps(reemplazo), encoding="utf-8")
+
+    extra = {
+        "codigoGeneracion": codigo_reemplazo,
+        "numeroControl": numero_control,
+        "dteJsonPath": str(json_path),
+        "selloRecibido": "Z" * 40,
+    }
+    venta_id = db_conn.add_venta("2023-12-20", 10, extra=extra)
+    db_conn.registrar_envio_dte(
+        venta_id,
+        "manual",
+        "Aceptado",
+        "Z" * 40,
+        respuesta_json=json.dumps({"documento": reemplazo}),
+        codigo_generacion=codigo_reemplazo,
+        numero_control=numero_control,
+    )
+
+    _patch_negocio(monkeypatch)
+    form = _build_form(codigo_reemplazo)
+
+    with pytest.raises(ValueError) as excinfo:
+        anulacion.build_invalidacion_json(
+            {**factura, "selloRecibido": sello},
+            form,
+            ambiente="00",
+            db=db_conn,
+        )
+    assert str(excinfo.value) == anulacion.ERROR_REEMPLAZO_FECHA
+
+
 def test_anular_dte_uses_sello_from_db(qt_app, db_conn, monkeypatch):
     def _create_sale(db):
         db.add_vendedor("V1")


### PR DESCRIPTION
## Summary
- extend the annulment helper logic to capture emitter metadata, create useful indexes, and enforce same-emitter and emission-date rules when validating replacement DTEs
- teach the annulment dialog and selector UI to pass along original emitter/date context, reuse shared error messages, and block candidates that are mismatched or not yet recepcionado
- switch the invoice detail annulment flow to build events via `anulacion.build_invalidacion_json` and expand the automated tests to cover the new validations

## Testing
- `pytest` *(fails: ImportError libGL.so.1 missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5e0089c8323a0894dd192d1a8eb