### PR TITLE
Ajustar totales de PDF para reflejar valores de DTE

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -9,6 +9,7 @@ from reportlab.lib.units import mm
 
 from utils.pdf_utils import draw_wrapped_text
 import utils.catalogos as catalogos
+from decimal import Decimal, InvalidOperation
 from urllib.parse import urlencode
 import json
 import os
@@ -459,61 +460,66 @@ def generar_factura_electronica_pdf(
     texto_y = bloque_totales_y + bloque_totales_h - 18
     salto = 18
 
+    def _venta_monto(*keys, default=0.0):
+        for key in keys:
+            valor = venta.get(key)
+            if valor in (None, ""):
+                continue
+            if isinstance(valor, (int, float)):
+                return float(valor)
+            try:
+                return float(Decimal(str(valor)))
+            except (InvalidOperation, ValueError, TypeError):
+                continue
+        return float(default)
+
+    total_sumas = _venta_monto("sumas", "subTotalVentas")
+    total_descuentos = _venta_monto("descuentos", "totalDescu")
+    total_iva = _venta_monto("totalIva", "iva")
+    subtotal = _venta_monto("subTotal", "subtotal", "subTotalVentas")
+    total_exentas = _venta_monto("ventas_exentas", "totalExenta")
+    total_no_sujetas = _venta_monto("ventas_no_sujetas", "totalNoSuj")
+    total_pagar = _venta_monto("total", "totalPagar", "montoTotalOperacion")
+
     c.setFont("Helvetica", 9)
-    c.drawString(x_linea + 10, texto_y, f"SUMA DE VENTAS:")
-    c.drawRightString(
-        bloque_totales_x + bloque_totales_w - 10,
-        texto_y,
-        f"{venta.get('subTotalVentas', venta.get('sumas', 0)):.2f}",
-    )
+    c.drawString(x_linea + 10, texto_y, "SUMA DE VENTAS:")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{total_sumas:.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "Descuentos y rebajas:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(
-        bloque_totales_x + bloque_totales_w - 10,
-        texto_y,
-        f"{venta.get('totalDescu', venta.get('descuentos', 0)):.2f}",
-    )
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{total_descuentos:.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "IVA 13%:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(
-        bloque_totales_x + bloque_totales_w - 10,
-        texto_y,
-        f"{venta.get('totalIva', venta.get('iva', 0)):.2f}",
-    )
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{total_iva:.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "Subtotal:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(
-        bloque_totales_x + bloque_totales_w - 10,
-        texto_y,
-        f"{venta.get('subTotal', venta.get('subtotal', 0)):.2f}",
-    )
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{subtotal:.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "Exentas:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('ventas_exentas', 0):.2f}")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{total_exentas:.2f}")
 
     texto_y -= salto
     c.setFont("Helvetica-Bold", 9)
     c.drawString(x_linea + 10, texto_y, "No sujetas:")
     c.setFont("Helvetica", 9)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('ventas_no_sujetas', 0):.2f}")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{total_no_sujetas:.2f}")
 
     texto_y -= salto + 10  # Más espacio antes de "Total a pagar"
     c.setFont("Helvetica-Bold", 10)
     c.drawString(x_linea + 10, texto_y, "Total a pagar:")
     c.setFont("Helvetica-Bold", 10)
-    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{venta.get('total', 0):.2f}")
+    c.drawRightString(bloque_totales_x + bloque_totales_w - 10, texto_y, f"{total_pagar:.2f}")
 
     # --- Valor en letras (columna izquierda del cuadro, texto más grande y solo el label en negrita) ---
     c.setFont("Helvetica-Bold", 11)

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -3,6 +3,7 @@ import os
 import uuid
 import logging
 from datetime import datetime
+from decimal import InvalidOperation
 
 import dte
 from factura_sv import generar_factura_electronica_pdf
@@ -363,18 +364,66 @@ def generate_invoice_pdf(manager, venta_id):
     except ValueError:
         logger.exception("Error al generar el DTE real")
         raise
-    resumen = json_data.get("resumen", {})
-    venta_data.update(
-        {
-            "sumas": resumen.get("sumas", 0),
-            "descuentos": resumen.get("descuentos", 0),
-            "iva": resumen.get("iva", 0),
-            "subtotal": resumen.get("subtotal", 0),
-            "ventas_exentas": resumen.get("ventasExentas", 0),
-            "ventas_no_sujetas": resumen.get("ventasNoSujetas", 0),
-            "total": resumen.get("totalPagar", 0),
-        }
-    )
+    resumen = json_data.get("resumen", {}) or {}
+
+    def _resumen_value(*keys):
+        for key in keys:
+            if key in resumen:
+                value = resumen[key]
+                if value not in (None, ""):
+                    return value
+        return None
+
+    def _normalize(value):
+        if isinstance(value, (int, float)):
+            return float(value)
+        try:
+            return float(D(str(value)))
+        except (InvalidOperation, ValueError, TypeError):
+            return None
+
+    def _update(keys, *source_keys):
+        value = _resumen_value(*source_keys)
+        if value is None:
+            return
+        normalized = _normalize(value)
+        if normalized is None:
+            return
+        for key in keys:
+            venta_data[key] = normalized
+
+    _update(("subTotalVentas",), "subTotalVentas")
+    _update(("sumas",), "sumas", "subTotalVentas")
+    _update(("descuentos", "totalDescu"), "descuentos", "totalDescu")
+
+    iva_value = _resumen_value("totalIva", "iva", "ivaPerci1")
+    if iva_value is None:
+        tributos = resumen.get("tributos")
+        if isinstance(tributos, list):
+            total = None
+            for tributo in tributos:
+                if not isinstance(tributo, dict):
+                    continue
+                valor = tributo.get("valor")
+                if valor in (None, ""):
+                    continue
+                monto = _normalize(valor)
+                if monto is None:
+                    continue
+                total = (total or 0.0) + monto
+            if total is not None:
+                iva_value = total
+    iva_normalized = _normalize(iva_value) if iva_value is not None else None
+    if iva_normalized is not None:
+        venta_data["iva"] = iva_normalized
+        venta_data["totalIva"] = iva_normalized
+
+    _update(("subTotal", "subtotal"), "subTotal", "subtotal", "subTotalVentas")
+    _update(("ventas_exentas", "totalExenta"), "totalExenta", "ventasExentas", "ventas_exentas")
+    _update(("ventas_no_sujetas", "totalNoSuj"), "totalNoSuj", "ventasNoSujetas", "ventas_no_sujetas")
+    _update(("ventas_gravadas", "totalGravada"), "totalGravada", "ventas_gravadas")
+    _update(("total", "totalPagar"), "totalPagar", "total", "montoTotalOperacion")
+
     if not venta_data.get("total_letras"):
         try:
             venta_data["total_letras"] = monto_a_texto_sv(venta_data.get("total", 0))


### PR DESCRIPTION
## Summary
- normalizar los campos del resumen del DTE al generar la venta para que conserven los montos de sumas, descuentos, IVA, subtotal y exenciones
- actualizar la plantilla PDF para usar esos valores normalizados al imprimir los totales y evitar que aparezcan en cero

## Testing
- pytest tests/test_factura_pdf.py tests/test_credito_fiscal_pdf_iva.py tests/test_factura_pdf_includes_iva_column.py

------
https://chatgpt.com/codex/tasks/task_e_68d202feb6148323b2b0e0761aea1be1