### PR TITLE
Show all invoices by default and enable client/vendor filters

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1143,19 +1143,23 @@ class FacturacionTab(QWidget):
 
             row_type = "venta"
             cliente_nombre = ""
+            cliente_id = None
+            vendedor_id = None
             total = None
             numero_control = None
             codigo_generacion = None
             tipo_desc = doc_tipo
             tipo_codigo = None
             ident_data = None
+            json_data = None
             if json_path and os.path.exists(json_path):
                 try:
                     with open(json_path, "r", encoding="utf-8") as fh:
-                        data = json.load(fh)
-                    ident_data = data.get("identificacion", {})
+                        json_data = json.load(fh)
+                    ident_data = json_data.get("identificacion", {})
                 except Exception:
                     ident_data = None
+                    json_data = None
             if venta:
                 getter = getattr(self.manager.db, "get_cliente", None)
                 if venta.get("cliente_id") and getter:
@@ -1164,6 +1168,8 @@ class FacturacionTab(QWidget):
                         cliente_nombre = cliente.get("nombre", "") if cliente else ""
                     except Exception:
                         cliente_nombre = ""
+                cliente_id = venta.get("cliente_id")
+                vendedor_id = venta.get("vendedor_id")
                 total = venta.get("total")
                 row_type = "ticket" if self._is_ticket_sale(venta) else "venta"
             else:
@@ -1171,6 +1177,14 @@ class FacturacionTab(QWidget):
                 if ident_data:
                     numero_control = ident_data.get("numeroControl")
                     codigo_generacion = ident_data.get("codigoGeneracion")
+            if not cliente_nombre and json_data:
+                try:
+                    cliente_nombre = json_data.get("receptor", {}).get("nombre", "") or cliente_nombre
+                except Exception:
+                    pass
+            if ident_data:
+                numero_control = numero_control or ident_data.get("numeroControl")
+                codigo_generacion = codigo_generacion or ident_data.get("codigoGeneracion")
 
             if tipo_codigo is None and ident_data:
                 tipo_codigo = ident_data.get("tipoDte")
@@ -1199,14 +1213,19 @@ class FacturacionTab(QWidget):
                 doc_tipo=doc_tipo,
             )
 
