### PR TITLE
Adjust DTE selection date filter toggle behavior

### DIFF
--- a/dialogs/seleccionar_dte_dialog.py
+++ b/dialogs/seleccionar_dte_dialog.py
@@ -101,20 +101,26 @@ class SeleccionarDteDialog(QDialog):
         filters_layout.addWidget(self.mismo_receptor_cb)
 
         self.filtrar_fecha_cb = QCheckBox("Filtrar por fecha")
-        self.filtrar_fecha_cb.setChecked(True)
+        self.filtrar_fecha_cb.setChecked(False)
         filters_layout.addWidget(self.filtrar_fecha_cb)
         filters_layout.addStretch(1)
 
         filters_layout.addWidget(QLabel("Desde:"))
         self.fecha_inicio = QDateEdit()
         self.fecha_inicio.setCalendarPopup(True)
-        self.fecha_inicio.setDate(QDate.currentDate().addDays(-60))
+        self.fecha_inicio.setDisplayFormat("yyyy-MM-dd")
+        self.fecha_inicio.setSpecialValueText("")
+        self.fecha_inicio.setMinimumDate(QDate(1900, 1, 1))
+        self.fecha_inicio.setDate(self.fecha_inicio.minimumDate())
         filters_layout.addWidget(self.fecha_inicio)
 
         filters_layout.addWidget(QLabel("Hasta:"))
         self.fecha_fin = QDateEdit()
         self.fecha_fin.setCalendarPopup(True)
-        self.fecha_fin.setDate(QDate.currentDate())
+        self.fecha_fin.setDisplayFormat("yyyy-MM-dd")
+        self.fecha_fin.setSpecialValueText("")
+        self.fecha_fin.setMinimumDate(QDate(1900, 1, 1))
+        self.fecha_fin.setDate(self.fecha_fin.minimumDate())
         filters_layout.addWidget(self.fecha_fin)
         layout.addLayout(filters_layout)
 
@@ -155,6 +161,7 @@ class SeleccionarDteDialog(QDialog):
         self.fecha_inicio.dateChanged.connect(lambda *_: self._refresh())
         self.fecha_fin.dateChanged.connect(lambda *_: self._refresh())
 
+        self._fecha_filtro_configurado = False
         self._on_toggle_fecha_filter(self.filtrar_fecha_cb.isChecked(), refresh=False)
 
         if self.db is None:
@@ -173,6 +180,25 @@ class SeleccionarDteDialog(QDialog):
     def _on_toggle_fecha_filter(self, enabled: bool, *, refresh: bool = True) -> None:
         self.fecha_inicio.setEnabled(enabled)
         self.fecha_fin.setEnabled(enabled)
+        if enabled:
+            if not self._fecha_filtro_configurado:
+                self._fecha_filtro_configurado = True
+                inicio = QDate.currentDate().addDays(-60)
+                fin = QDate.currentDate()
+                self.fecha_inicio.blockSignals(True)
+                self.fecha_fin.blockSignals(True)
+                self.fecha_inicio.setDate(inicio)
+                self.fecha_fin.setDate(fin)
+                self.fecha_inicio.blockSignals(False)
+                self.fecha_fin.blockSignals(False)
+        else:
+            self._fecha_filtro_configurado = False
+            self.fecha_inicio.blockSignals(True)
+            self.fecha_fin.blockSignals(True)
+            self.fecha_inicio.setDate(self.fecha_inicio.minimumDate())
+            self.fecha_fin.setDate(self.fecha_fin.minimumDate())
+            self.fecha_inicio.blockSignals(False)
+            self.fecha_fin.blockSignals(False)
         if refresh:
             self._refresh()
 
@@ -217,8 +243,6 @@ class SeleccionarDteDialog(QDialog):
                     "fecha_fin": self.fecha_fin.date().toString("yyyy-MM-dd"),
                 }
             )
-        else:
-            filtros.update({"fecha_inicio": None, "fecha_fin": None})
         try:
             self.candidates = anulacion.buscar_candidatos_reemplazo(self.db, filtros)
         except Exception:

