### PR TITLE
Ajustar filtros por defecto en selector de DTE

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -375,13 +375,13 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
     if tipo_objetivo is not None:
         tipo_objetivo = str(tipo_objetivo).zfill(2)
     receptor_docs_raw = filtros.get("receptor_documentos") or []
-    receptor_docs = {
-        _normalize_documento_id(val)
-        for val in receptor_docs_raw
-        if _normalize_documento_id(val)
-    }
+    receptor_docs: set[str] = set()
+    for val in receptor_docs_raw:
+        norm = _normalize_documento_id(val)
+        if norm:
+            receptor_docs.add(norm)
     recepcionado_only = bool(filtros.get("recepcionado"))
-    mismo_receptor = bool(filtros.get("mismo_receptor", True))
+    mismo_receptor = bool(filtros.get("mismo_receptor"))
     search = str(filtros.get("search") or "").strip().upper()
     limit = filtros.get("limit")
     if isinstance(limit, int) and limit <= 0:
@@ -389,7 +389,6 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
 
     results: list[dict] = []
     for row in rows:
-        codigo = str(row.get("codigo_generacion") or "").strip().upper()
         venta_id = row.get("venta_id")
         metadata: dict | None = None
 
@@ -404,12 +403,9 @@ def buscar_candidatos_reemplazo(db: DB | None, filtros: dict | None = None) -> l
 
         metadata = _get_metadata()
 
+        codigo = str(row.get("codigo_generacion") or "").strip().upper()
         if not codigo:
-            codigo_metadata = str(
-                (metadata.get("codigo_generacion") or "")
-            ).strip().upper()
-            if codigo_metadata:
-                codigo = codigo_metadata
+            codigo = str((metadata.get("codigo_generacion") or "")).strip().upper()
 
         if not codigo or (exclude_uuid and codigo == exclude_uuid):
             continue

