### PR TITLE
Validar sello de anulaciones como hexadecimal

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 UUID36_RE = re.compile(r"^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$")
-SELLO40_RE = re.compile(r"^[A-Z0-9]{40}$")
+SELLO40_RE = re.compile(r"^[0-9A-F]{40}$")
 NUM_CONTROL_RE = re.compile(r"^DTE-(0[0-9]|1[0-2])-[A-Z0-9]{8}-[0-9]{15}$")
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 TEL_EMISOR_RE = re.compile(r"^[0-9+;]{8,26}$")
@@ -706,7 +706,7 @@ def build_invalidacion_json(
         raise ValueError("Fecha de emisión del DTE inválida") from exc
     sello = str(sello_raw).strip().upper()
     if not SELLO40_RE.fullmatch(sello):
-        raise ValueError("selloRecibido inválido")
+        raise ValueError("selloRecibido inválido; debe coincidir con el sello hexadecimal emitido por MH")
 
     negocio = _load_datos_negocio() or {}
     nit = solo_digitos(negocio.get("nit", ""))

--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
     generar_cabecera_dte(
         codigo_generacion="ABCDEF1234567890",
         numero_control="DTE-001",
-        sello_recepcion="SELLO1234567890",
+        sello_recepcion="ABCDEF0123456789ABCDEF0123456789ABCDEF01",
         tipo_modelo=1,
         tipo_operacion=1,
         fecha_generacion="01/07/2025, 11:15 AM",
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     generar_cabecera_dte(
         codigo_generacion="ABCDEF1234567890",
         numero_control="DTE-001",
-        sello_recepcion="SELLO1234567890",
+        sello_recepcion="ABCDEF0123456789ABCDEF0123456789ABCDEF01",
         tipo_modelo=1,
         tipo_operacion=1,
         fecha_generacion="01/07/2025, 11:15 AM",

--- a/tests/test_buscar_candidatos_reemplazo.py
+++ b/tests/test_buscar_candidatos_reemplazo.py
@@ -29,14 +29,14 @@ def test_buscar_candidatos_reemplazo_filters(db_conn, tmp_path, dte_metadata_fac
         "codigoGeneracion": factura_a["identificacion"]["codigoGeneracion"],
         "numeroControl": factura_a["identificacion"]["numeroControl"],
         "dteJsonPath": str(json_a),
-        "selloRecibido": "Z" * 40,
+        "selloRecibido": "A" * 40,
     }
     venta_a = db_conn.add_venta("2024-02-01", 25.5, extra=extra)
     db_conn.registrar_envio_dte(
         venta_a,
         "manual",
         "Aceptada",
-        "Z" * 40,
+        "A" * 40,
         respuesta_json=json.dumps({"documento": factura_a}),
         codigo_generacion=factura_a["identificacion"]["codigoGeneracion"],
         numero_control=factura_a["identificacion"]["numeroControl"],
@@ -59,7 +59,7 @@ def test_buscar_candidatos_reemplazo_filters(db_conn, tmp_path, dte_metadata_fac
         None,
         "manual",
         "Recibida",
-        "Y" * 40,
+        "B" * 40,
         respuesta_json=json.dumps(respuesta_b),
         codigo_generacion=codigo_b,
         numero_control="DTE-01-S001P001-000000000000222",
@@ -82,14 +82,14 @@ def test_buscar_candidatos_reemplazo_filters(db_conn, tmp_path, dte_metadata_fac
         "codigoGeneracion": factura_c["identificacion"]["codigoGeneracion"],
         "numeroControl": factura_c["identificacion"]["numeroControl"],
         "dteJsonPath": str(json_c),
-        "selloRecibido": "X" * 40,
+        "selloRecibido": "C" * 40,
     }
     venta_c = db_conn.add_venta("2024-02-02", 10, extra=extra_c)
     db_conn.registrar_envio_dte(
         venta_c,
         "manual",
         "Aceptado",
-        "X" * 40,
+        "C" * 40,
         respuesta_json=json.dumps({"documento": factura_c}),
         codigo_generacion=factura_c["identificacion"]["codigoGeneracion"],
         numero_control=factura_c["identificacion"]["numeroControl"],

--- a/tests/test_dte_header_pdf.py
+++ b/tests/test_dte_header_pdf.py
@@ -7,7 +7,7 @@ def test_generar_cabecera_consumidor_final(tmp_path):
     generar_cabecera_dte(
         codigo_generacion="1234567890ABCDEF",
         numero_control="DTE-123",
-        sello_recepcion="SELLOXYZ",
+        sello_recepcion="ABCDEF0123456789ABCDEF0123456789ABCDEF01",
         tipo_modelo=1,
         tipo_operacion=1,
         fecha_generacion="01/07/2025, 11:15 AM",
@@ -27,7 +27,7 @@ def test_generar_cabecera_credito_fiscal(tmp_path):
     generar_cabecera_dte(
         codigo_generacion="1234567890ABCDEF",
         numero_control="DTE-987",
-        sello_recepcion="SELLO123",
+        sello_recepcion="1234567890ABCDEF1234567890ABCDEF12345678",
         tipo_modelo=1,
         tipo_operacion=1,
         fecha_generacion="01/07/2025, 11:15 AM",

--- a/tests/test_envio_registra_campos.py
+++ b/tests/test_envio_registra_campos.py
@@ -8,7 +8,7 @@ def test_registrar_envio_dte_guarda_campos():
         venta_id,
         "normal",
         "Procesado",
-        "SELLO",
+        "0" * 40,
         codigo_generacion="abc",
         numero_control="DTE-01-S001P001-000000000000001",
     )
@@ -19,4 +19,4 @@ def test_registrar_envio_dte_guarda_campos():
     assert row["codigo_generacion"] == "ABC"
     assert row["numero_control"] == "DTE-01-S001P001-000000000000001"
     assert row["estado"] == "Procesado"
-    assert row["sello"] == "SELLO"
+    assert row["sello"] == "0" * 40

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -116,15 +116,15 @@ def test_invalidacion_tipo3_requiere_codigo(monkeypatch, db_conn, tmp_path):
         "codigoGeneracion": codigo_reemplazo,
         "numeroControl": numero_control_reemplazo,
         "dteJsonPath": str(json_path),
-        "selloRecibido": "Z" * 40,
+        "selloRecibido": "E" * 40,
     }
     venta_id = db_conn.add_venta("2024-01-02", 10, extra=extra)
     db_conn.registrar_envio_dte(
         venta_id,
         "test",
         "Aceptado",
-        "Z" * 40,
-        respuesta_json=json.dumps({"sello": "Z" * 40}),
+        "E" * 40,
+        respuesta_json=json.dumps({"sello": "E" * 40}),
         codigo_generacion=codigo_reemplazo,
         numero_control=numero_control_reemplazo,
     )
@@ -246,14 +246,14 @@ def test_invalidacion_rechaza_emisor_distinto(monkeypatch, db_conn, tmp_path):
         "codigoGeneracion": codigo_reemplazo,
         "numeroControl": numero_control,
         "dteJsonPath": str(json_path),
-        "selloRecibido": "Z" * 40,
+        "selloRecibido": "E" * 40,
     }
     venta_id = db_conn.add_venta("2024-01-02", 10, extra=extra)
     db_conn.registrar_envio_dte(
         venta_id,
         "manual",
         "Aceptado",
-        "Z" * 40,
+        "E" * 40,
         respuesta_json=json.dumps({"documento": reemplazo}),
         codigo_generacion=codigo_reemplazo,
         numero_control=numero_control,
@@ -294,14 +294,14 @@ def test_invalidacion_rechaza_fecha_anterior(monkeypatch, db_conn, tmp_path):
         "codigoGeneracion": codigo_reemplazo,
         "numeroControl": numero_control,
         "dteJsonPath": str(json_path),
-        "selloRecibido": "Z" * 40,
+        "selloRecibido": "E" * 40,
     }
     venta_id = db_conn.add_venta("2023-12-20", 10, extra=extra)
     db_conn.registrar_envio_dte(
         venta_id,
         "manual",
         "Aceptado",
-        "Z" * 40,
+        "E" * 40,
         respuesta_json=json.dumps({"documento": reemplazo}),
         codigo_generacion=codigo_reemplazo,
         numero_control=numero_control,
@@ -333,7 +333,7 @@ def test_anular_dte_uses_sello_from_db(qt_app, db_conn, monkeypatch):
         return venta_id
 
     venta_id = _create_sale(db_conn)
-    sello = "S" * 40
+    sello = "1" * 40
     db_conn.registrar_envio_dte(venta_id, "test", "aceptado", sello)
 
     factura = {"venta_id": venta_id}
@@ -401,7 +401,7 @@ def test_enviar_invalidacion_guarda_archivos(monkeypatch):
 
     def fake_post(url, token, signed, payload):
         posted.append((url, token, signed, payload))
-        return {"estado": "aceptado", "sello": "SELLO"}
+        return {"estado": "aceptado", "sello": "0" * 40}
 
     monkeypatch.setattr(anulacion, "_post_invalidacion", fake_post)
 
@@ -443,7 +443,7 @@ def test_enviar_invalidacion_guarda_archivos(monkeypatch):
     assert saved_dict[jws_path][0] == "TOKEN"
     assert saved_dict[jws_path][1] is False
     assert posted and posted[0][2] == "TOKEN"
-    assert result["sello"] == "SELLO"
+    assert result["sello"] == "0" * 40
 
 
 def test_enviar_invalidacion_continua_si_falla_guardado(monkeypatch):
@@ -461,7 +461,7 @@ def test_enviar_invalidacion_continua_si_falla_guardado(monkeypatch):
 
     def fake_post(url, token, signed, payload):
         posted.append((url, token, signed, payload))
-        return {"estado": "procesado", "sello": "SIG"}
+        return {"estado": "procesado", "sello": "2" * 40}
 
     monkeypatch.setattr(anulacion, "_post_invalidacion", fake_post)
 
@@ -502,7 +502,7 @@ def test_anular_dte_uses_sello_from_respuesta(qt_app, db_conn, monkeypatch):
         return venta_id
 
     venta_id = _create_sale(db_conn)
-    sello = "R" * 40
+    sello = "3" * 40
     db_conn.registrar_envio_dte(
         venta_id,
         "test",

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -45,7 +45,7 @@ def _generate(tmp_path, tipo):
         codigo_generacion=str(uuid.uuid4()),
         numero_control=uuid.uuid4().hex[:8].upper(),
         fecha_generacion="01/01/2024",
-        sello_recepcion="SELLO",
+        sello_recepcion="0" * 40,
     )
     return out
 
@@ -118,7 +118,7 @@ def test_total_letras_is_wrapped(tmp_path):
         codigo_generacion=str(uuid.uuid4()),
         numero_control=uuid.uuid4().hex[:8].upper(),
         fecha_generacion="01/01/2024",
-        sello_recepcion="SELLO",
+        sello_recepcion="0" * 40,
     )
     with fitz.open(out) as doc:
         text = ''.join(p.get_text() for p in doc)
@@ -174,7 +174,7 @@ def test_qr_url_matches_environment(tmp_path, monkeypatch):
             codigo_generacion=str(uuid.uuid4()),
             numero_control=uuid.uuid4().hex[:8].upper(),
             fecha_generacion="01/01/2024",
-            sello_recepcion="SELLO",
+            sello_recepcion="0" * 40,
         )
         assert captured, 'QR value not generated'
         url = captured[0]
@@ -198,7 +198,7 @@ def test_contingencia_draws_message(tmp_path):
         codigo_generacion=str(uuid.uuid4()),
         numero_control=uuid.uuid4().hex[:8].upper(),
         fecha_generacion="01/01/2024",
-        sello_recepcion="SELLO",
+        sello_recepcion="0" * 40,
     )
     with fitz.open(out) as doc:
         text = ''.join(p.get_text() for p in doc)
@@ -241,7 +241,7 @@ def test_direccion_includes_municipio(tmp_path, monkeypatch):
         codigo_generacion=str(uuid.uuid4()),
         numero_control=uuid.uuid4().hex[:8].upper(),
         fecha_generacion="01/01/2024",
-        sello_recepcion="SELLO",
+        sello_recepcion="0" * 40,
     )
     with fitz.open(out) as doc:
         lines = ''.join(p.get_text() for p in doc).splitlines()
@@ -265,7 +265,7 @@ def test_direccion_as_text(tmp_path):
         codigo_generacion=str(uuid.uuid4()),
         numero_control=uuid.uuid4().hex[:8].upper(),
         fecha_generacion="01/01/2024",
-        sello_recepcion="SELLO",
+        sello_recepcion="0" * 40,
     )
     assert out.exists()
 

--- a/tests/test_factura_pdf_includes_iva_column.py
+++ b/tests/test_factura_pdf_includes_iva_column.py
@@ -34,7 +34,7 @@ def test_factura_pdf_includes_iva_column(tmp_path):
         archivo=str(pdf),
         codigo_generacion=str(uuid.uuid4()),
         numero_control=uuid.uuid4().hex[:8].upper(),
-        sello_recepcion="SELLO",
+        sello_recepcion="0" * 40,
         fecha_generacion="01/01/2024",
     )
     reader = PdfReader(str(pdf))

