### PR TITLE
Persistir facturas en contingencia

### DIFF
--- a/api/facturas.py
+++ b/api/facturas.py
@@ -1,13 +1,19 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from facturas_db.facturas_repo import FacturasRepo
-from models.factura import Factura
 from pydantic import BaseModel
 import logging
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
-repo = FacturasRepo()
+
+
+def get_repo(request: Request) -> FacturasRepo:
+    repo = getattr(request.app.state, "facturas_repo", None)
+    if repo is None:
+        repo = FacturasRepo()
+        request.app.state.facturas_repo = repo
+    return repo
 
 
 class ContingenciaIn(BaseModel):
@@ -16,7 +22,11 @@ class ContingenciaIn(BaseModel):
 
 
 @app.post("/api/facturas/{factura_id}/contingencia")
-def guardar_en_contingencia(factura_id: int, data: ContingenciaIn):
+def guardar_en_contingencia(
+    factura_id: int,
+    data: ContingenciaIn,
+    repo: FacturasRepo = Depends(get_repo),
+):
     factura = repo.get(factura_id)
     if not factura:
         raise HTTPException(status_code=404, detail="Factura no encontrada")

--- a/api/notas.py
+++ b/api/notas.py
@@ -7,8 +7,8 @@ from facturas_db.facturas_repo import FacturasRepo
 from models.factura import Factura  # noqa: F401 - reexport for tests
 
 app = FastAPI()
-repo = FacturasRepo()
 db = DB(":memory:")
+repo = FacturasRepo(db)
 
 
 @app.get("/api/facturas/{factura_id}")

--- a/facturas_db/facturas_repo.py
+++ b/facturas_db/facturas_repo.py
@@ -1,18 +1,80 @@
 from __future__ import annotations
-from typing import Dict, Optional
+
+from typing import Optional
+
+from db import DB
 from models.factura import Factura
 
-class FacturasRepo:
-    """Repositorio simple en memoria para facturas."""
 
