### PR TITLE
Polish 58mm thermal tickets for production printers

### DIFF
--- a/print/ticket_renderer.py
+++ b/print/ticket_renderer.py
@@ -1,40 +1,50 @@
 """Utilities to render DTE tickets as thermal PDFs.
 
-This module exposes :func:`render_ticket_pdf` which takes a DTE payload and
-returns the resulting PDF as ``bytes``.  The goal is to produce a clean ticket
-layout without leaking internal structures from the JSON payload.
+This module now renders tickets using HTML templates targeted at 58 mm
+thermal printers.  The templates live under :mod:`templates/` and share a
+common CSS stylesheet that enforces the typography, spacing and layout
+guidelines required for 203 dpi printers.
 """
 
 from __future__ import annotations
 
-from decimal import Decimal, ROUND_HALF_UP
+from base64 import b64encode
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from functools import lru_cache
 from io import BytesIO
-from typing import Any, Dict, List, Tuple
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
-from reportlab.graphics import renderPDF
-from reportlab.graphics.barcode import qr
-from reportlab.graphics.shapes import Drawing
-from reportlab.lib.units import mm
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfgen import canvas
+import qrcode
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from weasyprint import CSS, HTML
 
 from factura_sv import build_qr_url
 from utils.catalogos import (
     CAT_DEPTOS,
     CAT_MUNI44,
+    CAT_MUNI44_BY_DEPTO,
+    CONDICION_OPERACION,
     DTE_TIPOS,
     FORMA_PAGO,
     MODELO,
     OPERACION,
+    PLAZO,
     TIPO_DOC_REC,
 )
 
-try:  # pragma: no cover - defensive import
+try:  # pragma: no cover - defensive import for optional data
     from dte import _DEPARTAMENTOS as DTE_DEPARTAMENTOS
     from dte import _MUNICIPIOS_POR_DEPTO as DTE_MUNICIPIOS
 except Exception:  # pragma: no cover - fallback when running minimal envs
     DTE_DEPARTAMENTOS = {}
     DTE_MUNICIPIOS = {}
+
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+CSS_PATH = TEMPLATES_DIR / "ticket-58mm.css"
+
 
 # ---------------------------------------------------------------------------
 # Formatting helpers used inside the renderer
@@ -77,12 +87,22 @@ def q(value: Any) -> str:
 
 PAGO_LABELS = {code.zfill(2): value.upper() for code, value in FORMA_PAGO.items()}
 
+FISCAL_SUMMARY_LABELS = [
+    ("totalGravada", "Ventas gravadas"),
+    ("totalExenta", "Ventas exentas"),
+    ("totalNoSuj", "Ventas no sujetas"),
+    ("iva", "IVA débito fiscal"),
+    ("ivaRete1", "IVA retenido"),
+    ("ivaPercibido", "IVA percibido"),
+    ("reteRenta", "Retención renta"),
+]
 
-def document_title_label(ident: Dict[str, Any] | None) -> str:
+
+def document_title_label(ident: Mapping[str, Any] | None) -> str:
     """Return an uppercased label describing the DTE document type."""
 
     tipo_dte = ""
-    if ident and isinstance(ident, dict):
+    if ident and isinstance(ident, Mapping):
         tipo_dte = str(ident.get("tipoDte") or "").zfill(2)
 
     if tipo_dte == "01":