--- a/tests/test_nota_documento_relacionado.py
+++ b/tests/test_nota_documento_relacionado.py
@@ -30,7 +30,7 @@ def test_documento_relacionado_usa_uuid(monkeypatch):
     _patch_module(monkeypatch, nde_mod)
     with open("tests/goldens/ccf.json") as f:
         dte_origen = json.load(f)
-    dte_origen["selloRecibido"] = "SELLO"
+    dte_origen["selloRecibido"] = "0" * 40
     uuid = dte_origen["identificacion"]["codigoGeneracion"]
 
     nce = generar_nce_desde_dte(db, dte_origen, Decimal("1"))

--- a/tests/test_nota_origen_validations.py
+++ b/tests/test_nota_origen_validations.py
@@ -29,7 +29,7 @@ def test_nce_allows_missing_sello():
 def test_nce_without_mh_record():
     db = DB(":memory:")
     dte_origen = _base_dte()
-    dte_origen["selloRecibido"] = "SELLO"
+    dte_origen["selloRecibido"] = "0" * 40
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"))
     assert data["documentoRelacionado"][0]["numeroDocumento"] == "UUID"
 
@@ -45,7 +45,7 @@ def test_nde_allows_missing_sello():
 def test_nde_without_mh_record():
     db = DB(":memory:")
     dte_origen = _base_dte()
