### PR TITLE
Fix ambiente handling in DTE generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3233,7 +3233,10 @@ def validate_dte_json(
         ident.pop("numeroControl", None)
     config = _load_dte_api_config()
     ambiente = "01" if config.get("ambiente") == "produccion" else "00"
-    ident.setdefault("ambiente", ambiente)
+    if ambiente == "01":
+        ident["ambiente"] = "01"
+    else:
+        ident.setdefault("ambiente", ambiente)
     amb_val = str(ident.get("ambiente", "")).lower()
     if amb_val not in {"00", "01"}:
         ident["ambiente"] = "01" if amb_val.startswith("produc") else "00"

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -1053,6 +1053,64 @@ def test_generar_dte_json_normaliza_ambiente_param(ambiente, expected, monkeypat
     assert data["identificacion"]["ambiente"] == expected
 
 
+def test_generar_dte_json_config_produccion_impone_ambiente(tmp_path, monkeypatch):
+    import dte as dte_module
+    import svfe.config as svfe_config
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "123456",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "06", "municipio": "23", "complemento": "Calle 1"},
+        "dte_api": {"prefijo_control": "S001P001"},
+    }
+    datos_file = tmp_path / "datos_negocio.json"
+    datos_file.write_text(json.dumps(datos))
+    monkeypatch.setattr(dte_module, "DATOS_NEGOCIO_PATH", str(datos_file), raising=False)
+    monkeypatch.setattr(dte_module, "_load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(svfe_config, "DATOS_NEGOCIO_PATH", str(datos_file), raising=False)
+    monkeypatch.setattr(svfe_config, "load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        dte_module,
+        "_load_dte_api_config",
+        lambda: {"ambiente": "produccion", "url": "https://api.example.com/fesv"},
+    )
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "700001",
+        "06141990011019",
+        "",
+        "giro",
+        "22223333",
+        "",
+        "C",
+        "06",
+        "23",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta(
+        "2024-01-01",
+        5,
+        cliente_id=cliente_id,
+        extra={"precios_incluyen_iva": False, "ambiente": "00"},
+    )
+    db.add_detalle_venta(venta_id, prod_id, 1, 5, vendedor_id=vend_id)
+
+    data = dte_module.generar_dte_json(db, venta_id, ambiente="pruebas")
+    assert data["identificacion"]["ambiente"] == "01"
+
+
 def test_dte_comision_sin_advertencia_total(capsys):
     db = create_db()
     db.add_vendedor("V1")

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -262,10 +262,30 @@ def generate_invoice_pdf(manager, venta_id):
                 "cambiará a modo normal"
             )
             tipo_operacion = 1
-    ambiente = venta_data.get("ambiente") or extra.get("ambiente") or "00"
-    if ambiente not in ("00", "01"):
-        amb_cfg = str(ambiente).lower()
-        ambiente = "01" if amb_cfg.startswith("produc") else "00"
+    ambiente_cfg = venta_data.get("ambiente") or extra.get("ambiente")
+
+    def _normalize_ambiente_label(value):
+        if value is None:
+            return None
+        label = str(value).strip().lower()
+        if not label:
+            return None
+        if label in {"00", "0", "pruebas", "test", "testing", "sandbox"}:
+            return "pruebas"
+        if label in {"01", "1", "produccion", "producción", "production"}:
+            return "produccion"
+        return label
+
+    ambiente = _normalize_ambiente_label(ambiente_cfg)
+    if ambiente is None:
+        try:
+            ambiente = _normalize_ambiente_label(
+                (dte._load_dte_api_config() or {}).get("ambiente")
+            )
+        except Exception:
+            ambiente = None
+    if ambiente is None:
+        ambiente = "pruebas"
 
     if tipo_operacion == 1 and not sello_recepcion:
         sello_recepcion = f"SELLO-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary
- read the ambiente label from the DTE API configuration when preparing invoice data instead of defaulting to "00"
- force validate_dte_json to overwrite the identificacion.ambiente value when the configuration targets production
- add a regression test that exercises the production configuration and asserts the resulting DTE uses ambiente "01"

## Testing
- pytest tests/test_generar_dte_json.py::test_generar_dte_json_config_produccion_impone_ambiente

------
https://chatgpt.com/codex/tasks/task_e_68d3531113f08323ab9d350fc1798686