### PR TITLE
Recuperar código de generación desde metadatos de DTE

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -178,6 +178,7 @@ def _load_dte_json_from_venta(db: DB, venta_id: int | None) -> dict | None:
 
 def _extract_metadata(source: dict | None) -> dict:
     metadata = {
+        "codigo_generacion": None,
         "tipo_dte": None,
         "fecha_emision": None,
         "ambiente": None,
@@ -195,6 +196,9 @@ def _extract_metadata(source: dict | None) -> dict:
     if not isinstance(ident, dict):
         ident = source.get("identificacionDocumento")
     if isinstance(ident, dict):
+        codigo_generacion = ident.get("codigoGeneracion")
+        if codigo_generacion is not None:
+            metadata["codigo_generacion"] = str(codigo_generacion).strip().upper()
         tipo_val = ident.get("tipoDte") or ident.get("tipoDTE")
         if tipo_val is not None:
             metadata["tipo_dte"] = str(tipo_val).zfill(2)
@@ -271,6 +275,11 @@ def _extract_metadata(source: dict | None) -> dict:
         amb = source.get("ambiente")
         if amb is not None:
             metadata["ambiente"] = normalize_ambiente(amb)
+
+    if metadata["codigo_generacion"] in (None, ""):
+        codigo_generacion = source.get("codigoGeneracion")
+        if codigo_generacion is not None:
+            metadata["codigo_generacion"] = str(codigo_generacion).strip().upper()
 
     return metadata
 
@@ -381,8 +390,31 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
     results: list[dict] = []
     for row in rows:
         codigo = str(row.get("codigo_generacion") or "").strip().upper()
+        venta_id = row.get("venta_id")
+        metadata: dict | None = None
+
+        def _get_metadata() -> dict:
+            nonlocal metadata
+            if metadata is None:
+                payload_local = _load_dte_json_from_venta(db, venta_id)
+                respuesta_local = _parse_respuesta_documento(row.get("respuesta"))
+                primary = _extract_metadata(payload_local)
+                metadata = _merge_metadata(primary, _extract_metadata(respuesta_local))
+            return metadata
+
+        if not codigo:
+            codigo_metadata = str(
+                (_get_metadata().get("codigo_generacion") or "")
+            ).strip().upper()
+            if codigo_metadata:
+                codigo = codigo_metadata
+
         if not codigo or (exclude_uuid and codigo == exclude_uuid):
             continue
+
+        metadata = _get_metadata()
+        if metadata.get("codigo_generacion") in (None, ""):
+            metadata["codigo_generacion"] = codigo
 
         sello = str(row.get("sello") or "").strip().upper()
         sello_valido = bool(SELLO40_RE.fullmatch(sello))
@@ -391,12 +423,6 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
         if recepcionado_only:
             if estado_canonico not in ACCEPTED_EVENT_STATES or not sello_valido:
                 continue
-
-        venta_id = row.get("venta_id")
-        payload = _load_dte_json_from_venta(db, venta_id)
-        respuesta_doc = _parse_respuesta_documento(row.get("respuesta"))
-        metadata = _extract_metadata(payload)
-        metadata = _merge_metadata(metadata, _extract_metadata(respuesta_doc))
 
         numero_control = metadata.get("numero_control") or row.get("numero_control")
         ambiente_doc = metadata.get("ambiente")

--- a/tests/test_buscar_candidatos_reemplazo.py
+++ b/tests/test_buscar_candidatos_reemplazo.py
@@ -170,3 +170,68 @@ def test_buscar_candidatos_reemplazo_filters(db_conn, tmp_path, dte_metadata_fac
     sin_filtro = anulacion.buscar_candidatos_reemplazo(db_conn, filtros_sin_recepcionado)
     codigos_sin_filtro = {r["codigo_generacion"] for r in sin_filtro}
     assert codigo_d in codigos_sin_filtro
+
+
+@pytest.mark.parametrize("metadata_source", ["payload", "respuesta"])
+def test_buscar_candidatos_reemplazo_recupera_codigo_de_metadatos(
+    monkeypatch, dte_metadata_factory, metadata_source
+):
+    codigo_generacion = str(uuid.uuid4()).upper()
+    factura = _crear_factura(
+        dte_metadata_factory,
+        codigo=codigo_generacion,
+        numero="DTE-01-S001P001-000000000000555",
+    )
+
+    class DummyCursor:
+        def __init__(self, rows):
+            self._rows = rows
+            self._current_rows = []
+
+        def execute(self, query, params=None):
+            query_text = str(query or "").strip().lower()
+            if query_text.startswith("select"):
+                self._current_rows = self._rows
+            else:
+                self._current_rows = []
+            return self
+
+        def fetchall(self):
+            return self._current_rows
+
+    class DummyDB:
+        def __init__(self, rows):
+            self.cursor = DummyCursor(rows)
+
+        def ensure_column(self, *args, **kwargs):
+            return None
+
+    rows = [
+        {
+            "id": 1,
+            "venta_id": 10,
+            "fecha_hora": "2024-02-03T10:00:00",
+            "modo": "manual",
+            "estado": "Aceptado",
+            "sello": "A" * 40,
+            "codigo_generacion": None,
+            "numero_control": None,
+            "respuesta": "{}",
+            "ambiente": None,
+        }
+    ]
+    dummy_db = DummyDB(rows)
+
+    payload = factura if metadata_source == "payload" else None
+    respuesta_doc = factura if metadata_source == "respuesta" else None
+
+    monkeypatch.setattr(anulacion, "_load_dte_json_from_venta", lambda *_: payload)
+    monkeypatch.setattr(anulacion, "_parse_respuesta_documento", lambda *_: respuesta_doc)
+
+    resultados = anulacion.buscar_candidatos_reemplazo(dummy_db, {})
+
+    assert len(resultados) == 1
+    candidato = resultados[0]
+    assert candidato["codigo_generacion"] == codigo_generacion
+    assert candidato["numero_control"] == factura["identificacion"]["numeroControl"]
+    assert candidato["seleccionable"] is True


### PR DESCRIPTION
## Summary
- intenta recuperar el codigoGeneracion de los metadatos del DTE cuando la columna esta vacía antes de descartar el candidato
- extiende la extracción de metadatos para incluir el codigoGeneracion y reutilizarlo en los resultados
- agrega pruebas que cubren la reconstrucción del código desde payloads y respuestas almacenadas

## Testing
- pytest tests/test_buscar_candidatos_reemplazo.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0e768a4c83238d2e3e6fb0efadcd