-    dte_origen["selloRecibido"] = "SELLO"
+    dte_origen["selloRecibido"] = "0" * 40
     detalles = [{"descripcion": "Prod", "precio_unitario": 1, "ventas_gravadas": 1}]
     data = generar_nde_desde_dte(db, dte_origen, detalles, None)
     assert data["documentoRelacionado"][0]["numeroDocumento"] == "UUID"

--- a/tests/test_sello_persistencia.py
+++ b/tests/test_sello_persistencia.py
@@ -15,6 +15,11 @@ from utils import versioned_dte
 from tests.conftest import make_jws
 
 
+HEX_SEAL = "0" * 40
+ALT_HEX_SEAL = "1" * 40
+RESPONSE_SEAL = "2" * 40
+
+
 def create_sale(db: DB):
     db.add_vendedor("V1")
     vid = db.cursor.lastrowid
@@ -26,14 +31,14 @@ def create_sale(db: DB):
 
 
 def _stub_enviar_documento(db_obj, doc_id, data, modo, jws_token=None):
-    return {"estado": "Transmitido", "sello": "SELLO"}
+    return {"estado": "Transmitido", "sello": HEX_SEAL}
 
 
 def _assert_sello_guardado(db: DB, venta_id: int):
     row = db.cursor.execute("SELECT extra FROM ventas WHERE id=?", (venta_id,)).fetchone()
     assert row and row["extra"]
     extra = json.loads(row["extra"])
