### PR TITLE
Ajusta rutas de PyInstaller para VertexDTE

### DIFF
--- a/build/VertexDTE.spec
+++ b/build/VertexDTE.spec
@@ -53,9 +53,12 @@ for file_name in [
 
 block_cipher = None
 
+repo_root = Path(__file__).resolve().parent.parent
+main_script = repo_root / "main.py"
+
 a = Analysis(
-    ['main.py'],
-    pathex=[],
+    [str(main_script)],
+    pathex=[str(repo_root)],
     binaries=[],
     datas=datas,
     hiddenimports=hidden,


### PR DESCRIPTION
## Summary
- calcula la ruta raíz del repositorio y el script principal antes de invocar PyInstaller
- actualiza la especificación para apuntar al `main.py` absoluto y añadir el directorio raíz al `pathex`

## Testing
- `pwsh -File build/release_interactivo.ps1` *(falla: comando no encontrado en el entorno de CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b68f78148323b88dbd05032cf4d2