### PR TITLE
Handle missing WeasyPrint gracefully and bundle GTK assets

### DIFF
--- a/print/ticket_renderer.py
+++ b/print/ticket_renderer.py
@@ -16,9 +16,63 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
+import os
+import sys
+
 import qrcode
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from weasyprint import CSS, HTML
+
+# --- Bootstrap DLLs GTK/Pango/Cairo en Windows ---
+if sys.platform.startswith("win"):
+    here = os.path.dirname(__file__)
+    # 1) Ruta local dentro del repo: repo_root/gtk3/bin
+    repo_bin = os.path.abspath(os.path.join(here, "..", "gtk3", "bin"))
+    if os.path.isdir(repo_bin):
+        try:
+            os.add_dll_directory(repo_bin)  # Python 3.8+
+        except Exception:
+            pass
+    # 2) (Opcional) override por variable de entorno
+    gtk_bin = os.environ.get("GTK_BIN")
+    if gtk_bin and os.path.isdir(gtk_bin):
+        try:
+            os.add_dll_directory(gtk_bin)
+        except Exception:
+            pass
+# --- Fin bootstrap ---
+
+_HTML = _CSS = None
+_weasy_error = None
+
+
+def _ensure_weasyprint() -> None:
+    """Import WeasyPrint de forma diferida y controlar errores de dependencias."""
+
+    global _HTML, _CSS, _weasy_error
+    if _HTML and _CSS:
+        return
+    try:
+        from weasyprint import HTML as __HTML, CSS as __CSS
+
+        _HTML, _CSS = __HTML, __CSS
+        _weasy_error = None
+    except Exception as e:  # pragma: no cover - depende de entorno externo
+        _weasy_error = e
+        raise RuntimeError(
+            "WeasyPrint no está disponible. Instala las dependencias nativas (GTK/Pango/Cairo) "
+            "y el paquete Python WeasyPrint. Detalle: " + str(e)
+        )
+
+
+def _base_templates_dir() -> Path:
+    """Return the base path where templates live, supporting PyInstaller."""
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidate = Path(meipass) / "templates"
+        if candidate.exists():
+            return candidate
+    return Path(__file__).resolve().parent.parent / "templates"
 
 from factura_sv import build_qr_url
 from utils.catalogos import (
@@ -42,8 +96,16 @@ except Exception:  # pragma: no cover - fallback when running minimal envs
     DTE_MUNICIPIOS = {}
 
 
-TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+TEMPLATES_DIR = _base_templates_dir()
 CSS_PATH = TEMPLATES_DIR / "ticket-58mm.css"
+
+
+def render_ticket_html_to_pdf(html_str: str, css_path: str, out_path: str) -> str:
+    """Render *html_str* + *css_path* to *out_path* using WeasyPrint."""
+
+    _ensure_weasyprint()
+    _HTML(string=html_str).write_pdf(out_path, stylesheets=[_CSS(filename=css_path)])
+    return out_path
 
 
 # ---------------------------------------------------------------------------
@@ -560,7 +622,10 @@ def render_ticket_pdf(
     }
 
     html = template.render(**context)
-    stylesheets = [CSS(filename=str(CSS_PATH))]
-    pdf_bytes = HTML(string=html, base_url=str(TEMPLATES_DIR)).write_pdf(stylesheets=stylesheets)
+    _ensure_weasyprint()
+    stylesheets = [_CSS(filename=str(CSS_PATH))]
+    pdf_bytes = _HTML(string=html, base_url=str(TEMPLATES_DIR)).write_pdf(
+        stylesheets=stylesheets
+    )
     return pdf_bytes
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ PyInstaller.__main__.run([
     f'--add-data=inventario.json{SEP}.',
     f'--add-data=ultimo_inventario.json{SEP}.',
     f'--add-data=avatar.jpg{SEP}.',
+    f'--add-data=templates{SEP}templates',
+    f'--add-data=gtk3{SEP}gtk3',
     # Agrega aquí otros archivos necesarios (imágenes, .ui, etc.)
 ])
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -10,6 +10,7 @@ import dte
 from pathlib import Path
 from factura_sv import generar_factura_electronica_pdf
 from ticket_pdf import generar_ticket_personalizado, generar_ticket_fe_pdf
+from print.ticket_renderer import render_ticket_html_to_pdf
 from dte import generar_ticket_json, generar_dte_json, d4, generar_cabecera_dte_data
 from utils.monto import D, d2, monto_a_texto_sv, iva_item, to_base_iva
 from utils.docs import get_document_paths, build_invoice_json, write_pdf_atomically
@@ -728,8 +729,26 @@ def generate_invoice_pdf(manager, venta_id):
     return str(file_path)
 
 
-def generate_ticket_pdf(manager, venta_id):
-    """Generate and store the ticket PDF for the given sale."""
+def generate_ticket_pdf(manager_or_html, venta_id_or_css, out_path: str | None = None):
+    """Generate and store the ticket PDF for a sale or render arbitrary HTML."""
+
+    def _handle_ticket_runtime_error(exc: RuntimeError):
+        logger.error("No se pudo generar el PDF del ticket: %s", exc, exc_info=True)
+        print("[Ticket] No se pudo generar el PDF:", exc)
+        return None
+
+    if isinstance(manager_or_html, str):
+        html = manager_or_html
+        css = str(venta_id_or_css)
+        if not out_path:
+            raise ValueError("out_path es obligatorio cuando se usa HTML directo")
+        try:
+            return render_ticket_html_to_pdf(html, css, out_path)
+        except RuntimeError as exc:
+            return _handle_ticket_runtime_error(exc)
+
+    manager = manager_or_html
+    venta_id = venta_id_or_css
     venta = next((v for v in manager.db.get_ventas() if v["id"] == venta_id), None)
     if not venta:
         return None
@@ -829,10 +848,13 @@ def generate_ticket_pdf(manager, venta_id):
 
     dte_data = dict(extra)
     dte_data["dteJson"] = ticket_json
-    if tipo_dte == "01" and extra.get("es_ticket"):
-        generar_ticket_fe_pdf(venta, detalles, filename, dte_data=dte_data)
-    else:
-        generar_ticket_personalizado(venta, detalles, filename, dte_data=dte_data)
+    try:
+        if tipo_dte == "01" and extra.get("es_ticket"):
+            generar_ticket_fe_pdf(venta, detalles, filename, dte_data=dte_data)
+        else:
+            generar_ticket_personalizado(venta, detalles, filename, dte_data=dte_data)
+    except RuntimeError as exc:
+        return _handle_ticket_runtime_error(exc)
     if not os.path.exists(json_path):
         raise IOError(f"No se pudo guardar JSON en {json_path}")
     manager.db.add_ticket_pdf(venta_id, filename)


### PR DESCRIPTION
## Summary
- bootstrap GTK/Pango/Cairo DLL lookup on Windows and defer WeasyPrint imports so missing dependencies raise a controlled RuntimeError
- add a helper to render ticket HTML to PDF, reuse the lazy import in the ticket renderer, and update ticket generation to log failures without crashing the GUI
- include the templates/ and gtk3/ directories when building with PyInstaller so the bundled executable has everything it needs

## Testing
- pytest tests/test_ticket_renderer.py *(fails: extracted PDF text splits the heading into multiple lines so the expected substring is not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d61e703b2c83239ac45894b97be551