### PR TITLE
Clarify ticket titles by document type

### DIFF
--- a/print/ticket_renderer.py
+++ b/print/ticket_renderer.py
@@ -22,6 +22,7 @@ from factura_sv import build_qr_url
 from utils.catalogos import (
     CAT_DEPTOS,
     CAT_MUNI44,
+    DTE_TIPOS,
     FORMA_PAGO,
     MODELO,
     OPERACION,
@@ -75,6 +76,24 @@ def q(value: Any) -> str:
 
 
 PAGO_LABELS = {code.zfill(2): value.upper() for code, value in FORMA_PAGO.items()}
+
+
+def document_title_label(ident: Dict[str, Any] | None) -> str:
+    """Return an uppercased label describing the DTE document type."""
+
+    tipo_dte = ""
+    if ident and isinstance(ident, dict):
+        tipo_dte = str(ident.get("tipoDte") or "").zfill(2)
+
+    if tipo_dte == "01":
+        return "CONSUMIDOR FINAL"
+    if tipo_dte == "03":
+        return "CRÉDITO FISCAL"
+
+    label = DTE_TIPOS.get(tipo_dte)
+    if label:
+        return label.upper()
+    return "FACTURA"
 
 
 # ---------------------------------------------------------------------------
@@ -358,8 +377,9 @@ def render_ticket_pdf(
         )
 
     # Title ----------------------------------------------------------------------
+    title_label = document_title_label(ident)
     add_text(
-        "DOCUMENTO TRIBUTARIO ELECTRÓNICO — FACTURA",
+        f"DOCUMENTO TRIBUTARIO ELECTRÓNICO — {title_label}",
         size=11,
         bold=True,
         align="center",

--- a/tests/test_ticket_fe_pdf.py
+++ b/tests/test_ticket_fe_pdf.py
@@ -52,15 +52,13 @@ def test_ticket_fe_pdf_clean(tmp_path):
 
     with fitz.open(out) as doc:
         text = "\n".join(page.get_text() for page in doc)
+    normalized = " ".join(text.split())
 
     for bad in ("apendice", "cuerpoDocumento", "falta", "None"):
         assert bad not in text
 
-    for good in (
-        "ELECTRÓNICO — FACTURA",
-        "Forma de pago:",
-        "CANT. DESCRIPCIÓN",
-    ):
+    assert "ELECTRÓNICO — CONSUMIDOR FINAL" in normalized
+    for good in ("Forma de pago:", "CANT. DESCRIPCIÓN"):
         assert good in text
 
 
@@ -176,6 +174,7 @@ def test_generate_ticket_pdf_defaults_and_persists_es_ticket(tmp_path, monkeypat
 
     with fitz.open(pdf_path) as doc:
         text = "\n".join(page.get_text() for page in doc)
+    normalized = " ".join(text.split())
 
-    assert "ELECTRÓNICO — FACTURA" in text
+    assert "ELECTRÓNICO — CONSUMIDOR FINAL" in normalized
     assert "Forma de pago:" in text

--- a/tests/test_ticket_renderer.py
+++ b/tests/test_ticket_renderer.py
@@ -47,12 +47,27 @@ def test_render_ticket_pdf_clean(tmp_path):
 
     with fitz.open(out) as doc:
         text = "\n".join(page.get_text() for page in doc)
+    normalized = " ".join(text.split())
 
     assert "cuerpoDocumento" not in text
     assert "identificacion" not in text
     assert "DOCUMENTO TRIBUTARIO" in text
-    assert "ELECTRÓNICO — FACTURA" in text
+    assert "ELECTRÓNICO — CONSUMIDOR FINAL" in normalized
     assert "DETALLE DE FACTURA" in text
     assert "FORMA DE PAGO" in text or "Forma de pago" in text
     assert "Sello de Recepción: SEAL-123" in text
     assert "3.39" in text  # total
+
+
+def test_render_ticket_pdf_credito_fiscal_title(tmp_path):
+    payload = _sample_payload()
+    payload["identificacion"]["tipoDte"] = "03"
+    pdf_bytes = render_ticket_pdf(payload, accepted=True, sello="SEAL-123")
+    out = tmp_path / "ticket.pdf"
+    out.write_bytes(pdf_bytes)
+
+    with fitz.open(out) as doc:
+        text = "\n".join(page.get_text() for page in doc)
+    normalized = " ".join(text.split())
+
+    assert "ELECTRÓNICO — CRÉDITO FISCAL" in normalized

--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -7,7 +7,13 @@ from reportlab.graphics import renderPDF
 import json
 import os
 
-from print.ticket_renderer import PAGO_LABELS, money, q, render_ticket_pdf
+from print.ticket_renderer import (
+    PAGO_LABELS,
+    document_title_label,
+    money,
+    q,
+    render_ticket_pdf,
+)
 
 from paths import DATOS_NEGOCIO_PATH
 from factura_sv import build_qr_url
@@ -210,7 +216,12 @@ def generar_ticket_personalizado(
         y -= 1
 
     # Encabezado ---------------------------------------------------------------
-    draw_center("DOCUMENTO TRIBUTARIO ELECTRÓNICO — FACTURA", size=14, bold=True)
+    titulo = document_title_label(ident)
+    draw_center(
+        f"DOCUMENTO TRIBUTARIO ELECTRÓNICO — {titulo}",
+        size=14,
+        bold=True,
+    )
     draw_hr()
 
     # Datos del emisor --------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a shared helper to determine the printable DTE title based on tipoDte
- show "Consumidor final" or "Crédito fiscal" in ticket headers while keeping other types dynamic
- adjust ticket PDF unit tests to account for the updated headers

## Testing
- pytest tests/test_ticket_renderer.py tests/test_ticket_fe_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68d4d9f947ac8323aeb60af319e9aa9a