### PR TITLE
Ajusta campo Venta a cuenta en PDFs

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -271,6 +271,32 @@ def generar_factura_electronica_pdf(
     telefono = datos_negocio.get('telefono', '')
     correo_emisor = datos_negocio.get('correo') or datos_negocio.get('email_usuario', '')
 
+    extra_info = venta.get("extra")
+    if isinstance(extra_info, str):
+        try:
+            extra_info = json.loads(extra_info)
+        except Exception:
+            extra_info = {}
+    elif not isinstance(extra_info, dict):
+        extra_info = {}
+
+    def _clean_field(primary_value, fallback_value):
+        for candidate in (primary_value, fallback_value):
+            if candidate in (None, ""):
+                continue
+            text = str(candidate).strip()
+            if text:
+                return text
+        return ""
+
+    venta_a_cuenta_text = _clean_field(
+        venta.get("venta_a_cuenta_de"), extra_info.get("venta_a_cuenta_de")
+    )
+    documento_venta_a_cuenta_text = _clean_field(
+        venta.get("documento_venta_a_cuenta"),
+        extra_info.get("documento_venta_a_cuenta"),
+    )
+
     emisor_lines = [
         f"Nombre: {datos_negocio.get('nombre', '')}",
         f"NIT: {datos_negocio.get('nit', '')}  NRC: {datos_negocio.get('nrc', '')}",
@@ -290,7 +316,7 @@ def generar_factura_electronica_pdf(
         receptor_extra += 1  # línea "Condición pago"
     receptor_line_count += receptor_extra
     receptor_line_count += 1  # Dirección
-    if venta.get('venta_a_cuenta_de') or venta.get('documento_venta_a_cuenta'):
+    if venta_a_cuenta_text or documento_venta_a_cuenta_text:
         receptor_line_count += 1
 
     box_h_emisor = 14 + line_h * emisor_line_count
@@ -383,12 +409,13 @@ def generar_factura_electronica_pdf(
         line_h,
     )
 
-    if venta.get('venta_a_cuenta_de') or venta.get('documento_venta_a_cuenta'):
-        text_y -= line_h
-        if venta.get('venta_a_cuenta_de'):
-            c.drawString(left_x, text_y, f"Venta a cta de: {venta.get('venta_a_cuenta_de')}")
-        if venta.get('documento_venta_a_cuenta'):
-            c.drawString(right_x, text_y, f"DUI/NIT: {venta.get('documento_venta_a_cuenta')}")
+    if venta_a_cuenta_text or documento_venta_a_cuenta_text:
+        spacing = max(line_h - 4, 4)
+        text_y -= spacing
+        if venta_a_cuenta_text:
+            c.drawString(left_x, text_y, f"Venta a cta de: {venta_a_cuenta_text}")
+        if documento_venta_a_cuenta_text:
+            c.drawString(right_x, text_y, f"DUI/NIT: {documento_venta_a_cuenta_text}")
 
     # Posición inicial para la tabla de productos
     tabla_x = x_margin

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -129,6 +129,58 @@ def test_consumidor_final_pdf_omits_iva_column(tmp_path):
     assert '0.65' not in text
 
 
+def test_credito_fiscal_pdf_shows_venta_a_cuenta(tmp_path):
+    venta, detalles = _sample_data('Crédito Fiscal')
+    venta['venta_a_cuenta_de'] = 'Tercero Ejemplo'
+    venta['documento_venta_a_cuenta'] = '0614-1990-0110-19'
+    out = tmp_path / 'fact_cf_venta_cta.pdf'
+    generar_factura_electronica_pdf(
+        venta,
+        detalles,
+        {},
+        {},
+        'Crédito Fiscal',
+        archivo=str(out),
+        datos_negocio={},
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion='0' * 40,
+    )
+    with fitz.open(out) as doc:
+        text = ''.join(p.get_text() for p in doc)
+
+    assert 'Venta a cta de: Tercero Ejemplo' in text
+    assert 'DUI/NIT: 0614-1990-0110-19' in text
+
+
+def test_consumidor_final_pdf_shows_venta_a_cuenta_from_extra(tmp_path):
+    venta, detalles = _sample_data('Consumidor Final')
+    venta['extra'] = {
+        'venta_a_cuenta_de': 'Cliente CF',
+        'documento_venta_a_cuenta': '0614-2000-1111-19',
+    }
+    out = tmp_path / 'fact_cf_extra.pdf'
+    generar_factura_electronica_pdf(
+        venta,
+        detalles,
+        {},
+        {},
+        'Consumidor Final',
+        archivo=str(out),
+        datos_negocio={},
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion='0' * 40,
+    )
+    with fitz.open(out) as doc:
+        text = ''.join(p.get_text() for p in doc)
+
+    assert 'Venta a cta de: Cliente CF' in text
+    assert 'DUI/NIT: 0614-2000-1111-19' in text
+
+
 def test_total_letras_is_wrapped(tmp_path):
     venta = {
         'sumas': 0,


### PR DESCRIPTION
## Summary
- asegura que la información de "Venta a cta de" se lea también desde los datos extra de la venta y se muestre ligeramente más arriba dentro del recuadro
- añade pruebas que verifican la presencia de "Venta a cta de" tanto en facturas de crédito fiscal como de consumidor final

## Testing
- pytest tests/test_factura_pdf.py -k venta_a_cuenta


------
https://chatgpt.com/codex/tasks/task_e_68d47f43d9c88323abb764e2854c3d27