### PR TITLE
Persist canonical invoice PDF paths

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from datetime import datetime
 import json
@@ -1612,6 +1613,32 @@ class DB:
         )
         self.conn.commit()
         return self.cursor.lastrowid
+
+    def update_factura_pdf_path(self, venta_id: int, ruta: os.PathLike | str) -> bool:
+        """Actualizar la ruta almacenada de la factura PDF más reciente."""
+
+        canonical_path = os.fspath(ruta)
+        self.cursor.execute(
+            """
+            SELECT id, ruta FROM facturas_pdf
+            WHERE venta_id=?
+            ORDER BY fecha_creacion DESC
+            LIMIT 1
+            """,
+            (venta_id,),
+        )
+        row = self.cursor.fetchone()
+        if not row:
+            return False
+        if row["ruta"] == canonical_path:
+            return False
+
+        self.cursor.execute(
+            "UPDATE facturas_pdf SET ruta=? WHERE id=?",
+            (canonical_path, row["id"]),
+        )
+        self.conn.commit()
+        return True
 
     def add_ticket_pdf(self, venta_id, ruta):
         """Almacena la ruta de un ticket generado para una venta."""

--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -298,11 +298,38 @@ class InvoiceDetailDialog(QDialog):
         return None
 
     def _sync_standard_paths(self) -> None:
+        try:
+            original_pdf = (
+                os.fspath(self._pdf_path) if self._pdf_path is not None else None
+            )
+        except TypeError:
+            original_pdf = None
+
         pdf_path, json_path = self._ensure_standard_location(
             self._pdf_path, self._json_path
         )
         self._pdf_path = pdf_path
         self._json_path = json_path
