### PR TITLE
Propagar detalle de Hacienda en errores de token

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -5037,10 +5037,27 @@ def _post_dte(
         data = None
 
     if resp.status_code in {401, 403}:
+        detalle: Any
+        if isinstance(data, dict):
+            detalle = data.get("detalle") or data
+        elif data is not None:
+            detalle = data
+        else:
+            detalle = text
+
+        detalle_val = detalle
+        if isinstance(detalle_val, str):
+            detalle_val = detalle_val.strip() or None
+        elif isinstance(detalle_val, dict) and not detalle_val:
+            detalle_val = None
+
+        if detalle_val in (None, ""):
+            detalle_val = "Token inválido o caducado"
+
         result = {
             "estado": "Rechazado",
-            "http_status": 401,
-            "detalle": "Token inválido o caducado",
+            "http_status": resp.status_code,
+            "detalle": detalle_val,
         }
         print(json.dumps(result, ensure_ascii=False))
         return result

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1869,6 +1869,39 @@ class FacturacionTab(QWidget):
                     )
         return True
 
+    @staticmethod
+    def _stringify_token_detail(detalle):
+        if isinstance(detalle, dict):
+            for key in ("descripcionMsg", "observaciones", "message", "detalle"):
+                val = detalle.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val.strip()
+            if detalle:
+                try:
+                    return json.dumps(detalle, ensure_ascii=False)
+                except TypeError:
+                    return str(detalle)
+            return ""
+        if isinstance(detalle, str):
+            return detalle.strip()
+        if detalle is None:
+            return ""
+        try:
+            return json.dumps(detalle, ensure_ascii=False)
+        except TypeError:
+            return str(detalle)
+
+    @classmethod
+    def _token_warning_message(cls, response: dict, default: str) -> str:
+        detalle = cls._stringify_token_detail(response.get("detalle"))
+        if not detalle:
+            for key in ("descripcionMsg", "observaciones", "message"):
+                value = response.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            return default
+        return detalle
+
     def send_selected_invoice(self):
         entry = self._selected_entry()
         if not entry:
@@ -1906,7 +1939,8 @@ class FacturacionTab(QWidget):
                 try:
                     resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
                     if resp.get("http_status") in {401, 403}:
-                        QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
+                        message = self._token_warning_message(resp, token_msg)
+                        QMessageBox.warning(self, "Enviar a Hacienda", message)
                         return
                     estado = resp.get("estado")
                     if estado == "Error" and resp.get("detalle") == "Sin conexión a Internet":
@@ -1959,7 +1993,8 @@ class FacturacionTab(QWidget):
                         tipo_dte=tipo_dte,
                     )  # tickets también se transmiten con tipo "01"
                     if resp.get("http_status") in {401, 403}:
-                        QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
+                        message = self._token_warning_message(resp, token_msg)
+                        QMessageBox.warning(self, "Enviar a Hacienda", message)
                         return
                     estado = resp.get("estado")
                     if estado == "Error" and resp.get("detalle") == "Sin conexión a Internet":

--- a/tests/test_orphan_send.py
+++ b/tests/test_orphan_send.py
@@ -128,3 +128,53 @@ def test_send_orphan_invoice(monkeypatch, qt_app, tmp_path):
     tab.send_selected_invoice()
     assert json_path in map(Path, sent["attachments"])
     assert called["path"] == str(json_path)
+
+
+def test_send_orphan_invoice_warns_with_token_detail(monkeypatch, qt_app, tmp_path):
+    pdf_path = tmp_path / "20240101_Test_ConsumidorFinal.pdf"
+    pdf_path.write_text("PDF")
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text("{}")
+
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(tmp_path))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "cf"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    tab = facturacion_tab.FacturacionTab(man)
+    tab.table.selectRow(0)
+
+    class DummyCheck:
+        def __init__(self):
+            self._checked = False
+        def setChecked(self, value):
+            self._checked = value
+        def isChecked(self):
+            return self._checked
+
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+        def exec_(self):
+            self.email_cb.setChecked(False)
+            self.hacienda_cb.setChecked(True)
+            return QDialog.Accepted
+
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    warnings = {}
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+    def fake_warning(parent, title, message):
+        warnings["msg"] = message
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", fake_warning)
+
+    def fake_transmit(db_, path):
+        return {"http_status": 401, "detalle": "Credenciales revocadas"}
+
+    monkeypatch.setattr(facturacion_tab.dte, "transmitir_dte_orphan", fake_transmit)
+
+    tab.send_selected_invoice()
+    assert warnings["msg"] == "Credenciales revocadas"

