### PR TITLE
Harden atomic PDF writes

### DIFF
--- a/tests/test_canonical_dte_storage.py
+++ b/tests/test_canonical_dte_storage.py
@@ -209,3 +209,87 @@ def test_generate_invoice_pdf_logs_and_fails_on_pdf_error(canonical_env, fake_si
     with pytest.raises(IOError):
         doc_gen.generate_invoice_pdf(manager, 5)
     assert any("No se pudo escribir PDF" in rec.message for rec in caplog.records)
+    assert not db.added_pdfs
+
+
+def test_ensure_invoice_copies_raises_on_pdf_failure(tmp_path):
+    pdf_path = tmp_path / "factura.pdf"
+    json_path = tmp_path / "factura.json"
+    payload = {"identificacion": {}}
+
+    def _fail_renderer(_):
+        raise IOError("sin permisos")
+
+    with pytest.raises(IOError):
+        doc_gen._ensure_invoice_copies(pdf_path, json_path, payload, _fail_renderer)
+
+
+def test_ensure_invoice_copies_raises_on_json_failure(tmp_path, monkeypatch):
+    pdf_path = tmp_path / "factura.pdf"
+    pdf_path.write_bytes(b"PDF")
+    json_path = tmp_path / "factura.json"
+    payload = {"identificacion": {}}
+
+    def _raise(*_args, **_kwargs):
+        raise OSError("bloqueado")
+
+    monkeypatch.setattr(doc_gen, "save_file", _raise)
+
+    with pytest.raises(OSError):
+        doc_gen._ensure_invoice_copies(pdf_path, json_path, payload, lambda path: path.write_bytes(b"PDF"))
+
+
+def test_write_pdf_atomically_requires_non_empty_output(tmp_path):
+    destination = tmp_path / "factura.pdf"
+
+    def _empty_renderer(output_path):
+        output_path.write_bytes(b"")
+
+    with pytest.raises(IOError):
+        docs.write_pdf_atomically(destination, _empty_renderer)
+    assert not destination.exists()
+
+
+def test_write_pdf_atomically_rejects_missing_output(tmp_path):
+    destination = tmp_path / "factura.pdf"
+
+    def _no_output(_output_path):
+        return None
+
+    with pytest.raises(IOError):
+        docs.write_pdf_atomically(destination, _no_output)
+    assert not destination.exists()
+
+
+def test_generate_invoice_pdf_aborts_when_json_copy_cannot_be_written(
+    canonical_env,
+    fake_sign_and_save,
+    fake_save_dte,
+    fake_versioned_state,
+    fake_generar_dte,
+    fake_pdf_renderer,
+    monkeypatch,
+):
+    db = FakeDB()
+    venta = {"id": 6, "fecha": "2024-04-01", "total": 10}
+    db._ventas.append(venta)
+    db.detalles[6] = [{"cantidad": 1, "precio_unitario": 10}]
+    manager = type("Manager", (), {"db": db, "_clientes": [], "_Distribuidores": []})()
+
+    original_path_missing = doc_gen._path_missing
+
+    def _force_missing(path: Path) -> bool:
+        if Path(path).suffix == ".json":
+            return True
+        return original_path_missing(path)
+
+    def _raise_save(path, *_args, **_kwargs):
+        raise OSError(f"sin permisos para {path}")
+
+    monkeypatch.setattr(doc_gen, "_path_missing", _force_missing)
+    monkeypatch.setattr(doc_gen, "save_file", _raise_save)
+
+    with pytest.raises(OSError):
+        doc_gen.generate_invoice_pdf(manager, 6)
+
+    assert not db.added_pdfs

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -4,6 +4,7 @@ import uuid
 import logging
 from datetime import datetime
 from decimal import InvalidOperation
+from typing import Callable
 
 import dte
 from pathlib import Path
@@ -16,9 +17,68 @@ from utils.jws import sign_and_save
 from utils import versioned_dte
 from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
 from utils.sanitize import limpiar_documentos
+from utils.stable_json import save_file, stable_stringify
 
 
 logger = logging.getLogger(__name__)
+
+
+def _path_missing(path: Path) -> bool:
+    """Return ``True`` if ``path`` is absent or an empty file."""
+
+    try:
+        return not path.exists() or path.stat().st_size <= 0
+    except OSError:
+        return True
+
+
+def _ensure_invoice_copies(
+    pdf_path: Path,
+    json_path: Path,
+    json_payload: dict,
+    renderer: Callable[[Path], None] | None,
+) -> None:
+    """Guarantee copies of the invoice PDF and JSON exist at the target paths."""
+
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf_missing = _path_missing(pdf_path)
+    json_missing = _path_missing(json_path)
+    logger.info(
+        "Verificando copias de factura PDF=%s (missing=%s) JSON=%s (missing=%s)",
+        pdf_path,
+        pdf_missing,
+        json_path,
+        json_missing,
+    )
+    if pdf_missing and renderer is not None:
+        logger.warning("PDF faltante; intentando regenerar %s", pdf_path)
+        try:
+            write_pdf_atomically(pdf_path, renderer)
+        except Exception:
+            logger.exception("No se pudo regenerar PDF en %s", pdf_path)
+            raise
+        pdf_missing = _path_missing(pdf_path)
+
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    if json_missing:
+        logger.warning("JSON faltante; intentando reescribir %s", json_path)
+        try:
+            save_file(str(json_path), stable_stringify(json_payload, indent=2))
+        except Exception:
+            logger.exception("No se pudo garantizar copia JSON en %s", json_path)
+            raise
+        json_missing = _path_missing(json_path)
+    try:
+        folder_contents = sorted(p.name for p in pdf_path.parent.iterdir())
+    except Exception:
+        folder_contents = None
+    logger.info(
+        "Resultado verificación copias -> PDF missing=%s JSON missing=%s; contenido %s: %s",
+        pdf_missing,
+        json_missing,
+        pdf_path.parent,
+        folder_contents,
+    )
 
 
 def log_venta_vs_dte(manager, venta_id):
@@ -479,7 +539,20 @@ def generate_invoice_pdf(manager, venta_id):
             motivo_contin=motivo_contin,
         )
 