-    assert extra["selloRecibido"] == "SELLO"
+    assert extra["selloRecibido"] == HEX_SEAL
 
 
 def test_save_signed_dte_persists_stable_json(monkeypatch, tmp_path):
@@ -91,7 +96,7 @@ def test_transmitir_dte_guarda_sello(monkeypatch):
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
     res = transmitir_dte(db, venta_id)
-    assert res["sello"] == "SELLO"
+    assert res["sello"] == HEX_SEAL
     _assert_sello_guardado(db, venta_id)
 
 
@@ -107,7 +112,7 @@ def test_enviar_factura_guarda_sello(monkeypatch):
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
     res = enviar_factura(db, venta_id)
-    assert res["sello"] == "SELLO"
+    assert res["sello"] == HEX_SEAL
     _assert_sello_guardado(db, venta_id)
 
 
@@ -125,7 +130,7 @@ def test_enviar_nota_credito_guarda_sello(monkeypatch, tmp_path):
     monkeypatch.setattr(dte.os.path, "exists", lambda p: False)
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
     res = enviar_nota_credito(db, nota_id)
-    assert res["sello"] == "SELLO"
+    assert res["sello"] == HEX_SEAL
     _assert_sello_guardado(db, nota_id)
 
 
@@ -143,7 +148,7 @@ def test_enviar_nota_debito_guarda_sello(monkeypatch, tmp_path):
     monkeypatch.setattr(dte.os.path, "exists", lambda p: False)
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
     res = enviar_nota_debito(db, nota_id)
