### PR TITLE
Ensure DTE artifacts persist in canonical folders

### DIFF
--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -200,8 +200,14 @@ class InvoiceDetailDialog(QDialog):
         """Return the most relevant file path for the current invoice."""
 
         for path in (self._pdf_path, self._json_path):
-            if isinstance(path, str) and os.path.exists(path):
-                return path
+            if path is None:
+                continue
+            try:
+                candidate = os.fspath(path)
+            except TypeError:
+                continue
+            if os.path.exists(candidate):
+                return candidate
         return None
 
     def _should_add_open_button(self) -> bool:
@@ -292,15 +298,24 @@ class InvoiceDetailDialog(QDialog):
         return None
 
     def _sync_standard_paths(self) -> None:
-        pdf_path = self._pdf_path if isinstance(self._pdf_path, str) else None
-        json_path = self._json_path if isinstance(self._json_path, str) else None
-        pdf_path, json_path = self._ensure_standard_location(pdf_path, json_path)
+        pdf_path, json_path = self._ensure_standard_location(
+            self._pdf_path, self._json_path
+        )
         self._pdf_path = pdf_path
         self._json_path = json_path
 
     def _ensure_standard_location(
-        self, pdf_path: str | None, json_path: str | None
+        self, pdf_path: os.PathLike | str | None, json_path: os.PathLike | str | None
     ) -> tuple[str | None, str | None]:
+        try:
+            pdf_path = os.fspath(pdf_path) if pdf_path is not None else None
+        except TypeError:
+            pdf_path = None
+        try:
+            json_path = os.fspath(json_path) if json_path is not None else None
+        except TypeError:
+            json_path = None
+
         expected = self._expected_storage_paths()
         if not expected:
             return pdf_path, json_path
@@ -346,7 +361,10 @@ class InvoiceDetailDialog(QDialog):
         elif os.path.exists(expected_json):
             json_path = expected_json
 
