### PR TITLE
Centralize FC item tributos normalization

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1078,6 +1078,54 @@ def armar_tributos(tributos_raw, tipo_dte):
     return result or None
 
 
+def ensure_item_tributos_v3(item: dict[str, Any], tipo_dte: str) -> None:
+    """Normalize ``item['tributos']`` according to MH v3 requirements."""
+
+    if tipo_dte == "01":
+        item["tributos"] = None
+        if "codTributo" in item:
+            item["codTributo"] = None
+        return
+
+    if tipo_dte not in {"03", "05", "06"}:
+        return
+
+    venta_gravada = D(str(item.get("ventaGravada") or 0))
+    try:
+        tipo_item = int(item.get("tipoItem") or 0)
+    except Exception:
+        tipo_item = 0
+
+    raw_cod = item.get("codTributo")
+    cod_tributo = None
+    if raw_cod is not None:
+        raw_cod = str(raw_cod).strip().upper()
+        if raw_cod and raw_cod in TRIBUTOS_PERMITIDOS_ITEM and raw_cod != TRIBUTO_IVA:
+            cod_tributo = raw_cod
+
+    filtered: list[str] = []
+    seen: set[str] = set()
+    for code in item.get("tributos") or []:
+        code_str = str(code).strip().upper()
+        if not code_str or code_str == TRIBUTO_IVA:
+            continue
+        if code_str in TRIBUTOS_PERMITIDOS_ITEM and code_str not in seen:
+            filtered.append(code_str)
+            seen.add(code_str)
+
+    if cod_tributo and cod_tributo not in seen:
+        filtered.append(cod_tributo)
+        seen.add(cod_tributo)
+
+    # Ensure "20" appears exactly once at the beginning.
+    item["tributos"] = [TRIBUTO_IVA] + filtered
+
+    if venta_gravada > 0 and tipo_item == 4 and cod_tributo:
+        item["codTributo"] = cod_tributo
+    else:
+        item.pop("codTributo", None)
+
+
 def calcular_resumen(items_total, venta, fiscal=None, extra=None, tipo_dte="01"):
     """Calcula la sección resumen acorde al esquema oficial."""
 
