### PR TITLE
Ajusta envío de anulaciones con sobre JWS

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -19,12 +19,14 @@ from utils.fecha import TZ_EL_SALVADOR
 from dte import (
     _load_datos_negocio,
     _load_dte_api_config,
+    _decode_jws_payload,
     format_cliente_id_from_dui,
     detect_user_agent,
     build_auth_header,
     _parse_error_response,
     APP_VERSION,
 )
+from utils.jws import sign_json
 
 
 logger = logging.getLogger(__name__)
@@ -712,6 +714,9 @@ def _post_invalidacion(
     }, f"Host inválido: {url}"
     assert pu.path.rstrip("/") == "/fesv/anulardte", f"Path inválido: {url}"
 
+    if not isinstance(evento_data, dict):
+        raise ValueError("Evento de invalidación inválido")
+
     ident = evento_data.get("identificacion") if isinstance(evento_data, dict) else None
     ambiente_evento = normalize_ambiente((ident or {}).get("ambiente"))
     ambiente_cfg = normalize_ambiente(ambiente_config)
@@ -719,7 +724,74 @@ def _post_invalidacion(
     if ambiente_raiz is None:
         raise ValueError("No se pudo determinar el ambiente de envío de la invalidación")
 
-    body = {"ambiente": ambiente_raiz, "documento": evento_data}
+    if not isinstance(ident, dict):
+        ident = {}
+
+    documento_evento = evento_data.get("documento")
+    if not isinstance(documento_evento, dict):
+        documento_evento = {}
+
+    version_envio = 2
+    version_raw = ident.get("version")
+    if version_raw is not None:
+        try:
+            version_envio = int(str(version_raw))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Versión de la invalidación inválida") from exc
+    if version_envio != 2:
+        raise ValueError("La invalidación debe usar identificacion.version = 2")
+
+    id_envio_raw = evento_data.get("idEnvio")
+    if id_envio_raw in (None, ""):
+        id_envio_raw = ident.get("idEnvio")
+    try:
+        id_envio = int(str(id_envio_raw)) if id_envio_raw not in (None, "") else 1
+    except (TypeError, ValueError):
+        id_envio = 1
+    if id_envio <= 0:
+        id_envio = 1
+
+    firmado = str(sign_json(evento_data)).strip()
+    if firmado.count(".") != 2:
+        raise ValueError("Firma de invalidación inválida")
+
+    try:
+        payload_firmado = _decode_jws_payload(firmado)
+    except ValueError as exc:
+        raise ValueError("Firma de invalidación inválida") from exc
+
+    ident_firmado = payload_firmado.get("identificacion") or {}
+    if not isinstance(ident_firmado, dict):
+        ident_firmado = {}
+    documento_firmado = payload_firmado.get("documento") or {}
+    if not isinstance(documento_firmado, dict):
+        documento_firmado = {}
+
+    def _norm_codigo(value: object) -> str:
+        return str(value or "").strip().upper()
+
+    cod_evento = _norm_codigo(ident.get("codigoGeneracion"))
+    cod_evento_firmado = _norm_codigo(ident_firmado.get("codigoGeneracion"))
+    if cod_evento and cod_evento_firmado and cod_evento != cod_evento_firmado:
+        raise ValueError("codigoGeneracion del evento no coincide con la firma")
+
+    cod_doc = _norm_codigo(documento_evento.get("codigoGeneracion"))
+    cod_doc_firmado = _norm_codigo(documento_firmado.get("codigoGeneracion"))
+    if cod_doc and cod_doc_firmado and cod_doc != cod_doc_firmado:
+        raise ValueError("codigoGeneracion del documento no coincide con la firma")
+
+    ambiente_firmado = normalize_ambiente(ident_firmado.get("ambiente"))
+    if ambiente_firmado:
+        if ambiente_raiz and ambiente_firmado != ambiente_raiz:
+            raise ValueError("El ambiente del evento firmado no coincide con el solicitado")
+        ambiente_raiz = ambiente_firmado
+
+    body = {
+        "ambiente": ambiente_raiz,
+        "idEnvio": id_envio,
+        "version": version_envio,
+        "documento": firmado,
+    }
 
     body_types = {key: type(value).__name__ for key, value in body.items()}
     try:

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import QDialog, QWidget
 
 from dialogs.anular_factura_dialog import AnularFacturaDialog
 from utils.catalogos import TRIBUTO_IVA
+from tests.conftest import make_jws
 import facturacion_tab
 import anulacion
 
@@ -48,6 +49,74 @@ def _sample_factura():
         "receptor": receptor,
         "resumen": resumen,
     }
