### PR TITLE
Regenerar numeroControl al validar sin correlativo

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3063,6 +3063,11 @@ def validate_dte_json(
     negocio = _load_datos_negocio()
 
     ident = payload.get("identificacion", {})
+    if correlativo is None and isinstance(ident, dict):
+        # Forzar regeneración de ``numeroControl`` al validar cuando no se
+        # proporciona un correlativo explícito.  Si dejamos el valor entrante
+        # Hacienda puede rechazar el documento por duplicado.
+        ident.pop("numeroControl", None)
     config = _load_dte_api_config()
     ambiente = "01" if config.get("ambiente") == "produccion" else "00"
     ident.setdefault("ambiente", ambiente)


### PR DESCRIPTION
## Summary
- limpia numeroControl entrante durante la validación cuando no se indica un correlativo explícito para que se genere uno nuevo

## Testing
- python -m pytest tests/test_dte_correlativo.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9e52dbf48323b308bfdbacf4103c