--- a/dialogs/seleccionar_dte_dialog.py
+++ b/dialogs/seleccionar_dte_dialog.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Iterable, List
+from typing import Iterable
 
 from PyQt5.QtCore import QDate, QTimer, Qt
 from PyQt5.QtWidgets import (
@@ -55,7 +55,12 @@ class SeleccionarDteDialog(QDialog):
         self.tipo_dte = str(tipo_dte).zfill(2) if tipo_dte else None
         self.ambiente = anulacion.normalize_ambiente(ambiente)
         docs = receptor_documentos or []
-        self.receptor_documentos: List[str] = [str(doc) for doc in docs if doc]
+        normalizados: list[str] = []
+        for raw in docs:
+            norm = anulacion._normalize_documento_id(raw)
+            if norm and norm not in normalizados:
+                normalizados.append(norm)
+        self.receptor_documentos = normalizados
         self.exclude_uuid = (exclude_uuid or "").strip().upper()
         self.candidates: list[dict] = []
         self.selected_uuid: str | None = None
@@ -96,8 +101,16 @@ class SeleccionarDteDialog(QDialog):
 
         self.mismo_receptor_cb = QCheckBox("Mismo receptor")
         tiene_docs = bool(self.receptor_documentos)
-        self.mismo_receptor_cb.setChecked(tiene_docs)
+        self.mismo_receptor_cb.setChecked(False)
         self.mismo_receptor_cb.setEnabled(tiene_docs)
+        if tiene_docs:
+            self.mismo_receptor_cb.setToolTip(
+                "Restringe los resultados al receptor del documento original."
+            )
+        else:
+            self.mismo_receptor_cb.setToolTip(
+                "No hay identificadores de receptor para filtrar."
+            )
         filters_layout.addWidget(self.mismo_receptor_cb)
 
         self.filtrar_fecha_cb = QCheckBox("Filtrar por fecha")

--- a/tests/test_buscar_candidatos_reemplazo.py
+++ b/tests/test_buscar_candidatos_reemplazo.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 import uuid
 
 import pytest
@@ -278,3 +279,131 @@ def test_buscar_candidatos_reemplazo_incluye_codigo_vacio(
 
     codigos = {item["codigo_generacion"] for item in resultados}
     assert codigo_generacion in codigos
+
+
+@pytest.mark.usefixtures("qt_app")
+def test_buscar_candidatos_reemplazo_sin_filtros_muestra_todos(
+    db_conn, tmp_path, dte_metadata_factory
+):
+    ahora = datetime(2024, 4, 30, 9, 30)
+    fechas = [
+        ahora.isoformat(),
+        (ahora - timedelta(days=20)).isoformat(),
+        (ahora - timedelta(days=120)).isoformat(),
+    ]
+
+    codigos = []
+    for idx, fecha in enumerate(fechas, start=1):
+        factura = _crear_factura(
+            dte_metadata_factory,
+            codigo=str(uuid.uuid4()).upper(),
+            numero=f"DTE-01-S001P001-0000000000009{idx}",
+        )
+        if idx == 3:
+            factura["receptor"].pop("numDocumento", None)
+        json_path = tmp_path / f"cand_{idx}.json"
+        json_path.write_text(json.dumps(factura), encoding="utf-8")
+        extra = {
+            "codigoGeneracion": factura["identificacion"]["codigoGeneracion"],
+            "numeroControl": factura["identificacion"]["numeroControl"],
+            "dteJsonPath": str(json_path),
+            "selloRecibido": "S" * 40,
+        }
+        venta = db_conn.add_venta(fecha[:10], 10 + idx, extra=extra)
+        db_conn.registrar_envio_dte(
+            venta,
+            "manual",
+            "Aceptada",
+            "S" * 40,
+            respuesta_json=json.dumps({"documento": factura}),
+            codigo_generacion=factura["identificacion"]["codigoGeneracion"],
+            numero_control=factura["identificacion"]["numeroControl"],
+        )
+        row_id = db_conn.cursor.lastrowid
+        db_conn.ensure_column("dte_envios", "ambiente", "TEXT")
+        db_conn.cursor.execute(
+            "UPDATE dte_envios SET ambiente=?, fecha_hora=? WHERE id=?",
+            (factura["identificacion"]["ambiente"], fecha, row_id),
+        )
+        codigos.append(factura["identificacion"]["codigoGeneracion"])
+
+    db_conn.conn.commit()
+
+    filtros_base = {
+        "tipo_dte": "01",
+        "ambiente": "00",
+        "exclude_uuid": "",
+        "mismo_receptor": False,
+        "receptor_documentos": ["0614-140410-0016"],
+    }
+
+    todos = anulacion.buscar_candidatos_reemplazo(db_conn, filtros_base)
+    assert {item["codigo_generacion"] for item in todos} == set(codigos)
+
+    filtros_fecha = dict(filtros_base)
+    filtros_fecha.update({"fecha_inicio": "2024-02-01", "fecha_fin": "2024-04-30"})
+    recientes = anulacion.buscar_candidatos_reemplazo(db_conn, filtros_fecha)
+    assert {item["codigo_generacion"] for item in recientes} == set(codigos[:2])
+
+    sin_fecha = dict(filtros_fecha)
+    sin_fecha.pop("fecha_inicio")
+    sin_fecha.pop("fecha_fin")
+    reinicio = anulacion.buscar_candidatos_reemplazo(db_conn, sin_fecha)
+    assert {item["codigo_generacion"] for item in reinicio} == set(codigos)
+
+
+@pytest.mark.usefixtures("qt_app")
+def test_buscar_candidatos_reemplazo_mismo_receptor_normaliza_documentos(
+    db_conn, tmp_path, dte_metadata_factory
+):
+    factura_match = _crear_factura(
+        dte_metadata_factory,
+        codigo=str(uuid.uuid4()).upper(),
+        numero="DTE-01-S001P001-00000000000111",
+    )
+    factura_otro = _crear_factura(
+        dte_metadata_factory,
+        codigo=str(uuid.uuid4()).upper(),
+        numero="DTE-01-S001P001-00000000000222",
+    )
+    factura_otro["receptor"]["numDocumento"] = "06141404100099"
+
+    for idx, factura in enumerate((factura_match, factura_otro), start=1):
+        json_path = tmp_path / f"cand_norm_{idx}.json"
+        json_path.write_text(json.dumps(factura), encoding="utf-8")
+        extra = {
+            "codigoGeneracion": factura["identificacion"]["codigoGeneracion"],
+            "numeroControl": factura["identificacion"]["numeroControl"],
+            "dteJsonPath": str(json_path),
+            "selloRecibido": "R" * 40,
+        }
+        venta = db_conn.add_venta("2024-03-01", 20 + idx, extra=extra)
+        db_conn.registrar_envio_dte(
+            venta,
+            "manual",
+            "Aceptada",
+            "R" * 40,
+            respuesta_json=json.dumps({"documento": factura}),
+            codigo_generacion=factura["identificacion"]["codigoGeneracion"],
+            numero_control=factura["identificacion"]["numeroControl"],
+        )
+        row_id = db_conn.cursor.lastrowid
+        db_conn.ensure_column("dte_envios", "ambiente", "TEXT")
+        db_conn.cursor.execute(
+            "UPDATE dte_envios SET ambiente=?, fecha_hora=? WHERE id=?",
+            (factura["identificacion"]["ambiente"], "2024-03-01T08:00:00", row_id),
+        )
+
+    db_conn.conn.commit()
+
+    filtros = {
+        "tipo_dte": "01",
+        "ambiente": "00",
+        "mismo_receptor": True,
+        "receptor_documentos": ["0614-140410-0016"],
+    }
+
+    resultados = anulacion.buscar_candidatos_reemplazo(db_conn, filtros)
+    codigos = {item["codigo_generacion"] for item in resultados}
+    assert factura_match["identificacion"]["codigoGeneracion"] in codigos
+    assert factura_otro["identificacion"]["codigoGeneracion"] not in codigos


### PR DESCRIPTION
## Resumen
- normalizar la lista de documentos del receptor en `SeleccionarDteDialog` y dejar el filtro "Mismo receptor" desactivado al abrir el diálogo
- actualizar `buscar_candidatos_reemplazo` para que el filtro de receptor sea opcional por defecto y para reconstruir el código de generación antes de descartar registros
- cubrir los escenarios de filtros por fecha y normalización de receptor con nuevas pruebas en `test_buscar_candidatos_reemplazo`

## Pruebas
- `pytest tests/test_buscar_candidatos_reemplazo.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0b2b10d4c8323bd5e689b9da8f3e7