### PR TITLE
Mejora manejo de rechazos en anulaciones de DTE

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -21,6 +21,7 @@ from dte import (
     format_cliente_id_from_dui,
     detect_user_agent,
     build_auth_header,
+    _parse_error_response,
     APP_VERSION,
 )
 
@@ -661,6 +662,14 @@ def _post_invalidacion(
     if isinstance(resp.status_code, int) and resp.status_code >= 400:
         detalle = data if data is not None else text
         result = {"estado": "Rechazado", "http_status": resp.status_code, "detalle": detalle}
+        if isinstance(data, dict):
+            detalle_info = data.get("detalle") if isinstance(data.get("detalle"), dict) else data
+            for key in ("descripcionMsg", "observaciones"):
+                if key in detalle_info:
+                    result[key] = detalle_info[key]
+            err = _parse_error_response(result)
+            if err:
+                result["errores"] = err
         print(json.dumps(result, ensure_ascii=False))
         return result
 


### PR DESCRIPTION
## Summary
- reutilizar `_parse_error_response` de `dte` en `_post_invalidacion` para copiar `descripcionMsg` y `observaciones` cuando el API devuelve un error
- exponer el resumen legible en `result["errores"]` para que el diálogo de la UI muestre el rechazo concreto

## Testing
- `python - <<'PY'
from unittest.mock import patch
import anulacion

class DummyResp:
    status_code = 400
    text = "rejected"
    def json(self):
        return {
            "detalle": {
                "descripcionMsg": "Anulación rechazada",
                "observaciones": {"campo": "Dato inválido"},
            }
        }

def fake_post(url, headers=None, json=None, timeout=20):
    return DummyResp()

with patch("anulacion.requests.post", fake_post):
    respuesta = anulacion._post_invalidacion(
        "https://apitest.dtes.mh.gob.sv/fesv/anulardte",
        "token",
        "EVENTO",
        {"identificacion": {"ambiente": "00"}},
    )

print(respuesta)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c9e3df5c6c83239e287e6ba1e7d7fe