### PR TITLE
Ensure invoice persistence failures abort and add coverage

### DIFF
--- a/tests/test_canonical_dte_storage.py
+++ b/tests/test_canonical_dte_storage.py
@@ -209,3 +209,65 @@ def test_generate_invoice_pdf_logs_and_fails_on_pdf_error(canonical_env, fake_si
     with pytest.raises(IOError):
         doc_gen.generate_invoice_pdf(manager, 5)
     assert any("No se pudo escribir PDF" in rec.message for rec in caplog.records)
+    assert not db.added_pdfs
+
+
+def test_ensure_invoice_copies_raises_on_pdf_failure(tmp_path):
+    pdf_path = tmp_path / "factura.pdf"
+    json_path = tmp_path / "factura.json"
+    payload = {"identificacion": {}}
+
+    def _fail_renderer(_):
+        raise IOError("sin permisos")
+
+    with pytest.raises(IOError):
+        doc_gen._ensure_invoice_copies(pdf_path, json_path, payload, _fail_renderer)
+
+
+def test_ensure_invoice_copies_raises_on_json_failure(tmp_path, monkeypatch):
+    pdf_path = tmp_path / "factura.pdf"
+    pdf_path.write_bytes(b"PDF")
+    json_path = tmp_path / "factura.json"
+    payload = {"identificacion": {}}
+
+    def _raise(*_args, **_kwargs):
+        raise OSError("bloqueado")
+
+    monkeypatch.setattr(doc_gen, "save_file", _raise)
+
+    with pytest.raises(OSError):
+        doc_gen._ensure_invoice_copies(pdf_path, json_path, payload, lambda path: path.write_bytes(b"PDF"))
+
+
+def test_generate_invoice_pdf_aborts_when_json_copy_cannot_be_written(
+    canonical_env,
+    fake_sign_and_save,
+    fake_save_dte,
+    fake_versioned_state,
+    fake_generar_dte,
+    fake_pdf_renderer,
+    monkeypatch,
+):
+    db = FakeDB()
+    venta = {"id": 6, "fecha": "2024-04-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[6] = [{"cantidad": 1, "precio_unitario": 10}]
+    manager = type("Manager", (), {"db": db, "_clientes": [], "_Distribuidores": []})()
+
+    original_path_missing = doc_gen._path_missing
+
+    def _force_missing(path: Path) -> bool:
+        if Path(path).suffix == ".json":
+            return True
+        return original_path_missing(path)
+
+    def _raise_save(path, *_args, **_kwargs):
+        raise OSError(f"sin permisos para {path}")
+
+    monkeypatch.setattr(doc_gen, "_path_missing", _force_missing)
+    monkeypatch.setattr(doc_gen, "save_file", _raise_save)
+
+    with pytest.raises(OSError):
+        doc_gen.generate_invoice_pdf(manager, 6)
+
+    assert not db.added_pdfs

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -4,6 +4,7 @@ import uuid
 import logging
 from datetime import datetime
 from decimal import InvalidOperation
+from typing import Callable
 
 import dte
 from pathlib import Path
@@ -16,9 +17,46 @@ from utils.jws import sign_and_save
 from utils import versioned_dte
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 from utils.sanitize import limpiar_documentos
+from utils.stable_json import save_file, stable_stringify
 
 
 logger = logging.getLogger(__name__)
+
+
+def _path_missing(path: Path) -> bool:
+    """Return ``True`` if ``path`` is absent or an empty file."""
+
+    try:
+        return not path.exists() or path.stat().st_size <= 0
+    except OSError:
+        return True
+
+
+def _ensure_invoice_copies(
+    pdf_path: Path,
+    json_path: Path,
+    json_payload: dict,
+    renderer: Callable[[Path], None] | None,
+) -> None:
+    """Guarantee copies of the invoice PDF and JSON exist at the target paths."""
+
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    if _path_missing(pdf_path) and renderer is not None:
+        logger.warning("PDF faltante; intentando regenerar %s", pdf_path)
+        try:
+            write_pdf_atomically(pdf_path, renderer)
+        except Exception:
+            logger.exception("No se pudo regenerar PDF en %s", pdf_path)
+            raise
+
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    if _path_missing(json_path):
+        logger.warning("JSON faltante; intentando reescribir %s", json_path)
+        try:
+            save_file(str(json_path), stable_stringify(json_payload, indent=2))
+        except Exception:
+            logger.exception("No se pudo garantizar copia JSON en %s", json_path)
+            raise
 
 
 def log_venta_vs_dte(manager, venta_id):
@@ -514,7 +552,10 @@ def generate_invoice_pdf(manager, venta_id):
             pass
     except Exception:
         pass
-    if not json_path.exists():
+    _ensure_invoice_copies(file_path, json_path, json_data, _render_invoice_pdf)
+    if _path_missing(file_path):
+        raise IOError(f"No se pudo guardar PDF en {file_path}")
+    if _path_missing(json_path):
         raise IOError(f"No se pudo guardar JSON en {json_path}")
     manager.db.add_factura_pdf(venta_id, tipo_doc, str(file_path))
     return str(file_path)

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -72,13 +72,22 @@ def write_pdf_atomically(
     """
 
     dest_path = Path(os.fspath(destination))
-    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    parent = dest_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if not parent.exists():
+        raise FileNotFoundError(f"Directorio destino inexistente: {parent}")
+    if not os.access(parent, os.W_OK):
+        raise PermissionError(f"No hay permisos de escritura en {parent}")
     tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
     try:
+        logger.debug("Escribiendo PDF temporal %s (destino %s)", tmp_path, dest_path)
         render(tmp_path)
         if not tmp_path.exists():
             raise IOError(f"No se generó PDF temporal en {tmp_path}")
+        logger.debug("PDF temporal creado en %s (%s bytes)", tmp_path, tmp_path.stat().st_size)
+        logger.debug("Reemplazando %s con %s", dest_path, tmp_path)
         tmp_path.replace(dest_path)
+        logger.debug("PDF final escrito en %s", dest_path)
         return dest_path
     except Exception as exc:
         logger.error("No se pudo escribir PDF en %s: %s", dest_path, exc)


### PR DESCRIPTION
## Summary
- add warnings and propagate failures when regenerating missing invoice artifacts so persistence issues halt processing
- reinforce the atomic PDF writer with permission checks and detailed debug logging of the temporary file lifecycle
- cover critical persistence failures with targeted tests to ensure the database is not updated when artifacts are missing

## Testing
- pytest tests/test_canonical_dte_storage.py tests/test_invoice_json_save.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68d356d850dc8323880b8b65cc7b7e66