### PR TITLE
Align invoice PDF lines with DTE data

### DIFF
--- a/tests/test_credito_fiscal_pdf_iva.py
+++ b/tests/test_credito_fiscal_pdf_iva.py
@@ -1,8 +1,10 @@
 import json
 import uuid
+from decimal import Decimal
+
 import pytest
 
-from utils.monto import to_base_iva
+from utils.monto import to_base_iva, iva_item
 
 from utils.doc_generation import generate_invoice_pdf
 from utils.docs import build_invoice_json
@@ -176,6 +178,105 @@ def test_pdf_total_precios_incluyen_iva(tmp_path, monkeypatch):
     assert pytest.approx(captured["venta"]["total"], 0.01) == 15
     assert pytest.approx(captured["detalles"][0]["iva"], 0.01) == float(iva)
     assert pytest.approx(captured["detalles"][0]["ventas_gravadas"], 0.01) == float(base)
+
+
+def test_pdf_importa_detalles_dte(tmp_path, monkeypatch):
+    db = FakeDB()
+    venta = {
+        "id": 1,
+        "fecha": "2024-01-01",
+        "total": 12,
+    }
+    db._ventas.append(venta)
+    db.detalles[1] = [
+        {
+            "cantidad": 1,
+            "precio_unitario": 12,
+            "descripcion": "Producto",
+            "iva": 0,
+        }
+    ]
+    db.credito[1] = {
+        "sumas": 12,
+        "descuentos": 0,
+        "iva": 0,
+        "subtotal": 12,
+        "ventas_exentas": 0,
+        "ventas_no_sujetas": 0,
+    }
+    man = Manager(db)
+
+    pdf_path = tmp_path / "fact.pdf"
+    json_path = tmp_path / "fact.json"
+
+    def fake_paths(date, cliente, identifier, doc_type, root=None):
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(pdf_path), str(json_path)
+
+    base = Decimal("10.619469")
+    iva = iva_item(base)
+
+    def fake_generar(db_, vid, **_):
+        venta = next(v for v in db_.get_ventas() if v["id"] == vid)
+        detalles = db_.get_detalles_venta(vid)
+        data = build_invoice_json(venta, {}, detalles)
+        ident = data.setdefault("identificacion", {})
+        ident["codigoGeneracion"] = uuid.uuid4().hex
+        ident["numeroControl"] = uuid.uuid4().hex[:8].upper()
+        ident["tipoDte"] = "03"
+        data["cuerpoDocumento"] = [
+            {
+                "numItem": 1,
+                "cantidad": "1.0000",
+                "precioUni": str(base),
+                "ventaGravada": str(base),
+                "ventaExenta": "0",
+                "ventaNoSuj": "0",
+                "noGravado": "0",
+                "montoDescu": "0",
+            }
+        ]
+        resumen = {
+            "sumas": str(base),
+            "subTotalVentas": str(base),
+            "subTotal": str(base),
+            "totalGravada": str(base),
+            "totalExenta": "0",
+            "totalNoSuj": "0",
+            "montoTotalOperacion": "12.0000",
+            "totalPagar": "12.0000",
+            "condicionOperacion": 1,
+            "tributos": [
+                {
+                    "codigo": "20",
+                    "descripcion": "IVA",
+                    "valor": str(iva),
+                }
+            ],
+        }
+        data["resumen"] = resumen
+        return data
+
+    captured = {}
+
+    def fake_pdf(venta_d, detalles_d, cliente, distribuidor, tipo_doc, archivo="", **_):
+        captured["venta"] = venta_d
+        captured["detalles"] = [dict(item) for item in detalles_d]
+        with open(archivo, "wb") as fh:
+            fh.write(b"pdf")
+
+    monkeypatch.setattr("utils.doc_generation.get_document_paths", fake_paths)
+    monkeypatch.setattr("utils.doc_generation.generar_dte_json", fake_generar)
+    monkeypatch.setattr("utils.doc_generation.generar_factura_electronica_pdf", fake_pdf)
+
+    generate_invoice_pdf(man, 1)
+
+    detalle = captured["detalles"][0]
+    expected_base = float(base)
+    expected_iva = float(iva)
+    assert pytest.approx(detalle["precio_unitario"], rel=1e-6) == expected_base
+    assert pytest.approx(detalle["ventas_gravadas"], rel=1e-6) == expected_base
+    assert pytest.approx(detalle["iva"], rel=1e-6) == expected_iva
 
 
 def test_credito_fiscal_resumen_iva(tmp_path):

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -510,6 +510,96 @@ def generate_invoice_pdf(manager, venta_id):
     _update(("ventas_gravadas", "totalGravada"), "totalGravada", "ventas_gravadas")
     _update(("total", "totalPagar"), "totalPagar", "total", "montoTotalOperacion")
 