-    assert res["sello"] == "SELLO"
+    assert res["sello"] == HEX_SEAL
     _assert_sello_guardado(db, nota_id)
 
 
@@ -156,7 +161,7 @@ def test_enviar_nota_remision_guarda_sello(monkeypatch):
     monkeypatch.setattr(dte.catalogos, "get_dte_schema", lambda t: {})
     monkeypatch.setattr(dte, "_enviar_documento", _stub_enviar_documento)
     res = enviar_nota_remision(db, nota_id)
-    assert res["sello"] == "SELLO"
+    assert res["sello"] == HEX_SEAL
     _assert_sello_guardado(db, nota_id)
 
 
@@ -184,29 +189,29 @@ def test_sello_recibido_actualiza_envio_y_extra(monkeypatch):
         dte, "_load_dte_api_config", lambda: {"url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"}
     )
     monkeypatch.setattr(
-        dte, "_post_dte", lambda *a, **k: {"estado": "Transmitido", "selloRecibido": "SR"}
+        dte, "_post_dte", lambda *a, **k: {"estado": "Transmitido", "selloRecibido": RESPONSE_SEAL}
     )
     monkeypatch.setattr(dte, "_save_signed_dte", lambda *a, **k: None)
 
     resp = enviar_factura(db, venta_id)
-    assert resp["sello"] == "SR"
+    assert resp["sello"] == RESPONSE_SEAL
 
     row = db.cursor.execute(
         "SELECT estado, sello FROM dte_envios WHERE venta_id=?", (venta_id,)
     ).fetchone()
-    assert row["sello"] == "SR"
+    assert row["sello"] == RESPONSE_SEAL
 
     extra_row = db.cursor.execute(
         "SELECT extra FROM ventas WHERE id=?", (venta_id,)
     ).fetchone()
     extra = json.loads(extra_row["extra"])
-    assert extra["selloRecibido"] == "SR"
+    assert extra["selloRecibido"] == RESPONSE_SEAL
 
 
 def test_generar_dte_json_exposes_sello(monkeypatch):
     db = DB(":memory:")
     venta_id = create_sale(db)
-    db.update_venta_extra(venta_id, {"selloRecibido": "ABC", "es_ticket": True})
+    db.update_venta_extra(venta_id, {"selloRecibido": ALT_HEX_SEAL, "es_ticket": True})
     datos = {
         "nombre": "X",
         "nit": "06140010912506",
@@ -228,5 +233,5 @@ def test_generar_dte_json_exposes_sello(monkeypatch):
     )
     monkeypatch.setattr(dte, "validate_dte_json", lambda *a, **k: None)
     data = dte.generar_dte_json(db, venta_id, tipo_dte="01")
-    assert data["selloRecibido"] == "ABC"
+    assert data["selloRecibido"] == ALT_HEX_SEAL
 


### PR DESCRIPTION
## Summary
- restringir la validación de `selloRecibido` a sellos hexadecimales reales y aclarar el mensaje de error
- reemplazar valores de prueba por sellos de 40 caracteres hexadecimales en los tests y ejemplos afectados
- actualizar ejemplos de PDFs para que también muestren sellos con formato válido

## Testing
- pytest tests/test_evento_anulacion.py tests/test_buscar_candidatos_reemplazo.py tests/test_sello_persistencia.py tests/test_envio_registra_campos.py tests/test_dte_header_pdf.py tests/test_factura_pdf_includes_iva_column.py tests/test_factura_pdf.py tests/test_nota_documento_relacionado.py tests/test_nota_origen_validations.py *(falla: falta libGL.so.1 en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ef1b83e083238c28c19a304e6db8