### PR TITLE
Handle Windows Store path virtualization

### DIFF
--- a/dialogs/invoice_detail_dialog.py
+++ b/dialogs/invoice_detail_dialog.py
@@ -19,6 +19,7 @@ from PyQt5.QtGui import QDesktopServices
 
 from utils.catalogos import TRIBUTO_IVA
 from utils.docs import get_document_paths, get_dte_document_paths
+from paths import resolve_user_visible_path
 from .anular_factura_dialog import AnularFacturaDialog
 import anulacion
 import dte
@@ -254,7 +255,8 @@ class InvoiceDetailDialog(QDialog):
         directory = os.path.dirname(path)
         if not directory:
             return
-        QDesktopServices.openUrl(QUrl.fromLocalFile(directory))
+        visible_directory = resolve_user_visible_path(directory)
+        QDesktopServices.openUrl(QUrl.fromLocalFile(visible_directory))
 
     def _refresh_invoice_files(self) -> str | None:
         """Try to locate or regenerate the PDF/JSON for the invoice."""

--- a/paths.py
+++ b/paths.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+from functools import lru_cache
 from pathlib import Path
 
 from appdirs import user_data_dir
@@ -129,3 +130,92 @@ def migrate_datos_negocio() -> None:
 
     for filename in ("datos_negocio.json", "config_negocio.json"):
         _copy_if_missing(filename)
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+@lru_cache()
+def _get_store_package_dirs(local_app_data: str) -> tuple[Path, ...]:
+    base = Path(local_app_data)
+    packages_dir = base / "Packages"
+    try:
+        entries = list(packages_dir.iterdir())
+    except OSError:
+        return ()
+    matches = []
+    for entry in entries:
+        try:
+            is_dir = entry.is_dir()
+        except OSError:
+            continue
+        if not is_dir:
+            continue
+        if entry.name.startswith("PythonSoftwareFoundation.Python."):
+            matches.append(entry)
+    return tuple(matches)
+def resolve_user_visible_path(path: os.PathLike[str] | str) -> str:
+    """Return a path that points to the physical file visible to the user.
+
+    When running under the Windows Store distribution of Python the
+    application is executed within an AppContainer which transparently
+    redirects writes to ``%LocalAppData%`` into the package specific
+    ``LocalCache\\Local`` directory.  The logical path is still reported to the
+    application which results in confusing messages for end users.  This helper
+    attempts to map a logical path back to its physical counterpart so paths
+    shown in the UI are consistent with what Windows Explorer exposes.
+    """
+
+    try:
+        requested = os.fspath(path)
+    except TypeError:
+        return path  # type: ignore[return-value]
+
+    if not requested:
+        return requested
+
+    if not _is_windows():
+        return requested
+
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if not local_app_data:
+        return requested
+
+    package_dirs = _get_store_package_dirs(local_app_data)
+    if not package_dirs:
+        return requested
+
+    try:
+        base_abs = os.path.abspath(local_app_data)
+        requested_abs = os.path.abspath(requested)
+    except (OSError, TypeError, ValueError):
+        return requested
+
+    try:
+        relative = os.path.relpath(requested_abs, base_abs)
+    except ValueError:
+        return requested
+
+    if relative == ".":
+        relative = ""
+
+    if relative.startswith(".."):
+        return requested
+
+    relative_path = Path(relative) if relative else None
+    if relative_path and any(part == os.pardir for part in relative_path.parts):
+        return requested
+
+    for package_dir in package_dirs:
+        physical_root = package_dir / "LocalCache" / "Local"
+        physical_path = physical_root
+        if relative_path:
+            physical_path = physical_root.joinpath(relative_path)
+        try:
+            exists = physical_path.exists()
+        except OSError:
+            continue
+        if exists:
+            return os.fspath(physical_path)
+    return requested

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -39,6 +39,7 @@ from paths import (
     FACTURAS_CONSUMIDOR_FINAL_DIR,
     FACTURAS_CREDITO_FISCAL_DIR,
     TICKETS_OUTPUT_DIR,
+    resolve_user_visible_path,
 )
 import logging
 
@@ -622,7 +623,12 @@ class SalesTab(QWidget):
             )
         if not file_path:
             return
-        QMessageBox.information(self, "Guardar factura", f"{doc_type} guardado en {file_path}")
+        display_path = resolve_user_visible_path(file_path)
+        QMessageBox.information(
+            self,
+            "Guardar factura",
+            f"{doc_type} guardado en {display_path}",
+        )
 
     def save_ticket(self):
         """Generate a simple ticket PDF for the selected sale."""
@@ -639,7 +645,12 @@ class SalesTab(QWidget):
             "No se pudo generar el ticket.",
         )
         if file_path:
-            QMessageBox.information(self, "Ticket", f"Ticket guardado en {file_path}")
+            display_path = resolve_user_visible_path(file_path)
+            QMessageBox.information(
+                self,
+                "Ticket",
+                f"Ticket guardado en {display_path}",
+            )
         
     def preview_pdf(self):
         """Open the saved PDF for the selected sale."""

--- a/tests/test_resolve_user_visible_path.py
+++ b/tests/test_resolve_user_visible_path.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+
+import paths
+
+
+def _force_windows(monkeypatch):
+    monkeypatch.setattr(paths, "_is_windows", lambda: True)
+    paths._get_store_package_dirs.cache_clear()
+
+
+def test_resolve_user_visible_path_prefers_physical_location(tmp_path, monkeypatch):
+    base = tmp_path / "AppData" / "Local"
+    package_dir = (
+        base
+        / "Packages"
+        / "PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0"
+    )
+    physical_root = package_dir / "LocalCache" / "Local"
+    physical_file = physical_root / "VertexDTE" / "facturas" / "venta.pdf"
+    physical_file.parent.mkdir(parents=True, exist_ok=True)
+    physical_file.write_bytes(b"pdf")
+
+    virtual_file = base / "VertexDTE" / "facturas" / "venta.pdf"
+    virtual_file.parent.mkdir(parents=True, exist_ok=True)
+    virtual_file.write_bytes(b"pdf")
+
+    monkeypatch.setenv("LOCALAPPDATA", str(base))
+    _force_windows(monkeypatch)
+
+    resolved = paths.resolve_user_visible_path(str(virtual_file))
+    assert resolved == str(physical_file)
+
+
+def test_resolve_user_visible_path_falls_back_when_missing(tmp_path, monkeypatch):
+    base = tmp_path / "AppData" / "Local"
+    package_dir = (
+        base
+        / "Packages"
+        / "PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0"
+    )
+    package_dir.mkdir(parents=True, exist_ok=True)
+
+    virtual_file = base / "VertexDTE" / "facturas" / "venta.pdf"
+
+    monkeypatch.setenv("LOCALAPPDATA", str(base))
+    _force_windows(monkeypatch)
+
+    resolved = paths.resolve_user_visible_path(str(virtual_file))
+    assert resolved == str(virtual_file)


### PR DESCRIPTION
## Summary
- add a helper that resolves virtualized `%LocalAppData%` paths to the underlying Windows Store `LocalCache/Local` directory when available
- surface the user-visible paths in SalesTab success messages and when opening invoice folders from the detail dialog
- cover the new helper with regression tests that emulate an AppContainer packages layout

## Testing
- pytest tests/test_resolve_user_visible_path.py tests/test_invoice_detail_dialog_paths.py


------
https://chatgpt.com/codex/tasks/task_e_68d3821d961c83238e968ac5d6832a89