### PR TITLE
Ensure ivaItem included for non-taxed consumer final items

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1442,7 +1442,10 @@ def recalcular_totales(
             if not is_non_grav and venta_gravada_val <= D("0") and linea > D("0"):
                 venta_gravada_val = linea
             if is_non_grav and venta_gravada_val == D("0"):
-                item.pop("ivaItem", None)
+                if incluir_iva:
+                    item["ivaItem"] = d4(0)
+                else:
+                    item.pop("ivaItem", None)
                 item["ventaGravada"] = d4(0)
                 item["ventaExenta"] = venta_exenta_val
                 item["ventaNoSuj"] = venta_no_suj_val


### PR DESCRIPTION
## Summary
- ensure recalcular_totales keeps ivaItem set to zero for non-taxed consumer final lines when IVA fields are requested

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cb586e5304832396d25e61d50fae89