### PR TITLE
Handle vendor code collisions during inventory import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -569,19 +569,49 @@ class InventoryManager:
                 new_dist_id = (
                     Distribuidor_id_map.get(dist_id) if dist_id is not None else None
                 )
-                self.db.add_vendedor(
-                    vend["nombre"],
-                    vend.get("descripcion", ""),
-                    new_dist_id,
-                    vend.get("codigo"),
-                    vend.get("dui"),
-                    commit=False,
-                )
-                self.db.cursor.execute(
-                    "SELECT id FROM vendedores WHERE nombre=? ORDER BY id DESC LIMIT 1",
-                    (vend["nombre"],),
-                )
-                new_id = self.db.cursor.fetchone()["id"]
+                existing_id = None
+                codigo = vend.get("codigo")
+                if codigo:
+                    self.db.cursor.execute(
+                        "SELECT id FROM vendedores WHERE codigo=?",
+                        (codigo,),
+                    )
+                    row = self.db.cursor.fetchone()
+                    if row:
+                        existing_id = row["id"]
+
+                if existing_id is not None:
+                    self.db.cursor.execute(
+                        """
+                        UPDATE vendedores
+                        SET nombre=?, descripcion=?, Distribuidor_id=?, codigo=?, dui=?
+                        WHERE id=?
+                        """,
+                        (
+                            vend["nombre"],
+                            vend.get("descripcion", ""),
+                            new_dist_id,
+                            codigo,
+                            vend.get("dui"),
+                            existing_id,
+                        ),
+                    )
+                    new_id = existing_id
+                else:
+                    self.db.add_vendedor(
+                        vend["nombre"],
+                        vend.get("descripcion", ""),
+                        new_dist_id,
+                        codigo,
+                        vend.get("dui"),
+                        commit=False,
+                    )
+                    self.db.cursor.execute(
+                        "SELECT id FROM vendedores WHERE nombre=? ORDER BY id DESC LIMIT 1",
+                        (vend["nombre"],),
+                    )
+                    new_id = self.db.cursor.fetchone()["id"]
+
                 vendedor_id_map[vend["id"]] = new_id
 
             # Productos

--- a/tests/test_import_vendor_mapping.py
+++ b/tests/test_import_vendor_mapping.py
@@ -201,3 +201,93 @@ def test_import_supplier_and_employee_vendors(tmp_path):
     productos = manager.db.get_productos()
     assert len(productos) == 1
     assert productos[0]["vendedor_id"] == employee_vendor["id"]
+
+
+def test_import_supplier_employee_codigo_collision(tmp_path):
+    manager = im.InventoryManager(MemoryDB())
+
+    data = {
+        "Distribuidores": [{"id": 1, "nombre": "D1"}],
+        "vendedores": [
+            {
+                "id": 20,
+                "nombre": "Proveedor Shared",
+                "Distribuidor_id": 1,
+                "codigo": "SHARED",
+                "descripcion": "Proveedor",
+            },
+            {
+                "id": 21,
+                "nombre": "Empleado Shared",
+                "Distribuidor_id": None,
+                "codigo": "SHARED",
+                "descripcion": "Empleado",
+            },
+        ],
+        "trabajadores": [
+            {
+                "id": 21,
+                "nombre": "Empleado Shared",
+                "codigo": "SHARED",
+                "dui": "00000000-0",
+                "es_vendedor": True,
+            }
+        ],
+        "productos": [
+            {
+                "id": 101,
+                "nombre": "Producto Proveedor",
+                "codigo": "PP-1",
+                "sku": "SKU-PP",
+                "vendedor_id": 20,
+                "Distribuidor_id": 1,
+                "precio_compra": 0,
+                "precio_venta_minorista": 0,
+                "precio_venta_mayorista": 0,
+                "stock": 2,
+            },
+            {
+                "id": 102,
+                "nombre": "Producto Empleado",
+                "codigo": "PE-1",
+                "sku": "SKU-PE",
+                "vendedor_id": 21,
+                "Distribuidor_id": None,
+                "precio_compra": 0,
+                "precio_venta_minorista": 0,
+                "precio_venta_mayorista": 0,
+                "stock": 1,
+            },
+        ],
+        "clientes": [],
+        "ventas": [],
+        "compras": [],
+        "detalles_venta": [],
+        "detalles_compra": [],
+        "datos_negocio": None,
+        "ventas_credito_fiscal": [],
+    }
+    path = tmp_path / "inv_shared_codigo.json"
+    path.write_text(json.dumps(data))
+
+    try:
+        manager.importar_inventario_json(str(path))
+    except sqlite3.IntegrityError as exc:  # pragma: no cover - defensive
+        pytest.fail(f"Unexpected sqlite3.IntegrityError: {exc}")
+
+    productos = manager.db.get_productos()
+    assert len(productos) == 2
+
+    productos_por_nombre = {p["nombre"]: p for p in productos}
+    prod_proveedor = productos_por_nombre["Producto Proveedor"]
+    prod_empleado = productos_por_nombre["Producto Empleado"]
+
+    assert prod_proveedor["vendedor_id"] == prod_empleado["vendedor_id"]
+
+    trabajadores = manager.db.get_trabajadores()
+    assert len(trabajadores) == 1
+    trabajador = trabajadores[0]
+
+    # Both products should resolve to the trabajador vendor despite the shared codigo
+    assert prod_proveedor["vendedor_id"] == trabajador["id"]
+    assert prod_empleado["vendedor_id"] == trabajador["id"]


### PR DESCRIPTION
## Summary
- reuse existing vendor rows during legacy JSON imports when supplier codigos collide and keep downstream mappings intact
- add a regression test that covers importing suppliers and employees sharing the same codigo

## Testing
- pytest tests/test_import_vendor_mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b10b8f088323a6e4bf8ff04a65c2