@@ -97,590 +117,450 @@ def document_title_label(ident: Dict[str, Any] | None) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Internal structures used to build the template context
+
+
+@dataclass
+class ItemRow:
+    descripcion: str
+    cantidad: str
+    precio_unitario: str
+    subtotal: str
+    iva: str | None = None
+    descuentos: str | None = None
+
+
+def _map_modelo(code: Any) -> str:
+    try:
+        value = MODELO.get(int(code))
+    except Exception:
+        value = None
+    if value:
+        return value.title()
+    return str(code or "")
+
+
+def _map_operacion(code: Any) -> str:
+    try:
+        value = OPERACION.get(int(code))
+    except Exception:
+        value = None
+    if value:
+        return value.title()
+    return str(code or "")
+
+
+def _format_address(data: Mapping[str, Any]) -> str:
+    if not isinstance(data, Mapping):
+        return ""
+    complemento = str(data.get("complemento") or "").strip()
+    dep_raw = data.get("departamento")
+    muni_raw = data.get("municipio")
+    dep_code = f"{dep_raw}".zfill(2) if dep_raw is not None else None
+    muni_code = f"{muni_raw}".zfill(2) if muni_raw is not None else None
+
+    dep_name = (
+        DTE_DEPARTAMENTOS.get(dep_code)
+        or CAT_DEPTOS.get(dep_code)
+        or ""
+    )
+    muni_name = ""
+    if dep_code and muni_code:
+        try:
+            muni_name = DTE_MUNICIPIOS.get(dep_code, {}).get(muni_code, "")
+        except AttributeError:
+            muni_name = ""
+        if not muni_name:
+            muni_name = CAT_MUNI44_BY_DEPTO.get(dep_code, {}).get(muni_code, "")
+        if not muni_name:
+            muni_map = CAT_MUNI44.get(muni_code) or {}
+            if muni_map:
+                muni_name = next(iter(muni_map.values()))
+
+    parts = [p for p in (complemento, muni_name, dep_name) if p]
+    return ", ".join(parts)
+
+
+def _format_document_meta(ident: Mapping[str, Any]) -> List[Dict[str, str]]:
+    meta: List[Dict[str, str]] = []
+
+    numero_control = ident.get("numeroControl")
+    if numero_control:
+        meta.append({"label": "Número de control", "value": str(numero_control)})
+
+    codigo_generacion = ident.get("codigoGeneracion")
+    if codigo_generacion:
+        meta.append({"label": "Código de generación", "value": str(codigo_generacion)})
+
+    modelo = ident.get("tipoModelo")
+    if modelo:
+        meta.append({"label": "Modelo", "value": _map_modelo(modelo)})
+
+    operacion = ident.get("tipoOperacion")
+    if operacion:
+        meta.append({"label": "Operación", "value": _map_operacion(operacion)})
+
+    fecha = ident.get("fecEmi")
+    hora = ident.get("horEmi")
+    if fecha or hora:
+        value = " ".join(v for v in (str(fecha or "").strip(), str(hora or "").strip()) if v)
+        if value:
+            meta.append({"label": "Fecha y hora", "value": value})
+
+    return meta
+
+
+def _format_receptor(receptor: Mapping[str, Any]) -> Dict[str, Any]:
+    documento_codigo = str(receptor.get("tipoDocumento") or receptor.get("tipoDoc") or "").zfill(2)
+    documento_label = TIPO_DOC_REC.get(documento_codigo) if documento_codigo else None
+    documento_numero = (
+        receptor.get("numDocumento")
+        or receptor.get("numeroDocumento")
+        or receptor.get("nit")
+        or receptor.get("dui")
+    )
+
+    return {
+        "nombre": (receptor.get("nombre") or receptor.get("razonSocial") or "").strip(),
+        "documento_label": documento_label,
+        "documento_numero": str(documento_numero or "").strip(),
+        "nit": str(receptor.get("nit") or "").strip(),
+        "nrc": str(receptor.get("nrc") or "").strip(),
+        "direccion": _format_address(receptor.get("direccion", {})),
+        "correo": str(receptor.get("correo") or receptor.get("email") or "").strip(),
+        "telefono": str(receptor.get("telefono") or "").strip(),
+        "giro": str(receptor.get("descActividad") or receptor.get("giro") or "").strip(),
+    }
+
+
+def _format_emisor(emisor: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "nombre": (emisor.get("nombreComercial") or emisor.get("nombre") or "").strip(),
+        "razon_social": (emisor.get("nombre") or emisor.get("razonSocial") or "").strip(),
+        "nit": str(emisor.get("nit") or "").strip(),
+        "nrc": str(emisor.get("nrc") or "").strip(),
+        "giro": str(emisor.get("descActividad") or emisor.get("actividad") or "").strip(),
+        "direccion": _format_address(emisor.get("direccion", {})),
+        "telefono": str(emisor.get("telefono") or "").strip(),
+        "email": str(emisor.get("correo") or emisor.get("email") or "").strip(),
+        "logo_url": str(emisor.get("logoUrl") or emisor.get("logo") or "").strip() or None,
+    }
+
+
+def _calculate_item_total(entry: Mapping[str, Any]) -> Decimal:
+    total_candidates = (
+        entry.get("montoTotal"),
+        entry.get("ventaGravada"),
+        entry.get("ventaExenta"),
+        entry.get("ventaNoSuj"),
+        entry.get("montoTotalOperacion"),
+        entry.get("subTotal"),
+        entry.get("ventas_gravadas"),
+        entry.get("ventas_exentas"),
+        entry.get("ventas_no_sujetas"),
+    )
+    for candidate in total_candidates:
+        if candidate is not None:
+            value = _to_decimal(candidate)
+            if value != 0:
+                return value
+
+    qty = _to_decimal(entry.get("cantidad") or entry.get("cantidadUniMedida") or entry.get("uniCantidad"))
+    unit = _to_decimal(
+        entry.get("precio_unitario")
+        or entry.get("precioUnitario")
+        or entry.get("precioUnit")
+        or entry.get("precioUni")
+        or entry.get("precio")
+    )
+    return (qty * unit).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _extract_iva(entry: Mapping[str, Any]) -> Decimal:
+    tributos = entry.get("tributos")
+    if isinstance(tributos, Sequence):
+        total = Decimal("0")
+        for trib in tributos:
+            if not isinstance(trib, Mapping):
+                continue
+            valor = trib.get("valor") or trib.get("monto") or trib.get("importe")
+            if valor is not None:
+                total += _to_decimal(valor)
+        if total != 0:
+            return total
+
+    iva = entry.get("iva") or entry.get("montoIva") or entry.get("ivaItem")
+    if iva is not None:
+        return _to_decimal(iva)
+
+    return Decimal("0")
+
+
+def _format_items(items: Iterable[Mapping[str, Any]]) -> List[ItemRow]:
+    formatted: List[ItemRow] = []
+    for entry in items or []:
+        descripcion = str(
+            entry.get("descripcion")
+            or entry.get("nombre")
+            or entry.get("detalle")
+            or ""
+        ).strip()
+
+        cantidad = q(entry.get("cantidad") or entry.get("cantidadUniMedida") or entry.get("uniCantidad") or 0)
+        unit_price = money(
+            entry.get("precio_unitario")
+            or entry.get("precioUnitario")
+            or entry.get("precioUnit")
+            or entry.get("precioUni")
+            or entry.get("precio")
+            or entry.get("valorUni")
+            or 0
+        )
+        subtotal = money(_calculate_item_total(entry))
+        iva_value = _extract_iva(entry)
+        iva = money(iva_value) if iva_value else None
+
+        descuentos = entry.get("montoDescu") or entry.get("descuento")
+        if descuentos:
+            descuentos = money(descuentos)
+        else:
+            descuentos = None
+
+        formatted.append(
+            ItemRow(
+                descripcion=descripcion or "—",
+                cantidad=cantidad,
+                precio_unitario=unit_price,
+                subtotal=subtotal,
+                iva=iva,
+                descuentos=descuentos,
+            )
+        )
+
+    return formatted
+
+
+def _format_totals(resumen: Mapping[str, Any]) -> tuple[List[Dict[str, str]], Dict[str, str] | None]:
+    if not isinstance(resumen, Mapping):
+        return [], None
+
+    totals: List[Dict[str, str]] = []
+    labels = [
+        ("totalGravada", "Ventas gravadas"),
+        ("totalExenta", "Ventas exentas"),
+        ("totalNoSuj", "Ventas no sujetas"),
+        ("subTotalVentas", "Subtotal ventas"),
+        ("totalDescu", "Descuentos"),
+        ("iva", "IVA"),
+        ("ivaRete1", "IVA retenido"),
+        ("ivaPercibido", "IVA percibido"),
+        ("reteRenta", "Retención renta"),
+        ("montoTotalOperacion", "Monto total operación"),
+        ("saldoAFavor", "Saldo a favor"),
+    ]
+
+    seen = set()
+    for key, label in labels:
+        if key in seen:
+            continue
+        value = resumen.get(key)
+        if value in (None, "", 0, 0.0):
+            continue
+        totals.append({"label": label, "value": money(value)})
+        seen.add(key)
+
+    total_pagar_candidates = (
+        resumen.get("totalPagar"),
+        resumen.get("totalPagarSinRedondeo"),
+        resumen.get("montoTotalPagar"),
+    )
+    total_pagar_value = None
+    for candidate in total_pagar_candidates:
+        if candidate is not None:
+            total_pagar_value = candidate
+            break
+
+    total_to_pay = None
+    if total_pagar_value is not None:
+        total_to_pay = {"label": "Total a pagar", "value": money(total_pagar_value)}
+
+    return totals, total_to_pay
+
+
+def _format_condicion_operacion(resumen: Mapping[str, Any]) -> str | None:
+    if not isinstance(resumen, Mapping):
+        return None
+    value = resumen.get("condicionOperacion")
+    if value is None:
+        return None
+    try:
+        value = int(value)
+    except Exception:
+        return None
+    label = CONDICION_OPERACION.get(value)
+    if not label:
+        return None
+    return label.title()
+
+
+def _format_pagos(resumen: Mapping[str, Any]) -> List[Dict[str, str]]:
+    pagos = resumen.get("pagos") if isinstance(resumen, Mapping) else None
+    formatted: List[Dict[str, str]] = []
+    if not isinstance(pagos, Sequence):
+        return formatted
+
+    for pago in pagos:
+        if not isinstance(pago, Mapping):
+            continue
+        codigo = str(pago.get("codigo") or pago.get("formaPago") or "").zfill(2)
+        label = PAGO_LABELS.get(codigo, "Otro")
+        monto = pago.get("montoPago") or pago.get("valor") or pago.get("monto")
+        detalle: List[str] = []
+
+        plazo = pago.get("plazo") or pago.get("plazoPago")
+        if plazo not in (None, "", 0, 0.0):
+            detalle.append(f"Plazo: {q(plazo)}")
+
+        periodo = pago.get("periodo")
+        if periodo not in (None, "", 0, 0.0):
+            periodo_code = str(periodo).zfill(2)
+            periodo_label = PLAZO.get(periodo_code)
+            if periodo_label:
+                detalle.append(f"Periodo: {periodo_label}")
+            else:
+                detalle.append(f"Periodo: {periodo}")
+
+        referencia = pago.get("referencia") or pago.get("numeroDocumento")
+        if referencia:
+            detalle.append(f"Ref: {referencia}")
+        detail_text = " · ".join(detalle).strip()
+        formatted.append(
+            {
+                "label": label,
+                "amount": money(monto or 0),
+                "detail": detail_text or None,
+            }
+        )
+    return formatted
+
+
+def _format_fiscal_summary(resumen: Mapping[str, Any]) -> List[Dict[str, str]]:
+    if not isinstance(resumen, Mapping):
+        return []
+
+    summary: List[Dict[str, str]] = []
+    for key, label in FISCAL_SUMMARY_LABELS:
+        value = resumen.get(key)
+        summary.append({"label": label, "amount": money(value)})
+
+    return summary
+
+
+def _qr_data_uri(qr_url: str | None) -> str | None:
+    if not qr_url:
+        return None
+
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=6,
+        border=1,
+    )
+    qr.add_data(qr_url)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    encoded = b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+@lru_cache(maxsize=1)
+def _jinja_env() -> Environment:
+    loader = FileSystemLoader(str(TEMPLATES_DIR))
+    return Environment(loader=loader, autoescape=select_autoescape(["html", "xml"]))
+
+
+def _select_template_name(ident: Mapping[str, Any]) -> str:
+    tipo_dte = str(ident.get("tipoDte") or "").zfill(2)
+    if tipo_dte == "01":
+        return "ticket-consumidor-final-58mm.html"
+    if tipo_dte == "03":
+        return "ticket-credito-fiscal-58mm.html"
+    return "ticket-normal-58mm.html"
+
+
+def _collect_footer_notes(payload: Mapping[str, Any], accepted: bool) -> List[str]:
+    notes: List[str] = []
+    if accepted:
+        notes.append("Documento validado por el Ministerio de Hacienda")
+    if payload.get("selloRecibido") or payload.get("acuseRecibo"):
+        notes.append("Sello de recepción disponible")
+    return notes
+
+
+# ---------------------------------------------------------------------------
 # Public API
 
 
 def render_ticket_pdf(
-    payload: Dict[str, Any], accepted: bool, sello: str | None = None
+    payload: Dict[str, Any],
+    accepted: bool,
+    sello: str | None = None,
 ) -> bytes:
