### PR TITLE
Handle missing sale selection gracefully

### DIFF
--- a/sales_tab.py
+++ b/sales_tab.py
@@ -281,6 +281,14 @@ class SalesTab(QWidget):
         row = self.sales_table.currentRow()
         venta_id = int(self.sales_table.item(row, 0).text())
         venta = next((v for v in self.manager.db.get_ventas() if v["id"] == venta_id), None)
+        if not venta:
+            QMessageBox.warning(
+                self,
+                "Venta no encontrada",
+                f"No se encontraron datos para la venta seleccionada (ID {venta_id}).",
+            )
+            self.show_sale(clear=True)
+            return
         cliente = ""
         cliente_email = ""
         if venta and venta.get("cliente_id"):


### PR DESCRIPTION
## Summary
- show a warning when a selected sale record cannot be loaded
- clear the preview instead of crashing when the sale is missing

## Testing
- pytest *(fails: ImportError: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d03fb54438832397805b2cafef1695