### PR TITLE
Fix PowerShell interpolation for retry message

### DIFF
--- a/build/release_interactivo.ps1
+++ b/build/release_interactivo.ps1
@@ -151,7 +151,7 @@ function Compress-DirectoryWithRetry {
                 [System.GC]::Collect(); [System.GC]::WaitForPendingFinalizers()
                 Start-Sleep -Milliseconds (250 * $i)
                 Compress-Archive -Path (Join-Path $tempDir '*') -DestinationPath $ZipPath -Force -ErrorAction Stop
-                Write-Host "ZIP creado en intento $i: $ZipPath"
+                Write-Host ("ZIP creado en intento {0}: {1}" -f $i, $ZipPath)
                 return $true
             } catch {
                 $hr = $_.Exception.HResult


### PR DESCRIPTION
## Summary
- update the retry logging in build/release_interactivo.ps1 to avoid parsing the colon as part of the variable name

## Testing
- attempted to run `[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'build/release_interactivo.ps1'), [ref]$null, [ref]$null)` but `powershell` is not available in the container

------
https://chatgpt.com/codex/tasks/task_e_68d1c51dc84c8323b33d3d344b069574