+    logger.info(
+        "Intentando generar PDF en %s con renderer=%s",
+        file_path,
+        _render_invoice_pdf,
+    )
+    logger.info("Generando PDF de factura en %s", file_path)
     write_pdf_atomically(file_path, _render_invoice_pdf)
+    try:
+        pdf_size = file_path.stat().st_size
+    except OSError:
+        logger.warning("No se pudo obtener tamaño de PDF en %s", file_path, exc_info=True)
+        pdf_size = None
+    else:
+        logger.info("PDF de factura escrito en %s (%s bytes)", file_path, pdf_size)
     if tipo_operacion == 2:
         manager.db.add_dte_pendiente(venta_id, json_data, str(tipo_operacion))
     try:
@@ -497,7 +570,8 @@ def generate_invoice_pdf(manager, venta_id):
     try:
         _, jws_token = sign_and_save(json_data, str(json_path), return_token=True)
     except Exception:
-        pass
+        logger.exception("Fallo al firmar y guardar JSON en %s", json_path)
+        jws_token = None
     try:
         pend_json_path = dte.save_dte_json(json_data, filename=json_path.name)
         version_dir = os.path.dirname(pend_json_path)
@@ -514,8 +588,46 @@ def generate_invoice_pdf(manager, venta_id):
             pass
     except Exception:
         pass
-    if not json_path.exists():
+    _ensure_invoice_copies(file_path, json_path, json_data, _render_invoice_pdf)
+    try:
+        ensured_contents = sorted(p.name for p in file_path.parent.iterdir())
+    except Exception:
+        ensured_contents = None
+    logger.info(
+        "Estado post _ensure_invoice_copies -> PDF missing=%s JSON missing=%s; contenido %s: %s",
+        _path_missing(file_path),
+        _path_missing(json_path),
+        file_path.parent,
+        ensured_contents,
+    )
+    if _path_missing(file_path):
+        try:
+            contents = sorted(p.name for p in file_path.parent.iterdir())
+        except Exception:
+            contents = None
+        logger.error(
+            "No se encontró PDF en %s; contenido de la carpeta: %s",
+            file_path,
+            contents,
+        )
+        raise IOError(f"No se pudo guardar PDF en {file_path}")
+    if _path_missing(json_path):
+        try:
+            contents = sorted(p.name for p in json_path.parent.iterdir())
+        except Exception:
+            contents = None
+        logger.error(
+            "No se encontró JSON en %s; contenido de la carpeta: %s",
+            json_path,
+            contents,
+        )
         raise IOError(f"No se pudo guardar JSON en {json_path}")
+    try:
+        json_size = json_path.stat().st_size
+    except OSError:
+        logger.warning("No se pudo obtener tamaño de JSON en %s", json_path, exc_info=True)
+    else:
+        logger.info("JSON de factura escrito en %s (%s bytes)", json_path, json_size)
     manager.db.add_factura_pdf(venta_id, tipo_doc, str(file_path))
     return str(file_path)
 

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -72,13 +72,44 @@ def write_pdf_atomically(
     """
 
     dest_path = Path(os.fspath(destination))
-    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    parent = dest_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    parent_exists = parent.exists()
+    parent_writable = os.access(parent, os.W_OK)
+    logger.info(
+        "Validando carpeta destino %s (existe=%s writable=%s)",
+        parent,
+        parent_exists,
+        parent_writable,
+    )
+    if not parent_exists:
+        raise FileNotFoundError(f"Directorio destino inexistente: {parent}")
+    if not parent_writable:
+        raise PermissionError(f"No hay permisos de escritura en {parent}")
     tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
     try:
+        logger.info("Escribiendo PDF temporal %s (destino final %s)", tmp_path, dest_path)
+        logger.info(
+            "TMP path parent %s existe=%s writable=%s",
+            tmp_path.parent,
+            tmp_path.parent.exists(),
+            os.access(tmp_path.parent, os.W_OK),
+        )
         render(tmp_path)
         if not tmp_path.exists():
             raise IOError(f"No se generó PDF temporal en {tmp_path}")
+        tmp_size = tmp_path.stat().st_size
+        if tmp_size <= 0:
+            raise IOError(f"PDF temporal vacío en {tmp_path}")
+        logger.info("PDF temporal creado en %s (%s bytes)", tmp_path, tmp_size)
+        logger.info("Reemplazando %s con %s", dest_path, tmp_path)
         tmp_path.replace(dest_path)
+        if not dest_path.exists():
+            raise IOError(f"No se pudo mover PDF final a {dest_path}")
+        final_size = dest_path.stat().st_size
+        if final_size <= 0:
+            raise IOError(f"PDF final vacío en {dest_path}")
+        logger.info("PDF final escrito en %s (%s bytes)", dest_path, final_size)
         return dest_path
     except Exception as exc:
         logger.error("No se pudo escribir PDF en %s: %s", dest_path, exc)


### PR DESCRIPTION
## Summary
- guard the atomic PDF writer against empty or missing temporary files and recheck the final destination to ensure bytes were persisted
- add regression tests that confirm atomic writing fails when the renderer outputs nothing or an empty file

## Testing
- pytest tests/test_canonical_dte_storage.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d356d850dc8323880b8b65cc7b7e66