### PR TITLE
Include runtime resources in PyInstaller spec

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -1,6 +1,12 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.building.datastruct import Tree
+
+resource_trees = [
+    Tree('schema_patches', prefix='schema_patches'),
+    Tree('svfe-json-schemas', prefix='svfe-json-schemas'),
+]
 
 # Collect all barcode submodules so ReportLab barcodes such as Code93 and
 # Code128 are bundled with the executable.
@@ -10,7 +16,19 @@ a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[
+        ('avatar.jpg', '.'),
+        ('logoinventario.jpg', '.'),
+        ('style.qss', '.'),
+        ('inventario.json', '.'),
+        ('ultimo_inventario.json', '.'),
+        ('formato_factura.json', '.'),
+        ('datos_negocio.json', '.'),
+        ('config_negocio.json', '.'),
+        ('VERSION', '.'),
+        ('schema_patches', 'schema_patches'),
+        ('svfe-json-schemas', 'svfe-json-schemas'),
+    ],
     hiddenimports=hidden_imports,
     hookspath=[],
     hooksconfig={},
@@ -42,6 +60,7 @@ coll = COLLECT(
     exe,
     a.binaries,
     a.datas,
+    *resource_trees,
     strip=False,
     upx=True,
     upx_exclude=[],


### PR DESCRIPTION
## Summary
- bundle every resource referenced via utils.resource_path when building the main executable
- ship schema directories using PyInstaller Tree objects so JSON schemas are available at runtime

## Testing
- pyinstaller main.spec

------
https://chatgpt.com/codex/tasks/task_e_68d2579b4f70832385c7c202e587d7ef