+
+        if (
+            self.venta_id
+            and original_pdf
+            and pdf_path
+            and os.path.abspath(original_pdf) != os.path.abspath(pdf_path)
+        ):
+            parent_fn = getattr(self, "parent", None)
+            parent = parent_fn() if callable(parent_fn) else None
+            manager = getattr(parent, "manager", None) if parent else None
+            db = getattr(manager, "db", None) if manager else None
+            updater = getattr(db, "update_factura_pdf_path", None) if db else None
+            if callable(updater):
+                try:
+                    updater(self.venta_id, pdf_path)
+                except Exception:
+                    logger.warning(
+                        "No se pudo actualizar la ruta canónica de la factura",
+                        exc_info=True,
+                    )
 
     def _ensure_standard_location(
         self, pdf_path: os.PathLike | str | None, json_path: os.PathLike | str | None

--- a/tests/test_db_factura_pdf_update.py
+++ b/tests/test_db_factura_pdf_update.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+def _insert_sale(db):
+    db.cursor.execute(
+        "INSERT INTO clientes (codigo, nombre) VALUES (?, ?)",
+        ("C001", "Cliente"),
+    )
+    cliente_id = db.cursor.lastrowid
+    db.cursor.execute(
+        "INSERT INTO ventas (fecha, total, cliente_id) VALUES (?, ?, ?)",
+        ("2024-01-01", 10, cliente_id),
+    )
+    db.conn.commit()
+    return db.cursor.lastrowid
+
+
+def test_update_factura_pdf_path_updates_latest_entry(db_conn, tmp_path):
+    venta_id = _insert_sale(db_conn)
+
+    older = str(tmp_path / "old.pdf")
+    newer = str(tmp_path / "new.pdf")
+    canonical = str(tmp_path / "canonical.pdf")
+
+    db_conn.cursor.execute(
+        "INSERT INTO facturas_pdf (venta_id, tipo, ruta, fecha_creacion) VALUES (?, ?, ?, ?)",
+        (venta_id, "CF", older, "2024-01-01 09:00:00"),
+    )
+    db_conn.cursor.execute(
+        "INSERT INTO facturas_pdf (venta_id, tipo, ruta, fecha_creacion) VALUES (?, ?, ?, ?)",
+        (venta_id, "CF", newer, "2024-01-01 10:00:00"),
+    )
+    db_conn.conn.commit()
+
+    assert db_conn.update_factura_pdf_path(venta_id, canonical) is True
+
+    rows = db_conn.cursor.execute(
+        "SELECT ruta FROM facturas_pdf WHERE venta_id=? ORDER BY fecha_creacion",
+        (venta_id,),
+    ).fetchall()
+
+    assert rows[0]["ruta"] == older
+    assert rows[1]["ruta"] == canonical
+    assert db_conn.update_factura_pdf_path(venta_id, canonical) is False
+
+
+def test_update_factura_pdf_path_missing_entry(db_conn, tmp_path):
+    missing_path = str(tmp_path / "missing.pdf")
+    assert db_conn.update_factura_pdf_path(9999, missing_path) is False

--- a/tests/test_invoice_detail_dialog_paths.py
+++ b/tests/test_invoice_detail_dialog_paths.py
@@ -118,6 +118,7 @@ def _make_dialog():
     dialog.venta_id = None
     dialog._pdf_path = None
     dialog._json_path = None
+    dialog._open_button = None
     dialog.factura = {}
     return dialog
 
@@ -309,4 +310,89 @@ def test_open_file_location_regenerates_and_opens_canonical(tmp_path, monkeypatc
     assert dialog._pdf_path == str(expected_pdf)
     assert dialog._json_path == str(expected_json)
     assert dialog._open_button.enabled is True
+
+
+def test_sync_standard_paths_updates_db_and_reuses_canonical(tmp_path, monkeypatch):
+    dialog = _make_dialog()
+    dialog.factura = {
+        "identificacion": {
+            "tipoDte": "01",
+            "numeroControl": "CTRL-002",
+            "fecEmi": "2024-08-01",
+        },
+        "receptor": {"nombre": "Cliente"},
+    }
+    dialog.venta_id = 77
+
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    pdf_source = custom_dir / "factura.pdf"
+    json_source = custom_dir / "factura.json"
+    pdf_source.write_bytes(b"pdf")
+    json_source.write_text("{}", encoding="utf-8")
+
+    canonical_dir = tmp_path / "canonical"
+    expected_pdf = canonical_dir / "canon.pdf"
+    expected_json = canonical_dir / "canon.json"
+
+    def fake_get_document_paths(fecha, cliente, numero_control, doc_type, root=None):
+        assert doc_type == "ConsumidorFinal"
+        expected_pdf.parent.mkdir(parents=True, exist_ok=True)
+        return str(expected_pdf), str(expected_json)
+
+    monkeypatch.setattr(
+        "dialogs.invoice_detail_dialog.get_document_paths", fake_get_document_paths
+    )
+    monkeypatch.setattr(
+        "dialogs.invoice_detail_dialog.get_dte_document_paths",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not call")),
+    )
+
+    class RecordingDB:
+        def __init__(self):
+            self.paths = {}
+            self.updated = []
+
+        def update_factura_pdf_path(self, venta_id, ruta):
+            self.updated.append((venta_id, ruta))
+            self.paths[venta_id] = ruta
+
+        def get_factura_pdf(self, venta_id):
+            return self.paths.get(venta_id)
+
+    db = RecordingDB()
+    db.paths[dialog.venta_id] = str(pdf_source)
+
+    class FakeParent:
+        def __init__(self, database):
+            self.manager = types.SimpleNamespace(db=database)
+
+    parent = FakeParent(db)
+
+    dialog.parent = lambda: parent
+    dialog._pdf_path = str(pdf_source)
+    dialog._json_path = str(json_source)
+
+    dialog._sync_standard_paths()
+
+    assert expected_pdf.exists()
+    assert expected_json.exists()
+    assert dialog._pdf_path == str(expected_pdf)
+    assert dialog._json_path == str(expected_json)
+    assert db.updated == [(dialog.venta_id, str(expected_pdf))]
+    assert db.get_factura_pdf(dialog.venta_id) == str(expected_pdf)
+
+    dialog2 = _make_dialog()
+    dialog2.factura = dialog.factura
+    dialog2.venta_id = dialog.venta_id
+    dialog2.parent = lambda: parent
+    dialog2._pdf_path = None
+    dialog2._json_path = None
+
+    refreshed = dialog2._refresh_invoice_files()
+
+    assert refreshed == str(expected_pdf)
+    assert dialog2._pdf_path == str(expected_pdf)
+    assert dialog2._json_path == str(expected_json)
+    assert db.updated == [(dialog.venta_id, str(expected_pdf))]
 


### PR DESCRIPTION
## Summary
- add a database helper to persist the canonical PDF path for invoice records
- update `InvoiceDetailDialog` to push canonical paths back to the database when they differ
- extend the dialog path tests and add coverage for the new database helper

## Testing
- pytest tests/test_db_factura_pdf_update.py tests/test_invoice_detail_dialog_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68d235cd2dfc8323b710ce6910dfb1a7