-    """Render ``payload`` into a thermal ticket PDF.
+    """Render ``payload`` into a thermal ticket PDF."""
 
-    Parameters
-    ----------
-    payload:
-        Mapping with DTE information.  It is assumed to already contain all
-        fiscal data; this function only performs presentation tweaks.
-    accepted:
-        ``True`` when the DTE has been accepted by the Ministry of Finance.
-
-    Returns
-    -------
-    bytes
-        The generated PDF contents.
-    """
-
-    ident = payload.get("identificacion", {})
-    emisor = payload.get("emisor", {})
-    receptor = payload.get("receptor", {})
-    resumen = payload.get("resumen", {})
+    ident = payload.get("identificacion", {}) or {}
+    emisor = payload.get("emisor", {}) or {}
+    receptor = payload.get("receptor", {}) or {}
+    resumen = payload.get("resumen", {}) or {}
     items = payload.get("cuerpoDocumento", []) or []
 
-    # ------------------------------------------------------------------ helpers
-    page_width = 80 * mm
-    margin_x = 4 * mm
-    margin_top = 8 * mm
-    margin_bottom = 6 * mm
-    content_width = page_width - 2 * margin_x
+    env = _jinja_env()
+    template_name = _select_template_name(ident)
+    template = env.get_template(template_name)
 
-    def _wrap_text(text: str, width: float, font: str, size: float) -> List[str]:
-        lines: List[str] = []
-        for paragraph in str(text or "").splitlines():
-            paragraph = paragraph.strip()
-            if not paragraph:
-                continue
-            words = paragraph.split()
-            current = ""
-            for word in words:
-                candidate = f"{current} {word}".strip()
-                if not candidate:
-                    continue
-                if (
-                    current
-                    and pdfmetrics.stringWidth(candidate, font, size) > width
-                ):
-                    lines.append(current)
-                    current = word
-                else:
-                    current = candidate
-            if current:
-                lines.append(current)
-        if not lines:
-            lines.append("")
-        return lines
+    document_label = document_title_label(ident)
+    qr_url = build_qr_url(payload) if payload else None
+    qr_image = _qr_data_uri(qr_url)
 
-    def _format_section_heading(title: str) -> str:
-        title = title.strip().upper()
-        filler = "-" * 11
-        return f"{filler} {title} {filler}"
+    totals, total_to_pay = _format_totals(resumen)
+    pagos = _format_pagos(resumen)
+    condicion_operacion = _format_condicion_operacion(resumen)
 
-    def _map_modelo(code: Any) -> str:
-        try:
-            value = MODELO.get(int(code))
-        except Exception:
-            value = None
-        if value:
-            return value.title()
-        return str(code or "")
+    condicion_operacion_raw = None
+    if isinstance(resumen, Mapping):
+        condicion_operacion_raw = resumen.get("condicionOperacion")
+    is_credit_operation = False
+    try:
+        is_credit_operation = int(condicion_operacion_raw) == 2
+    except Exception:
+        is_credit_operation = False
 
