### PR TITLE
Limit purchase flows to distributor vendors

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -1385,6 +1385,7 @@ class RegisterPurchaseDialog(QDialog):
         self.productos = productos
         self.Distribuidores = Distribuidores
         self.Vendedores = Vendedores
+        self._vendedores_map = {v["id"]: v for v in self.Vendedores}
         self.compra_items = []
 
         layout = QVBoxLayout()
@@ -1401,7 +1402,9 @@ class RegisterPurchaseDialog(QDialog):
         vendedor_layout = QHBoxLayout()
         vendedor_layout.addWidget(QLabel("Vendedor:"))
         self.vendedor_combo = QComboBox()
-        self.vendedor_combo.addItems([v["nombre"] for v in self.Vendedores])
+        self.vendedor_combo.addItem("Seleccionar proveedor", None)
+        for v in self.Vendedores:
+            self.vendedor_combo.addItem(v["nombre"], v["id"])
         vendedor_layout.addWidget(self.vendedor_combo)
         layout.addLayout(vendedor_layout)
 
@@ -1683,23 +1686,33 @@ class RegisterPurchaseDialog(QDialog):
         producto = self.productos[idx]
         vendedor_id = producto.get("vendedor_id")
         # Selecciona el vendedor correspondiente
-        for i, v in enumerate(self.Vendedores):
-            if v["id"] == vendedor_id:
-                self.vendedor_combo.setCurrentIndex(i)
-                break
+        combo_idx = self.vendedor_combo.findData(vendedor_id)
+        self.vendedor_combo.blockSignals(True)
+        if combo_idx >= 0:
+            self.vendedor_combo.setCurrentIndex(combo_idx)
+        else:
+            self.vendedor_combo.setCurrentIndex(0)
+        self.vendedor_combo.blockSignals(False)
         self._actualizar_Distribuidor()
 
     def _actualizar_Distribuidor(self):
-        idx = self.vendedor_combo.currentIndex()
-        if idx < 0:
-            self.Distribuidor_combo.clear()
-            return
-        vendedor = self.Vendedores[idx]
-        Distribuidor_id = vendedor.get("Distribuidor_id")
+        vendedor_id = self.vendedor_combo.currentData()
         self.Distribuidor_combo.clear()
+        if vendedor_id is None:
+            self.comision_label_resumen.setText("Comisión vendedor: 0%")
+            self.comision_pct_spin.setValue(0)
+            return
+        vendedor = self._vendedores_map.get(vendedor_id)
+        if not vendedor:
+            self.comision_label_resumen.setText("Comisión vendedor: 0%")
+            self.comision_pct_spin.setValue(0)
+            return
+        Distribuidor_id = self._vendedor_Distribuidor_map.get(vendedor_id)
+        if Distribuidor_id is None:
+            Distribuidor_id = vendedor.get("Distribuidor_id")
         for d in self.Distribuidores:
             if d["id"] == Distribuidor_id:
-                self.Distribuidor_combo.addItem(d["nombre"])
+                self.Distribuidor_combo.addItem(d["nombre"], d["id"])
                 break
         # Actualiza comisión base del vendedor
         comision = vendedor.get("comision_base", 0)
@@ -1839,15 +1852,12 @@ class RegisterPurchaseDialog(QDialog):
         # Obtén los datos DIRECTAMENTE de los combos y la lista de items
         fecha = QDate.currentDate().toString("yyyy-MM-dd")
         total_general = sum(item["total"] for item in self.compra_items)
