### PR TITLE
Include avatar image in PyInstaller bundle

### DIFF
--- a/build/VertexDTE.spec
+++ b/build/VertexDTE.spec
@@ -70,6 +70,7 @@ resource_files = [
     'datos_negocio.json',
     'config_negocio.json',
     'inventario.json',
+    'avatar.jpg',
 ]
 
 existing_files = []


### PR DESCRIPTION
## Summary
- include `avatar.jpg` in the list of resource files that PyInstaller copies to the bundle root so the default avatar ships with the app

## Testing
- pyinstaller build/VertexDTE.spec
- QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt5.QtWidgets import QApplication
from user_picker_dialog import DEFAULT_AVATAR, square_avatar
app = QApplication([])
pix = square_avatar(DEFAULT_AVATAR, 96)
print(pix.isNull())
PY

------
https://chatgpt.com/codex/tasks/task_e_68d2ed2e141c8323918cfcdbab9bec80