+
+
+def _basic_form(tipo: str = "2") -> dict:
+    return {
+        "tipoAnulacion": tipo,
+        "motivoAnulacion": "Error en factura",
+        "nombreResponsable": "Responsable Uno",
+        "tipDocResponsable": "36",
+        "numDocResponsable": "123456789",
+        "nombreSolicita": "Solicita Dos",
+        "tipDocSolicita": "13",
+        "numDocSolicita": "987654321",
+    }
+
+
+def _evento_minimo() -> dict:
+    codigo_evento = str(uuid.uuid4()).upper()
+    codigo_dte = str(uuid.uuid4()).upper()
+    return {
+        "identificacion": {
+            "version": 2,
+            "ambiente": "00",
+            "codigoGeneracion": codigo_evento,
+            "fecAnula": "2024-01-05",
+            "horAnula": "08:00:00",
+        },
+        "documento": {
+            "tipoDte": "01",
+            "codigoGeneracion": codigo_dte,
+            "selloRecibido": SELLO_BASE36,
+            "numeroControl": "DTE-01-S001P001-000000000000099",
+            "fecEmi": "2024-01-01",
+            "montoIva": 1.23,
+            "codigoGeneracionR": None,
+            "tipoDocumento": "36",
+            "numDocumento": "123456789",
+            "nombre": "Cliente Demo",
+        },
+        "motivo": {"tipoAnulacion": 2},
+    }
+
+
+def test_build_invalidacion_tributos_null_usa_totaliva(monkeypatch):
+    factura = _sample_factura()
+    factura["resumen"]["tributos"] = None
+    factura["resumen"]["totalIva"] = "5.50"
+    factura["selloRecibido"] = SELLO_BASE36
+    form = _basic_form()
+
+    _patch_negocio(monkeypatch)
+
+    evento = anulacion.build_invalidacion_json(factura, form, ambiente="00")
+
+    assert evento["documento"]["montoIva"] == pytest.approx(5.5)
+
+
+def test_build_invalidacion_tributos_null_sin_totaliva(monkeypatch):
+    factura = _sample_factura()
+    factura["resumen"]["tributos"] = None
+    factura["resumen"].pop("totalIva", None)
+    factura["selloRecibido"] = SELLO_BASE36
+    form = _basic_form()
+
+    _patch_negocio(monkeypatch)
+
+    evento = anulacion.build_invalidacion_json(factura, form, ambiente="00")
+
+    assert evento["documento"]["montoIva"] is None
 
 
 def test_generar_evento_anulacion(qt_app, monkeypatch):
@@ -321,6 +390,82 @@ def test_invalidacion_rechaza_fecha_anterior(monkeypatch, db_conn, tmp_path):
             db=db_conn,
         )
     assert str(excinfo.value) == anulacion.ERROR_REEMPLAZO_FECHA
+
+
+def test_post_invalidacion_envia_sobre_con_jws(monkeypatch):
+    evento = _evento_minimo()
+    firmado = make_jws(evento)
+
+    monkeypatch.setattr(anulacion, "sign_json", lambda data: firmado)
+
+    captured = {}
+
+    class DummyResp:
+        status_code = 200
+        text = ""
+
+        @staticmethod
+        def json():
+            return {"estado": "aceptado", "sello": "S" * 40}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = json
+        captured["timeout"] = timeout
+        return DummyResp()
+
+    monkeypatch.setattr(anulacion.requests, "post", fake_post)
+
+    result = anulacion._post_invalidacion(
+        "https://apitest.dtes.mh.gob.sv/fesv/anulardte",
+        "token123",
+        evento,
+        ambiente_config="00",
+    )
+
+    assert captured["url"] == "https://apitest.dtes.mh.gob.sv/fesv/anulardte"
+    assert captured["timeout"] == 20
+    assert captured["body"]["documento"] == firmado
+    assert isinstance(captured["body"]["documento"], str)
+    assert captured["body"]["ambiente"] == "00"
+    assert captured["body"]["idEnvio"] == 1
+    assert captured["body"]["version"] == 2
+    assert captured["headers"]["Authorization"] == "Bearer token123"
+    assert result["estado"] == "aceptado"
+
+
+def test_post_invalidacion_reporta_detalle_error(monkeypatch):
+    evento = _evento_minimo()
+    firmado = make_jws(evento)
+
+    monkeypatch.setattr(anulacion, "sign_json", lambda data: firmado)
+
+    class DummyResp:
+        status_code = 400
+        text = "Bad Request"
+
+        @staticmethod
+        def json():
+            return {
+                "detalle": {
+                    "descripcionMsg": "Formato inválido",
+                    "observaciones": ["Falta campo"],
+                }
+            }
+
+    monkeypatch.setattr(anulacion.requests, "post", lambda *a, **k: DummyResp())
+
+    result = anulacion._post_invalidacion(
+        "https://apitest.dtes.mh.gob.sv/fesv/anulardte",
+        "token456",
+        evento,
+    )
+
+    assert result["estado"] == "Rechazado"
+    assert result["http_status"] == 400
+    assert result["descripcionMsg"] == "Formato inválido"
+    assert result["observaciones"] == ["Falta campo"]
 
 
 def test_anular_dte_uses_sello_from_db(qt_app, db_conn, monkeypatch):


### PR DESCRIPTION
## Summary
- firma el evento de anulación, valida la coherencia con la firma JWS y construye el sobre con ambiente, idEnvio y versión requeridos por MH
- mantiene el logging del sobre enviado y deja el documento como cadena firmada
- amplía las pruebas de anulaciones para cubrir cálculo de IVA sin tributos, el nuevo sobre firmado y el manejo de errores del backend

## Testing
- QT_QPA_PLATFORM=offscreen pytest tests/test_evento_anulacion.py *(falla: falta libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0bd1819c8323802b36d91d71cf9a