### PR TITLE
Fix tasks entry formatting in VertexDTE installer script

### DIFF
--- a/build/VertexDTE.iss
+++ b/build/VertexDTE.iss
@@ -19,7 +19,7 @@ Name: "{group}\\Vertex DTE"; Filename: "{app}\\VertexDTE.exe"
 Name: "{commondesktop}\\Vertex DTE"; Filename: "{app}\\VertexDTE.exe"; Tasks: desktopicon
 
 [Tasks]
-Name: "desktopicon"; Description: "Crear acceso directo en el escritorio"; Flags: unchecked; GroupDescription: "Accesos directos:"
+Name: "desktopicon"; Description: "Crear acceso directo en el escritorio"; GroupDescription: "Accesos directos:"; Flags: unchecked
 
 [Run]
 Filename: "{app}\\VertexDTE.exe"; Description: "Ejecutar Vertex DTE"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- ensure the desktop icon task definition sits on a single line in the installer script

## Testing
- ISCC.exe "/DAppVersion=1.0.0" "/DOutputDir=dist" build/VertexDTE.iss *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d17932aca4832398f96b498bec0a15