+    dte_items = json_data.get("cuerpoDocumento")
+
+    def _normalize_item_value(value):
+        if value in (None, ""):
+            return None
+        try:
+            return float(D(str(value)))
+        except (InvalidOperation, ValueError, TypeError):
+            return None
+
+    if isinstance(dte_items, list) and detalles:
+        index_by_num: dict[int, int] = {}
+        for idx, detalle in enumerate(detalles):
+            num_val = None
+            for key in ("numItem", "num_item", "numero", "num", "item"):
+                raw = detalle.get(key)
+                if raw in (None, ""):
+                    continue
+                try:
+                    num_val = int(str(raw).strip())
+                except (ValueError, TypeError):
+                    continue
+                else:
+                    break
+            if num_val is not None:
+                index_by_num.setdefault(num_val, idx)
+
+        used_indices: set[int] = set()
+
+        def _pick_index(item: dict) -> int | None:
+            num_raw = item.get("numItem")
+            if num_raw not in (None, ""):
+                try:
+                    num_int = int(str(num_raw).strip())
+                except (ValueError, TypeError):
+                    num_int = None
+                if num_int is not None:
+                    idx = index_by_num.get(num_int)
+                    if idx is not None and idx not in used_indices:
+                        return idx
+            for candidate in range(len(detalles)):
+                if candidate not in used_indices:
+                    return candidate
+            return None
+
+        for item in dte_items:
+            if not isinstance(item, dict):
+                continue
+            idx = _pick_index(item)
+            if idx is None:
+                continue
+            used_indices.add(idx)
+            detalle = detalles[idx]
+
+            cantidad = _normalize_item_value(item.get("cantidad"))
+            if cantidad is not None:
+                detalle["cantidad"] = cantidad
+
+            precio = _normalize_item_value(item.get("precioUni"))
+            if precio is not None:
+                detalle["precio_unitario"] = precio
+
+            descuento = _normalize_item_value(item.get("montoDescu"))
+            if descuento is not None:
+                detalle["descuento"] = descuento
+                if descuento and str(detalle.get("descuento_tipo", "")).strip() == "%":
+                    detalle["descuento_tipo"] = "$"
+
+            for dest, src in (
+                ("ventas_gravadas", "ventaGravada"),
+                ("ventas_exentas", "ventaExenta"),
+                ("ventas_no_sujetas", "ventaNoSuj"),
+            ):
+                value = _normalize_item_value(item.get(src))
+                if value is not None:
+                    detalle[dest] = value
+
+            iva_val = _normalize_item_value(item.get("ivaItem"))
+            if iva_val is None:
+                base_val = detalle.get("ventas_gravadas")
+                if base_val is None:
+                    base_val = _normalize_item_value(item.get("ventaGravada"))
+                if base_val is not None:
+                    try:
+                        iva_val = float(iva_item(D(str(base_val))))
+                    except (InvalidOperation, ValueError, TypeError):
+                        iva_val = None
+            if iva_val is not None:
+                detalle["iva"] = iva_val
+
     if not venta_data.get("total_letras"):
         try:
             venta_data["total_letras"] = monto_a_texto_sv(venta_data.get("total", 0))


### PR DESCRIPTION
## Summary
- sync invoice PDF line items with the generated DTE payload so unit price, bases and IVA match
- add regression test ensuring PDF generation adopts DTE values for crédito fiscal invoices

## Testing
- pytest tests/test_credito_fiscal_pdf_iva.py

------
https://chatgpt.com/codex/tasks/task_e_68d4c28f8ffc83238850ef0928f5ca41