### PR TITLE
Fix spec path resolution in VertexDTE build

### DIFF
--- a/build/VertexDTE.spec
+++ b/build/VertexDTE.spec
@@ -2,6 +2,7 @@
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 import os
+import sys
 from pathlib import Path
 
 icon_path = 'assets/app.ico'
@@ -53,7 +54,8 @@ for file_name in [
 
 block_cipher = None
 
-repo_root = Path(__file__).resolve().parent.parent
+spec_path = Path(locals().get('__file__', sys.argv[0])).resolve()
+repo_root = spec_path.parent.parent
 main_script = repo_root / "main.py"
 
 a = Analysis(


### PR DESCRIPTION
## Summary
- ensure the VertexDTE spec calculates its location using a tolerant expression
- derive the repository root and main script path from the resolved spec path
- keep the Analysis script list and pathex pointing at main.py and the repo root

## Testing
- powershell -File build/release_interactivo.ps1 *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b8aa4dc08323980f867dc7f2f4ed