@@ -2508,18 +2556,33 @@ def generar_dte_json(
             commission_total += D(str(d.get("comision") or 0))
         except Exception:
             pass
+        raw_tributos_list: list[str] = []
         trib_code_raw = d.get("codTributo")
         if not trib_code_raw:
             raw = d.get("tributos")
-            if isinstance(raw, list) and raw:
-                raw_list = [str(item).strip().upper() for item in raw if str(item).strip()]
-                raw_list = [item for item in raw_list if item != TRIBUTO_IVA]
+            if isinstance(raw, list):
+                raw_tributos_list = [
+                    str(item).strip().upper() for item in raw if str(item).strip()
+                ]
+                raw_list = [item for item in raw_tributos_list if item != TRIBUTO_IVA]
                 if raw_list:
                     trib_code_raw = raw_list[0]
             elif isinstance(raw, str):
                 raw_str = raw.strip().upper()
-                if raw_str and raw_str != TRIBUTO_IVA:
-                    trib_code_raw = raw_str
+                if raw_str:
+                    raw_tributos_list = [raw_str]
+                    if raw_str != TRIBUTO_IVA:
+                        trib_code_raw = raw_str
+        else:
+            raw = d.get("tributos")
+            if isinstance(raw, list):
+                raw_tributos_list = [
+                    str(item).strip().upper() for item in raw if str(item).strip()
+                ]
+            elif isinstance(raw, str):
+                raw_str = raw.strip().upper()
+                if raw_str:
+                    raw_tributos_list = [raw_str]
         trib_code = str(trib_code_raw).upper() if trib_code_raw else ""
         if trib_code == TRIBUTO_IVA:
             raise ValueError("El IVA 13% (20) no va por ítem; solo en resumen")
@@ -2558,30 +2621,16 @@ def generar_dte_json(
             trib_list: list[str] = []
             if venta_gravada_val > 0:
                 trib_list.append(TRIBUTO_IVA)
+            trib_list.extend(raw_tributos_list)
             if tipo_item == 4 and trib_code:
                 item_data["codTributo"] = trib_code
-                trib_list.append(trib_code)
+                if trib_code not in trib_list:
+                    trib_list.append(trib_code)
             else:
                 item_data["codTributo"] = None
 
-            if tipo_dte in {"03", "05", "06"}:
-                if venta_gravada_val > 0:
-                    filtered = []
-                    seen: set[str] = set()
-                    for code in trib_list:
-                        if code == TRIBUTO_IVA or code in TRIBUTOS_PERMITIDOS_ITEM:
-                            if code not in seen:
-                                filtered.append(code)
-                                seen.add(code)
-                    if TRIBUTO_IVA not in seen:
-                        filtered.insert(0, TRIBUTO_IVA)
-                        seen.add(TRIBUTO_IVA)
-                    item_data["tributos"] = filtered
-                else:
-                    item_data.pop("tributos", None)
-                    item_data["codTributo"] = None
-            else:
-                item_data["tributos"] = trib_list
+            item_data["tributos"] = trib_list
+            ensure_item_tributos_v3(item_data, tipo_dte)
         for key in ("ventaNoSuj", "ventaExenta", "ventaGravada"):
             item_data[key] = _zero_or_item(D(str(item_data[key])))
         total_no_suj_sum += D(str(item_data["ventaNoSuj"]))
@@ -3359,27 +3408,6 @@ def validate_dte_json(
         item.setdefault("psv", cero)
         if tipo_dte == "01":
             item["tributos"] = None
-        elif tipo_dte in {"03", "05", "06"}:
-            venta_grav_item = D(str(item.get("ventaGravada") or 0))
-            if venta_grav_item > 0:
-                tributos_raw = item.get("tributos") or []
-                filtered: list[str] = []
-                seen: set[str] = set()
-                for code in tributos_raw:
-                    code_str = str(code).strip().upper()
-                    if not code_str:
-                        continue
-                    if code_str == TRIBUTO_IVA or code_str in TRIBUTOS_PERMITIDOS_ITEM:
-                        if code_str not in seen:
-                            filtered.append(code_str)
-                            seen.add(code_str)
-                if TRIBUTO_IVA not in seen:
-                    filtered.insert(0, TRIBUTO_IVA)
-                    seen.add(TRIBUTO_IVA)
-                item["tributos"] = filtered
-            else:
-                item.pop("tributos", None)
-                item["codTributo"] = None
         else:
             item.setdefault("tributos", [])
         if iva_key:
@@ -3450,33 +3478,11 @@ def validate_dte_json(
                     f"Código(s) de tributo inválido(s): {', '.join(invalid)}"
                 )
 
+            item["codTributo"] = cod_tri
+            item["tributos"] = tributos
+
             if tipo_dte in {"03", "05", "06"}:
-                if venta_gravada_val > 0:
-                    combined = tributos[:]
-                    if cod_tri and cod_tri not in combined:
-                        combined.append(cod_tri)
-                    filtered: list[str] = []
-                    seen: set[str] = set()
-                    for code in combined:
-                        if code == TRIBUTO_IVA or code in TRIBUTOS_PERMITIDOS_ITEM:
-                            if code not in seen:
-                                filtered.append(code)
-                                seen.add(code)
-                    if TRIBUTO_IVA not in seen:
-                        filtered.insert(0, TRIBUTO_IVA)
-                        seen.add(TRIBUTO_IVA)
-                    item["tributos"] = filtered
-                    if item.get("tipoItem") == 4:
-                        extra_code = next(
-                            (c for c in filtered if c != TRIBUTO_IVA),
-                            None,
-                        )
-                        item["codTributo"] = extra_code
-                    else:
-                        item["codTributo"] = None
-                else:
-                    item.pop("tributos", None)
-                    item["codTributo"] = None
+                ensure_item_tributos_v3(item, tipo_dte)
             else:
                 if venta_gravada_val <= 0:
                     item["tributos"] = []

--- a/tests/test_dte_from_venta_extra.py
+++ b/tests/test_dte_from_venta_extra.py
@@ -250,18 +250,520 @@ def test_credito_mixto_includes_iva_only_for_gravadas(db_conn, monkeypatch):
 
     tributos_resumen = resumen.get("tributos") or []
     assert any(t.get("codigo") == dte_module.TRIBUTO_IVA for t in tributos_resumen)
+    assert Decimal(str(resumen["totalGravada"])) == Decimal(str(extra["sumas"]))
+    assert Decimal(str(resumen["totalExenta"])) == Decimal(str(extra["ventas_exentas"]))
+    assert Decimal(str(resumen["totalNoGravado"])) == Decimal(str(extra["no_gravado"]))
+    assert Decimal(str(resumen["montoTotalOperacion"])) == Decimal("173")
+    assert Decimal(str(resumen["totalPagar"])) == Decimal("173")
 
     cuerpo = data["cuerpoDocumento"]
+    for item in cuerpo:
+        tributos = item.get("tributos") or []
+        assert tributos, "cada ítem debe exponer tributos no vacíos"
+
     grav_item = next(i for i in cuerpo if Decimal(str(i.get("ventaGravada", 0))) > 0)
     exento_item = next(i for i in cuerpo if Decimal(str(i.get("ventaExenta", 0))) > 0)
     no_grav_item = next(i for i in cuerpo if Decimal(str(i.get("noGravado", 0))) > 0)
 
     grav_tributos = grav_item.get("tributos") or []
-    assert dte_module.TRIBUTO_IVA in grav_tributos
-    assert grav_item.get("tributos") == [dte_module.TRIBUTO_IVA] or all(
+    assert grav_tributos
+    assert grav_tributos[0] == dte_module.TRIBUTO_IVA
+    assert all(
         code == dte_module.TRIBUTO_IVA or code in dte_module.TRIBUTOS_PERMITIDOS_ITEM
         for code in grav_tributos
     )
 
-    assert "tributos" not in exento_item
-    assert "tributos" not in no_grav_item
+    exento_tributos = exento_item.get("tributos") or []
+    assert exento_tributos
+    assert exento_tributos[0] == dte_module.TRIBUTO_IVA
+
+    no_grav_tributos = no_grav_item.get("tributos") or []
+    assert no_grav_tributos
+    assert no_grav_tributos[0] == dte_module.TRIBUTO_IVA
+
+
+def test_fc_exenta_no_suj_siempre_incluye_tributos(db_conn, monkeypatch):
+    _configure_negocio(monkeypatch)
+
+    db_conn.add_cliente(
+        nombre="Cliente FC",
+        nrc="1234567",
+        nit="06141990011019",
+        dui="",
+        giro="Comercio",
+        telefono="22223333",
+        email="cli@example.com",
+        direccion="San Salvador",
+        departamento="06",
+        municipio="23",
+    )
+    cliente_id = db_conn.cursor.lastrowid
+
+    db_conn.add_producto("Servicio Exento", "E03", "SKU-E03", None, None, 0, 0, 0, 0)
+    prod_exento = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio No Sujeto", "NS02", "SKU-NS02", None, None, 0, 0, 0, 0)
+    prod_no_suj = db_conn.cursor.lastrowid
+
+    extra = {
+        "sumas": 0,
+        "descuentos": 0,
+        "iva": 0,
+        "subtotal": 100,
+        "ventas_exentas": 60,
+        "ventas_no_sujetas": 40,
+        "no_gravado": 0,
+        "precios_incluyen_iva": True,
+    }
+
+    venta_id = db_conn.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-03-10",
+        total=100,
+        nrc="1234567",
+        nit="06141990011019",
+        giro="Comercio",
+        sumas=extra["sumas"],
+        descuentos=extra["descuentos"],
+        iva=extra["iva"],
+        subtotal=extra["subtotal"],
+        ventas_exentas=extra["ventas_exentas"],
+        ventas_no_sujetas=extra["ventas_no_sujetas"],
+        total_letras="CIEN",
+        extra=extra,
+    )
+
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_exento,
+        1,
+        60,
+        iva=0,
+        tipo_fiscal="venta exenta",
+        precio_con_iva=60,
+        base=60,
+        total=60,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_no_suj,
+        1,
+        40,
+        iva=0,
+        tipo_fiscal="venta no sujeta",
+        precio_con_iva=40,
+        base=40,
+        total=40,
+    )
+
+    data = dte_module.generar_dte_json(db_conn, venta_id, tipo_dte="03")
+
+    resumen = data["resumen"]
+    assert (resumen.get("tributos") or []) == []
+    assert Decimal(str(resumen["totalGravada"])) == Decimal("0")
+    assert Decimal(str(resumen["totalExenta"])) == Decimal("60")
+    assert Decimal(str(resumen["totalNoSuj"])) == Decimal("40")
+    assert Decimal(str(resumen.get("totalIva", 0))) == Decimal("0")
+    assert Decimal(str(resumen["montoTotalOperacion"])) == Decimal("100")
+    assert Decimal(str(resumen["totalPagar"])) == Decimal("100")
+
+    cuerpo = data["cuerpoDocumento"]
+    assert len(cuerpo) == 2
+    for item in cuerpo:
+        tributos = item.get("tributos") or []
+        assert tributos
+        assert tributos[0] == dte_module.TRIBUTO_IVA
+        assert Decimal(str(item.get("ventaGravada") or 0)) == Decimal("0")
+
+
+def test_dte03_exentas_no_suj_sin_iva(db_conn, monkeypatch):
+    _configure_negocio(monkeypatch)
+
+    db_conn.add_cliente(
+        nombre="Cliente FC",
+        nrc="1234567",
+        nit="06141990011019",
+        dui="",
+        giro="Comercio",
+        telefono="22223333",
+        email="cli@example.com",
+        direccion="San Salvador",
+        departamento="06",
+        municipio="23",
+    )
+    cliente_id = db_conn.cursor.lastrowid
+
+    db_conn.add_producto("Servicio Exento", "E10", "SKU-E10", None, None, 0, 0, 0, 0)
+    prod_exento = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio No Sujeto", "NS10", "SKU-NS10", None, None, 0, 0, 0, 0)
+    prod_no_suj = db_conn.cursor.lastrowid
+
+    extra = {
+        "sumas": 0,
+        "descuentos": 0,
+        "iva": 0,
+        "subtotal": 100,
+        "ventas_exentas": 60,
+        "ventas_no_sujetas": 40,
+        "no_gravado": 0,
+        "precios_incluyen_iva": True,
+    }
+
+    venta_id = db_conn.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-04-10",
+        total=100,
+        nrc="1234567",
+        nit="06141990011019",
+        giro="Comercio",
+        sumas=extra["sumas"],
+        descuentos=extra["descuentos"],
+        iva=extra["iva"],
+        subtotal=extra["subtotal"],
+        ventas_exentas=extra["ventas_exentas"],
+        ventas_no_sujetas=extra["ventas_no_sujetas"],
+        total_letras="CIEN",
+        extra=extra,
+    )
+
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_exento,
+        1,
+        60,
+        iva=0,
+        tipo_fiscal="venta exenta",
+        precio_con_iva=60,
+        base=60,
+        total=60,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_no_suj,
+        1,
+        40,
+        iva=0,
+        tipo_fiscal="venta no sujeta",
+        precio_con_iva=40,
+        base=40,
+        total=40,
+    )
+
+    data = dte_module.generar_dte_json(db_conn, venta_id, tipo_dte="03")
+    resumen = data["resumen"]
+
+    assert resumen.get("tributos") in (None, [])
+    assert Decimal(str(resumen.get("totalIva", 0))) == Decimal("0")
+    assert Decimal(str(resumen["totalPagar"])) == Decimal("100")
+    assert Decimal(str(resumen["montoTotalOperacion"])) == Decimal("100")
+
+    bases = Decimal("0")
+    for item in data["cuerpoDocumento"]:
+        assert item.get("tributos") == [dte_module.TRIBUTO_IVA]
+        bases += Decimal(str(item.get("ventaExenta") or 0))
+        bases += Decimal(str(item.get("ventaNoSuj") or 0))
+        bases += Decimal(str(item.get("ventaGravada") or 0))
+
+    assert bases == Decimal("100")
+
+    iva_resumen = Decimal(str(resumen["montoTotalOperacion"]))
+    iva_resumen -= Decimal(str(resumen["totalGravada"]))
+    iva_resumen -= Decimal(str(resumen["totalExenta"]))
+    iva_resumen -= Decimal(str(resumen["totalNoSuj"]))
+    iva_resumen -= Decimal(str(resumen.get("totalNoGravado", 0)))
+    assert iva_resumen == Decimal("0")
+
+
+def test_dte03_mixto(db_conn, monkeypatch):
+    _configure_negocio(monkeypatch)
+
+    db_conn.add_cliente(
+        nombre="Cliente FC",
+        nrc="1234567",
+        nit="06141990011019",
+        dui="",
+        giro="Comercio",
+        telefono="22223333",
+        email="cli@example.com",
+        direccion="San Salvador",
+        departamento="06",
+        municipio="23",
+    )
+    cliente_id = db_conn.cursor.lastrowid
+
+    db_conn.add_producto("Servicio Gravado", "G10", "SKU-G10", None, None, 0, 0, 0, 0)
+    prod_grav = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio Exento", "E11", "SKU-E11", None, None, 0, 0, 0, 0)
+    prod_exento = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio No Sujeto", "NS11", "SKU-NS11", None, None, 0, 0, 0, 0)
+    prod_no_suj = db_conn.cursor.lastrowid
+
+    extra = {
+        "sumas": 100,
+        "descuentos": 0,
+        "iva": 13,
+        "subtotal": 113,
+        "ventas_exentas": 40,
+        "ventas_no_sujetas": 10,
+        "no_gravado": 0,
+        "precios_incluyen_iva": True,
+    }
+
+    venta_id = db_conn.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-04-11",
+        total=163,
+        nrc="1234567",
+        nit="06141990011019",
+        giro="Comercio",
+        sumas=extra["sumas"],
+        descuentos=extra["descuentos"],
+        iva=extra["iva"],
+        subtotal=extra["subtotal"],
+        ventas_exentas=extra["ventas_exentas"],
+        ventas_no_sujetas=extra["ventas_no_sujetas"],
+        total_letras="CIENTO SESENTA Y TRES",
+        extra=extra,
+    )
+
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_grav,
+        1,
+        100,
+        iva=13,
+        tipo_fiscal="venta gravada",
+        precio_con_iva=113,
+        base=100,
+        total=113,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_exento,
+        1,
+        40,
+        iva=0,
+        tipo_fiscal="venta exenta",
+        precio_con_iva=40,
+        base=40,
+        total=40,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_no_suj,
+        1,
+        10,
+        iva=0,
+        tipo_fiscal="venta no sujeta",
+        precio_con_iva=10,
+        base=10,
+        total=10,
+    )
+
+    data = dte_module.generar_dte_json(db_conn, venta_id, tipo_dte="03")
+    resumen = data["resumen"]
+
+    total_gravada = Decimal(str(resumen["totalGravada"]))
+    assert total_gravada == Decimal("100")
+    expected_iva = (total_gravada * Decimal("0.13")).quantize(Decimal("0.01"))
+    iva_resumen = Decimal(str(resumen["montoTotalOperacion"]))
+    iva_resumen -= Decimal(str(resumen["totalGravada"]))
+    iva_resumen -= Decimal(str(resumen["totalExenta"]))
+    iva_resumen -= Decimal(str(resumen["totalNoSuj"]))
+    iva_resumen -= Decimal(str(resumen.get("totalNoGravado", 0)))
+    assert iva_resumen == expected_iva
+    assert Decimal(str(resumen["totalExenta"])) == Decimal("40")
+    assert Decimal(str(resumen["totalNoSuj"])) == Decimal("10")
+
+    for item in data["cuerpoDocumento"]:
+        assert item.get("tributos") == [dte_module.TRIBUTO_IVA]
+        if Decimal(str(item.get("ventaGravada") or 0)) == Decimal("0"):
+            assert Decimal(str(item.get("ivaItem") or 0)) == Decimal("0")
+
+
+def test_dte01_regresion(db_conn, monkeypatch):
+    _configure_negocio(monkeypatch)
+
+    db_conn.add_producto("Servicio Gravado", "G20", "SKU-G20", None, None, 0, 0, 0, 0)
+    prod_grav = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio Exento", "E20", "SKU-E20", None, None, 0, 0, 0, 0)
+    prod_exento = db_conn.cursor.lastrowid
+
+    db_conn.add_cliente(
+        nombre="Consumidor Final",
+        nrc="",
+        nit="",
+        dui="01234567-8",
+        giro="",
+        telefono="",
+        email="",
+        direccion="San Salvador",
+        departamento="06",
+        municipio="23",
+    )
+    cliente_id = db_conn.cursor.lastrowid
+
+    extra = {
+        "sumas": 50,
+        "descuentos": 0,
+        "iva": 6.5,
+        "subtotal": 96.5,
+        "ventas_exentas": 40,
+        "ventas_no_sujetas": 0,
+        "no_gravado": 0,
+        "precios_incluyen_iva": True,
+    }
+
+    venta_id = db_conn.add_venta(
+        "2024-04-12",
+        96.5,
+        cliente_id=cliente_id,
+        extra=extra,
+    )
+
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_grav,
+        1,
+        50,
+        iva=6.5,
+        tipo_fiscal="venta gravada",
+        precio_con_iva=56.5,
+        base=50,
+        total=56.5,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_exento,
+        1,
+        40,
+        iva=0,
+        tipo_fiscal="venta exenta",
+        precio_con_iva=40,
+        base=40,
+        total=40,
+    )
+
+    data = dte_module.generar_dte_json(db_conn, venta_id, tipo_dte="01")
+    resumen = data["resumen"]
+
+    total_gravada = Decimal(str(resumen["totalGravada"]))
+    assert total_gravada == Decimal(str(extra["sumas"])) + Decimal(str(extra["iva"]))
+    assert total_gravada - Decimal(str(extra["sumas"])) == Decimal(str(extra["iva"]))
+    assert Decimal(str(resumen["totalExenta"])) == Decimal(str(extra["ventas_exentas"]))
+    if "totalIva" in resumen:
+        assert Decimal(str(resumen["totalIva"])) == Decimal(str(extra["iva"]))
+    assert Decimal(str(resumen["montoTotalOperacion"])) == Decimal(str(extra["subtotal"]))
+    assert Decimal(str(resumen["totalPagar"])) == Decimal(str(extra["subtotal"]))
+
+    for item in data["cuerpoDocumento"]:
+        assert item.get("tributos") is None
+
+
+def test_concordancia_ventas(db_conn, monkeypatch):
+    _configure_negocio(monkeypatch)
+
+    db_conn.add_cliente(
+        nombre="Cliente FC",
+        nrc="1234567",
+        nit="06141990011019",
+        dui="",
+        giro="Comercio",
+        telefono="22223333",
+        email="cli@example.com",
+        direccion="San Salvador",
+        departamento="06",
+        municipio="23",
+    )
+    cliente_id = db_conn.cursor.lastrowid
+
+    db_conn.add_producto("Servicio Gravado", "G30", "SKU-G30", None, None, 0, 0, 0, 0)
+    prod_grav = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio Exento", "E30", "SKU-E30", None, None, 0, 0, 0, 0)
+    prod_exento = db_conn.cursor.lastrowid
+    db_conn.add_producto("Servicio No Sujeto", "NS30", "SKU-NS30", None, None, 0, 0, 0, 0)
+    prod_no_suj = db_conn.cursor.lastrowid
+
+    extra = {
+        "sumas": 120,
+        "descuentos": 0,
+        "iva": 15.6,
+        "subtotal": 215.6,
+        "ventas_exentas": 60,
+        "ventas_no_sujetas": 20,
+        "no_gravado": 0,
+        "precios_incluyen_iva": True,
+    }
+
+    venta_id = db_conn.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-04-13",
+        total=215.6,
+        nrc="1234567",
+        nit="06141990011019",
+        giro="Comercio",
+        sumas=extra["sumas"],
+        descuentos=extra["descuentos"],
+        iva=extra["iva"],
+        subtotal=extra["subtotal"],
+        ventas_exentas=extra["ventas_exentas"],
+        ventas_no_sujetas=extra["ventas_no_sujetas"],
+        total_letras="DOSCIENTOS",
+        extra=extra,
+    )
+
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_grav,
+        1,
+        120,
+        iva=15.6,
+        tipo_fiscal="venta gravada",
+        precio_con_iva=135.6,
+        base=120,
+        total=135.6,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_exento,
+        1,
+        60,
+        iva=0,
+        tipo_fiscal="venta exenta",
+        precio_con_iva=60,
+        base=60,
+        total=60,
+    )
+    db_conn.add_detalle_venta(
+        venta_id,
+        prod_no_suj,
+        1,
+        20,
+        iva=0,
+        tipo_fiscal="venta no sujeta",
+        precio_con_iva=20,
+        base=20,
+        total=20,
+    )
+
+    data = dte_module.generar_dte_json(db_conn, venta_id, tipo_dte="03")
+    resumen = data["resumen"]
+
+    venta_cf = db_conn.get_venta_credito_fiscal(venta_id)
+    assert venta_cf is not None
+    extra_guardado = venta_cf["extra"]
+
+    assert Decimal(str(resumen["totalGravada"])) == Decimal(str(extra_guardado["sumas"]))
+    assert Decimal(str(resumen["descuGravada"])) == Decimal(str(extra_guardado["descuentos"]))
+    iva_resumen = Decimal(str(resumen["montoTotalOperacion"]))
+    iva_resumen -= Decimal(str(resumen["totalGravada"]))
+    iva_resumen -= Decimal(str(resumen["totalExenta"]))
+    iva_resumen -= Decimal(str(resumen["totalNoSuj"]))
+    iva_resumen -= Decimal(str(resumen.get("totalNoGravado", 0)))
+    assert iva_resumen == Decimal(str(extra_guardado["iva"]))
+    assert Decimal(str(resumen["totalExenta"])) == Decimal(str(extra_guardado["ventas_exentas"]))
+    assert Decimal(str(resumen["totalNoSuj"])) == Decimal(str(extra_guardado["ventas_no_sujetas"]))
+    assert Decimal(str(resumen["totalNoGravado"])) == Decimal(str(extra_guardado.get("no_gravado", 0)))
+    assert Decimal(str(resumen["totalPagar"])) == Decimal(str(extra_guardado["subtotal"]))
+
+    venta_row = next(v for v in db_conn.get_ventas() if v["id"] == venta_id)
+    assert Decimal(str(venta_row["total"])) == Decimal(str(resumen["totalPagar"]))


### PR DESCRIPTION
## Summary
- ensure `ensure_item_tributos_v3` always prefixes a single IVA code and removes `codTributo` when it does not apply to the line
- add regression suites for DTE03 exenta/no sujeta, mixed ventas, DTE01 behavior, and ventas↔DTE resumen concordance to guard MH v3 normalization

## Testing
- pytest -q tests/test_dte_from_venta_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68cb814779208323b92d46070d2a2db1