--- a/tests/test_evento_anulacion.py
+++ b/tests/test_evento_anulacion.py
@@ -1,12 +1,14 @@
 import json
 import os
 import uuid
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
 from PyQt5.QtWidgets import QDialog, QWidget
 
 from dialogs.anular_factura_dialog import AnularFacturaDialog
+from dialogs.seleccionar_dte_dialog import SeleccionarDteDialog
 from utils.catalogos import TRIBUTO_IVA
 from tests.conftest import make_jws
 import facturacion_tab
@@ -163,6 +165,70 @@ def test_generar_evento_anulacion(qt_app, monkeypatch):
     assert evento["documento"]["telefono"] == "50377778888"
     assert evento["documento"]["correo"] == "cliente@example.com"
     assert evento["motivo"]["tipoAnulacion"] == 2
+
+
+@pytest.mark.usefixtures("qt_app")
+def test_seleccionar_dte_fecha_filter_respects_checkbox(
+    db_conn, tmp_path, dte_metadata_factory
+):
+    factura = dte_metadata_factory()
+    codigo = str(uuid.uuid4()).upper()
+    numero = "DTE-01-S001P001-000000000000601"
+    factura["identificacion"]["codigoGeneracion"] = codigo
+    factura["identificacion"]["numeroControl"] = numero
+    json_path = tmp_path / "dte_antiguo.json"
+    json_path.write_text(json.dumps(factura), encoding="utf-8")
+
+    extra = {
+        "codigoGeneracion": codigo,
+        "numeroControl": numero,
+        "dteJsonPath": str(json_path),
+        "selloRecibido": "S" * 40,
+    }
+    venta_id = db_conn.add_venta("2024-01-01", 10, extra=extra)
+    db_conn.registrar_envio_dte(
+        venta_id,
+        "manual",
+        "Aceptado",
+        "S" * 40,
+        respuesta_json=json.dumps({"documento": factura}),
+        codigo_generacion=codigo,
+        numero_control=numero,
+    )
+    row_id = db_conn.cursor.lastrowid
+    antiguo = datetime.now() - timedelta(days=90)
+    db_conn.ensure_column("dte_envios", "ambiente", "TEXT")
+    db_conn.cursor.execute(
+        "UPDATE dte_envios SET fecha_hora=?, ambiente=? WHERE id=?",
+        (
+            antiguo.isoformat(),
+            factura["identificacion"].get("ambiente"),
+            row_id,
+        ),
+    )
+    db_conn.conn.commit()
+
+    dialog = SeleccionarDteDialog(
+        db_conn,
+        tipo_dte=factura["identificacion"].get("tipoDte"),
+        ambiente=factura["identificacion"].get("ambiente"),
+        receptor_documentos=[factura["receptor"].get("numDocumento")],
+    )
+
+    assert not dialog.filtrar_fecha_cb.isChecked()
+    assert dialog.fecha_inicio.date() == dialog.fecha_inicio.minimumDate()
+    assert dialog.fecha_fin.date() == dialog.fecha_fin.minimumDate()
+
+    codigos_sin_filtro = {c["codigo_generacion"] for c in dialog.candidates}
+    assert codigo in codigos_sin_filtro
+
+    dialog.filtrar_fecha_cb.setChecked(True)
+
+    assert dialog.fecha_inicio.date() <= dialog.fecha_fin.date()
+    codigos_con_filtro = {c["codigo_generacion"] for c in dialog.candidates}
+    assert codigo not in codigos_con_filtro
+
+    dialog.deleteLater()
 
 
 def test_invalidacion_tipo3_requiere_codigo(monkeypatch, db_conn, tmp_path):


### PR DESCRIPTION
## Summary
- default the DTE selection dialog date filter to off and leave date fields empty until the user enables it
- update refresh logic so date constraints are only passed when the checkbox is active and reset when disabled
- add a regression test that verifies old DTEs appear with the date filter off and are hidden once the filter is enabled

## Testing
- pytest tests/test_evento_anulacion.py


------
https://chatgpt.com/codex/tasks/task_e_68d0b0ac86b48323b745c84dbfef1a6d