-    def __init__(self) -> None:
-        self._data: Dict[int, Factura] = {}
+class FacturasRepo:
+    """Repositorio persistente para estados de facturas."""
+
+    def __init__(self, db: DB | None = None) -> None:
+        self._db = db or DB()
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._db.lock:
+            self._db.cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS facturas_estado (
+                    id INTEGER PRIMARY KEY,
+                    modo_transmision TEXT NOT NULL,
+                    estado_envio TEXT NOT NULL,
+                    tipo_contingencia INTEGER,
+                    motivo_contin TEXT
+                )
+                """
+            )
+            self._db.conn.commit()
 
     def add(self, factura: Factura) -> None:
-        self._data[factura.id] = factura
+        with self._db.lock:
+            self._db.cursor.execute(
+                """
+                INSERT INTO facturas_estado (
+                    id,
+                    modo_transmision,
+                    estado_envio,
+                    tipo_contingencia,
+                    motivo_contin
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    modo_transmision=excluded.modo_transmision,
+                    estado_envio=excluded.estado_envio,
+                    tipo_contingencia=excluded.tipo_contingencia,
+                    motivo_contin=excluded.motivo_contin
+                """,
+                (
+                    factura.id,
+                    factura.modo_transmision,
+                    factura.estado_envio,
+                    factura.tipo_contingencia,
+                    factura.motivo_contin,
+                ),
+            )
+            self._db.conn.commit()
 
     def get(self, factura_id: int) -> Optional[Factura]:
-        return self._data.get(factura_id)
+        with self._db.lock:
+            self._db.cursor.execute(
+                """
+                SELECT id, modo_transmision, estado_envio, tipo_contingencia, motivo_contin
+                FROM facturas_estado
+                WHERE id=?
+                """,
+                (factura_id,),
+            )
+            row = self._db.cursor.fetchone()
+        if not row:
+            return None
+        return Factura(
+            id=row["id"],
+            modo_transmision=row["modo_transmision"],
+            estado_envio=row["estado_envio"],
+            tipo_contingencia=row["tipo_contingencia"],
+            motivo_contin=row["motivo_contin"],
+        )
 
     def guardar_en_contingencia(
         self,
@@ -27,4 +89,10 @@ class FacturasRepo:
         factura.estado_envio = "Pendiente"
         factura.tipo_contingencia = tipo_contingencia
         factura.motivo_contin = motivo_contin
+        self.add(factura)
         return factura
+
+    def clear(self) -> None:
+        with self._db.lock:
+            self._db.cursor.execute("DELETE FROM facturas_estado")
+            self._db.conn.commit()

--- a/tests/test_contingencia_api.py
+++ b/tests/test_contingencia_api.py
@@ -1,48 +1,105 @@
+from __future__ import annotations
+
+import pytest
 from fastapi.testclient import TestClient
-from api.facturas import app, repo
+
+from api import facturas as facturas_api
+from db import DB
+from facturas_db.facturas_repo import FacturasRepo
 from models.factura import Factura
 
-client = TestClient(app)
 
-def setup_function(_):
-    repo._data.clear()
+@pytest.fixture
+def client_repo(tmp_path):
+    db_path = tmp_path / "inventario.db"
+    db = DB(db_path)
+    repo = FacturasRepo(db)
 
-def test_guardar_en_contingencia_actualiza_estado():
+    def override_repo() -> FacturasRepo:
+        return repo
+
+    facturas_api.app.dependency_overrides[facturas_api.get_repo] = override_repo
+    client = TestClient(facturas_api.app)
+    repo.clear()
+    try:
+        yield client, repo, db_path
+    finally:
+        repo.clear()
+        client.close()
+        facturas_api.app.dependency_overrides.clear()
+        db.conn.close()
+
+
+def test_guardar_en_contingencia_actualiza_estado(client_repo):
+    client, repo, _ = client_repo
     repo.add(Factura(id=1))
     resp = client.post(
-        '/api/facturas/1/contingencia',
-        json={'tipoContingencia': 1, 'motivoContin': ''},
+        "/api/facturas/1/contingencia",
+        json={"tipoContingencia": 1, "motivoContin": ""},
     )
     assert resp.status_code == 200
     factura = repo.get(1)
-    assert factura.modo_transmision == 'contingencia'
-    assert factura.estado_envio == 'Pendiente'
+    assert factura.modo_transmision == "contingencia"
+    assert factura.estado_envio == "Pendiente"
     assert factura.tipo_contingencia == 1
-    assert factura.motivo_contin == ''
+    assert factura.motivo_contin == ""
 
-def test_guardar_en_contingencia_idempotente():
+
+def test_guardar_en_contingencia_idempotente(client_repo):
+    client, repo, _ = client_repo
     repo.add(
         Factura(
             id=2,
-            modo_transmision='contingencia',
-            estado_envio='Pendiente',
+            modo_transmision="contingencia",
+            estado_envio="Pendiente",
             tipo_contingencia=1,
         )
     )
     resp = client.post(
-        '/api/facturas/2/contingencia',
-        json={'tipoContingencia': 1, 'motivoContin': ''},
+        "/api/facturas/2/contingencia",
+        json={"tipoContingencia": 1, "motivoContin": ""},
     )
     assert resp.status_code == 200
     factura = repo.get(2)
-    assert factura.modo_transmision == 'contingencia'
-    assert factura.estado_envio == 'Pendiente'
+    assert factura.modo_transmision == "contingencia"
+    assert factura.estado_envio == "Pendiente"
     assert factura.tipo_contingencia == 1
 
-def test_guardar_en_contingencia_rechaza_enviado():
-    repo.add(Factura(id=3, estado_envio='Enviado'))
+
+def test_guardar_en_contingencia_rechaza_enviado(client_repo):
+    client, repo, _ = client_repo
+    repo.add(Factura(id=3, estado_envio="Enviado"))
     resp = client.post(
-        '/api/facturas/3/contingencia',
-        json={'tipoContingencia': 1, 'motivoContin': ''},
+        "/api/facturas/3/contingencia",
+        json={"tipoContingencia": 1, "motivoContin": ""},
     )
     assert resp.status_code == 400
+
+
+def test_repo_persists_contingencia_between_instances(client_repo):
+    client, repo, db_path = client_repo
+    repo.add(Factura(id=4))
+    resp = client.post(
+        "/api/facturas/4/contingencia",
+        json={"tipoContingencia": 2, "motivoContin": "Fallo"},
+    )
+    assert resp.status_code == 200
+
+    new_repo = FacturasRepo(DB(db_path))
+    factura = new_repo.get(4)
+    assert factura is not None
+    assert factura.modo_transmision == "contingencia"
+    assert factura.estado_envio == "Pendiente"
+    assert factura.tipo_contingencia == 2
+    assert factura.motivo_contin == "Fallo"
+
+
+def test_repo_persists_estado_enviado(client_repo):
+    _, repo, db_path = client_repo
+    repo.add(Factura(id=5, estado_envio="Enviado"))
+
+    new_repo = FacturasRepo(DB(db_path))
+    factura = new_repo.get(5)
+    assert factura is not None
+    assert factura.estado_envio == "Enviado"
+    assert factura.modo_transmision == "normal"

--- a/tests/test_notas_api.py
+++ b/tests/test_notas_api.py
@@ -8,7 +8,7 @@ client = TestClient(notas_api.app)
 
 
 def setup_function(_):
-    notas_api.repo._data.clear()
+    notas_api.repo.clear()
     notas_api.db.cursor.execute("DELETE FROM notas")
     notas_api.db.cursor.execute("DELETE FROM ventas")
     notas_api.db.cursor.execute("DELETE FROM clientes")


### PR DESCRIPTION
## Summary
- reemplazar FacturasRepo por una implementación respaldada por SQLite que persiste modo de transmisión, estado y datos de contingencia
- inyectar el repositorio compartido en el endpoint de contingencia y compartir la misma instancia en la API de notas
- actualizar las pruebas de la API para usar el backend persistente y verificar que el estado sobreviva a reinicios del repositorio

## Testing
- pytest tests/test_contingencia_api.py tests/test_notas_api.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ef32b1048323b245101e97bda08b