### PR TITLE
Fix unchecked flag formatting in tasks section

### DIFF
--- a/build/VertexDTE.iss
+++ b/build/VertexDTE.iss
@@ -19,7 +19,7 @@ Name: "{group}\\Vertex DTE"; Filename: "{app}\\VertexDTE.exe"
 Name: "{commondesktop}\\Vertex DTE"; Filename: "{app}\\VertexDTE.exe"; Tasks: desktopicon
 
 [Tasks]
-Name: "desktopicon"; Description: "Crear acceso directo en el escritorio"; GroupDescription: "Accesos directos:"; Flags: unchecked
+Name: "desktopicon"; Description: "Crear acceso directo en el escritorio"; Flags: unchecked; GroupDescription: "Accesos directos:"
 
 [Run]
 Filename: "{app}\\VertexDTE.exe"; Description: "Ejecutar Vertex DTE"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- keep the desktop icon task definition on a single line and ensure the Flags entry uses the unchecked value directly.

## Testing
- not run (Inno Setup compiler is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1679719bc8323a5a1ed0154f05a90