-        vendedor_idx = self.vendedor_combo.currentIndex()
-        vendedor_id = self.Vendedores[vendedor_idx]["id"] if vendedor_idx >= 0 else None
-        Distribuidor_id = None
-        if self.Distribuidor_combo.count() > 0:
-            dist_name = self.Distribuidor_combo.currentText()
-            for d in self.Distribuidores:
-                if d["nombre"] == dist_name:
-                    Distribuidor_id = d["id"]
-                    break
+        vendedor_id = self.vendedor_combo.currentData()
+        Distribuidor_id = (
+            self.Distribuidor_combo.currentData()
+            if self.Distribuidor_combo.count() > 0
+            else None
+        )
 
         if vendedor_id is None or Distribuidor_id is None:
             respuesta = QMessageBox.question(
@@ -1897,15 +1907,12 @@ class RegisterPurchaseDialog(QDialog):
 
     def get_data(self):
         total_general = sum(item["total"] for item in self.compra_items)
-        vendedor_idx = self.vendedor_combo.currentIndex()
-        vendedor_id = self.Vendedores[vendedor_idx]["id"] if vendedor_idx >= 0 else None
-        Distribuidor_id = None
-        if self.Distribuidor_combo.count() > 0:
-            dist_name = self.Distribuidor_combo.currentText()
-            for d in self.Distribuidores:
-                if d["nombre"] == dist_name:
-                    Distribuidor_id = d["id"]
-                    break
+        vendedor_id = self.vendedor_combo.currentData()
+        Distribuidor_id = (
+            self.Distribuidor_combo.currentData()
+            if self.Distribuidor_combo.count() > 0
+            else None
+        )
         return {
             "fecha": QDate.currentDate().toString("yyyy-MM-dd"),
             "vendedor_id": vendedor_id,

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -45,8 +45,12 @@ class InventoryManager:
 
     def refresh_data(self):
         self._vendedores = self.db.get_vendedores()
+        self._vendedores_compra = self.db.get_vendedores_distribuidores()
         self._Distribuidores = self.db.get_Distribuidores()
         self._vendedores_by_id = {vend["id"]: vend["nombre"] for vend in self._vendedores}
+        self._vendedores_compra_by_id = {
+            vend["id"]: vend["nombre"] for vend in self._vendedores_compra
+        }
         self._Distribuidores_by_id = {dist["id"]: dist["nombre"] for dist in self._Distribuidores}
         self._products = self.db.get_productos(
             vendedor_id=self._filter_vendedor_id,
@@ -76,6 +80,9 @@ class InventoryManager:
 
     def get_vendedores(self):
         return self._vendedores
+
+    def get_vendedores_compra(self):
+        return self._vendedores_compra
 
     def get_Distribuidores(self):
         return self._Distribuidores

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -303,7 +303,7 @@ class MainWindow(QMainWindow):
         filtros_layout = QHBoxLayout()
         self.vendedor_combo_filtro = QComboBox()
         self.vendedor_combo_filtro.addItem("Todos", None)
-        for v in self.manager._vendedores:
+        for v in self.manager.get_vendedores_compra():
             self.vendedor_combo_filtro.addItem(v["nombre"], v["id"])
 
         self.vendedor_combo_filtro.currentIndexChanged.connect(self.filter_products)
@@ -872,10 +872,11 @@ class MainWindow(QMainWindow):
     def registrar_compra(self):
         productos = [dict(p) for p in self.manager._products]
         Distribuidores = [dict(v) for v in self.manager._Distribuidores]
+        proveedores = [dict(v) for v in self.manager.get_vendedores_compra()]
         dialog = RegisterPurchaseDialog(
             productos,
             Distribuidores,
-            self.manager._vendedores,
+            proveedores,
             self
         )
         try:
@@ -1341,7 +1342,7 @@ class MainWindow(QMainWindow):
 
     def _actualizar_arbol_vendedores(self):
         self.vendedores_tree.clear()
-        for vend in self.manager._vendedores:
+        for vend in self.manager.get_vendedores_compra():
             text = f"{vend.get('codigo', '')} - {vend['nombre']}"
             vend_item = QTreeWidgetItem([text])
             vend_item.setData(0, Qt.UserRole, vend.get("id"))
@@ -1353,7 +1354,11 @@ class MainWindow(QMainWindow):
         for dist in self.manager._Distribuidores:
             dist_item = QTreeWidgetItem([dist["nombre"]])
             dist_item.setData(0, Qt.UserRole, dist.get("id"))
-            vendedores = [v for v in self.manager._vendedores if v.get("Distribuidor_id") == dist["id"]]
+            vendedores = [
+                v
+                for v in self.manager.get_vendedores_compra()
+                if v.get("Distribuidor_id") == dist["id"]
+            ]
             for vend in vendedores:
                 text = f"{vend.get('codigo', '')} - {vend['nombre']}"
                 vend_item = QTreeWidgetItem([text])
@@ -1394,7 +1399,14 @@ class MainWindow(QMainWindow):
             return
         item = selected_items[0]
         vendedor_id = item.data(0, Qt.UserRole)
-        vendedor = next((c for c in self.manager._vendedores if c["id"] == vendedor_id), None)
+        vendedor = next(
+            (
+                c
+                for c in self.manager.get_vendedores_compra()
+                if c["id"] == vendedor_id
+            ),
+            None,
+        )
         if not vendedor:
             QMessageBox.warning(self, "Editar vendedor", "No se encontró la vendedor seleccionada.")
             return


### PR DESCRIPTION
## Summary
- add a purchase-focused vendor cache in the inventory manager
- use the supplier-only vendor list in the main window filters, vendor tree, and purchase dialog
- update the purchase dialog to look up vendors/distributors via the filtered list and handle missing selections safely

## Testing
- python -m compileall inventory_manager.py ui_mainwindow.py dialogs/dialogs.py

------
https://chatgpt.com/codex/tasks/task_e_68d6bca3748c83238d10e54d8c95b5eb