--- a/tests/test_token_warning.py
+++ b/tests/test_token_warning.py
@@ -45,12 +45,33 @@ def test_post_dte_token_invalid(monkeypatch):
         status_code = 401
         text = "Unauthorized"
         def json(self):
-            return {"foo": "bar"}
+            return {"detalle": "Token expirado en Hacienda"}
     monkeypatch.setattr(dte.requests, "post", lambda *a, **k: Resp())
     resp = dte._post_dte("https://apitest.dtes.mh.gob.sv/fesv/recepciondte", "tok", "doc")
     assert resp == {
         "estado": "Rechazado",
         "http_status": 401,
+        "detalle": "Token expirado en Hacienda",
+    }
+
+
+def test_post_dte_token_invalid_without_detail(monkeypatch):
+    monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda doc, data: {})
+    monkeypatch.setattr(dte, "format_cliente_id_from_dui", lambda dui: "cid")
+    monkeypatch.setattr(dte, "detect_user_agent", lambda ua, opts, app_version, client_id: "UA")
+    monkeypatch.setattr(dte, "build_auth_header", lambda auth, app_version, client_id: {})
+
+    class Resp:
+        status_code = 403
+        text = "Forbidden"
+        def json(self):
+            return {}
+
+    monkeypatch.setattr(dte.requests, "post", lambda *a, **k: Resp())
+    resp = dte._post_dte("https://apitest.dtes.mh.gob.sv/fesv/recepciondte", "tok", "doc")
+    assert resp == {
+        "estado": "Rechazado",
+        "http_status": 403,
         "detalle": "Token inválido o caducado",
     }
 
@@ -71,6 +92,59 @@ def test_request_new_token_raises_runtimeerror(monkeypatch):
 
 
 def test_send_selected_invoice_warns_on_token(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_text("pdf")
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text("{}")
+    db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
+
+    tab = _make_tab(db, cid)
+    monkeypatch.setattr(
+        tab,
+        "_selected_entry",
+        lambda: {"row_type": "venta", "id": 1, "venta_id": venta_id},
+    )
+    monkeypatch.setattr(
+        tab,
+        "_selected_factura",
+        lambda: {"venta_id": venta_id, "json": str(json_path), "control": "X"},
+    )
+
+    class DummyCheck:
+        def __init__(self):
+            self._checked = False
+        def setChecked(self, v):
+            self._checked = v
+        def isChecked(self):
+            return self._checked
+    class DummyDlg:
+        def __init__(self, parent=None):
+            self.email_cb = DummyCheck()
+            self.hacienda_cb = DummyCheck()
+        def exec_(self):
+            self.email_cb.setChecked(False)
+            self.hacienda_cb.setChecked(True)
+            return QDialog.Accepted
+    monkeypatch.setattr(facturacion_tab, "SendOptionsDialog", DummyDlg)
+
+    warnings = {}
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "critical", lambda *a, **k: None)
+    def fake_warning(parent, title, message):
+        warnings["msg"] = message
+    monkeypatch.setattr(facturacion_tab.QMessageBox, "warning", fake_warning)
+
+    def fake_transmitir(db_, vid, tipo_dte="01"):
+        return {"http_status": 401, "detalle": "Token rechazado por Hacienda"}
+    monkeypatch.setattr(facturacion_tab, "transmitir_dte", fake_transmitir)
+
+    tab.send_selected_invoice()
+    assert warnings["msg"] == "Token rechazado por Hacienda"
+
+
+def test_send_selected_invoice_warns_on_token_generic(monkeypatch, qt_app, tmp_path):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)
     pdf_path = tmp_path / "doc.pdf"


### PR DESCRIPTION
## Summary
- conservar el detalle devuelto por Hacienda cuando la recepción responde 401/403
- mostrar mensajes dinámicos en la pestaña de facturación para ventas y huérfanos
- cubrir los nuevos flujos con pruebas que validan tanto mensajes específicos como la reserva del texto genérico

## Testing
- `pytest tests/test_token_warning.py tests/test_orphan_send.py` *(falla: falta libGL en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d230b735b48323a891d699e0b3dd44