### PR TITLE
Corrige exportación y ruta de guardado de inventario

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -254,7 +254,7 @@ class InventoryManager:
                 write_kv("appVersion", APP_VERSION)
                 write_array("productos", self._products)
                 write_array("vendedores", (dict(v) for v in self._vendedores))
-                write_array("Distribuidores", (dict(v) for v in self._Distribuidores))
+                write_array("distribuidores", (dict(v) for v in self._Distribuidores))
                 write_array("clientes", (dict(c) for c in self._clientes))
                 # Export only synchronized sales.  Older installations might lack the
                 # ``sincronizada`` column, so ensure it exists with a sensible

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -86,6 +86,7 @@ class MainWindow(QMainWindow):
         self.db = DB()
         self.manager = InventoryManager(self.db)
         self.ultimo_archivo_json = None  # Guarda la ruta del último archivo .json usado
+        self._load_last_inventory_path()
         self.firmador_proc = None
         # Contador de cambios en la base de datos para detectar si hay datos sin guardar
         self._mark_saved()
@@ -2085,6 +2086,28 @@ class MainWindow(QMainWindow):
         modificado sin guardar.
         """
         self._db_change_counter = self.manager.db.conn.total_changes
+
+    def _load_last_inventory_path(self):
+        """Carga la última ruta usada para guardar el inventario.
+
+        Permite que la opción "Guardar rápido" funcione al iniciar la
+        aplicación reutilizando el mismo archivo utilizado previamente.
+        """
+        if not os.path.exists(LAST_INVENTORY_PATH):
+            return
+        try:
+            with open(LAST_INVENTORY_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            logger.warning(
+                "No se pudo leer %s para restaurar el último inventario",
+                LAST_INVENTORY_PATH,
+            )
+            return
+
+        ultimo = data.get("ultimo") if isinstance(data, dict) else None
+        if ultimo:
+            self.ultimo_archivo_json = ultimo
 
     def closeEvent(self, event):
         if self.manager.db.conn.total_changes == self._db_change_counter:


### PR DESCRIPTION
## Resumen
- Ajusta la exportación del inventario para usar la sección `distribuidores` con el nombre esperado por el validador.
- Restaura automáticamente la última ruta utilizada al iniciar la aplicación para habilitar "Guardar rápido" tras reinicios.

## Pruebas
- `pytest tests/test_inventory_manager_filters_export.py -k export_json_contains_sections` *(falla: falta libGL.so.1 en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1ef6a73c8323aeb8363056484dfe