### PR TITLE
Fix ventas_credito_fiscal extra serialization

### DIFF
--- a/db.py
+++ b/db.py
@@ -932,6 +932,11 @@ class DB:
         self.ensure_column("ventas", "sincronizada", "INTEGER DEFAULT 1")
         self.ensure_column("ventas_credito_fiscal", "documento_venta_a_cuenta", "TEXT")
         try:
+            if isinstance(extra, str):
+                raise TypeError(
+                    "extra for ventas_credito_fiscal must be a mapping or list,"
+                    " not a serialized JSON string"
+                )
             extra_json = json.dumps(extra) if extra is not None else None
             cols = ["fecha", "total", "cliente_id", "estado", "sincronizada"]
             vals = [fecha, total, cliente_id, estado, 1]

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -807,7 +807,14 @@ class InventoryManager:
             self.db.conn.execute("BEGIN")
             for vcf in data.get("ventas_credito_fiscal", []):
                 extra = vcf.get("extra")
-                extra_json = json.dumps(extra) if extra is not None else None
+                if extra is None:
+                    extra_json = None
+                elif isinstance(extra, str):
+                    extra_json = extra
+                elif isinstance(extra, (dict, list)):
+                    extra_json = json.dumps(extra)
+                else:
+                    extra_json = json.dumps(extra)
                 self.db.cursor.execute(
                     """
                     INSERT INTO ventas_credito_fiscal (

--- a/tests/test_import_inventory_cleanup.py
+++ b/tests/test_import_inventory_cleanup.py
@@ -56,3 +56,53 @@ def test_import_inventory_clears_related_tables(tmp_path):
     for table in ["pagos", "facturas_pdf", "tickets_pdf", "ventas", "clientes"]:
         db.cursor.execute(f"SELECT COUNT(*) FROM {table}")
         assert db.cursor.fetchone()[0] == 0
+
+
+def test_import_inventory_preserves_vcf_extra_string(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+    db = manager.db
+
+    cliente_id = db.add_cliente(
+        "Cliente",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+    )
+
+    extra_payload = {"foo": "bar", "nested": {"value": 1}}
+    db.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-01-01",
+        total=10,
+        nrc="123456-7",
+        nit="06141407100012",
+        giro="Giro",
+        extra=extra_payload,
+    )
+
+    manager.refresh_data()
+
+    export_path = tmp_path / "inventario_export.json"
+    manager.exportar_inventario_json(str(export_path))
+    original_data = json.loads(export_path.read_text())
+    assert len(original_data["ventas_credito_fiscal"]) == 1
+    original_extra = original_data["ventas_credito_fiscal"][0]["extra"]
+
+    assert isinstance(original_extra, str)
+
+    manager.importar_inventario_json(str(export_path))
+
+    reexport_path = tmp_path / "inventario_reexport.json"
+    manager.exportar_inventario_json(str(reexport_path))
+    reexport_data = json.loads(reexport_path.read_text())
+    assert len(reexport_data["ventas_credito_fiscal"]) == 1
+    reexport_extra = reexport_data["ventas_credito_fiscal"][0]["extra"]
+
+    assert isinstance(reexport_extra, str)
+    assert reexport_extra == original_extra


### PR DESCRIPTION
## Summary
- avoid re-serializing ventas_credito_fiscal extra payloads when importing legacy inventories
- validate that credit-fiscal sales only pass structured extras so they are encoded once
- add a regression test covering an export/import/export cycle for ventas_credito_fiscal extras

## Testing
- pytest tests/test_import_inventory_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68d2472e78008323a58031b4608c01b5