+            base_name = os.path.splitext(os.path.basename(ruta or ""))[0]
+            if not base_name:
+                base_name = numero_control or ""
             row = {
                 "row_type": row_type,
                 "id": rec["id"],
                 "venta_id": rec["venta_id"],
-                "name": os.path.splitext(os.path.basename(ruta or ""))[0],
+                "name": base_name,
                 "fecha": fecha_str,
                 "_parsed_fecha": fdate,
                 "cliente": cliente_nombre,
+                "cliente_id": cliente_id,
+                "vendedor_id": vendedor_id,
                 "total": total,
                 "estado": estado,
                 "envio": envio,
@@ -1242,6 +1261,16 @@ class FacturacionTab(QWidget):
         else:
             d_from = d_to = None
         tipo = self.tipo_filter.currentText()
+        cliente_filter_value = None
+        vendedor_filter_value = None
+        if hasattr(self, "client_filter"):
+            cliente_filter_value = self.client_filter.currentData()
+            if cliente_filter_value is not None:
+                cliente_filter_value = str(cliente_filter_value)
+        if hasattr(self, "vendedor_filter"):
+            vendedor_filter_value = self.vendedor_filter.currentData()
+            if vendedor_filter_value is not None:
+                vendedor_filter_value = str(vendedor_filter_value)
 
         rows = self._scan_documents()
 
@@ -1257,6 +1286,14 @@ class FacturacionTab(QWidget):
             if tipo != "Todos" and r.get("tipo") != tipo:
                 rows.remove(r)
                 continue
+            if cliente_filter_value is not None:
+                if str(r.get("cliente_id")) != cliente_filter_value:
+                    rows.remove(r)
+                    continue
+            if vendedor_filter_value is not None:
+                if str(r.get("vendedor_id")) != vendedor_filter_value:
+                    rows.remove(r)
+                    continue
             cliente = r.get("cliente", "")
             if search and search not in r.get("name", "").lower() and search not in cliente.lower():
                 rows.remove(r)
@@ -1449,6 +1486,8 @@ class FacturacionTab(QWidget):
                     "estado": estado,
                     "envio": envio,
                     "cliente": cliente,
+                    "cliente_id": None,
+                    "vendedor_id": None,
                     "total": total,
                     "sign": signo,
                     "tipo": tipo,

--- a/tests/test_facturacion_tab_loading.py
+++ b/tests/test_facturacion_tab_loading.py
@@ -108,3 +108,85 @@ def test_orders_by_datetime(qt_app, tmp_path, monkeypatch):
     second = tab.table.item(1, 1).text()
     assert first.endswith("11:00")
     assert second.endswith("10:00")
+
+
+def test_client_and_vendor_filters(qt_app, tmp_path, monkeypatch):
+    inv_dir = tmp_path / "facturas_consumidor_final"
+    inv_dir.mkdir()
+
+    base1 = "20240101_Alpha_1_ConsumidorFinal"
+    data1 = {
+        "identificacion": {
+            "numeroControl": base1,
+            "tipoDte": "01",
+            "fecEmi": "2024-01-01",
+        },
+        "receptor": {"nombre": "Alice"},
+        "resumen": {"totalPagar": 10},
+    }
+    (inv_dir / f"{base1}.json").write_text(json.dumps(data1))
+    (inv_dir / f"{base1}.pdf").write_text("pdf")
+
+    base2 = "20240102_Beta_2_ConsumidorFinal"
+    data2 = {
+        "identificacion": {
+            "numeroControl": base2,
+            "tipoDte": "01",
+            "fecEmi": "2024-01-02",
+        },
+        "receptor": {"nombre": "Bob"},
+        "resumen": {"totalPagar": 20},
+    }
+    (inv_dir / f"{base2}.json").write_text(json.dumps(data2))
+    (inv_dir / f"{base2}.pdf").write_text("pdf")
+
+    db = DB(":memory:")
+    db.cursor.executemany(
+        "INSERT INTO clientes (id, nombre) VALUES (?, ?)",
+        [(1, "Alice"), (2, "Bob")],
+    )
+    db.cursor.executemany(
+        "INSERT INTO trabajadores (id, codigo, nombre, es_vendedor) VALUES (?, ?, ?, 1)",
+        [(1, "V1", "Vend 1"), (2, "V2", "Vend 2")],
+    )
+    db.conn.commit()
+
+    venta1 = db.add_venta("2024-01-01", 10, cliente_id=1, vendedor_id=1)
+    venta2 = db.add_venta("2024-01-02", 20, cliente_id=2, vendedor_id=2)
+    db.add_factura_pdf(venta1, "ConsumidorFinal", str(inv_dir / f"{base1}.pdf"))
+    db.add_factura_pdf(venta2, "ConsumidorFinal", str(inv_dir / f"{base2}.pdf"))
+
+    manager = SimpleNamespace(
+        db=db,
+        _clientes=[{"id": 1, "nombre": "Alice"}, {"id": 2, "nombre": "Bob"}],
+    )
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(inv_dir))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "credito"))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(tmp_path / "tickets"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_DEBITO_DIR", str(tmp_path / "nd"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_CREDITO_DIR", str(tmp_path / "nc"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_REMISION_DIR", str(tmp_path / "nr"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    tab = facturacion_tab.FacturacionTab(manager)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 2
+
+    idx = tab.client_filter.findData(1)
+    tab.client_filter.setCurrentIndex(idx)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 1
+
+    tab.client_filter.setCurrentIndex(0)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 2
+
+    idx_v = tab.vendedor_filter.findData(2)
+    tab.vendedor_filter.setCurrentIndex(idx_v)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 1
+
+    tab.vendedor_filter.setCurrentIndex(0)
+    tab.load_invoices()
+    assert tab.table.rowCount() == 2


### PR DESCRIPTION
## Summary
- keep every invoice visible by enriching database rows with client/vendor identifiers and JSON fallbacks when metadata is missing
- apply client and vendor filters only when a specific value is selected while leaving the default view unfiltered
- add a regression test that covers the client and vendor filter interactions to ensure invoices reappear when filters are cleared

## Testing
- `pytest tests/test_facturacion_tab_loading.py tests/test_dte_filter_status.py tests/test_facturacion_tab_actions.py tests/test_note_signs.py` *(fails: libGL.so.1 missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0452e7f648323b69b65b46a3a1e1d