### PR TITLE
Persistir evento de anulacion

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import uuid
 import re
@@ -11,6 +12,7 @@ import requests
 import auth
 from db import DB
 from utils import jws
+from utils import stable_json
 from utils.catalogos import TRIBUTO_IVA
 from utils.sanitize import solo_digitos
 from utils.fecha import TZ_EL_SALVADOR
@@ -24,6 +26,9 @@ from dte import (
     _parse_error_response,
     APP_VERSION,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 UUID36_RE = re.compile(r"^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$")
@@ -999,6 +1004,41 @@ def enviar_invalidacion(db: DB, data: dict) -> dict:
     pu = urlparse(config["url"])
     url = f"{pu.scheme}://{pu.netloc}/fesv/anulardte"
     signed = jws.sign_json(data)
+    codigo_generacion = None
+    target_dir = None
+    if isinstance(data, dict):
+        ident = data.get("identificacion")
+        if isinstance(ident, dict):
+            raw_codigo = ident.get("codigoGeneracion")
+            if raw_codigo:
+                codigo_generacion = str(raw_codigo).strip()
+    if codigo_generacion:
+        base_dir = os.path.join(
+            os.path.dirname(__file__), "dtes", "eventos", "anulacion"
+        )
+        target_dir = os.path.join(base_dir, codigo_generacion)
+        try:
+            os.makedirs(target_dir, exist_ok=True)
+        except Exception:
+            logger.exception(
+                "No se pudo crear el directorio para el evento de anulación %s",
+                codigo_generacion,
+            )
+            target_dir = None
+    if target_dir and isinstance(data, dict):
+        try:
+            json_path = os.path.join(target_dir, "documento.json")
+            stable_json.save_file(
+                json_path, stable_json.stable_stringify(data, indent=2)
+            )
+            jws_path = os.path.join(target_dir, "documento.jws")
+            signed_str = signed if isinstance(signed, str) else str(signed)
+            stable_json.save_file(jws_path, signed_str, add_final_newline=False)
+        except Exception:
+            logger.exception(
+                "No se pudo guardar el evento de anulación %s",
+                codigo_generacion or "",
+            )
     token = auth.get_token()
     respuesta = _post_invalidacion(url, token, signed, data)
     sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from types import SimpleNamespace
 
@@ -105,6 +106,7 @@ def test_invalidacion_tipo3_requiere_codigo(monkeypatch, db_conn, tmp_path):
             "numeroControl": numero_control_reemplazo,
             "fecEmi": "2024-01-02",
         },
+        "emisor": factura.get("emisor", {}),
         "receptor": factura.get("receptor", {}),
     }
     json_path = tmp_path / "reemplazo.json"
@@ -382,6 +384,109 @@ def test_anular_dte_uses_sello_from_db(qt_app, db_conn, monkeypatch):
 
     assert not called
     assert data["selloRecibido"] == sello
+
+
+def test_enviar_invalidacion_guarda_archivos(monkeypatch):
+    codigo = "ABC123XYZ789"
+    data = {
+        "identificacion": {"codigoGeneracion": codigo},
+        "documento": {"ejemplo": True},
+    }
+
+    monkeypatch.setattr(anulacion, "_load_dte_api_config", lambda: {"url": "https://mh.test"})
+    monkeypatch.setattr(anulacion.jws, "sign_json", lambda payload: "TOKEN")
+    monkeypatch.setattr(anulacion.auth, "get_token", lambda: "token")
+
+    posted = []
+
+    def fake_post(url, token, signed, payload):
+        posted.append((url, token, signed, payload))
+        return {"estado": "aceptado", "sello": "SELLO"}
+
+    monkeypatch.setattr(anulacion, "_post_invalidacion", fake_post)
+
+    created_dirs = []
+
+    def fake_makedirs(path, exist_ok=False):
+        created_dirs.append((path, exist_ok))
+
+    monkeypatch.setattr(anulacion.os, "makedirs", fake_makedirs)
+
+    saved = []
+
+    def fake_save_file(path, content, add_final_newline=True):
+        saved.append((path, content, add_final_newline))
+
+    monkeypatch.setattr("utils.stable_json.save_file", fake_save_file)
+
+    result = anulacion.enviar_invalidacion(None, data)
+
+    expected_dir = os.path.join(
+        os.path.dirname(anulacion.__file__),
+        "dtes",
+        "eventos",
+        "anulacion",
+        codigo,
+    )
+    assert created_dirs == [(expected_dir, True)]
+
+    assert len(saved) == 2
+    saved_dict = {
+        path: (content, add_final_newline)
+        for path, content, add_final_newline in saved
+    }
+    json_path = os.path.join(expected_dir, "documento.json")
+    jws_path = os.path.join(expected_dir, "documento.jws")
+    assert json_path in saved_dict
+    assert saved_dict[json_path][1] is True
+    assert jws_path in saved_dict
+    assert saved_dict[jws_path][0] == "TOKEN"
+    assert saved_dict[jws_path][1] is False
+    assert posted and posted[0][2] == "TOKEN"
+    assert result["sello"] == "SELLO"
+
+
+def test_enviar_invalidacion_continua_si_falla_guardado(monkeypatch):
+    codigo = "ERR123456789"
+    data = {
+        "identificacion": {"codigoGeneracion": codigo},
+        "documento": {"ejemplo": True},
+    }
+
+    monkeypatch.setattr(anulacion, "_load_dte_api_config", lambda: {"url": "https://mh.test"})
+    monkeypatch.setattr(anulacion.jws, "sign_json", lambda payload: "TOKEN")
+    monkeypatch.setattr(anulacion.auth, "get_token", lambda: "token")
+
+    posted = []
+
+    def fake_post(url, token, signed, payload):
+        posted.append((url, token, signed, payload))
+        return {"estado": "procesado", "sello": "SIG"}
+
+    monkeypatch.setattr(anulacion, "_post_invalidacion", fake_post)
+
+    monkeypatch.setattr(anulacion.os, "makedirs", lambda *args, **kwargs: None)
+
+    def failing_save_file(*args, **kwargs):
+        raise OSError("permiso denegado")
+
+    monkeypatch.setattr("utils.stable_json.save_file", failing_save_file)
+
+    class DummyLogger:
+        def __init__(self):
+            self.calls = []
+
+        def exception(self, msg, *args, **kwargs):
+            self.calls.append((msg, args, kwargs))
+
+    dummy_logger = DummyLogger()
+    monkeypatch.setattr(anulacion, "logger", dummy_logger)
+
+    result = anulacion.enviar_invalidacion(None, data)
+
+    assert posted and posted[0][2] == "TOKEN"
+    assert result["estado"] == "procesado"
+    assert dummy_logger.calls
 
 
 def test_anular_dte_uses_sello_from_respuesta(qt_app, db_conn, monkeypatch):


### PR DESCRIPTION
## Summary
- Guardar el JSON y el token firmando de eventos de anulacion en `dtes/eventos/anulacion/<codigoGeneracion>` usando serializacion estable
- Registrar en el log cualquier error al crear el directorio o al escribir los archivos
- Agregar pruebas que interceptan `save_file` para asegurar las rutas esperadas y que el flujo sigue ante errores de escritura

## Testing
- pytest tests/test_evento_anulacion.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e73f22608323abf6ad2d98a4e2cd