### PR TITLE
Permitir candidatos con UUID vacío en buscar_candidatos_reemplazo

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -354,7 +354,7 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
         "       TRIM(codigo_generacion) AS codigo_generacion, numero_control,",
         "       respuesta, ambiente",
         "  FROM dte_envios",
-        " WHERE TRIM(COALESCE(codigo_generacion, '')) <> ''",
+        " WHERE 1=1",
     ]
     if fecha_inicio:
         query.append("   AND date(fecha_hora) >= date(?)")
@@ -402,17 +402,17 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
                 metadata = _merge_metadata(primary, _extract_metadata(respuesta_local))
             return metadata
 
+        metadata = _get_metadata()
+
         if not codigo:
             codigo_metadata = str(
-                (_get_metadata().get("codigo_generacion") or "")
+                (metadata.get("codigo_generacion") or "")
             ).strip().upper()
             if codigo_metadata:
                 codigo = codigo_metadata
 
         if not codigo or (exclude_uuid and codigo == exclude_uuid):
             continue
-
-        metadata = _get_metadata()
         if metadata.get("codigo_generacion") in (None, ""):
             metadata["codigo_generacion"] = codigo
 

--- a/tests/test_buscar_candidatos_reemplazo.py
+++ b/tests/test_buscar_candidatos_reemplazo.py
@@ -235,3 +235,46 @@ def test_buscar_candidatos_reemplazo_recupera_codigo_de_metadatos(
     assert candidato["codigo_generacion"] == codigo_generacion
     assert candidato["numero_control"] == factura["identificacion"]["numeroControl"]
     assert candidato["seleccionable"] is True
+
+
+def test_buscar_candidatos_reemplazo_incluye_codigo_vacio(
+    db_conn, tmp_path, dte_metadata_factory
+):
+    codigo_generacion = str(uuid.uuid4()).upper()
+    factura = _crear_factura(
+        dte_metadata_factory,
+        codigo=codigo_generacion,
+        numero="DTE-01-S001P001-000000000000777",
+    )
+    json_path = tmp_path / "candidato_codigo_vacio.json"
+    json_path.write_text(json.dumps(factura), encoding="utf-8")
+    extra = {
+        "codigoGeneracion": codigo_generacion,
+        "numeroControl": factura["identificacion"]["numeroControl"],
+        "dteJsonPath": str(json_path),
+        "selloRecibido": "Z" * 40,
+    }
+    venta_id = db_conn.add_venta("2024-03-01", 15.75, extra=extra)
+    db_conn.registrar_envio_dte(
+        venta_id,
+        "manual",
+        "Aceptado",
+        "Z" * 40,
+        respuesta_json=json.dumps({"documento": factura}),
+        codigo_generacion="",
+        numero_control=factura["identificacion"]["numeroControl"],
+    )
+    envio_id = db_conn.cursor.lastrowid
+    db_conn.ensure_column("dte_envios", "codigo_generacion", "TEXT")
+    db_conn.cursor.execute(
+        "UPDATE dte_envios SET codigo_generacion='' WHERE id=?",
+        (envio_id,),
+    )
+    db_conn.conn.commit()
+
+    resultados = anulacion.buscar_candidatos_reemplazo(
+        db_conn, {"recepcionado": True}
+    )
+
+    codigos = {item["codigo_generacion"] for item in resultados}
+    assert codigo_generacion in codigos


### PR DESCRIPTION
## Summary
- elimina el filtro SQL que descartaba envíos sin `codigo_generacion` y reutiliza los metadatos para completar el UUID
- descarta candidatos sólo cuando siguen sin UUID o coinciden con `exclude_uuid`
- agrega una prueba que cubre registros con `codigo_generacion` vacío

## Testing
- pytest tests/test_buscar_candidatos_reemplazo.py

------
https://chatgpt.com/codex/tasks/task_e_68d0b0ac45548323ab8cf8ebb00ea27e