### PR TITLE
Allow ventas with null cliente

### DIFF
--- a/inventory_validator.py
+++ b/inventory_validator.py
@@ -118,7 +118,7 @@ def validate_inventory_json(data: dict) -> List[Issue]:
                 "message": f"vendedor_id {vend_id} no existe",
             })
         cid = v.get("cliente_id")
-        if cid not in cliente_ids:
+        if cid is not None and cid not in cliente_ids:
             issues.append({
                 "path": f"ventas[{i}].cliente_id",
                 "severity": "error",

--- a/tests/test_inventory_import_validation.py
+++ b/tests/test_inventory_import_validation.py
@@ -109,3 +109,13 @@ def test_vendedor_id_optional(tmp_path):
     path.write_text(json.dumps(data), encoding="utf-8")
     summary = manager.importar_inventario_json(str(path), dry_run=True, strict=False)
     assert not any(issue["path"] == "ventas[0].vendedor_id" for issue in summary["errors"])
+
+
+def test_cliente_id_optional(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    data = make_valid_data()
+    data["ventas"][0]["cliente_id"] = None
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = manager.importar_inventario_json(str(path), dry_run=True, strict=False)
+    assert not any(issue["path"] == "ventas[0].cliente_id" for issue in summary["errors"])


### PR DESCRIPTION
## Summary
- skip cliente existence validation when cliente_id is null during inventory import
- cover cliente_id optional scenario with a regression test

## Testing
- pytest tests/test_inventory_import_validation.py -k cliente_id_optional *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9e8286dc8323abc5b56c14b9d715