### PR TITLE
Separar vendedores de distribuidores de trabajadores

### DIFF
--- a/db.py
+++ b/db.py
@@ -926,40 +926,50 @@ class DB:
         codigo=None,
         dui=None,
         commit: bool = True,
-        trabajador_id=None,
     ):
         """Insert a new vendor.
 
         ``commit`` can be set to ``False`` when called inside an existing
         transaction to avoid committing after each insertion.
 
-        If ``trabajador_id`` is provided, the corresponding record in
-        ``trabajadores`` will be updated (and marked as vendor) instead of
-        inserting a new one.
+        When ``Distribuidor_id`` is provided the vendor is treated as a
+        supplier and no entry is created in ``trabajadores``.
         """
         if codigo is None:
             codigo = self.get_next_vendedor_codigo()
 
-        self.cursor.execute(
-            "SELECT 1 FROM trabajadores WHERE codigo=?",
-            (codigo,),
-        )
-        if self.cursor.fetchone():
-            raise ValueError("El código ya existe")
+        if Distribuidor_id is None:
+            self.cursor.execute(
+                "SELECT 1 FROM trabajadores WHERE codigo=?",
+                (codigo,),
+            )
+            if self.cursor.fetchone():
+                raise ValueError("El código ya existe")
 
-        self.cursor.execute(
-            """
-            INSERT INTO trabajadores (codigo, nombre, dui, es_vendedor)
-            VALUES (?, ?, ?, 1)
-            """,
-            (codigo, nombre, dui),
-        )
-        trabajador_id = self.cursor.lastrowid
+            self.cursor.execute(
+                """
+                INSERT INTO trabajadores (codigo, nombre, dui, es_vendedor)
+                VALUES (?, ?, ?, 1)
+                """,
+                (codigo, nombre, dui),
+            )
+            trabajador_id = self.cursor.lastrowid
 
-        self.cursor.execute(
-            "INSERT INTO vendedores (id, codigo, nombre, dui, descripcion, Distribuidor_id) VALUES (?, ?, ?, ?, ?, ?)",
-            (trabajador_id, codigo, nombre, dui, descripcion, Distribuidor_id),
-        )
+            self.cursor.execute(
+                """
+                INSERT INTO vendedores (id, codigo, nombre, dui, descripcion, Distribuidor_id)
+                VALUES (?, ?, ?, ?, ?, NULL)
+                """,
+                (trabajador_id, codigo, nombre, dui, descripcion),
+            )
+        else:
+            self.cursor.execute(
+                """
+                INSERT INTO vendedores (codigo, nombre, dui, descripcion, Distribuidor_id)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (codigo, nombre, dui, descripcion, Distribuidor_id),
+            )
         if commit:
             self.conn.commit()
 
@@ -981,9 +991,14 @@ class DB:
 
             )
             self.cursor.execute(
-                "UPDATE trabajadores SET codigo=?, nombre=?, dui=? WHERE id=?",
-                (codigo, nombre, dui, id),
+                "SELECT 1 FROM trabajadores WHERE id=?",
+                (id,),
             )
+            if self.cursor.fetchone():
+                self.cursor.execute(
+                    "UPDATE trabajadores SET codigo=?, nombre=?, dui=? WHERE id=?",
+                    (codigo, nombre, dui, id),
+                )
             self.conn.commit()
         except Exception as e:
             logger.exception("Error al actualizar vendedor: %s", e)
@@ -1012,7 +1027,12 @@ class DB:
                         f"UPDATE {table} SET {column}=? WHERE {column}=?", (reassign_to, id)
                     )
             self.cursor.execute("DELETE FROM vendedores WHERE id=?", (id,))
-            self.cursor.execute("DELETE FROM trabajadores WHERE id=?", (id,))
+            self.cursor.execute(
+                "SELECT 1 FROM trabajadores WHERE id=?",
+                (id,),
+            )
+            if self.cursor.fetchone():
+                self.cursor.execute("DELETE FROM trabajadores WHERE id=?", (id,))
             self.conn.commit()
         except ValueError:
             raise

--- a/tests/test_trabajador_vendedor_independencia.py
+++ b/tests/test_trabajador_vendedor_independencia.py
@@ -15,3 +15,14 @@ def test_update_trabajador_es_vendedor_no_crea_vendedor(tmp_path):
     db.update_trabajador(tid, {"codigo": "T1", "nombre": "Ana", "es_vendedor": True})
     db.cursor.execute("SELECT COUNT(*) FROM vendedores")
     assert db.cursor.fetchone()[0] == 0
+
+
+def test_add_vendedor_distribuidor_no_crea_trabajador(tmp_path):
+    db = DB(str(tmp_path / "db.sqlite"))
+    db.add_Distribuidor("Dist 1")
+    dist_id = db.get_Distribuidores()[0]["id"]
+    db.add_vendedor("Proveedor", Distribuidor_id=dist_id)
+    db.cursor.execute("SELECT COUNT(*) FROM trabajadores")
+    assert db.cursor.fetchone()[0] == 0
+    db.cursor.execute("SELECT COUNT(*) FROM vendedores")
+    assert db.cursor.fetchone()[0] == 1


### PR DESCRIPTION
## Summary
- evitar que los vendedores asociados a un distribuidor se inserten en la tabla de trabajadores y solo crear el registro laboral cuando corresponde
- sincronizar las operaciones de actualización/eliminación con trabajadores únicamente cuando existe la relación
- agregar una prueba que verifica que agregar un vendedor con distribuidor no crea un trabajador

## Testing
- pytest tests/test_trabajador_vendedor_independencia.py

------
https://chatgpt.com/codex/tasks/task_e_68d5b9f3bbbc83238b132421c64e84b1