### PR TITLE
Normalizar estados exitosos en reenvío de DTE

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4985,12 +4985,12 @@ def _enviar_documento(
 
     Si ``jws_token`` se proporciona, se reutiliza en lugar de firmar nuevamente.
     """
-    SUCCESS_STATES = {"Transmitido", "Recibido", "Procesado", "Aceptado"}
+    SUCCESS_STATES = ("TRANSMITIDO", "RECIBIDO", "PROCESADO", "ACEPTADO")
     if doc_id is not None:
         row = db.cursor.execute(
             """
             SELECT estado FROM dte_envios
-            WHERE venta_id=? AND estado IN (?, ?, ?, ?)
+            WHERE venta_id=? AND UPPER(estado) IN (?, ?, ?, ?)
             ORDER BY id DESC LIMIT 1
             """,
             (doc_id, *SUCCESS_STATES),

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -908,22 +908,17 @@ class FacturacionTab(QWidget):
 
         envio = "Pendiente de envío"
         env_row = None
+        success_states = ("TRANSMITIDO", "RECIBIDO", "PROCESADO", "ACEPTADO")
         try:
             if cur is not None:
                 if venta_id is not None:
                     success = cur.execute(
                         """
                         SELECT estado FROM dte_envios
-                        WHERE venta_id=? AND estado IN (?, ?, ?, ?)
+                        WHERE venta_id=? AND UPPER(estado) IN (?, ?, ?, ?)
                         ORDER BY id DESC LIMIT 1
                         """,
-                        (
-                            venta_id,
-                            "Transmitido",
-                            "Recibido",
-                            "Procesado",
-                            "Aceptado",
-                        ),
+                        (venta_id, *success_states),
                     ).fetchone()
                     if success:
                         env_row = success
@@ -934,7 +929,10 @@ class FacturacionTab(QWidget):
                         ).fetchone()
                 elif codigo_generacion or numero_control:
                     query_success = (
-                        "SELECT estado FROM dte_envios WHERE venta_id IS NULL AND respuesta LIKE ? AND estado IN (?, ?, ?, ?) ORDER BY id DESC LIMIT 1"
+                        "SELECT estado FROM dte_envios "
+                        "WHERE venta_id IS NULL AND respuesta LIKE ? "
+                        "AND UPPER(estado) IN (?, ?, ?, ?) "
+                        "ORDER BY id DESC LIMIT 1"
                     )
                     query_latest = (
                         "SELECT estado FROM dte_envios WHERE venta_id IS NULL AND respuesta LIKE ? ORDER BY id DESC LIMIT 1"
@@ -944,10 +942,7 @@ class FacturacionTab(QWidget):
                             query_success,
                             (
                                 f"%{codigo_generacion}%",
-                                "Transmitido",
-                                "Recibido",
-                                "Procesado",
-                                "Aceptado",
+                                *success_states,
                             ),
                         ).fetchone()
                         if not env_row:
@@ -960,10 +955,7 @@ class FacturacionTab(QWidget):
                             query_success,
                             (
                                 f"%{numero_control}%",
-                                "Transmitido",
-                                "Recibido",
-                                "Procesado",
-                                "Aceptado",
+                                *success_states,
                             ),
                         ).fetchone()
                         if not env_row:

--- a/tests/test_dte_resend_block.py
+++ b/tests/test_dte_resend_block.py
@@ -20,7 +20,8 @@ def create_sale(db: DB) -> int:
 def test_enviar_documento_rechaza_reenvio_exitoso(monkeypatch):
     db = DB(":memory:")
     venta = create_sale(db)
-    db.registrar_envio_dte(venta, "normal", "Procesado", "S")
+    db.registrar_envio_dte(venta, "normal", "PROCESADO", "S")
+    db.registrar_envio_dte(venta, "normal", "Rechazado", "")
 
     called = {"sign": 0, "post": 0}
 
@@ -59,7 +60,7 @@ def test_detectar_estado_factura_prioriza_exitosos(monkeypatch):
 
     db = DB(":memory:")
     venta = create_sale(db)
-    db.registrar_envio_dte(venta, "normal", "Transmitido", "S")
+    db.registrar_envio_dte(venta, "normal", "PROCESADO", "S")
     db.registrar_envio_dte(venta, "normal", "Rechazado", "")
 
     _, envio = FacturacionTab._detectar_estado_factura(


### PR DESCRIPTION
## Summary
- Normalizar la verificación de estados exitosos en `_enviar_documento` para evitar reenvíos tras registros en mayúsculas.
- Ajustar `FacturacionTab._detectar_estado_factura` para priorizar estados exitosos aunque existan rechazos posteriores.
- Extender las pruebas de bloqueo de reenvíos y de la UI de facturación para cubrir el flujo con `PROCESADO` seguido de un rechazo.

## Testing
- pytest tests/test_dte_resend_block.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f28fa4f08323b5fd1b77996af6ec