-        return pdf_path, json_path
+        return (
+            os.fspath(pdf_path) if pdf_path is not None else None,
+            os.fspath(json_path) if json_path is not None else None,
+        )
 
     def _expected_storage_paths(self) -> tuple[str, str] | None:
         factura = self.factura or {}

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -49,7 +49,7 @@ from dte import (
 from nota_debito_electronica import generar_nde_desde_dte
 from nota_remision import generar_nota_remision_desde_db
 import nota_credito_electronica
-from utils.docs import get_document_paths, get_dte_document_paths
+from utils.docs import get_document_paths, get_dte_document_paths, write_pdf_atomically
 from utils.doc_generation import generate_invoice_pdf
 from utils.email_sender import EmailSender
 from utils.jws import sign_and_save
@@ -2802,16 +2802,19 @@ class FacturacionTab(QWidget):
         codigo_gen = identificacion.get("codigoGeneracion")
         num_ctrl = identificacion.get("numeroControl")
         fec_emision = identificacion.get("fecEmi") or identificacion.get("fechaEmi")
-        pdf_func(
-            venta_data,
-            detalles_pdf,
-            cliente or {},
-            distribuidor or {},
-            archivo=str(pdf_path),
-            codigo_generacion=codigo_gen,
-            numero_control=num_ctrl,
-            fecha_generacion=fec_emision,
-        )
+        def _render_note_pdf(output_path):
+            pdf_func(
+                venta_data,
+                detalles_pdf,
+                cliente or {},
+                distribuidor or {},
+                archivo=str(output_path),
+                codigo_generacion=codigo_gen,
+                numero_control=num_ctrl,
+                fecha_generacion=fec_emision,
+            )
+
+        pdf_path = write_pdf_atomically(pdf_path, _render_note_pdf)
 
         # Mostrar previsualización del PDF generado
         try:

--- a/paths.py
+++ b/paths.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 
 from appdirs import user_data_dir
+
+
+_CANONICAL_DTE_SUBDIRS = {
+    "ConsumidorFinal": "facturas_consumidor_final",
+    "CreditoFiscal": "facturas_credito_fiscal",
+    "NotaRemision": "notas_remision",
+    "NotaCredito": "notas_credito",
+    "NotaDebito": "notas_debito",
+}
+
+_DTE_CODE_TO_DOC = {
+    "01": "ConsumidorFinal",
+    "03": "CreditoFiscal",
+    "04": "NotaRemision",
+    "05": "NotaCredito",
+    "06": "NotaDebito",
+}
 
 APP_NAME = "VertexDTE"
 
@@ -32,6 +50,45 @@ def ensure_user_dir(*parts: str) -> Path:
     return path
 
 
+def _normalise_doc_type(tipo_dte: str | int | None) -> str | None:
+    if tipo_dte is None:
+        return None
+    if isinstance(tipo_dte, int):
+        return _DTE_CODE_TO_DOC.get(f"{tipo_dte:02d}")
+    if not isinstance(tipo_dte, str):
+        tipo_dte = os.fspath(tipo_dte)
+    value = tipo_dte.strip()
+    if not value:
+        return None
+    if value.isdigit() and len(value) <= 2:
+        return _DTE_CODE_TO_DOC.get(f"{int(value):02d}")
+    if value in _DTE_CODE_TO_DOC:
+        return _DTE_CODE_TO_DOC[value]
+    for canonical in _CANONICAL_DTE_SUBDIRS:
+        if canonical.lower() == value.lower():
+            return canonical
+    return value
+
+
+def get_canonical_dte_dir(tipo_dte: str | int | os.PathLike | None) -> Path:
+    """Return the canonical storage directory for ``tipo_dte``.
+
+    The directory is created if it doesn't exist and accepts either the DTE
+    numeric code (``01`` → ``ConsumidorFinal``) or the descriptive name used
+    throughout the application.  Any :class:`os.PathLike` inputs are coerced
+    via :func:`os.fspath` to provide compatibility with ``pathlib.Path``
+    instances that may leak from older call sites.
+    """
+
+    doc_key = _normalise_doc_type(tipo_dte)
+    if not doc_key:
+        raise ValueError("tipo_dte inválido para ruta canónica")
+    subdir = _CANONICAL_DTE_SUBDIRS.get(doc_key)
+    if not subdir:
+        subdir = re.sub(r"[^A-Za-z0-9_.-]", "_", doc_key).strip("_") or "dtes"
+    return ensure_user_dir(subdir)
+
+
 def _copy_if_missing(filename: str) -> None:
     src = Path(__file__).resolve().parent / filename
     dst = user_data_path(filename)
@@ -49,12 +106,12 @@ LAST_INVENTORY_PATH = str(user_data_path("ultimo_inventario.json"))
 CERT_UPLOAD_DIR = str(ensure_user_dir("certificados"))
 LOG_DIR = str(ensure_user_dir("logs"))
 
-FACTURAS_CONSUMIDOR_FINAL_DIR = str(ensure_user_dir("facturas_consumidor_final"))
-FACTURAS_CREDITO_FISCAL_DIR = str(ensure_user_dir("facturas_credito_fiscal"))
+FACTURAS_CONSUMIDOR_FINAL_DIR = str(get_canonical_dte_dir("ConsumidorFinal"))
+FACTURAS_CREDITO_FISCAL_DIR = str(get_canonical_dte_dir("CreditoFiscal"))
 TICKETS_OUTPUT_DIR = str(ensure_user_dir("tickets"))
-NOTAS_DEBITO_DIR = str(ensure_user_dir("notas_debito"))
-NOTAS_CREDITO_DIR = str(ensure_user_dir("notas_credito"))
-NOTAS_REMISION_DIR = str(ensure_user_dir("notas_remision"))
+NOTAS_DEBITO_DIR = str(get_canonical_dte_dir("NotaDebito"))
+NOTAS_CREDITO_DIR = str(get_canonical_dte_dir("NotaCredito"))
+NOTAS_REMISION_DIR = str(get_canonical_dte_dir("NotaRemision"))
 DTES_DIR = str(ensure_user_dir("dtes"))
 DTE_FALLIDOS_DIR = str(ensure_user_dir("dte_fallidos"))
 DTES_PENDIENTES_DIR = str(ensure_user_dir("dtes_pendientes"))

--- a/tests/test_canonical_dte_storage.py
+++ b/tests/test_canonical_dte_storage.py
@@ -1,0 +1,211 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+import paths
+import utils.docs as docs
+import utils.doc_generation as doc_gen
+try:
+    import facturacion_tab  # type: ignore
+except Exception:  # pragma: no cover - optional for headless testing
+    facturacion_tab = None
+
+
+class FakeDB:
+    def __init__(self):
+        self._ventas = []
+        self.detalles = {}
+        self.added_pdfs = []
+        self.extra_updates = []
+
+    def get_ventas(self):
+        return self._ventas
+
+    def get_venta_credito_fiscal(self, venta_id):
+        return None
+
+    def get_detalles_venta(self, venta_id):
+        return self.detalles.get(venta_id, [])
+
+    def get_trabajador(self, trabajador_id):
+        return None
+
+    def add_factura_pdf(self, venta_id, tipo_doc, path):
+        self.added_pdfs.append((venta_id, tipo_doc, path))
+
+    def add_dte_pendiente(self, *a, **k):
+        pass
+
+    def update_venta_extra(self, venta_id, data):
+        self.extra_updates.append((venta_id, data))
+
+    def next_dte_correlativo(self, tipo, sucursal, punto):
+        return 1
+
+
+def _patch_canonical_environment(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths, "USER_DATA_DIR", tmp_path)
+    # Refresh canonical directories after overriding USER_DATA_DIR
+    for attr, tipo in [
+        ("FACTURAS_CONSUMIDOR_FINAL_DIR", "ConsumidorFinal"),
+        ("FACTURAS_CREDITO_FISCAL_DIR", "CreditoFiscal"),
+        ("NOTAS_CREDITO_DIR", "NotaCredito"),
+        ("NOTAS_DEBITO_DIR", "NotaDebito"),
+        ("NOTAS_REMISION_DIR", "NotaRemision"),
+    ]:
+        monkeypatch.setattr(paths, attr, str(paths.get_canonical_dte_dir(tipo)), raising=False)
+    monkeypatch.setattr(docs, "BASE_DIR", paths.user_data_path())
+    if facturacion_tab is not None:
+        for attr in [
+            "NOTAS_CREDITO_OUTPUT_DIR",
+            "NOTAS_DEBITO_OUTPUT_DIR",
+            "NOTAS_REMISION_OUTPUT_DIR",
+            "NOTAS_CREDITO_DIR",
+            "NOTAS_DEBITO_DIR",
+            "NOTAS_REMISION_DIR",
+        ]:
+            if hasattr(facturacion_tab, attr):
+                tipo = (
+                    "NotaCredito"
+                    if "CREDITO" in attr
+                    else "NotaDebito"
+                    if "DEBITO" in attr
+                    else "NotaRemision"
+                )
+                monkeypatch.setattr(
+                    facturacion_tab,
+                    attr,
+                    str(paths.get_canonical_dte_dir(tipo)),
+                    raising=False,
+                )
+
+
+@pytest.fixture
+def canonical_env(tmp_path, monkeypatch):
+    _patch_canonical_environment(monkeypatch, tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def fake_sign_and_save(monkeypatch, tmp_path):
+    def _fake(payload, json_path, return_token=False, **_):
+        path = Path(json_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        if return_token:
+            return str(path), "TOKEN"
+        return str(path)
+
+    monkeypatch.setattr(doc_gen, "sign_and_save", _fake)
+    return _fake
+
+
+@pytest.fixture
+def fake_save_dte(monkeypatch, tmp_path):
+    def _fake(data, filename):
+        target = tmp_path / "pendientes" / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(data), encoding="utf-8")
+        return str(target)
+
+    monkeypatch.setattr(doc_gen.dte, "save_dte_json", _fake)
+    return _fake
+
+
+@pytest.fixture
+def fake_versioned_state(monkeypatch):
+    monkeypatch.setattr(doc_gen.versioned_dte, "save_estado", lambda *a, **k: None)
+
+
+@pytest.fixture
+def fake_generar_dte(monkeypatch):
+    def _fake(db, venta_id, **_):
+        venta = next(v for v in db.get_ventas() if v["id"] == venta_id)
+        detalles = db.get_detalles_venta(venta_id)
+        data = docs.build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident.setdefault("codigoGeneracion", "GENERACION")
+        ident.setdefault("numeroControl", "CTRL-001")
+        return data
+
+    monkeypatch.setattr(doc_gen, "generar_dte_json", _fake)
+    return _fake
+
+
+@pytest.fixture
+def fake_pdf_renderer(monkeypatch):
+    def _fake(*args, archivo=None, **kwargs):
+        path = Path(archivo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"PDF")
+
+    monkeypatch.setattr(doc_gen, "generar_factura_electronica_pdf", _fake)
+    return _fake
+
+
+def test_generate_invoice_files_in_canonical_dir(canonical_env, fake_sign_and_save, fake_save_dte, fake_versioned_state, fake_generar_dte, fake_pdf_renderer):
+    db = FakeDB()
+    venta = {"id": 1, "fecha": "2024-04-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[1] = [{"cantidad": 1, "precio_unitario": 10}]
+    manager = type("Manager", (), {"db": db, "_clientes": [], "_Distribuidores": []})()
+
+    pdf_path = doc_gen.generate_invoice_pdf(manager, 1)
+
+    canonical_dir = paths.get_canonical_dte_dir("ConsumidorFinal")
+    pdf_file = Path(pdf_path)
+    assert pdf_file.parent == canonical_dir
+    json_file = pdf_file.with_suffix(".json")
+    assert json_file.exists()
+    assert pdf_file.exists()
+    assert not any(pdf_file.parent.glob("*.tmp"))
+
+
+def test_credit_note_files_use_canonical_dir(canonical_env, fake_sign_and_save, fake_save_dte, fake_versioned_state, fake_generar_dte, monkeypatch):
+    nota_json = {
+        "identificacion": {
+            "tipoDte": "05",
+            "fecEmi": "2024-05-10",
+            "numeroControl": "DTE-05-AAA-1",
+            "codigoGeneracion": "NC-001",
+        }
+    }
+    cliente = {"nombre": "Cliente"}
+    venta_data = {"total": 5, "total_letras": "CINCO"}
+    detalles = []
+
+    pdf_path, json_path = docs.get_dte_document_paths(
+        nota_json["identificacion"].get("fecEmi"),
+        cliente.get("nombre"),
+        nota_json["identificacion"].get("numeroControl"),
+        "NotaCredito",
+    )
+
+    def _fake_pdf(output_path):
+        output_path.write_bytes(b"NC")
+
+    docs.write_pdf_atomically(pdf_path, _fake_pdf)
+    Path(json_path).write_text(json.dumps({"nota": nota_json, "venta": venta_data, "detalles": detalles}), encoding="utf-8")
+
+    canonical_dir = paths.get_canonical_dte_dir("NotaCredito")
+    assert Path(pdf_path).parent == canonical_dir
+    assert Path(json_path).parent == canonical_dir
+
+
+def test_generate_invoice_pdf_logs_and_fails_on_pdf_error(canonical_env, fake_sign_and_save, fake_save_dte, fake_versioned_state, fake_generar_dte, monkeypatch, caplog):
+    db = FakeDB()
+    venta = {"id": 5, "fecha": "2024-04-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[5] = [{"cantidad": 1, "precio_unitario": 10}]
+    manager = type("Manager", (), {"db": db, "_clientes": [], "_Distribuidores": []})()
+
+    def _fail(*args, **kwargs):
+        raise IOError("fallo render")
+
+    monkeypatch.setattr(doc_gen, "generar_factura_electronica_pdf", _fail)
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(IOError):
+        doc_gen.generate_invoice_pdf(manager, 5)
+    assert any("No se pudo escribir PDF" in rec.message for rec in caplog.records)

--- a/tests/test_invoice_detail_dialog_paths.py
+++ b/tests/test_invoice_detail_dialog_paths.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 import sys
 import types
 from pathlib import Path
@@ -212,4 +213,100 @@ def test_sync_standard_paths_nota_credito(tmp_path, monkeypatch):
     assert dialog._pdf_path == str(expected_pdf)
     assert dialog._json_path == str(expected_json)
     assert expected_json.read_text(encoding="utf-8") == "{\"nota\": true}"
+
+
+def test_determine_file_path_accepts_pathlike(tmp_path):
+    dialog = _make_dialog()
+    pdf_path = tmp_path / "nota.pdf"
+    pdf_path.write_text("pdf", encoding="utf-8")
+    dialog._pdf_path = pdf_path
+    dialog._json_path = None
+
+    class DummyButton:
+        def __init__(self):
+            self.enabled = None
+
+        def setEnabled(self, value):
+            self.enabled = value
+
+    button = DummyButton()
+    dialog._open_button = button
+
+    assert dialog._determine_file_path() == os.fspath(pdf_path)
+
+    dialog._update_open_button_state()
+    assert dialog._open_button.enabled is True
+
+
+def test_open_file_location_regenerates_and_opens_canonical(tmp_path, monkeypatch):
+    dialog = _make_dialog()
+    dialog.factura = {
+        "identificacion": {
+            "tipoDte": "01",
+            "numeroControl": "CTRL-001",
+            "fecEmi": "2024-07-01",
+        },
+        "receptor": {"nombre": "Cliente"},
+    }
+    dialog.venta_id = 42
+
+    class FakeButton:
+        def __init__(self):
+            self.enabled = None
+
+        def setEnabled(self, value):
+            self.enabled = value
+
+    button = FakeButton()
+    dialog._open_button = button
+
+    canonical_dir = tmp_path / "facturas_consumidor_final"
+    expected_pdf = canonical_dir / "canon.pdf"
+    expected_json = canonical_dir / "canon.json"
+
+    def fake_get_document_paths(fecha, cliente, numero_control, doc_type, root=None):
+        expected_pdf.parent.mkdir(parents=True, exist_ok=True)
+        return str(expected_pdf), str(expected_json)
+
+    monkeypatch.setattr(
+        "dialogs.invoice_detail_dialog.get_document_paths", fake_get_document_paths
+    )
+    monkeypatch.setattr(
+        "dialogs.invoice_detail_dialog.get_dte_document_paths",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not call")),
+    )
+
+    class FakeDB:
+        def get_factura_pdf(self, venta_id):
+            return None
+
+    class FakeParent:
+        def __init__(self):
+            self.manager = types.SimpleNamespace(db=FakeDB())
+
+        def _generate_invoice_pdf(self, venta_id):
+            expected_pdf.parent.mkdir(parents=True, exist_ok=True)
+            expected_pdf.write_text("pdf", encoding="utf-8")
+            expected_json.write_text("{}", encoding="utf-8")
+            return str(expected_pdf)
+
+    parent = FakeParent()
+    dialog.parent = lambda: parent
+
+    opened = []
+
+    def fake_open(url):
+        opened.append(url)
+
+    monkeypatch.setattr(invoice_detail_dialog.QDesktopServices, "openUrl", fake_open)
+
+    dialog._pdf_path = None
+    dialog._json_path = None
+
+    dialog._open_file_location()
+
+    assert opened == [str(canonical_dir)]
+    assert dialog._pdf_path == str(expected_pdf)
+    assert dialog._json_path == str(expected_json)
+    assert dialog._open_button.enabled is True
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -6,11 +6,12 @@ from datetime import datetime
 from decimal import InvalidOperation
 
 import dte
+from pathlib import Path
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado, generar_ticket_fe_pdf
 from dte import generar_ticket_json, generar_dte_json, d4, generar_cabecera_dte_data
 from utils.monto import D, d2, monto_a_texto_sv, iva_item, to_base_iva
-from utils.docs import get_document_paths, build_invoice_json
+from utils.docs import get_document_paths, build_invoice_json, write_pdf_atomically
 from utils.jws import sign_and_save
 from utils import versioned_dte
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
@@ -433,27 +434,32 @@ def generate_invoice_pdf(manager, venta_id):
     venta_data["codigo_generacion"] = codigo_generacion
     venta_data["numero_control"] = numero_control
 
-    file_path, json_path = get_document_paths(
+    file_path_str, json_path_str = get_document_paths(
         venta_data.get("fecha"), cliente_nombre, numero_control or venta_id, doc_key
     )
+    file_path = Path(file_path_str)
+    json_path = Path(json_path_str)
 
-    generar_factura_electronica_pdf(
-        venta_data,
-        detalles,
-        cliente or {},
-        distribuidor or {},
-        tipo_doc,
-        archivo=file_path,
-        codigo_generacion=codigo_generacion,
-        numero_control=numero_control,
-        sello_recepcion=sello_recepcion,
-        tipo_modelo=tipo_modelo,
-        tipo_operacion=tipo_operacion,
-        fecha_generacion=fecha_generacion,
-        ambiente=ambiente,
-        tipo_contingencia=tipo_contingencia,
-        motivo_contin=motivo_contin,
-    )
+    def _render_invoice_pdf(output_path: Path) -> None:
+        generar_factura_electronica_pdf(
+            venta_data,
+            detalles,
+            cliente or {},
+            distribuidor or {},
+            tipo_doc,
+            archivo=str(output_path),
+            codigo_generacion=codigo_generacion,
+            numero_control=numero_control,
+            sello_recepcion=sello_recepcion,
+            tipo_modelo=tipo_modelo,
+            tipo_operacion=tipo_operacion,
+            fecha_generacion=fecha_generacion,
+            ambiente=ambiente,
+            tipo_contingencia=tipo_contingencia,
+            motivo_contin=motivo_contin,
+        )
+
+    write_pdf_atomically(file_path, _render_invoice_pdf)
     if tipo_operacion == 2:
         manager.db.add_dte_pendiente(venta_id, json_data, str(tipo_operacion))
     try:
@@ -469,11 +475,11 @@ def generate_invoice_pdf(manager, venta_id):
         raise ValueError(f"DTE inválido: {exc}") from exc
     jws_token = None
     try:
-        _, jws_token = sign_and_save(json_data, json_path, return_token=True)
+        _, jws_token = sign_and_save(json_data, str(json_path), return_token=True)
     except Exception:
         pass
     try:
-        pend_json_path = dte.save_dte_json(json_data, filename=os.path.basename(json_path))
+        pend_json_path = dte.save_dte_json(json_data, filename=json_path.name)
         version_dir = os.path.dirname(pend_json_path)
         if jws_token:
             try:
@@ -488,10 +494,10 @@ def generate_invoice_pdf(manager, venta_id):
             pass
     except Exception:
         pass
-    if not os.path.exists(json_path):
+    if not json_path.exists():
         raise IOError(f"No se pudo guardar JSON en {json_path}")
-    manager.db.add_factura_pdf(venta_id, tipo_doc, file_path)
-    return file_path
+    manager.db.add_factura_pdf(venta_id, tipo_doc, str(file_path))
+    return str(file_path)
 
 
 def generate_ticket_pdf(manager, venta_id):

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -1,33 +1,93 @@
 import json
+import logging
 import os
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 from dte import _map_departamento, _map_municipio, _build_receptor_direccion
 from paths import (
-    FACTURAS_CONSUMIDOR_FINAL_DIR,
-    FACTURAS_CREDITO_FISCAL_DIR,
     TICKETS_OUTPUT_DIR,
-    NOTAS_DEBITO_DIR,
-    NOTAS_CREDITO_DIR,
-    NOTAS_REMISION_DIR,
+    get_canonical_dte_dir,
     user_data_path,
 )
 from utils import resource_path
 
+logger = logging.getLogger(__name__)
+
 BASE_DIR = user_data_path()
 
-FOLDERS = {
-    'ConsumidorFinal': Path(FACTURAS_CONSUMIDOR_FINAL_DIR),
-    'CreditoFiscal': Path(FACTURAS_CREDITO_FISCAL_DIR),
-    'Ticket': Path(TICKETS_OUTPUT_DIR),
-    'NotaDebito': Path(NOTAS_DEBITO_DIR),
-    'NotaCredito': Path(NOTAS_CREDITO_DIR),
-    'NotaRemision': Path(NOTAS_REMISION_DIR),
+_CANONICAL_TYPES = {
+    "ConsumidorFinal": "ConsumidorFinal",
+    "CreditoFiscal": "CreditoFiscal",
+    "NotaDebito": "NotaDebito",
+    "NotaCredito": "NotaCredito",
+    "NotaRemision": "NotaRemision",
 }
 
 TEMPLATE_PATH = resource_path('formato_factura.json')
+
+
+def _canonical_folder_name(doc_type: str | None) -> str:
+    if not doc_type:
+        return "documentos"
+    canonical = _CANONICAL_TYPES.get(doc_type)
+    if canonical:
+        return get_canonical_dte_dir(canonical).name
+    if doc_type == "Ticket":
+        return Path(TICKETS_OUTPUT_DIR).name
+    return sanitize_filename(doc_type or "documentos")
+
+
+def _resolve_folder(doc_type: str | None, *, root: str | os.PathLike | None) -> Path:
+    if root:
+        base = Path(root)
+        name = _canonical_folder_name(doc_type)
+        folder = base / name
+        folder.mkdir(parents=True, exist_ok=True)
+        return folder
+
+    canonical = _CANONICAL_TYPES.get(doc_type or "")
+    if canonical:
+        return get_canonical_dte_dir(canonical)
+    if doc_type == "Ticket":
+        folder = Path(TICKETS_OUTPUT_DIR)
+    else:
+        folder = Path(BASE_DIR) / sanitize_filename(doc_type or "documentos")
+    folder.mkdir(parents=True, exist_ok=True)
+    return folder
+
+
+def write_pdf_atomically(
+    destination: os.PathLike | str,
+    render: Callable[[Path], None],
+) -> Path:
+    """Render a PDF to ``destination`` atomically.
+
+    ``render`` receives a :class:`Path` pointing to a temporary location where
+    it should persist the PDF contents.  The helper ensures the destination is
+    created via ``Path.replace`` to avoid partially written files.  Any
+    failure is logged and re-raised so callers can react accordingly.
+    """
+
+    dest_path = Path(os.fspath(destination))
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
+    try:
+        render(tmp_path)
+        if not tmp_path.exists():
+            raise IOError(f"No se generó PDF temporal en {tmp_path}")
+        tmp_path.replace(dest_path)
+        return dest_path
+    except Exception as exc:
+        logger.error("No se pudo escribir PDF en %s: %s", dest_path, exc)
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def sanitize_filename(value: str) -> str:
@@ -56,13 +116,7 @@ def generate_document_name(date, cliente, identifier, doc_type) -> str:
 def get_document_paths(date, cliente, identifier, doc_type, root=None):
     """Return PDF and JSON paths for the given document."""
 
-    folder = FOLDERS.get(doc_type)
-    if folder is None:
-        folder = Path(BASE_DIR) / sanitize_filename(doc_type or "documentos")
-    if root:
-        root_path = Path(root)
-        folder = root_path / folder.name
-    folder.mkdir(parents=True, exist_ok=True)
+    folder = _resolve_folder(doc_type, root=root)
     base_name = generate_document_name(date, cliente, identifier, doc_type)
     pdf_path = folder / f"{base_name}.pdf"
     json_path = folder / f"{base_name}.json"
@@ -71,11 +125,7 @@ def get_document_paths(date, cliente, identifier, doc_type, root=None):
 
 def get_dte_document_paths(fecha, empresa, numero_control, doc_type, root=None):
     """Return paths ensuring MH-required naming for DTE notes."""
-    base = Path(root) if root else Path(BASE_DIR)
-    folder = Path(FOLDERS.get(doc_type, base))
-    if root:
-        folder = base / folder.name
-    folder.mkdir(parents=True, exist_ok=True)
+    folder = _resolve_folder(doc_type, root=root)
     if isinstance(fecha, datetime):
         d = fecha
     else:


### PR DESCRIPTION
## Summary
- introduce `paths.get_canonical_dte_dir` so each DTE type resolves to its canonical user-data folder and reuse it from the document helper utilities
- update PDF/JSON generation for invoices and notes to render into canonical paths with atomic *.tmp replacements and add coverage to the invoice dialog when regenerating missing files
- add regression tests ensuring invoices, credit notes, and the invoice detail dialog all work correctly with canonical directories and PathLike values

## Testing
- pytest tests/test_canonical_dte_storage.py tests/test_invoice_detail_dialog_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68d22d5bf7d8832392860d5d0ad94e06