### PR TITLE
Adjust PyInstaller resource handling for VertexDTE

### DIFF
--- a/build/VertexDTE.spec
+++ b/build/VertexDTE.spec
@@ -1,5 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.building.datastruct import TOC, Tree
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 import os
 import sys
@@ -22,40 +23,51 @@ spec_path = Path(locals().get('__file__', sys.argv[0])).resolve()
 repo_root = spec_path.parent.parent
 
 resource_directories = [
-    'assets',
-    'templates',
-    'dtes',
-    'dte_fallidos',
-    'dtes_pendientes',
-    'schema_patches',
-    'svfe-json-schemas',
-    'tickets',
+    Path('assets'),
+    Path('templates'),
+    Path('dtes'),
+    Path('dte_fallidos'),
+    Path('dtes_pendientes'),
+    Path('schema_patches'),
+    Path('svfe-json-schemas'),
+    Path('tickets'),
 ]
 
 for pattern in ['facturas_*', 'notas_*']:
     for match in repo_root.glob(pattern):
         if match.is_dir():
-            resource_directories.append(str(match.relative_to(repo_root)))
+            resource_directories.append(match.relative_to(repo_root))
 
-firmador_dir = os.path.join('extras', 'firmador')
+firmador_dir = Path('extras') / 'firmador'
 resource_directories.append(firmador_dir)
 
-for directory in resource_directories:
-    source = repo_root / directory
-    if source.is_dir():
-        datas.append((str(source), directory))
+extra_datas = []
+existing_directories = []
 
-for file_name in [
+for directory in resource_directories:
+    source_path = repo_root / directory
+    if source_path.is_dir():
+        datas.append((str(source_path), str(directory)))
+        extra_datas.append(Tree(str(source_path), prefix=str(directory)))
+        existing_directories.append(str(directory))
+
+resource_files = [
     'style.qss',
     'logoinventario.jpg',
     'formato_factura.json',
     'datos_negocio.json',
     'config_negocio.json',
     'inventario.json',
-]:
-    source = repo_root / file_name
-    if source.is_file():
-        datas.append((str(source), '.'))
+]
+
+existing_files = []
+
+for file_name in resource_files:
+    source_path = repo_root / file_name
+    if source_path.is_file():
+        datas.append((str(source_path), '.'))
+        extra_datas.append(TOC([(file_name, str(source_path), 'DATA')]))
+        existing_files.append(file_name)
 
 block_cipher = None
 
@@ -75,6 +87,15 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
+
+def _should_keep_data(entry: tuple[str, str, str]) -> bool:
+    dest_name = entry[0]
+    for directory in existing_directories:
+        if dest_name == directory or dest_name.startswith(f"{directory}/"):
+            return False
+    return dest_name not in existing_files
+
+a.datas = TOC([entry for entry in a.datas if _should_keep_data(entry)])
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,
@@ -90,12 +111,14 @@ exe = EXE(
     runtime_tmpdir=None,
     console=False,
     icon=icon_path,
+    contents_directory='.',
 )
 coll = COLLECT(
     exe,
     a.binaries,
     a.zipfiles,
     a.datas,
+    *extra_datas,
     strip=False,
     upx=False,
     upx_exclude=[],


### PR DESCRIPTION
## Summary
- resolve data directories and files in VertexDTE.spec using pathlib paths relative to the repository root
- add Tree/TOC entries so that PyInstaller collects existing resource folders and files into the onedir bundle while keeping Analysis datas clean
- configure the executable to emit resources at the top level rather than under `_internal`

## Testing
- `pyinstaller --noconfirm build/VertexDTE.spec`


------
https://chatgpt.com/codex/tasks/task_e_68d1bd3ace288323b685956adc78a4b0