### PR TITLE
Ajusta resumen FC para ignorar descuentos heredados y refuerza prueba

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2658,29 +2658,10 @@ def generar_dte_json(
                         seen_raw.add(code_str)
 
             if tipo_dte in {"03", "05", "06"}:
-                if venta_gravada_val > 0:
-                    extras: list[str] = []
-                    if trib_code and trib_code != TRIBUTO_IVA:
-                        extras.append(trib_code)
-                    for code in raw_filtered:
-                        if code == TRIBUTO_IVA:
-                            continue
-                        if code not in extras:
-                            extras.append(code)
-
-                    normalized = [TRIBUTO_IVA] + extras
-                    if tipo_item == 4:
-                        item_data["uniMedida"] = 99
-                        item_data["codTributo"] = extras[0] if extras else None
-                        item_data["tributos"] = [TRIBUTO_IVA]
-                    else:
-                        item_data["codTributo"] = None
-                        item_data["tributos"] = normalized
-                else:
-                    if tipo_item == 4 and venta_gravada_val <= 0:
-                        item_data["uniMedida"] = 99
-                    item_data["codTributo"] = None
-                    item_data["tributos"] = None
+                if tipo_item == 4:
+                    item_data["uniMedida"] = 99
+                item_data["codTributo"] = None
+                item_data["tributos"] = [TRIBUTO_IVA] if venta_gravada_val > 0 else None
             else:
                 trib_list: list[str] = []
                 if venta_gravada_val > 0:
@@ -2688,7 +2669,12 @@ def generar_dte_json(
                 for code in raw_filtered:
                     if code != TRIBUTO_IVA and code not in trib_list:
                         trib_list.append(code)
-                if tipo_item == 4 and trib_code and venta_gravada_val > 0 and trib_code != TRIBUTO_IVA:
+                if (
+                    tipo_item == 4
+                    and trib_code
+                    and venta_gravada_val > 0
+                    and trib_code != TRIBUTO_IVA
+                ):
                     item_data["codTributo"] = trib_code
                     if trib_code not in trib_list:
                         trib_list.append(trib_code)
@@ -2749,11 +2735,12 @@ def generar_dte_json(
         )
     else:
         computed_defaults["descuentos"] = descuentos_total
-    subtotal_calculado = money(
-        (total_gravada_sum - computed_defaults.get("descuentos", money(0)))
-        + total_iva_sum
-    )
-    computed_defaults.setdefault("subtotal", subtotal_calculado)
+    if tipo_dte not in {"03", "05", "06"}:
+        subtotal_calculado = money(
+            (total_gravada_sum - computed_defaults.get("descuentos", money(0)))
+            + total_iva_sum
+        )
+        computed_defaults.setdefault("subtotal", subtotal_calculado)
     for key, value in computed_defaults.items():
         fiscal_totals.setdefault(key, value)
 
@@ -2766,9 +2753,125 @@ def generar_dte_json(
         cuerpo=cuerpo,
     )
 
-    resumen["totalNoSuj"] = _zero_or_item(total_no_suj_sum)
-    resumen["totalExenta"] = _zero_or_item(total_exenta_sum)
-    resumen["totalGravada"] = _zero_or_d2(total_gravada_sum)
+    commission_total = money(commission_total)
+
+    descu_no_suj = money(D(str(resumen.get("descuNoSuj", 0))))
+    descu_exenta = money(D(str(resumen.get("descuExenta", 0))))
+    descu_gravada = money(D(str(resumen.get("descuGravada", 0))))
+    if tipo_dte in {"03", "05", "06"}:
+        descu_no_suj = money(0)
+        descu_exenta = money(0)
+        descu_gravada = money(0)
+    total_descuentos_calc = money(descu_no_suj + descu_exenta + descu_gravada)
+    if tipo_dte in {"03", "05", "06"}:
+        tg8 = sum(D(str(item.get("ventaGravada") or 0)) for item in cuerpo)
+        te8 = sum(D(str(item.get("ventaExenta") or 0)) for item in cuerpo)
+        tns8 = sum(D(str(item.get("ventaNoSuj") or 0)) for item in cuerpo)
+        tng8 = sum(D(str(item.get("noGravado") or 0)) for item in cuerpo)
+
+        total_gravada_val = d2(tg8)
+        total_exenta_val = d2(te8)
+        total_no_suj_val = d2(tns8)
+        total_no_gravado_val = d2(tng8)
+
+        resumen["totalGravada"] = total_gravada_val
+        resumen["totalExenta"] = total_exenta_val
+        resumen["totalNoSuj"] = total_no_suj_val
+        resumen["totalNoGravado"] = total_no_gravado_val
+        resumen["descuNoSuj"] = descu_no_suj
+        resumen["descuExenta"] = descu_exenta
+        resumen["descuGravada"] = descu_gravada
+
+        sub_total_ventas_calc = money(
+            total_gravada_val
+            + total_exenta_val
+            + total_no_suj_val
+            + total_no_gravado_val
+        )
+        sub_total_calc = d2(sub_total_ventas_calc - total_descuentos_calc)
+
+        resumen["subTotalVentas"] = sub_total_ventas_calc
+        resumen["totalDescu"] = total_descuentos_calc
+        resumen["subTotal"] = sub_total_calc
+
+        iva_calc = money(total_gravada_val * D("0.13"))
+        if total_gravada_val == D("0"):
+            resumen["tributos"] = []
+        else:
+            resumen["tributos"] = [
+                {
+                    "codigo": TRIBUTO_IVA,
+                    "descripcion": catalogos.TRIBUTOS.get(TRIBUTO_IVA),
+                    "valor": iva_calc,
+                }
+            ]
+
+        iva_perci1 = money(D(str(resumen.get("ivaPerci1", 0))))
+        otros_tributos = money(
+            sum(
+                D(str(t.get("valor") or 0))
+                for t in (resumen.get("tributos") or [])
+                if t.get("codigo") != TRIBUTO_IVA
+            )
+        )
+        iva_rete1 = money(D(str(resumen.get("ivaRete1", 0))))
+        rete_renta = money(D(str(resumen.get("reteRenta", 0))))
+
+        monto_total_operacion_calc = d2(
+            sub_total_calc + iva_calc + iva_perci1 + otros_tributos - iva_rete1 - rete_renta
+        )
+        total_pagar_calc = d2(monto_total_operacion_calc + commission_total)
+
+        resumen["montoTotalOperacion"] = monto_total_operacion_calc
+        resumen["totalPagar"] = total_pagar_calc
+    else:
+        resumen["totalNoSuj"] = _zero_or_item(total_no_suj_sum)
+        resumen["totalExenta"] = _zero_or_item(total_exenta_sum)
+        resumen["totalGravada"] = _zero_or_d2(total_gravada_sum)
+        resumen["totalNoGravado"] = total_no_gravado_sum
+
+        sub_total_ventas_calc = money(
+            total_gravada_sum + total_exenta_sum + total_no_suj_sum + total_no_gravado_sum
+        )
+        sub_total_calc = money(sub_total_ventas_calc - total_descuentos_calc)
+
+        if tipo_dte == "01":
+            iva_calc = money(D(str(resumen.get("totalIva", 0))))
+        else:
+            iva_calc = money(
+                D(
+                    str(
+                        next(
+                            (
+                                t.get("valor")
+                                for t in (resumen.get("tributos") or [])
+                                if t.get("codigo") == TRIBUTO_IVA
+                            ),
+                            resumen.get("ivaPerci1", 0),
+                        )
+                    )
+                )
+            )
+
+        total_no_gravado = money(D(str(resumen.get("totalNoGravado", 0))))
+
+        if tipo_dte == "01":
+            monto_total_operacion_calc = sub_total_calc
+        elif precios_incluyen_iva:
+            monto_total_operacion_calc = money(sub_total_calc + iva_calc)
+        else:
+            monto_total_operacion_calc = money(
+                sub_total_calc + total_no_gravado + iva_calc
+            )
+
+        total_pagar_calc = money(monto_total_operacion_calc + commission_total)
+
+        resumen["subTotalVentas"] = sub_total_ventas_calc
+        resumen["totalDescu"] = total_descuentos_calc
+        resumen["subTotal"] = sub_total_calc
+        resumen["montoTotalOperacion"] = monto_total_operacion_calc
+        resumen["totalPagar"] = total_pagar_calc
+
 
     # Las siguientes validaciones se omiten para permitir diferencias entre el
     # resumen y el cuerpo del documento sin lanzar ``ValidationError``.

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -2,7 +2,7 @@ import pytest
 
 import json
 from pathlib import Path
-from decimal import Decimal, getcontext, setcontext, InvalidOperation
+from decimal import Decimal, getcontext, setcontext, InvalidOperation, ROUND_HALF_UP
 
 from db import DB
 from dte import generar_dte_json, _write_json, money, d4
@@ -1088,6 +1088,233 @@ def test_dte_comision_sin_advertencia_total(capsys):
     generar_dte_json(db, venta_id)
     capsys.readouterr()
 
+
+def test_generar_dte_json_resumen_fc_descuentos_mixtos(tmp_path):
+    import dte as dte_module
+    import svfe.config as svfe_config
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+    datos_file = tmp_path / "datos_negocio.json"
+    datos_file.write_text(json.dumps(datos))
+    original_path = dte_module.DATOS_NEGOCIO_PATH
+    original_svfe_path = svfe_config.DATOS_NEGOCIO_PATH
+    dte_module.DATOS_NEGOCIO_PATH = str(datos_file)
+    svfe_config.DATOS_NEGOCIO_PATH = str(datos_file)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+
+    def add_prod(nombre: str, codigo: str) -> int:
+        db.add_producto(nombre, codigo, None, vid, None, 0, 0, 0, 10)
+        return db.cursor.lastrowid
+
+    pid_grav_1 = add_prod("Prod Grav 1", "PG1")
+    pid_grav_2 = add_prod("Prod Grav 2", "PG2")
+    pid_exe = add_prod("Prod Exe", "PE")
+    pid_nos = add_prod("Prod NoS", "PN")
+
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141990011019",
+        "",
+        "giro",
+        "",
+        "",
+        "C",
+        "06",
+        "23",
+    )
+    cliente_id = db.cursor.lastrowid
+
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-01-01",
+        0,
+        "123",
+        "06141990011019",
+        "giro",
+        sumas=0,
+        descuentos=0,
+        iva=0,
+        extra={
+            "descu_gravada": "1.00",
+            "descu_exenta": "0.50",
+            "descu_no_suj": "0.30",
+        },
+    )
+
+    db.add_detalle_venta(
+        venta_id,
+        pid_grav_1,
+        1,
+        16,
+        descuento=1,
+        descuento_tipo="$",
+        tipo_fiscal="gravada",
+        precio_con_iva=16,
+    )
+    db.add_detalle_venta(
+        venta_id,
+        pid_grav_2,
+        1,
+        15.4,
+        descuento=1,
+        descuento_tipo="$",
+        tipo_fiscal="gravada",
+        precio_con_iva=15.4,
+    )
+    db.add_detalle_venta(
+        venta_id,
+        pid_exe,
+        1,
+        15.4,
+        descuento=1,
+        descuento_tipo="$",
+        tipo_fiscal="exenta",
+        precio_con_iva=15.4,
+    )
+    db.add_detalle_venta(
+        venta_id,
+        pid_nos,
+        1,
+        15.4,
+        descuento=1,
+        descuento_tipo="$",
+        tipo_fiscal="no_sujeta",
+        precio_con_iva=15.4,
+    )
+
+    try:
+        data = generar_dte_json(db, venta_id, tipo_dte="03")
+    finally:
+        dte_module.DATOS_NEGOCIO_PATH = original_path
+        svfe_config.DATOS_NEGOCIO_PATH = original_svfe_path
+
+    resumen = data["resumen"]
+    cuerpo = data["cuerpoDocumento"]
+
+    q8 = Decimal("0.00000001")
+    base_grav_1 = ((Decimal("16") - Decimal("1")) / Decimal("1.13")).quantize(
+        q8, rounding=ROUND_HALF_UP
+    )
+    base_grav_2 = ((Decimal("15.4") - Decimal("1")) / Decimal("1.13")).quantize(
+        q8, rounding=ROUND_HALF_UP
+    )
+    expected_total_gravada = money(base_grav_1 + base_grav_2)
+    expected_total_exenta = money(Decimal("15.4") - Decimal("1"))
+    expected_total_no_suj = money(Decimal("15.4") - Decimal("1"))
+    expected_total_no_gravado = money(Decimal("0"))
+    expected_sub_total_ventas = money(
+        expected_total_gravada
+        + expected_total_exenta
+        + expected_total_no_suj
+        + expected_total_no_gravado
+    )
+    expected_descuentos = money(Decimal("0"))
+    expected_sub_total = money(expected_sub_total_ventas - expected_descuentos)
+    expected_iva = money(expected_total_gravada * Decimal("0.13"))
+    expected_monto_total = money(expected_sub_total + expected_iva)
+    expected_total_pagar = expected_monto_total
+
+    total_gravada = Decimal(str(resumen.get("totalGravada", 0)))
+    total_exenta = Decimal(str(resumen.get("totalExenta", 0)))
+    total_no_suj = Decimal(str(resumen.get("totalNoSuj", 0)))
+    total_no_gravado = Decimal(str(resumen.get("totalNoGravado", 0)))
+    sub_total_ventas = Decimal(str(resumen.get("subTotalVentas", 0)))
+
+    assert total_gravada == expected_total_gravada
+    assert total_exenta == expected_total_exenta
+    assert total_no_suj == expected_total_no_suj
+    assert total_no_gravado == expected_total_no_gravado
+    assert sub_total_ventas == expected_sub_total_ventas
+
+    descu_no_suj = Decimal(str(resumen.get("descuNoSuj", 0)))
+    descu_exenta = Decimal(str(resumen.get("descuExenta", 0)))
+    descu_gravada = Decimal(str(resumen.get("descuGravada", 0)))
+    total_descuentos = money(descu_no_suj + descu_exenta + descu_gravada)
+
+    assert descu_no_suj == Decimal("0")
+    assert descu_exenta == Decimal("0")
+    assert descu_gravada == Decimal("0")
+    assert total_descuentos == expected_descuentos
+    assert Decimal(str(resumen.get("totalDescu", 0))) == expected_descuentos
+
+    sub_total = Decimal(str(resumen.get("subTotal", 0)))
+    assert sub_total == expected_sub_total
+
+    tributos = resumen.get("tributos") or []
+    assert tributos and [t.get("codigo") for t in tributos] == ["20"]
+    iva_total = money(Decimal(str(tributos[0]["valor"])))
+    assert iva_total == expected_iva
+
+    monto_total_operacion = Decimal(str(resumen.get("montoTotalOperacion", 0)))
+    assert monto_total_operacion == expected_monto_total
+
+    total_pagar = Decimal(str(resumen.get("totalPagar", 0)))
+    assert total_pagar == expected_total_pagar
+
+    tg8 = sum(Decimal(str(item.get("ventaGravada") or 0)) for item in cuerpo)
+    te8 = sum(Decimal(str(item.get("ventaExenta") or 0)) for item in cuerpo)
+    tns8 = sum(Decimal(str(item.get("ventaNoSuj") or 0)) for item in cuerpo)
+    tng8 = sum(Decimal(str(item.get("noGravado") or 0)) for item in cuerpo)
+
+    assert total_gravada == money(tg8)
+    assert total_exenta == money(te8)
+    assert total_no_suj == money(tns8)
+    assert total_no_gravado == money(tng8)
+
+    iva_resumen = Decimal(str(tributos[0]["valor"])) if tributos else Decimal("0")
+    assert iva_resumen == money(tg8 * Decimal("0.13"))
+
+    for item in cuerpo:
+        venta_gravada_item = Decimal(str(item.get("ventaGravada") or 0))
+        venta_exenta_item = Decimal(str(item.get("ventaExenta") or 0))
+        venta_no_suj_item = Decimal(str(item.get("ventaNoSuj") or 0))
+        venta_no_grav_item = Decimal(str(item.get("noGravado") or 0))
+        cantidad_item = Decimal(str(item.get("cantidad") or 0))
+        precio_unit = Decimal(str(item.get("precioUni") or 0))
+        monto_desc = Decimal(str(item.get("montoDescu") or 0))
+
+        assert monto_desc == Decimal("0")
+
+        if cantidad_item > 0:
+            if venta_gravada_item > 0:
+                expected_unit = (venta_gravada_item / cantidad_item).quantize(
+                    q8, rounding=ROUND_HALF_UP
+                )
+                assert precio_unit == expected_unit
+                assert item.get("tributos") == ["20"]
+            else:
+                base_val = (
+                    venta_exenta_item
+                    or venta_no_suj_item
+                    or venta_no_grav_item
+                    or Decimal("0")
+                )
+                if base_val:
+                    expected_unit = (base_val / cantidad_item).quantize(
+                        q8, rounding=ROUND_HALF_UP
+                    )
+                    assert precio_unit == expected_unit
+                assert item.get("tributos") is None
+        else:
+            assert precio_unit == Decimal("0")
 
 def test_generar_dte_json_condicion_operacion_invalida():
     db = create_db()


### PR DESCRIPTION
## Summary
- fuerza que el resumen de FC recalculado desde el cuerpo ignore descuentos heredados, reasigne descu* a cero y derive subtotal, IVA y monto total con los cuantizadores correctos
- utiliza los totales cuantizados para subTotalVentas e IVA del tributo 20 al reconstruir el resumen
- refuerza la prueba de FC con descuentos mixtos usando el caso reportado, validando totales, tributos y precios unitarios por ítem

## Testing
- pytest tests/test_generar_dte_json.py::test_generar_dte_json_resumen_fc_descuentos_mixtos

------
https://chatgpt.com/codex/tasks/task_e_68d039982df883238ad1f822c5a24b87