### PR TITLE
Automate Windows release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,12 @@ build/*
 !build/VertexDTE.spec
 !build/VertexDTE.iss
 !build/build.ps1
+!build/release_interactivo.ps1
 dist/
 *.spec
 !build/VertexDTE.spec
 assets/app.ico
+extras/firmador/
 
 # Logs y DB locales
 *.log

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,85 +1,62 @@
 # Compilación y empaquetado de Vertex DTE
 
-Este documento describe cómo construir el ejecutable de Vertex DTE con PyInstaller
-(
-modo *onedir*) y cómo generar el instalador de Windows con Inno Setup. Los pasos
-fueron probados en Windows 11 con PowerShell.
+Este documento explica cómo generar, con un único comando, tanto el directorio
+"onedir" de PyInstaller como el instalador de Windows usando Inno Setup.
 
 ## Requisitos previos
 
 * Windows 10 u 11.
 * [Python 3.11](https://www.python.org/downloads/windows/) instalado y agregado al `PATH`.
-* [Inno Setup 6](https://jrsoftware.org/isinfo.php) (para generar el instalador).
+* [Inno Setup 6](https://jrsoftware.org/isinfo.php) disponible en el `PATH` (opcional, sólo si se desea generar el instalador).
 * Permisos para ejecutar scripts de PowerShell (`Set-ExecutionPolicy -Scope Process RemoteSigned`).
 
-## Construir el ejecutable con PyInstaller
+## Flujo interactivo
 
-1. Clona el repositorio y abre una sesión de PowerShell en la raíz del proyecto.
-2. Ejecuta el script de build:
+1. Abre PowerShell en la raíz del repositorio.
+2. Ejecuta el script todo-en-uno:
 
    ```powershell
-   ./build/build.ps1
+   powershell -ExecutionPolicy Bypass -File .\build\release_interactivo.ps1
    ```
 
-   El script crea un entorno virtual, instala las dependencias y ejecuta
-   PyInstaller con la especificación `build/VertexDTE.spec`. Al finalizar se
-   valida que `dist/VertexDTE/VertexDTE.exe` se inicie correctamente.
+3. Selecciona la carpeta de salida, el archivo del firmador y confirma (o ajusta)
+   la versión que se utilizará en los artefactos.
 
-   El icono de la aplicación se reconstruye automáticamente desde un blob
-   codificado en Base64 dentro de la especificación, evitando versionar
-   binarios.
+El proceso crea:
 
-3. El ejecutable se encuentra en `dist/VertexDTE/`. Copia el directorio completo
-   para distribuirlo manualmente o continuar con el instalador.
+* `dist/VertexDTE/`: carpeta lista para ejecutar `VertexDTE.exe` en modo *onedir*.
+* `<OutputDir>\VertexDTE-<versión>-win64.zip`: copia comprimida de la carpeta anterior.
+* `<OutputDir>\VertexDTE-Setup-<versión>.exe`: instalador generado con Inno Setup (si `ISCC.exe` está disponible).
 
-> **Nota:** PyInstaller se ejecuta en modo *onedir* para reducir falsos positivos
-de antivirus y permitir inspeccionar fácilmente los archivos generados.
+El firmador seleccionado se copia dentro del paquete en `extras\firmador\` y el
+instalador genera `%APPDATA%\VertexDTE\settings.json` con la ruta instalada del
+firmador (`{app}\extras\firmador\...`).
 
-## Generar el instalador con Inno Setup
+## Flujo no interactivo
 
-1. Asegúrate de haber ejecutado previamente PyInstaller; `dist/VertexDTE/` debe
-   contener los binarios actualizados.
-2. Abre "Inno Setup Compiler" y carga `build/VertexDTE.iss`.
-3. Compila el script (`F9`). El archivo resultante `VertexDTE-Setup.exe` se
-   guarda en el directorio `build/Output/` por defecto.
-
-La versión utilizada por Inno Setup se lee automáticamente desde el archivo
-`VERSION` del proyecto, por lo que no es necesario editar el script manualmente.
-
-### Compilación silenciosa
-
-Si prefieres una compilación automatizada, puedes ejecutar en PowerShell (desde
-la raíz del repositorio):
+Para automatizar el proceso (por ejemplo en CI) ejecuta:
 
 ```powershell
-& "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /Qp build/VertexDTE.iss
+powershell -ExecutionPolicy Bypass -File .\build\release_interactivo.ps1 `
+  -NoUI -OutputDir "D:\Releases" -Signer "D:\Firmador\FirmadorMH.exe" -Version 1.4.2
 ```
 
-Ajusta la ruta de `ISCC.exe` si instalaste Inno Setup en otra ubicación.
+Los parámetros `-OutputDir` y `-Signer` son obligatorios cuando se usa `-NoUI`.
+Si omites `-Version`, se tomará el valor del archivo `VERSION` (o `1.0.0` por
+omisión).
 
-## Pruebas manuales recomendadas (VM "limpia")
+## Dónde quedan los datos de la aplicación
 
-1. Ejecuta `VertexDTE-Setup.exe` e instala en la ubicación predeterminada.
-2. Abre la aplicación desde el menú Inicio y confirma que la interfaz carga los
-   recursos (iconos, plantillas, estilos).
-3. Genera un PDF de prueba desde la pestaña correspondiente.
-4. Envía un DTE en ambiente de pruebas (puedes simular o reutilizar un token).
-5. Verifica que los archivos de configuración y los registros se creen en
-   `%APPDATA%\VertexDTE`.
-6. Comprueba que el selector de DTE lista resultados (si la base de datos está
-   disponible en esa máquina).
-7. Valida la previsualización o impresión utilizando QtPrintSupport.
+Vertex DTE guarda su configuración, registros y documentos generados en
+`%APPDATA%\VertexDTE\`. Durante la instalación se crea (o actualiza)
+`settings.json` apuntando al firmador instalado en `{app}\extras\firmador\`.
 
-## Integración continua
+## Pruebas manuales recomendadas
 
-El repositorio incluye el flujo de trabajo `.github/workflows/windows-build.yml`
-que ejecuta PyInstaller en `windows-latest`, sube el artefacto resultante y puede
-servir como base para acciones de publicación.
-
-## Consideraciones de seguridad
-
-* Windows SmartScreen y algunos antivirus pueden marcar binarios nuevos como
-  desconocidos. Distribuir el directorio completo (*onedir*) facilita la
-  inspección y reduce falsos positivos.
-* Usa certificados de firma de código si cuentas con ellos para reducir alertas
-  durante la instalación.
+1. Ejecuta `VertexDTE-Setup-<versión>.exe` e instala en la ubicación predeterminada.
+2. Comprueba que la aplicación se inicia desde el menú Inicio y que los recursos
+   (iconos, plantillas, estilos) se cargan correctamente.
+3. Genera un PDF de prueba y verifica que se guarda en la carpeta de usuario
+   (`%APPDATA%\VertexDTE`).
+4. Comprueba que el firmador quedó instalado en
+   `C:\Program Files\Vertex DTE\extras\firmador\`.

--- a/build/VertexDTE.iss
+++ b/build/VertexDTE.iss
@@ -1,25 +1,77 @@
 #define VersionFile "..\\VERSION"
-#define AppVersion Trim(StringChange(GetIniString(VersionFile, "VertexDTE", "version", "1.0.0"), "\n", ""))
+#define DefaultAppVersion Trim(StringChange(GetIniString(VersionFile, "VertexDTE", "version", "1.0.0"), "\n", ""))
+#define AppVersion GetStringParam("AppVersion", DefaultAppVersion)
+#define OutputDirParam GetStringParam("OutputDir", "build\\Output")
 
 [Setup]
 AppName=Vertex DTE
 AppVersion={#AppVersion}
 DefaultDirName={pf}\\Vertex DTE
 DefaultGroupName=Vertex DTE
-OutputBaseFilename=VertexDTE-Setup
+OutputDir={#OutputDirParam}
+OutputBaseFilename=VertexDTE-Setup-{#AppVersion}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 
 [Files]
-Source: "dist\\VertexDTE\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "dist\\VertexDTE\\*"; DestDir: "{app}"; Flags: recursesubdirs
 
 [Icons]
 Name: "{group}\\Vertex DTE"; Filename: "{app}\\VertexDTE.exe"
 Name: "{commondesktop}\\Vertex DTE"; Filename: "{app}\\VertexDTE.exe"; Tasks: desktopicon
 
 [Tasks]
-Name: "desktopicon"; Description: "Crear acceso directo en el escritorio"; Flags: unchecked; GroupDescription: "Accesos directos:"
+Name: "desktopicon"; Description: "Crear acceso directo en el escritorio"; GroupDescription: "Accesos directos"; Flags: unchecked
 
 [Run]
 Filename: "{app}\\VertexDTE.exe"; Description: "Ejecutar Vertex DTE"; Flags: nowait postinstall skipifsilent
+
+[Code]
+function GetSignerPath(): string;
+var
+  SignerDir: string;
+  FindRec: TFindRec;
+begin
+  SignerDir := ExpandConstant('{app}\extras\firmador');
+  Result := '';
+  if FindFirst(SignerDir + '\*', FindRec) then
+  begin
+    try
+      repeat
+        if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY) = 0 then
+        begin
+          Result := SignerDir + '\' + FindRec.Name;
+          Break;
+        end;
+      until not FindNext(FindRec);
+    finally
+      FindClose(FindRec);
+    end;
+  end;
+
+  if Result = '' then
+    Result := SignerDir;
+end;
+
+procedure CreateDefaultSettings();
+var
+  AppDataDir: string;
+  JsonPath: string;
+  SignerEntry: string;
+begin
+  AppDataDir := ExpandConstant('{userappdata}\VertexDTE');
+  if not DirExists(AppDataDir) then
+    ForceDirectories(AppDataDir);
+
+  SignerEntry := GetSignerPath();
+  SignerEntry := StringChange(SignerEntry, '\', '\\');
+  JsonPath := AppDataDir + '\settings.json';
+  SaveStringToFile(JsonPath, Format('{"firmador_path": "%s"}', [SignerEntry]), False);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+    CreateDefaultSettings();
+end;

--- a/build/VertexDTE.spec
+++ b/build/VertexDTE.spec
@@ -26,18 +26,24 @@ datas += [(certifi.where(), 'certifi')]
 resource_folders = [
     'assets',
     'templates',
-    'facturas_consumidor_final',
-    'facturas_credito_fiscal',
-    'notas_credito',
-    'notas_debito',
-    'notas_remision',
     'dtes',
     'dte_fallidos',
     'dtes_pendientes',
-    'tickets',
-    'svfe-json-schemas',
+    'extras/firmador',
     'schema_patches',
+    'svfe-json-schemas',
+    'tickets',
 ]
+
+resource_patterns = [
+    'facturas_*',
+    'notas_*',
+]
+
+for pattern in resource_patterns:
+    for match in Path('.').glob(pattern):
+        if match.is_dir():
+            resource_folders.append(str(match))
 
 for folder in resource_folders:
     if os.path.isdir(folder):

--- a/build/release_interactivo.ps1
+++ b/build/release_interactivo.ps1
@@ -1,0 +1,174 @@
+param(
+    [string]$OutputDir,
+    [string]$Signer,
+    [string]$Version,
+    [switch]$NoUI
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+Set-Location $repoRoot
+
+function Get-DefaultVersion {
+    param([string]$Current)
+
+    if ($Current -and $Current.Trim().Length -gt 0) {
+        return $Current.Trim()
+    }
+
+    $versionFile = Join-Path $repoRoot 'VERSION'
+    if (Test-Path $versionFile) {
+        foreach ($line in Get-Content -Path $versionFile -ErrorAction SilentlyContinue) {
+            $trimmed = $line.Trim()
+            if ($trimmed -like 'version=*') {
+                return $trimmed.Split('=')[-1].Trim()
+            }
+        }
+    }
+
+    return '1.0.0'
+}
+
+if (-not $NoUI) {
+    Add-Type -AssemblyName System.Windows.Forms
+
+    $folderDialog = New-Object System.Windows.Forms.FolderBrowserDialog
+    $folderDialog.Description = 'Selecciona la carpeta donde se guardarán los artefactos.'
+    if ($OutputDir) {
+        try {
+            $folderDialog.SelectedPath = (Resolve-Path $OutputDir -ErrorAction Stop).Path
+        } catch {
+            $folderDialog.SelectedPath = [Environment]::GetFolderPath('Desktop')
+        }
+    }
+
+    if ($folderDialog.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) {
+        throw 'Operación cancelada: no se seleccionó carpeta de salida.'
+    }
+    $OutputDir = $folderDialog.SelectedPath
+
+    $fileDialog = New-Object System.Windows.Forms.OpenFileDialog
+    $fileDialog.Title = 'Selecciona el archivo del firmador'
+    $fileDialog.Filter = 'Todos los archivos (*.*)|*.*'
+    if ($Signer) {
+        try {
+            $fileDialog.InitialDirectory = (Split-Path (Resolve-Path $Signer -ErrorAction Stop).Path -Parent)
+        } catch {
+            $fileDialog.InitialDirectory = $repoRoot
+        }
+    }
+
+    if ($fileDialog.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) {
+        throw 'Operación cancelada: no se seleccionó el firmador.'
+    }
+    $Signer = $fileDialog.FileName
+
+    $defaultVersion = Get-DefaultVersion -Current $null
+    if (-not $Version) {
+        Add-Type -AssemblyName Microsoft.VisualBasic
+        $inputVersion = [Microsoft.VisualBasic.Interaction]::InputBox('Versión a publicar:', 'Vertex DTE', $defaultVersion)
+        if ([string]::IsNullOrWhiteSpace($inputVersion)) {
+            $Version = $defaultVersion
+        } else {
+            $Version = $inputVersion.Trim()
+        }
+    } else {
+        $Version = $Version.Trim()
+    }
+} else {
+    if (-not $OutputDir) {
+        throw 'Debe especificar -OutputDir cuando usa -NoUI.'
+    }
+    if (-not $Signer) {
+        throw 'Debe especificar -Signer cuando usa -NoUI.'
+    }
+    $Version = Get-DefaultVersion -Current $Version
+}
+
+$OutputDir = (Resolve-Path -LiteralPath (New-Item -ItemType Directory -Path $OutputDir -Force).FullName).Path
+$Signer = (Resolve-Path -LiteralPath $Signer).Path
+
+Write-Host "Versión objetivo: $Version"
+Write-Host "Directorio de salida: $OutputDir"
+Write-Host "Firmador seleccionado: $Signer"
+
+$pythonCmd = Get-Command python -ErrorAction Stop
+$venvPath = Join-Path $repoRoot '.venv-release'
+
+if (-not (Test-Path $venvPath)) {
+    Write-Host 'Creando entorno virtual...'
+    & $pythonCmd.Path -m venv $venvPath
+}
+
+$pythonExe = Join-Path $venvPath 'Scripts/python.exe'
+if (-not (Test-Path $pythonExe)) {
+    throw "No se encontró el intérprete de Python en el entorno virtual ($pythonExe)."
+}
+
+Write-Host 'Actualizando pip y dependencias...'
+& $pythonExe -m pip install --upgrade pip | Out-String | Write-Verbose
+& $pythonExe -m pip install -r (Join-Path $repoRoot 'requirements.txt') | Out-String | Write-Verbose
+& $pythonExe -m pip install pyinstaller appdirs certifi | Out-String | Write-Verbose
+
+$extrasRoot = Join-Path $repoRoot 'extras'
+$extrasDir = Join-Path $extrasRoot 'firmador'
+if (Test-Path $extrasDir) {
+    Write-Host 'Limpiando firmador previo...'
+    Get-ChildItem -Path $extrasDir -Recurse -Force | Remove-Item -Force -Recurse
+} else {
+    New-Item -ItemType Directory -Path $extrasDir -Force | Out-Null
+}
+
+Copy-Item -LiteralPath $Signer -Destination $extrasDir -Force
+$signerFileName = Split-Path $Signer -Leaf
+
+Write-Host 'Ejecutando PyInstaller...'
+& $pythonExe -m PyInstaller (Join-Path $repoRoot 'build/VertexDTE.spec')
+
+$distDir = Join-Path $repoRoot 'dist/VertexDTE'
+if (-not (Test-Path $distDir)) {
+    throw "No se encontró la carpeta generada por PyInstaller ($distDir)."
+}
+
+$zipName = "VertexDTE-$Version-win64.zip"
+$zipPath = Join-Path $OutputDir $zipName
+if (Test-Path $zipPath) {
+    Remove-Item -LiteralPath $zipPath -Force
+}
+
+Write-Host 'Comprimiendo distribución onedir...'
+$distParent = Split-Path $distDir -Parent
+$distFolder = Split-Path $distDir -Leaf
+Push-Location $distParent
+try {
+    Compress-Archive -Path $distFolder -DestinationPath $zipPath
+} finally {
+    Pop-Location
+}
+
+$installerPath = $null
+$innosetup = Get-Command 'ISCC.exe' -ErrorAction SilentlyContinue
+if ($innosetup) {
+    Write-Host 'Compilando instalador con Inno Setup...'
+    $issFile = Join-Path $repoRoot 'build/VertexDTE.iss'
+    & $innosetup.Path "/DAppVersion=$Version" "/DOutputDir=$OutputDir" $issFile
+    $expectedInstaller = Join-Path $OutputDir "VertexDTE-Setup-$Version.exe"
+    if (Test-Path $expectedInstaller) {
+        $installerPath = $expectedInstaller
+    } else {
+        Write-Warning "Inno Setup terminó sin generar $expectedInstaller. Revisa la salida para más detalles."
+    }
+} else {
+    Write-Warning 'No se encontró ISCC.exe en el PATH. Se omitió la generación del instalador.'
+}
+
+Write-Host ''
+Write-Host 'Artefactos generados:'
+Write-Host "  Ejecutable onedir: $distDir"
+Write-Host "  Paquete ZIP:      $zipPath"
+if ($installerPath) {
+    Write-Host "  Instalador:       $installerPath"
+}
+Write-Host ''
+Write-Host "Firmador empaquetado en: dist/VertexDTE/extras/firmador/$signerFileName"


### PR DESCRIPTION
## Summary
- add a PowerShell release script with interactive and headless modes to drive PyInstaller, zip creation and optional Inno Setup builds
- bundle the signer and resource directories in the PyInstaller spec while documenting the new workflow
- parameterize the Inno Setup script to accept version/output overrides and create the signer path setting during installation
- keep signer binaries out of version control via .gitignore updates

## Testing
- not run (Windows-only build tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d175853cac832385a3824616b5626c