-    def _map_operacion(code: Any) -> str:
-        try:
-            value = OPERACION.get(int(code))
-        except Exception:
-            value = None
-        if value:
-            return value.title()
-        return str(code or "")
-
-    def _format_address(data: Dict[str, Any]) -> str:
-        if not isinstance(data, dict):
-            return ""
-        complemento = data.get("complemento") or ""
-        dep_raw = data.get("departamento")
-        muni_raw = data.get("municipio")
-        dep_code = None
-        muni_code = None
-        if dep_raw is not None:
-            dep_code = f"{dep_raw}".zfill(2)
-        if muni_raw is not None:
-            muni_code = f"{muni_raw}".zfill(2)
-
-        dep_name = (
-            DTE_DEPARTAMENTOS.get(dep_code)
-            or CAT_DEPTOS.get(dep_code)
-            or ""
-        )
-        muni_name = ""
-        if dep_code and muni_code:
-            muni_name = DTE_MUNICIPIOS.get(dep_code, {}).get(muni_code, "")
-        if not muni_name and muni_code:
-            muni_info = CAT_MUNI44.get(muni_code)
-            if muni_info:
-                if dep_code and dep_code in muni_info:
-                    muni_name = muni_info[dep_code]
-                else:
-                    muni_name = next(iter(muni_info.values()))
-
-        parts: List[str] = []
-        if complemento:
-            parts.append(str(complemento))
-        if muni_name and dep_name:
-            parts.append(f"{muni_name.upper()}, {dep_name}")
-        elif muni_name:
-            parts.append(muni_name.upper())
-        elif dep_name:
-            parts.append(dep_name)
-        return ", ".join(part for part in parts if part)
-
-    def _format_document_line(rec: Dict[str, Any]) -> Tuple[str, str] | None:
-        doc_number = rec.get("numDocumento") or rec.get("numeroDocumento")
-        if not doc_number:
-            return None
-        doc_type = rec.get("tipoDocumento") or rec.get("tipoDoc")
-        label = None
-        if doc_type is not None:
-            label = TIPO_DOC_REC.get(str(doc_type).zfill(2))
-        if not label:
-            label = "Documento"
-        return f"{label}:", str(doc_number)
-
-    def _to_money(value: Any) -> str:
-        return money(value)
-
-    def _item_totals(it: Dict[str, Any]) -> Decimal:
-        for key in ("montoTotal", "ventaGravada", "ventaExenta", "ventaNoSuj"):
-            val = it.get(key)
-            if val not in (None, ""):
-                return _to_decimal(val)
-        cantidad = _to_decimal(it.get("cantidad", 0))
-        precio = _to_decimal(it.get("precioUni", 0))
-        return cantidad * precio
-
-    def _iva_total() -> Decimal:
-        total_iva = resumen.get("totalIva")
-        if total_iva not in (None, ""):
-            return _to_decimal(total_iva)
-        iva_sum = Decimal("0")
-        for it in items:
-            iva_item = it.get("ivaItem") or it.get("tributoIva")
-            if iva_item not in (None, ""):
-                iva_sum += _to_decimal(iva_item)
-        if iva_sum > 0:
-            return iva_sum
-        q = Decimal("0.01")
-        calculated = Decimal("0")
-        for it in items:
-            gravada = _to_decimal(it.get("ventaGravada"))
-            if gravada > 0:
-                calculated += (gravada * Decimal("0.13")).quantize(
-                    q, rounding=ROUND_HALF_UP
-                )
-        return calculated
-
-    # ----------------------------------------------------------------- build data
-    elements: List[Dict[str, Any]] = []
-
-    def add_text(
-        text: str,
-        *,
-        size: float = 8,
-        bold: bool = False,
-        align: str = "left",
-        spacing_before: float = 0,
-        spacing_after: float = 4,
-    ) -> None:
-        font = "Helvetica-Bold" if bold else "Helvetica"
-        lines = _wrap_text(text, content_width, font, size)
-        elements.append(
-            {
-                "type": "text",
-                "lines": lines,
-                "font": font,
-                "size": size,
-                "align": align,
-                "leading": size + 2,
-                "spacing_before": spacing_before,
-                "spacing_after": spacing_after,
-            }
-        )
-
-    def add_pair(
-        label: str,
-        value: str,
-        *,
-        size: float = 8,
-        bold_value: bool = False,
-        spacing_before: float = 0,
-        spacing_after: float = 2,
-    ) -> None:
-        elements.append(
-            {
-                "type": "pair",
-                "label": str(label),
-                "value": str(value),
-                "size": size,
-                "bold_value": bold_value,
-                "spacing_before": spacing_before,
-                "spacing_after": spacing_after,
-                "leading": size + 2,
-            }
-        )
-
-    def add_hr(spacing_before: float = 4, spacing_after: float = 4) -> None:
-        elements.append(
-            {
-                "type": "hr",
-                "spacing_before": spacing_before,
-                "spacing_after": spacing_after,
-            }
-        )
-
-    col_widths = [0.10, 0.55, 0.15, 0.20]
-    col_widths = [w * content_width for w in col_widths]
-
-    def add_table_header() -> None:
-        elements.append(
-            {
-                "type": "table_header",
-                "labels": ["CANT.", "DESCRIPCIÓN", "P. UNIT.", "TOTAL"],
-                "font": "Helvetica-Bold",
-                "size": 8,
-                "leading": 10,
-                "spacing_before": 4,
-                "spacing_after": 2,
-            }
-        )
-
-    def add_table_row(item: Dict[str, Any]) -> None:
-        cantidad = q(item.get("cantidad", 0))
-        precio = _to_money(item.get("precioUni", 0))
-        total = _to_money(_item_totals(item))
-        descripcion = str(item.get("descripcion", ""))
-        desc_lines = _wrap_text(
-            descripcion, col_widths[1], "Helvetica", 8
-        )
-        row_height = (8 + 2) * len(desc_lines)
-        elements.append(
-            {
-                "type": "table_row",
-                "cantidad": cantidad,
-                "precio": precio,
-                "total": total,
-                "desc_lines": desc_lines,
-                "leading": 10,
-                "size": 8,
-                "row_height": row_height,
-                "spacing_before": 0,
-                "spacing_after": 2,
-            }
-        )
-
-    def add_qr_block(url: str) -> None:
-        qr_size = min(50 * mm, content_width)
-        elements.append(
-            {
-                "type": "qr",
-                "url": url,
-                "size": qr_size,
-                "spacing_before": 6,
-                "spacing_after": 0,
-            }
-        )
-
-    # Title ----------------------------------------------------------------------
-    title_label = document_title_label(ident)
-    add_text(
-        f"DOCUMENTO TRIBUTARIO ELECTRÓNICO — {title_label}",
-        size=11,
-        bold=True,
-        align="center",
-        spacing_after=6,
-    )
-
-    # Emisor ---------------------------------------------------------------------
-    add_text(_format_section_heading("Datos del Emisor"), align="center", size=8, bold=True)
-    emisor_nombre = emisor.get("nombreComercial") or emisor.get("nombre")
-    if emisor_nombre:
-        add_text(str(emisor_nombre), bold=True, align="center", size=9, spacing_after=2)
-    if emisor.get("nit"):
-        add_text(f"NIT: {emisor.get('nit')}", size=8)
-    if emisor.get("nrc"):
-        add_text(f"NRC: {emisor.get('nrc')}", size=8)
-    sucursal = emisor.get("sucursal") or emisor.get("nombreEstablecimiento")
-    if not sucursal:
-        sucursal = emisor.get("codEstableMH") or emisor.get("codEstable")
-    if sucursal:
-        add_text(f"Sucursal: {sucursal}", size=8)
-    actividad = emisor.get("descActividad") or emisor.get("actividadEconomica")
-    if actividad:
-        add_text(f"Actividad Económica: {actividad}", size=8)
-    direccion = _format_address(emisor.get("direccion", {}))
-    if direccion:
-        add_text(f"Dirección: {direccion}", size=8)
-
-    # Datos de factura -----------------------------------------------------------
-    add_text(_format_section_heading("Datos de Factura"), align="center", size=8, bold=True)
-    if ident.get("codigoGeneracion"):
-        add_text(
-            f"Código de Generación: {ident.get('codigoGeneracion')}",
-            size=8,
-        )
-    if ident.get("numeroControl"):
-        add_text(f"Número de control: {ident.get('numeroControl')}", size=8)
-    sello = sello or payload.get("selloRecibido") or ident.get("selloRecibido")
-    if sello:
-        add_text(f"Sello de Recepción: {sello}", size=8)
-    modelo = _map_modelo(ident.get("tipoModelo"))
-    if modelo:
-        add_text(f"Modelo de Facturación: {modelo}", size=8)
-    operacion = _map_operacion(ident.get("tipoOperacion"))
-    if operacion:
-        add_text(f"Tipo de Transmisión: {operacion}", size=8)
-    fecha = ident.get("fecEmi")
-    hora = ident.get("horEmi")
-    if fecha or hora:
-        add_text(
-            f"Fecha y hora de Generación: {fecha or ''} {hora or ''}".strip(),
-            size=8,
-        )
-
-    # Receptor -------------------------------------------------------------------
-    add_text(_format_section_heading("Datos del Receptor"), align="center", size=8, bold=True)
-    add_pair("Nombre:", receptor.get("nombre") or "", size=8)
-    if receptor.get("nit"):
-        add_pair("NIT:", receptor.get("nit"), size=8)
-    doc_line = _format_document_line(receptor)
-    if doc_line:
-        add_pair(doc_line[0], doc_line[1], size=8)
-    if receptor.get("nrc"):
-        add_pair("NRC:", receptor.get("nrc"), size=8)
-    direccion_rec = _format_address(receptor.get("direccion", {}))
-    if direccion_rec:
-        add_text(f"Dirección: {direccion_rec}", size=8)
-    correo_rec = receptor.get("correo")
-    if correo_rec:
-        add_pair("Correo:", correo_rec, size=8)
-
-    # Detalle --------------------------------------------------------------------
-    add_text(_format_section_heading("Detalle de Factura"), align="center", size=8, bold=True)
-    add_table_header()
-    for item in items:
-        add_table_row(item)
-
-    # Sumarios -------------------------------------------------------------------
-    add_hr(spacing_before=2, spacing_after=2)
-    add_pair("Suma Ventas No Sujetas:", _to_money(resumen.get("totalNoSuj", 0)))
-    add_pair("Suma Ventas Exentas:", _to_money(resumen.get("totalExenta", 0)))
-    add_pair("Suma Ventas Gravadas:", _to_money(resumen.get("totalGravada", 0)))
-    add_pair(
-        "Sumatoria Total de Operaciones:",
-        _to_money(resumen.get("subTotalVentas", 0)),
-    )
-    add_pair(
-        "Monto global Desc. a ventas no sujetas:",
-        _to_money(resumen.get("descuNoSuj", 0)),
-    )
-    add_pair(
-        "Monto global Desc. a ventas exentas:",
-        _to_money(resumen.get("descuExenta", 0)),
-    )
-    add_pair(
-        "Monto global Desc. a ventas gravadas:",
-        _to_money(resumen.get("descuGravada", 0)),
-    )
-    add_pair("Tributo (IVA):", _to_money(_iva_total()))
-    add_pair("Sub-Total:", _to_money(resumen.get("subTotal", 0)))
-    iva_percibido = _to_decimal(resumen.get("ivaPerci1"))
-    if iva_percibido > 0:
-        add_pair("IVA Percibido:", _to_money(iva_percibido))
-    iva_retenido = _to_decimal(resumen.get("ivaRete1"))
-    if iva_retenido > 0:
-        add_pair("IVA Retenido:", _to_money(iva_retenido))
-    add_pair(
-        "Monto Total de la Operación:",
-        _to_money(resumen.get("montoTotalOperacion", 0)),
-    )
-    total_no_afectos = (
-        resumen.get("totalOtrosMontosNoAfectos")
-        or resumen.get("totalOtrosMontosNoAfectos1")
-        or resumen.get("totalOtros")
-        or 0
-    )
-    add_pair(
-        "Total otros montos no afectos:",
-        _to_money(total_no_afectos),
-    )
-    add_pair(
-        "Total a pagar:",
-        _to_money(resumen.get("totalPagar", resumen.get("montoTotalOperacion", 0))),
-        bold_value=True,
-    )
-    total_letras = resumen.get("totalLetras")
-    if total_letras:
-        add_text(f"TOTAL EN LETRAS: {total_letras}", size=8, bold=True)
-
-    # Pagos y otros --------------------------------------------------------------
-    pagos = resumen.get("pagos") or []
-    if pagos:
-        pago = pagos[0]
-        code = str(pago.get("codigo")).zfill(2)
-        label = PAGO_LABELS.get(code, FORMA_PAGO.get(code, "Otros")).upper()
-        add_text(f"Forma de pago: {label}", size=8, spacing_before=4)
-        if pago.get("montoPago") not in (None, ""):
-            add_pair("Monto pago:", _to_money(pago.get("montoPago")), size=8)
-        if pago.get("referencia"):
-            add_pair("Referencia:", pago.get("referencia"), size=8)
-        if pago.get("plazo"):
-            add_pair("Plazo:", pago.get("plazo"), size=8)
-        if pago.get("periodo"):
-            add_pair("Periodo:", pago.get("periodo"), size=8)
-
-    # QR -------------------------------------------------------------------------
-    qr_url = None
-    if ident.get("codigoGeneracion"):
-        try:
-            qr_url = build_qr_url(payload)
-        except Exception:
-            qr_url = None
-    if qr_url:
-        add_qr_block(qr_url)
-
-    # ----------------------------------------------------------------- rendering
-    def _elements_height() -> float:
-        total = margin_top + margin_bottom
-        for el in elements:
-            total += el.get("spacing_before", 0)
-            if el["type"] == "text":
-                total += el["leading"] * len(el["lines"])
-            elif el["type"] == "pair":
-                total += el["leading"]
-            elif el["type"] == "hr":
-                total += 1
-            elif el["type"] == "table_header":
-                total += el["leading"]
-            elif el["type"] == "table_row":
-                total += el["row_height"]
-            elif el["type"] == "qr":
-                total += el["size"]
-            total += el.get("spacing_after", 0)
-        return total
-
-    height = _elements_height()
-    buffer = BytesIO()
-    c = canvas.Canvas(buffer, pagesize=(page_width, height))
-    y = height - margin_top
-
-    def _draw_text(el: Dict[str, Any]) -> None:
-        nonlocal y
-        y -= el.get("spacing_before", 0)
-        font = el["font"]
-        size = el["size"]
-        leading = el["leading"]
-        c.setFont(font, size)
-        for line in el["lines"]:
-            y -= leading
-            if el["align"] == "center":
-                c.drawCentredString(page_width / 2, y + (leading - size) / 2, line)
-            elif el["align"] == "right":
-                c.drawRightString(page_width - margin_x, y + (leading - size) / 2, line)
-            else:
-                c.drawString(margin_x, y + (leading - size) / 2, line)
-        y -= el.get("spacing_after", 0)
-
-    def _draw_pair(el: Dict[str, Any]) -> None:
-        nonlocal y
-        y -= el.get("spacing_before", 0)
-        size = el["size"]
-        leading = el["leading"]
-        y -= leading
-        c.setFont("Helvetica", size)
-        c.drawString(margin_x, y + (leading - size) / 2, el["label"])
-        font_value = "Helvetica-Bold" if el.get("bold_value") else "Helvetica"
-        c.setFont(font_value, size)
-        c.drawRightString(
-            page_width - margin_x, y + (leading - size) / 2, el["value"]
-        )
-        y -= el.get("spacing_after", 0)
-
-    def _draw_hr(el: Dict[str, Any]) -> None:
-        nonlocal y
-        y -= el.get("spacing_before", 0)
-        y -= 1
-        c.setLineWidth(0.4)
-        c.line(margin_x, y, page_width - margin_x, y)
-        y -= el.get("spacing_after", 0)
-
-    def _draw_table_header(el: Dict[str, Any]) -> None:
-        nonlocal y
-        y -= el.get("spacing_before", 0)
-        leading = el["leading"]
-        size = el["size"]
-        y -= leading
-        x = margin_x
-        c.setFont(el["font"], size)
-        for idx, label in enumerate(el["labels"]):
-            if idx == 1:
-                c.drawString(x, y + (leading - size) / 2, label)
-            else:
-                c.drawRightString(
-                    x + col_widths[idx] - 2,
-                    y + (leading - size) / 2,
-                    label,
-                )
-            x += col_widths[idx]
-        y -= el.get("spacing_after", 0)
-
-    def _draw_table_row(el: Dict[str, Any]) -> None:
-        nonlocal y
-        y -= el.get("spacing_before", 0)
-        leading = el["leading"]
-        size = el["size"]
-        row_height = el["row_height"]
-        y -= row_height
-        row_top = y + row_height
-        base_offset = (leading - size) / 2
-
-        qty_y = row_top - leading + base_offset
-        price_y = qty_y
-        total_y = qty_y
-        x = margin_x
-        c.setFont("Helvetica", size)
-        c.drawRightString(x + col_widths[0] - 2, qty_y, el["cantidad"])
-        x += col_widths[0]
-
-        desc_lines = el["desc_lines"]
-        for idx, line in enumerate(desc_lines):
-            line_y = row_top - leading * (idx + 1) + base_offset
-            c.drawString(x, line_y, line)
-        x += col_widths[1]
-
-        c.drawRightString(x + col_widths[2] - 2, price_y, el["precio"])
-        x += col_widths[2]
-        c.drawRightString(x + col_widths[3] - 2, total_y, el["total"])
-
-        y -= el.get("spacing_after", 0)
-
-    def _draw_qr(el: Dict[str, Any]) -> None:
-        nonlocal y
-        y -= el.get("spacing_before", 0)
-        size = el["size"]
-        qr_code = qr.QrCodeWidget(el["url"])
-        bounds = qr_code.getBounds()
-        w = bounds[2] - bounds[0]
-        h = bounds[3] - bounds[1]
-        drawing = Drawing(
-            size,
-            size,
-            transform=[size / w, 0, 0, size / h, 0, 0],
-        )
-        drawing.add(qr_code)
-        qr_x = (page_width - size) / 2
-        qr_y = y - size
-        renderPDF.draw(drawing, c, qr_x, qr_y)
-        c.linkURL(el["url"], (qr_x, qr_y, qr_x + size, qr_y + size), relative=0)
-        y = qr_y - el.get("spacing_after", 0)
-
-    draw_map = {
-        "text": _draw_text,
-        "pair": _draw_pair,
-        "hr": _draw_hr,
-        "table_header": _draw_table_header,
-        "table_row": _draw_table_row,
-        "qr": _draw_qr,
+    context = {
+        "title": "Documento Tributario Electrónico",
+        "document_label": document_label,
+        "emisor": _format_emisor(emisor),
+        "receptor": _format_receptor(receptor),
+        "document_meta": _format_document_meta(ident),
+        "items": _format_items(items),
+        "totals": totals,
+        "total_to_pay": total_to_pay,
+        "pagos": pagos,
+        "condicion_operacion": condicion_operacion,
+        "fiscal_summary": _format_fiscal_summary(resumen),
+        "show_payments_block": bool(pagos) or is_credit_operation,
+        "is_credit_operation": is_credit_operation,
+        "qr_url": qr_url,
+        "qr_image": qr_image,
+        "accepted": accepted,
+        "sello": sello,
+        "firma": payload.get("firmaElectronica"),
+        "footer_notes": _collect_footer_notes(payload, accepted),
     }
 
-    for element in elements:
-        draw_map[element["type"]](element)
+    html = template.render(**context)
+    stylesheets = [CSS(filename=str(CSS_PATH))]
+    pdf_bytes = HTML(string=html, base_url=str(TEMPLATES_DIR)).write_pdf(stylesheets=stylesheets)
+    return pdf_bytes
 
-    c.showPage()
-    c.save()
-    return buffer.getvalue()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ Pillow==10.4.0
 requests==2.32.5
 tzdata==2024.1
 Jinja2==3.1.4
+qrcode==7.4.2
+tinycss2==1.4.0
+cssselect2==0.8.0
+WeasyPrint==62.3

--- a/templates/ticket-58mm.css
+++ b/templates/ticket-58mm.css
@@ -1,0 +1,270 @@
+@page {
+  size: 58mm auto;
+  margin: 0;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 58mm;
+  background: #fff;
+}
+
+body {
+  font-family: "Inter", "Roboto", system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+  font-size: 15pt;
+  line-height: 1.35;
+  color: #000;
+  -webkit-font-smoothing: antialiased;
+  font-variant-numeric: tabular-nums;
+}
+
+.ticket {
+  box-sizing: border-box;
+  width: 57mm;
+  min-height: 100%;
+  padding: 3mm 3mm 9mm;
+  display: flex;
+  flex-direction: column;
+  gap: 2mm;
+}
+
+.ticket,
+.header,
+.meta-list,
+.info-list,
+.items,
+.totals,
+.payments,
+.fiscal-block,
+.qr,
+.footer {
+  break-inside: avoid;
+}
+
+.header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2mm;
+}
+
+.header .title {
+  font-weight: 700;
+  font-size: 18pt;
+  letter-spacing: 0.3pt;
+  text-transform: uppercase;
+}
+
+.header .doc-label {
+  font-size: 16pt;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.header .meta {
+  font-size: 14pt;
+}
+
+.logo {
+  max-width: 46mm;
+  max-height: 16mm;
+  margin: 0 auto 1mm;
+  object-fit: contain;
+}
+
+.meta-list,
+.info-list,
+.totals,
+.payments,
+.fiscal-block,
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 1mm;
+}
+
+.section-title {
+  font-size: 16pt;
+  font-weight: 600;
+  margin: 2mm 0 0.6mm;
+  text-transform: uppercase;
+  letter-spacing: 0.3pt;
+}
+
+.divider {
+  border-top: 0.35pt solid #000;
+  margin: 2mm 0 0.5mm;
+}
+
+.key-value {
+  display: flex;
+  justify-content: space-between;
+  gap: 2mm;
+}
+
+.key-value .label {
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.key-value .value {
+  text-align: right;
+  flex: 1 1 auto;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  white-space: pre-wrap;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4mm;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8mm;
+  break-inside: avoid;
+}
+
+.item-desc {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.item-meta {
+  display: flex;
+  align-items: flex-end;
+  gap: 1mm;
+  flex-wrap: wrap;
+  font-size: 14pt;
+}
+
+.item-meta .calc {
+  flex: 1 1 auto;
+  min-width: 20mm;
+  text-align: right;
+}
+
+.item-meta .subtotal {
+  min-width: 22mm;
+  text-align: right;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.item-meta .tax,
+.item-meta .discount {
+  font-size: 13pt;
+  text-align: right;
+}
+
+.totals {
+  margin-top: 1mm;
+  padding-top: 1mm;
+  border-top: 0.35pt solid #000;
+}
+
+.totals .row {
+  display: flex;
+  justify-content: space-between;
+  gap: 2mm;
+}
+
+.totals .amount {
+  font-weight: 600;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.totals .highlight {
+  font-size: 19pt;
+  font-weight: 800;
+  margin-top: 1mm;
+}
+
+.payments .row,
+.fiscal-block .row {
+  display: flex;
+  justify-content: space-between;
+  gap: 2mm;
+}
+
+.payments .label,
+.fiscal-block .label {
+  font-weight: 600;
+}
+
+.payments .detail {
+  font-size: 13pt;
+  color: #000;
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.fiscal-block .detail {
+  font-size: 13pt;
+  white-space: pre-wrap;
+  text-align: left;
+}
+
+.qr {
+  margin-top: 2mm;
+  text-align: center;
+}
+
+.qr img {
+  max-width: 50mm;
+  width: 100%;
+  height: auto;
+}
+
+.qr .caption {
+  font-size: 13pt;
+  margin-top: 0.6mm;
+}
+
+.footer {
+  font-size: 13pt;
+  text-align: center;
+  gap: 0.6mm;
+  margin-top: 2mm;
+  white-space: pre-wrap;
+}
+
+.cut-line {
+  margin-top: 3mm;
+  padding-top: 1mm;
+  border-top: 0.35pt dashed #444;
+  text-align: center;
+  font-size: 12pt;
+  letter-spacing: 0.3em;
+  color: #555;
+}
+
+strong {
+  font-weight: 700;
+}
+
+em {
+  font-style: italic;
+}
+
+@media print {
+  @page {
+    size: 58mm auto;
+    margin: 0;
+  }
+
+  html,
+  body {
+    width: 58mm;
+  }
+
+  .ticket {
+    width: 57mm;
+  }
+}

--- a/templates/ticket-consumidor-final-58mm.html
+++ b/templates/ticket-consumidor-final-58mm.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }} · {{ document_label }}</title>
+    <link rel="stylesheet" href="ticket-58mm.css" />
+  </head>
+  <body>
+    <article class="ticket">
+      <header class="header">
+        {% if emisor.logo_url %}
+          <img src="{{ emisor.logo_url }}" alt="Logo" class="logo" />
+        {% endif %}
+        <div class="title">{{ title }}</div>
+        <div class="doc-label">{{ document_label }}</div>
+        {% if emisor.nombre %}
+          <div class="meta">{{ emisor.nombre }}</div>
+        {% endif %}
+      </header>
+
+      <section class="info-list">
+        <div class="section-title">Datos del emisor</div>
+        {% if emisor.razon_social and emisor.razon_social != emisor.nombre %}
+          <div class="key-value"><span class="label">Razón social</span><span class="value">{{ emisor.razon_social }}</span></div>
+        {% endif %}
+        {% if emisor.nit %}
+          <div class="key-value"><span class="label">NIT</span><span class="value">{{ emisor.nit }}</span></div>
+        {% endif %}
+        {% if emisor.nrc %}
+          <div class="key-value"><span class="label">NRC</span><span class="value">{{ emisor.nrc }}</span></div>
+        {% endif %}
+        {% if emisor.giro %}
+          <div class="key-value"><span class="label">Actividad</span><span class="value">{{ emisor.giro }}</span></div>
+        {% endif %}
+        {% if emisor.direccion %}
+          <div class="key-value"><span class="label">Dirección</span><span class="value">{{ emisor.direccion }}</span></div>
+        {% endif %}
+        {% if emisor.telefono %}
+          <div class="key-value"><span class="label">Teléfono</span><span class="value">{{ emisor.telefono }}</span></div>
+        {% endif %}
+        {% if emisor.email %}
+          <div class="key-value"><span class="label">Correo</span><span class="value">{{ emisor.email }}</span></div>
+        {% endif %}
+      </section>
+
+      {% if document_meta %}
+        <section class="meta-list">
+          <div class="section-title">Documento</div>
+          {% for row in document_meta %}
+            <div class="key-value"><span class="label">{{ row.label }}</span><span class="value">{{ row.value }}</span></div>
+          {% endfor %}
+        </section>
+      {% endif %}
+
+      <section class="info-list">
+        <div class="section-title">Consumidor final</div>
+        {% if receptor.nombre %}
+          <div class="key-value"><span class="label">Nombre</span><span class="value">{{ receptor.nombre }}</span></div>
+        {% endif %}
+        {% if receptor.documento_numero %}
+          <div class="key-value"><span class="label">{{ receptor.documento_label or 'Documento' }}</span><span class="value">{{ receptor.documento_numero }}</span></div>
+        {% endif %}
+        {% if receptor.nit and receptor.nit != receptor.documento_numero %}
+          <div class="key-value"><span class="label">NIT</span><span class="value">{{ receptor.nit }}</span></div>
+        {% endif %}
+        {% if receptor.direccion %}
+          <div class="key-value"><span class="label">Dirección</span><span class="value">{{ receptor.direccion }}</span></div>
+        {% endif %}
+        {% if receptor.correo %}
+          <div class="key-value"><span class="label">Correo</span><span class="value">{{ receptor.correo }}</span></div>
+        {% endif %}
+      </section>
+
+      <section>
+        <div class="section-title">Detalle</div>
+        <div class="divider"></div>
+        <div class="items">
+          {% for item in items %}
+            <div class="item">
+              <div class="item-desc">{{ item.descripcion }}</div>
+              <div class="item-meta">
+                <span class="calc">{{ item.cantidad }} × {{ item.precio_unitario }}</span>
+                {% if item.iva %}<span class="tax">IVA {{ item.iva }}</span>{% endif %}
+                <span class="subtotal">{{ item.subtotal }}</span>
+              </div>
+              {% if item.descuentos %}
+                <div class="item-meta">
+                  <span class="calc"></span>
+                  <span class="discount">Descuento {{ item.descuentos }}</span>
+                  <span class="subtotal"></span>
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="totals">
+        {% for row in totals %}
+          <div class="row"><span class="label">{{ row.label }}</span><span class="amount">{{ row.value }}</span></div>
+        {% endfor %}
+        {% if total_to_pay %}
+          <div class="row highlight">
+            <span class="label">{{ total_to_pay.label | upper }}</span>
+            <span class="amount">{{ total_to_pay.value }}</span>
+          </div>
+        {% endif %}
+        {% if condicion_operacion %}
+          <div class="row"><span class="label">Condición</span><span class="amount">{{ condicion_operacion }}</span></div>
+        {% endif %}
+      </section>
+
+      {% if pagos %}
+        <section class="payments">
+          <div class="section-title">Pagos</div>
+          {% for pago in pagos %}
+            <div class="row"><span class="label">{{ pago.label }}</span><span class="amount">{{ pago.amount }}</span></div>
+            {% if pago.detail %}<div class="detail">{{ pago.detail }}</div>{% endif %}
+          {% endfor %}
+        </section>
+      {% endif %}
+
+      {% if sello or firma %}
+        <section class="fiscal-block">
+          <div class="section-title">Información fiscal</div>
+          {% if sello %}<div class="row"><span class="label">Sello recibido</span><span class="amount">{{ sello }}</span></div>{% endif %}
+          {% if firma %}<div class="row"><span class="label">Firma electrónica</span><span class="amount">{{ firma }}</span></div>{% endif %}
+        </section>
+      {% endif %}
+
+      {% if qr_image %}
+        <section class="qr">
+          <img src="{{ qr_image }}" alt="Código QR" />
+          {% if qr_url %}<div class="caption">Consulta pública: {{ qr_url }}</div>{% endif %}
+        </section>
+      {% elif qr_url %}
+        <section class="qr">
+          <div class="caption">Consulta pública: {{ qr_url }}</div>
+        </section>
+      {% endif %}
+
+      <footer class="footer">
+        <div>Documento válido como comprobante para consumidor final.</div>
+        {% for note in footer_notes %}<div>{{ note }}</div>{% endfor %}
+      </footer>
+
+      <div class="cut-line">··················</div>
+    </article>
+  </body>
+</html>

--- a/templates/ticket-credito-fiscal-58mm.html
+++ b/templates/ticket-credito-fiscal-58mm.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }} · {{ document_label }}</title>
+    <link rel="stylesheet" href="ticket-58mm.css" />
+  </head>
+  <body>
+    <article class="ticket">
+      <header class="header">
+        {% if emisor.logo_url %}
+          <img src="{{ emisor.logo_url }}" alt="Logo" class="logo" />
+        {% endif %}
+        <div class="title">{{ title }}</div>
+        <div class="doc-label">{{ document_label }}</div>
+        {% if emisor.nombre %}
+          <div class="meta">{{ emisor.nombre }}</div>
+        {% endif %}
+      </header>
+
+      <section class="info-list">
+        <div class="section-title">Datos del emisor</div>
+        {% if emisor.razon_social and emisor.razon_social != emisor.nombre %}
+          <div class="key-value"><span class="label">Razón social</span><span class="value">{{ emisor.razon_social }}</span></div>
+        {% endif %}
+        {% if emisor.nit %}
+          <div class="key-value"><span class="label">NIT</span><span class="value">{{ emisor.nit }}</span></div>
+        {% endif %}
+        {% if emisor.nrc %}
+          <div class="key-value"><span class="label">NRC</span><span class="value">{{ emisor.nrc }}</span></div>
+        {% endif %}
+        {% if emisor.giro %}
+          <div class="key-value"><span class="label">Actividad</span><span class="value">{{ emisor.giro }}</span></div>
+        {% endif %}
+        {% if emisor.direccion %}
+          <div class="key-value"><span class="label">Dirección</span><span class="value">{{ emisor.direccion }}</span></div>
+        {% endif %}
+        {% if emisor.telefono %}
+          <div class="key-value"><span class="label">Teléfono</span><span class="value">{{ emisor.telefono }}</span></div>
+        {% endif %}
+        {% if emisor.email %}
+          <div class="key-value"><span class="label">Correo</span><span class="value">{{ emisor.email }}</span></div>
+        {% endif %}
+      </section>
+
+      {% if document_meta %}
+        <section class="meta-list">
+          <div class="section-title">Documento</div>
+          {% for row in document_meta %}
+            <div class="key-value"><span class="label">{{ row.label }}</span><span class="value">{{ row.value }}</span></div>
+          {% endfor %}
+        </section>
+      {% endif %}
+
+      <section class="info-list">
+        <div class="section-title">Receptor</div>
+        {% if receptor.nombre %}
+          <div class="key-value"><span class="label">Nombre</span><span class="value">{{ receptor.nombre }}</span></div>
+        {% endif %}
+        {% if receptor.documento_numero %}
+          <div class="key-value"><span class="label">{{ receptor.documento_label or 'Documento' }}</span><span class="value">{{ receptor.documento_numero }}</span></div>
+        {% endif %}
+        {% if receptor.nit and receptor.nit != receptor.documento_numero %}
+          <div class="key-value"><span class="label">NIT</span><span class="value">{{ receptor.nit }}</span></div>
+        {% endif %}
+        {% if receptor.nrc %}
+          <div class="key-value"><span class="label">NRC</span><span class="value">{{ receptor.nrc }}</span></div>
+        {% endif %}
+        {% if receptor.giro %}
+          <div class="key-value"><span class="label">Actividad</span><span class="value">{{ receptor.giro }}</span></div>
+        {% endif %}
+        {% if receptor.direccion %}
+          <div class="key-value"><span class="label">Dirección</span><span class="value">{{ receptor.direccion }}</span></div>
+        {% endif %}
+        {% if receptor.correo %}
+          <div class="key-value"><span class="label">Correo</span><span class="value">{{ receptor.correo }}</span></div>
+        {% endif %}
+      </section>
+
+      <section>
+        <div class="section-title">Detalle</div>
+        <div class="divider"></div>
+        <div class="items">
+          {% for item in items %}
+            <div class="item">
+              <div class="item-desc">{{ item.descripcion }}</div>
+              <div class="item-meta">
+                <span class="calc">{{ item.cantidad }} × {{ item.precio_unitario }}</span>
+                {% if item.iva %}<span class="tax">IVA {{ item.iva }}</span>{% endif %}
+                <span class="subtotal">{{ item.subtotal }}</span>
+              </div>
+              {% if item.descuentos %}
+                <div class="item-meta">
+                  <span class="calc"></span>
+                  <span class="discount">Descuento {{ item.descuentos }}</span>
+                  <span class="subtotal"></span>
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="totals">
+        {% for row in totals %}
+          <div class="row"><span class="label">{{ row.label }}</span><span class="amount">{{ row.value }}</span></div>
+        {% endfor %}
+        {% if total_to_pay %}
+          <div class="row highlight">
+            <span class="label">{{ total_to_pay.label | upper }}</span>
+            <span class="amount">{{ total_to_pay.value }}</span>
+          </div>
+        {% endif %}
+      </section>
+
+      <section class="fiscal-block">
+        <div class="section-title">Resumen fiscal</div>
+        <div class="row"><span class="label">Condición de operación</span><span class="amount">{{ condicion_operacion or 'Sin especificar' }}</span></div>
+        {% if is_credit_operation %}
+          <div class="detail">Operación a crédito. Revise los plazos y periodos declarados.</div>
+        {% endif %}
+        {% for row in fiscal_summary %}
+          <div class="row"><span class="label">{{ row.label }}</span><span class="amount">{{ row.amount }}</span></div>
+        {% endfor %}
+      </section>
+
+      {% if pagos or show_payments_block %}
+        <section class="payments">
+          <div class="section-title">Pagos</div>
+          {% if pagos %}
+            {% for pago in pagos %}
+              <div class="row"><span class="label">{{ pago.label }}</span><span class="amount">{{ pago.amount }}</span></div>
+              {% if pago.detail %}<div class="detail">{{ pago.detail }}</div>{% endif %}
+            {% endfor %}
+          {% elif is_credit_operation %}
+            <div class="detail">Sin detalle de pagos registrado.</div>
+          {% endif %}
+        </section>
+      {% endif %}
+
+      {% if sello or firma %}
+        <section class="fiscal-block">
+          <div class="section-title">Control fiscal</div>
+          {% if sello %}<div class="row"><span class="label">Sello recibido</span><span class="amount">{{ sello }}</span></div>{% endif %}
+          {% if firma %}<div class="row"><span class="label">Firma electrónica</span><span class="amount">{{ firma }}</span></div>{% endif %}
+        </section>
+      {% endif %}
+
+      {% if qr_image %}
+        <section class="qr">
+          <img src="{{ qr_image }}" alt="Código QR" />
+          {% if qr_url %}<div class="caption">Consulta pública: {{ qr_url }}</div>{% endif %}
+        </section>
+      {% elif qr_url %}
+        <section class="qr">
+          <div class="caption">Consulta pública: {{ qr_url }}</div>
+        </section>
+      {% endif %}
+
+      <footer class="footer">
+        <div>Documento emitido para crédito fiscal.</div>
+        {% for note in footer_notes %}<div>{{ note }}</div>{% endfor %}
+      </footer>
+
+      <div class="cut-line">··················</div>
+    </article>
+  </body>
+</html>

--- a/templates/ticket-normal-58mm.html
+++ b/templates/ticket-normal-58mm.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }} · {{ document_label }}</title>
+    <link rel="stylesheet" href="ticket-58mm.css" />
+  </head>
+  <body>
+    <article class="ticket">
+      <header class="header">
+        {% if emisor.logo_url %}
+          <img src="{{ emisor.logo_url }}" alt="Logo" class="logo" />
+        {% endif %}
+        <div class="title">{{ title }}</div>
+        <div class="doc-label">{{ document_label }}</div>
+        {% if emisor.nombre %}
+          <div class="meta">{{ emisor.nombre }}</div>
+        {% endif %}
+      </header>
+
+      <section class="info-list">
+        <div class="section-title">Datos del emisor</div>
+        {% if emisor.razon_social and emisor.razon_social != emisor.nombre %}
+          <div class="key-value"><span class="label">Razón social</span><span class="value">{{ emisor.razon_social }}</span></div>
+        {% endif %}
+        {% if emisor.nit %}
+          <div class="key-value"><span class="label">NIT</span><span class="value">{{ emisor.nit }}</span></div>
+        {% endif %}
+        {% if emisor.nrc %}
+          <div class="key-value"><span class="label">NRC</span><span class="value">{{ emisor.nrc }}</span></div>
+        {% endif %}
+        {% if emisor.giro %}
+          <div class="key-value"><span class="label">Actividad</span><span class="value">{{ emisor.giro }}</span></div>
+        {% endif %}
+        {% if emisor.direccion %}
+          <div class="key-value"><span class="label">Dirección</span><span class="value">{{ emisor.direccion }}</span></div>
+        {% endif %}
+        {% if emisor.telefono %}
+          <div class="key-value"><span class="label">Teléfono</span><span class="value">{{ emisor.telefono }}</span></div>
+        {% endif %}
+        {% if emisor.email %}
+          <div class="key-value"><span class="label">Correo</span><span class="value">{{ emisor.email }}</span></div>
+        {% endif %}
+      </section>
+
+      {% if document_meta %}
+        <section class="meta-list">
+          <div class="section-title">Documento</div>
+          {% for row in document_meta %}
+            <div class="key-value"><span class="label">{{ row.label }}</span><span class="value">{{ row.value }}</span></div>
+          {% endfor %}
+        </section>
+      {% endif %}
+
+      <section class="info-list">
+        <div class="section-title">Cliente</div>
+        {% if receptor.nombre %}
+          <div class="key-value"><span class="label">Nombre</span><span class="value">{{ receptor.nombre }}</span></div>
+        {% endif %}
+        {% if receptor.documento_numero %}
+          <div class="key-value"><span class="label">{{ receptor.documento_label or 'Documento' }}</span><span class="value">{{ receptor.documento_numero }}</span></div>
+        {% endif %}
+        {% if receptor.nit and receptor.nit != receptor.documento_numero %}
+          <div class="key-value"><span class="label">NIT</span><span class="value">{{ receptor.nit }}</span></div>
+        {% endif %}
+        {% if receptor.nrc %}
+          <div class="key-value"><span class="label">NRC</span><span class="value">{{ receptor.nrc }}</span></div>
+        {% endif %}
+        {% if receptor.giro %}
+          <div class="key-value"><span class="label">Actividad</span><span class="value">{{ receptor.giro }}</span></div>
+        {% endif %}
+        {% if receptor.direccion %}
+          <div class="key-value"><span class="label">Dirección</span><span class="value">{{ receptor.direccion }}</span></div>
+        {% endif %}
+        {% if receptor.correo %}
+          <div class="key-value"><span class="label">Correo</span><span class="value">{{ receptor.correo }}</span></div>
+        {% endif %}
+        {% if receptor.telefono %}
+          <div class="key-value"><span class="label">Teléfono</span><span class="value">{{ receptor.telefono }}</span></div>
+        {% endif %}
+      </section>
+
+      <section>
+        <div class="section-title">Detalle</div>
+        <div class="divider"></div>
+        <div class="items">
+          {% for item in items %}
+            <div class="item">
+              <div class="item-desc">{{ item.descripcion }}</div>
+              <div class="item-meta">
+                <span class="calc">{{ item.cantidad }} × {{ item.precio_unitario }}</span>
+                {% if item.iva %}<span class="tax">IVA {{ item.iva }}</span>{% endif %}
+                <span class="subtotal">{{ item.subtotal }}</span>
+              </div>
+              {% if item.descuentos %}
+                <div class="item-meta">
+                  <span class="calc"></span>
+                  <span class="discount">Descuento {{ item.descuentos }}</span>
+                  <span class="subtotal"></span>
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="totals">
+        {% for row in totals %}
+          <div class="row"><span class="label">{{ row.label }}</span><span class="amount">{{ row.value }}</span></div>
+        {% endfor %}
+        {% if total_to_pay %}
+          <div class="row highlight">
+            <span class="label">{{ total_to_pay.label | upper }}</span>
+            <span class="amount">{{ total_to_pay.value }}</span>
+          </div>
+        {% endif %}
+      </section>
+
+      {% if pagos %}
+        <section class="payments">
+          <div class="section-title">Pagos</div>
+          {% for pago in pagos %}
+            <div class="row"><span class="label">{{ pago.label }}</span><span class="amount">{{ pago.amount }}</span></div>
+            {% if pago.detail %}<div class="detail">{{ pago.detail }}</div>{% endif %}
+          {% endfor %}
+        </section>
+      {% endif %}
+
+      {% if sello or firma %}
+        <section class="fiscal-block">
+          <div class="section-title">Información fiscal</div>
+          {% if sello %}<div class="row"><span class="label">Sello recibido</span><span class="amount">{{ sello }}</span></div>{% endif %}
+          {% if firma %}<div class="row"><span class="label">Firma electrónica</span><span class="amount">{{ firma }}</span></div>{% endif %}
+        </section>
+      {% endif %}
+
+      {% if qr_image %}
+        <section class="qr">
+          <img src="{{ qr_image }}" alt="Código QR" />
+          {% if qr_url %}<div class="caption">Consulta pública: {{ qr_url }}</div>{% endif %}
+        </section>
+      {% elif qr_url %}
+        <section class="qr">
+          <div class="caption">Consulta pública: {{ qr_url }}</div>
+        </section>
+      {% endif %}
+
+      {% if footer_notes %}
+        <footer class="footer">
+          {% for note in footer_notes %}<div>{{ note }}</div>{% endfor %}
+        </footer>
+      {% endif %}
+
+      <div class="cut-line">··················</div>
+    </article>
+  </body>
+</html>

