### PR TITLE
Allow base36 seals in invalidation

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 UUID36_RE = re.compile(r"^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$")
-SELLO40_RE = re.compile(r"^[0-9A-F]{40}$")
+SELLO40_RE = re.compile(r"^[0-9A-Z]{40}$")
 NUM_CONTROL_RE = re.compile(r"^DTE-(0[0-9]|1[0-2])-[A-Z0-9]{8}-[0-9]{15}$")
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 TEL_EMISOR_RE = re.compile(r"^[0-9+;]{8,26}$")
@@ -706,7 +706,9 @@ def build_invalidacion_json(
         raise ValueError("Fecha de emisión del DTE inválida") from exc
     sello = str(sello_raw).strip().upper()
     if not SELLO40_RE.fullmatch(sello):
-        raise ValueError("selloRecibido inválido; debe coincidir con el sello hexadecimal emitido por MH")
+        raise ValueError(
+            "selloRecibido inválido; debe coincidir con el sello alfanumérico de 40 caracteres emitido por MH"
+        )
 
     negocio = _load_datos_negocio() or {}
     nit = solo_digitos(negocio.get("nit", ""))

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -12,6 +12,9 @@ import facturacion_tab
 import anulacion
 
 
+SELLO_BASE36 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZABCD"
+
+
 def _sample_factura():
     ident = {
         "ambiente": "00",
@@ -59,7 +62,7 @@ def test_generar_evento_anulacion(qt_app, monkeypatch):
     dlg.tdoc_sol.setCurrentIndex(dlg.tdoc_sol.findData("13"))
     dlg.ndoc_sol.setText("987654321")
     form = dlg.get_data()
-    sello = "A" * 40
+    sello = SELLO_BASE36
 
     monkeypatch.setattr(
         anulacion,
@@ -95,7 +98,7 @@ def test_generar_evento_anulacion(qt_app, monkeypatch):
 
 def test_invalidacion_tipo3_requiere_codigo(monkeypatch, db_conn, tmp_path):
     factura = _sample_factura()
-    sello = "B" * 40
+    sello = "Z" * 40
 
     codigo_reemplazo = str(uuid.uuid4()).upper()
     numero_control_reemplazo = "DTE-01-S001P001-000000000000777"
@@ -116,7 +119,7 @@ def test_invalidacion_tipo3_requiere_codigo(monkeypatch, db_conn, tmp_path):
         "codigoGeneracion": codigo_reemplazo,
         "numeroControl": numero_control_reemplazo,
         "dteJsonPath": str(json_path),
-        "selloRecibido": "E" * 40,
+        "selloRecibido": "Y" * 40,
     }
     venta_id = db_conn.add_venta("2024-01-02", 10, extra=extra)
     db_conn.registrar_envio_dte(


### PR DESCRIPTION
## Summary
- accept MH seals with any uppercase alphanumeric characters when building anulacion payloads
- refresh the anulacion tests to cover base-36 seals

## Testing
- pytest tests/test_evento_anulacion.py *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f8865ef88323857a08d8083b4d24