### PR TITLE
Persist fiscal totals on sales records

### DIFF
--- a/db.py
+++ b/db.py
@@ -919,6 +919,7 @@ class DB:
         self.ensure_column("ventas", "sincronizada", "INTEGER DEFAULT 1")
         self.ensure_column("ventas_credito_fiscal", "documento_venta_a_cuenta", "TEXT")
         try:
+            extra_json = json.dumps(extra) if extra is not None else None
             cols = ["fecha", "total", "cliente_id", "estado", "sincronizada"]
             vals = [fecha, total, cliente_id, estado, 1]
             if Distribuidor_id is not None:
@@ -927,6 +928,9 @@ class DB:
             if vendedor_id is not None:
                 cols.append("vendedor_id")
                 vals.append(vendedor_id)
+            if extra_json is not None:
+                cols.append("extra")
+                vals.append(extra_json)
             placeholders = ", ".join(["?"] * len(vals))
             q = f"INSERT INTO ventas ({', '.join(cols)}) VALUES ({placeholders})"
             self.cursor.execute(q, vals)
@@ -958,7 +962,6 @@ class DB:
                     FOREIGN KEY (cliente_id) REFERENCES clientes(id)
                 )
             """)
-            extra_json = json.dumps(extra) if extra else None
             self.cursor.execute("""
                 INSERT INTO ventas_credito_fiscal (
                     venta_id, cliente_id, nrc, nit, giro,

--- a/tests/test_venta_extra.py
+++ b/tests/test_venta_extra.py
@@ -12,3 +12,52 @@ def test_add_venta_with_extra_dict(db_conn):
     assert venta["id"] == venta_id
     stored = json.loads(venta["extra"])
     assert stored == {"note": "test", "flag": True}
+
+
+def test_credito_fiscal_extra_persisted_in_ventas(db_conn):
+    db_conn.add_cliente(
+        nombre="Cliente",
+        nrc="",
+        nit="",
+        dui="",
+        giro="",
+        telefono="",
+        email="cli@example.com",
+        direccion="San Salvador",
+        departamento="06",
+        municipio="23",
+    )
+    cliente_id = db_conn.cursor.lastrowid
+
+    extra = {
+        "sumas": 100,
+        "descuentos": 5,
+        "iva": 13,
+        "subtotal": 108,
+        "ventas_exentas": 10,
+        "ventas_no_sujetas": 2,
+    }
+
+    venta_id = db_conn.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-01-01",
+        total=120,
+        nrc="",
+        nit="",
+        giro="",
+        sumas=extra["sumas"],
+        descuentos=extra["descuentos"],
+        iva=extra["iva"],
+        subtotal=extra["subtotal"],
+        ventas_exentas=extra["ventas_exentas"],
+        ventas_no_sujetas=extra["ventas_no_sujetas"],
+        total_letras="CIENTO VEINTE",
+        extra=extra,
+    )
+
+    row = db_conn.cursor.execute(
+        "SELECT extra FROM ventas WHERE id=?", (venta_id,)
+    ).fetchone()
+    assert row is not None and row["extra"]
+    stored = json.loads(row["extra"])
+    assert stored == extra

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -789,7 +789,14 @@ class MainWindow(QMainWindow):
                 Distribuidor_id = Distribuidor["id"] if Distribuidor else None
                 vendedor_id = data.get("vendedor_id")
                 estado = data.get("estado", "Pagada")
-                extra = {}
+                extra = {
+                    "sumas": data.get("sumas", 0),
+                    "descuentos": data.get("descuentos", 0),
+                    "iva": data.get("iva", 0),
+                    "subtotal": data.get("subtotal", 0),
+                    "ventas_exentas": data.get("ventas_exentas", 0),
+                    "ventas_no_sujetas": data.get("ventas_no_sujetas", 0),
+                }
                 if data.get("venta_a_cuenta_de") or data.get("documento_venta_a_cuenta"):
                     extra["venta_a_cuenta_de"] = data.get("venta_a_cuenta_de", "")
                     extra["documento_venta_a_cuenta"] = data.get("documento_venta_a_cuenta", "")
@@ -926,6 +933,18 @@ class MainWindow(QMainWindow):
                 Distribuidor = next((v for v in self.manager._Distribuidores if v["nombre"] == Distribuidor_nombre), None)
                 Distribuidor_id = Distribuidor["id"] if Distribuidor else None
                 vendedor_id = data.get("vendedor_id")
+                extra = {
+                    "sumas": sumas,
+                    "descuentos": descuentos,
+                    "iva": iva,
+                    "subtotal": subtotal,
+                    "ventas_exentas": data.get("ventas_exentas", 0),
+                    "ventas_no_sujetas": data.get("ventas_no_sujetas", 0),
+                }
+                if data.get("venta_a_cuenta_de") or data.get("documento_venta_a_cuenta"):
+                    extra["venta_a_cuenta_de"] = data.get("venta_a_cuenta_de", "")
+                    extra["documento_venta_a_cuenta"] = data.get("documento_venta_a_cuenta", "")
+
                 venta_id = self.manager.db.add_venta_credito_fiscal(
                     cliente_id=data["cliente"]["id"],
                     fecha=fecha,
@@ -948,7 +967,8 @@ class MainWindow(QMainWindow):
                     subtotal=subtotal,
                     ventas_exentas=data.get("ventas_exentas", 0),
                     ventas_no_sujetas=data.get("ventas_no_sujetas", 0),
-                    total_letras=total_letras
+                    total_letras=total_letras,
+                    extra=extra or None,
                 )
                 if not venta_id:
                     raise ValueError(


### PR DESCRIPTION
## Summary
- include fiscal totals in the extra payload saved for ventas normales
- persist credit-fiscal extra JSON on the base ventas row
- cover the regression with a dedicated test for credit-fiscal sales

## Testing
- pytest tests/test_venta_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68cb333911a48323b1568410699f34fd