--- a/tests/test_ticket_fe_pdf.py
+++ b/tests/test_ticket_fe_pdf.py
@@ -57,9 +57,10 @@ def test_ticket_fe_pdf_clean(tmp_path):
     for bad in ("apendice", "cuerpoDocumento", "falta", "None"):
         assert bad not in text
 
-    assert "ELECTRÓNICO — CONSUMIDOR FINAL" in normalized
-    for good in ("Forma de pago:", "CANT. DESCRIPCIÓN"):
-        assert good in text
+    assert "DOCUMENTO TRIBUTARIO ELECTRÓNICO" in normalized
+    assert "CONSUMIDOR FINAL" in normalized
+    assert "TOTAL A PAGAR" in normalized or "Total a pagar" in text
+    assert "EFECTIVO" in text or "PAGOS" in text
 
 
 def test_generate_ticket_pdf_defaults_and_persists_es_ticket(tmp_path, monkeypatch):
@@ -176,5 +177,6 @@ def test_generate_ticket_pdf_defaults_and_persists_es_ticket(tmp_path, monkeypat
         text = "\n".join(page.get_text() for page in doc)
     normalized = " ".join(text.split())
 
-    assert "ELECTRÓNICO — CONSUMIDOR FINAL" in normalized
-    assert "Forma de pago:" in text
+    assert "DOCUMENTO TRIBUTARIO ELECTRÓNICO" in normalized
+    assert "CONSUMIDOR FINAL" in normalized
+    assert "EFECTIVO" in text or "PAGOS" in text


### PR DESCRIPTION
## Summary
- refine the ticket renderer to map plazo/periodo in payment rows, expose fiscal summaries, and pass credit operation flags to the templates
- tighten the shared 58 mm stylesheet for a 57 mm printable area, larger type, break avoidance, and explicit print-media rules
- adjust the normal, consumidor final, and crédito fiscal templates to emphasise the total due, keep fiscal data readable, and show payment placeholders for credit operations
- declare tinycss2 and cssselect2 dependencies required alongside WeasyPrint

## Testing
- pytest tests/test_ticket_fe_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ab7a62dc832398dd4d7a92516602