### PR TITLE
Fix PowerShell throw message quoting

### DIFF
--- a/build/release_interactivo.ps1
+++ b/build/release_interactivo.ps1
@@ -165,11 +165,11 @@ try {
 
     $distDir = Join-Path $repoRoot 'dist/VertexDTE'
     if (-not (Test-Path $distDir)) {
-        throw "No se encontró la carpeta generada por PyInstaller (`"$distDir"`)."
+        throw "No se encontró la carpeta generada por PyInstaller (`"$distDir`")."
     }
 
     if (-not (Test-Path $bundleSignerPath)) {
-        throw "El bundle no contiene la carpeta del firmador esperada (`"$bundleSignerPath"`)."
+        throw "El bundle no contiene la carpeta del firmador esperada (`"$bundleSignerPath`")."
     }
 
     $bundledFiles = Get-ChildItem -Path $bundleSignerPath -Recurse -File -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- fix the escaped double quote placement in the PyInstaller bundle validation errors inside build/release_interactivo.ps1

## Testing
- not run (PowerShell is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d18acd5a508323a60e6a542f51011c