### PR TITLE
Add diagnostic prints for DTE transmission flow

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4626,6 +4626,7 @@ def _load_dte_api_config():
     datos = _load_datos_negocio()
     dte_api = datos.get("dte_api") or {}
     raw_datos_url = dte_api.get("url") or dte_api.get("endpoint")
+    token = dte_api.get("token")
 
     def _norm(amb):
         amb = "" if amb is None else str(amb).strip().lower()
@@ -4662,6 +4663,8 @@ def _load_dte_api_config():
     )
     url = _normalize_recepcion_url(raw_datos_url or raw_cfg_url)
     logger.info("Recepción configurada → %s", url)
+    print("CFG: AMB=", ambiente, "URL=", url)
+    print("CFG: HAS_MANUAL_TOKEN=", bool(token))
     return {"ambiente": ambiente, "url": url}
 
 
@@ -4991,6 +4994,7 @@ def _post_dte(
     dui: str | None = None,
     client_id: str | None = None,
 ) -> dict:
+    print("HTTP: POST_ENTER")
     token = token or ""
     if token:
         logger.debug("Token: %s...%s", token[:5], token[-5:])
@@ -5505,6 +5509,7 @@ def _enviar_documento(
 
     Si ``jws_token`` se proporciona, se reutiliza en lugar de firmar nuevamente.
     """
+    print("DTE: START_enviar_documento", "modo=", modo)
     SUCCESS_STATES = ("TRANSMITIDO", "RECIBIDO", "PROCESADO", "ACEPTADO")
     if doc_id is not None:
         row = db.cursor.execute(
@@ -5516,6 +5521,7 @@ def _enviar_documento(
             (doc_id, *SUCCESS_STATES),
         ).fetchone()
         if row:
+            print("DTE: ALREADY_SENT_GUARD", row[0] if row else None)
             raise ValueError("DTE ya enviado")
 
     config = _load_dte_api_config()
@@ -5537,7 +5543,9 @@ def _enviar_documento(
         data["identificacion"] = ident
     elif "identificador" in data:
         data["identificador"] = ident
+    manual_token = False
     token = auth.get_token()
+    print("AUTH: USING", "MANUAL" if manual_token else "AUTO")
     auth_host = auth.get_last_auth_host()
     recep_host = urlparse(url).netloc
     if auth_host and recep_host != auth_host:
@@ -5548,15 +5556,19 @@ def _enviar_documento(
         )
     try:
         resumen = data.get("resumen", {})
+        print("DTE: VALIDATE_IN", list((resumen or {}).keys()))
         condicion = normalize_condicion_operacion(resumen.get("condicionOperacion"))
         resumen["condicionOperacion"] = condicion
         validate_pagos_basico(resumen, condicion)
         data["resumen"] = resumen
+        print("DTE: VALIDATE_OK")
     except ValueError as exc:
         logger.error("ERROR: DTE inválido: %s", exc)
         raise ValueError(f"DTE inválido: {exc}") from exc
 
+    print("DTE: BEFORE_SIGN")
     signed = jws_token or jws.sign_json(data)
+    print("DTE: SIGNED_OK")
 
     if modo == "contingencia":
         try:
@@ -5591,6 +5603,7 @@ def _enviar_documento(
     meta["codigoGeneracion"] = p_cod
 
     try:
+        print("DTE: BEFORE_POST")
         respuesta = _post_dte(url, token, signed, meta)
         sello = (
             respuesta.get("sello")

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1903,6 +1903,7 @@ class FacturacionTab(QWidget):
         return detalle
 
     def send_selected_invoice(self):
+        print("UI: SEND_START")
         entry = self._selected_entry()
         if not entry:
             QMessageBox.warning(self, "Enviar", "Seleccione un documento")
@@ -1937,6 +1938,7 @@ class FacturacionTab(QWidget):
             if rtype == "orphan" and factura:
                 json_path = factura.get("json")
                 try:
+                    print("UI: CALL_ENVIAR_DOCUMENTO")
                     resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
                     if resp.get("http_status") in {401, 403}:
                         message = self._token_warning_message(resp, token_msg)
@@ -1975,18 +1977,22 @@ class FacturacionTab(QWidget):
                             mensaje or "Fallo al enviar",
                         )
                 except dte.DTEValidationError as exc:
+                    print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", "\n".join(exc.errors)
                     )
-                except RuntimeError:
+                except RuntimeError as exc:
+                    print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
                 except Exception as exc:
+                    print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", str(exc)
                     )
             else:
                 tipo_dte = self._determine_tipo_dte(entry)
                 try:
+                    print("UI: CALL_ENVIAR_DOCUMENTO")
                     resp = transmitir_dte(
                         self.manager.db,
                         entry.get("venta_id"),
@@ -2032,12 +2038,15 @@ class FacturacionTab(QWidget):
                             mensaje or "Fallo al enviar",
                         )
                 except dte.DTEValidationError as exc:
+                    print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", "\n".join(exc.errors)
                     )
-                except RuntimeError:
+                except RuntimeError as exc:
+                    print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
                 except Exception as exc:
+                    print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     QMessageBox.critical(
                         self, "Enviar a Hacienda", str(exc)
                     )

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -91,12 +91,21 @@ def sign_json(
     tipo_dte: str | None = None,
 ) -> str:
     """Sign ``payload`` using the external ``svfe-api-firmador`` service."""
+    print("SIGN: START")
     if nit is None or passwordPri is None:
         nit, passwordPri, activo = _load_config()
     if not nit:
         raise RuntimeError("NIT del certificado no configurado")
     _ensure_cert_file(nit)
     url = url or _get_sign_url()
+    print(
+        "SIGN: CERT?",
+        bool(nit),
+        "KEY?",
+        bool(passwordPri),
+        "REMOTE_SIGNER?",
+        url is not None,
+    )
 
     if isinstance(payload, str):
         payload_str = payload
@@ -137,11 +146,14 @@ def sign_json(
             logger.debug("Respuesta del firmador %s: %s", status_code, resp_text)
         response.raise_for_status()
     except requests.Timeout as exc:
+        print("SIGN: ERROR", type(exc).__name__, str(exc)[:200])
         raise RuntimeError("Tiempo de espera agotado al firmar") from exc
     except requests.HTTPError as exc:
+        print("SIGN: ERROR", type(exc).__name__, str(exc)[:200])
         status = exc.response.status_code
         raise RuntimeError(f"Error HTTP {status} al firmar: {exc.response.text}") from exc
     except requests.RequestException as exc:
+        print("SIGN: ERROR", type(exc).__name__, str(exc)[:200])
         raise RuntimeError(f"Error al firmar: {exc}") from exc
 
     data = response.json()


### PR DESCRIPTION
## Summary
- add temporary instrumentation prints in `FacturacionTab.send_selected_invoice` to trace UI flow and captured exceptions when transmitting a DTE
- emit diagnostics in `_load_dte_api_config`, `_enviar_documento`, and `_post_dte` to verify configuration, validation, signing, and POST execution order
- add signing diagnostics in `utils.jws.sign_json` to show certificate/credential status and any signer errors

## Testing
- python - <<'PY'
import auth
import dte
from types import SimpleNamespace

class DummyCursor:
    def execute(self, *args, **kwargs):
        return self
    def fetchone(self):
        return None

class DummyDB:
    def __init__(self):
        self.cursor = DummyCursor()
    def registrar_envio_dte(self, *args, **kwargs):
        print("DB: registrar_envio_dte", args, kwargs)
    def update_venta_extra(self, *args, **kwargs):
        print("DB: update_venta_extra", args, kwargs)

auth.get_token = lambda: "dummy-token"
auth.get_last_auth_host = lambda: None

data = {
    "identificacion": {
        "ambiente": "00",
        "version": "1",
        "tipoDte": "01",
        "codigoGeneracion": "ABC123456789",
        "numeroControl": "NC-1",
    },
    "resumen": {
        "totalLetras": "Diez",
        "condicionOperacion": "1",
    },
}

try:
    dte._enviar_documento(DummyDB(), 1, data, modo="normal")
except Exception as exc:
    print("RUN: EXCEPTION", type(exc).__name__, str(exc))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d22cc2a6308323ab957250dd10d7fc