### PR TITLE
Normalize bearer headers for lote DTE requests

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -5483,10 +5483,11 @@ def enviar_lote_dtes(pendientes, db: DB | None = None):
             ],
         }
 
+        auth_headers = build_auth_header({"access_token": token})
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "Authorization": f"Bearer {token}",
+            **auth_headers,
         }
 
         try:
@@ -5519,9 +5520,10 @@ def consultar_estado_lote(codigo_lote: str) -> dict:
     cfg = _load_dte_api_config()
     url = cfg["url"].rstrip("/") + f"/lote/{codigo_lote}"
     token = auth.get_token()
+    auth_headers = build_auth_header({"access_token": token})
     headers = {
         "Accept": "application/json",
-        "Authorization": f"Bearer {token}",
+        **auth_headers,
     }
     try:
         resp = requests.get(url, headers=headers, timeout=20)

--- a/tests/test_lote_dte.py
+++ b/tests/test_lote_dte.py
@@ -22,7 +22,7 @@ def test_enviar_lote_dtes_envia_lote_y_registra_codigo(monkeypatch):
     captured = {"posts": []}
 
     def fake_post(url, headers=None, json=None, timeout=None):
-        captured["posts"].append((url, json))
+        captured["posts"].append((url, headers, json))
 
         class Resp:
             content = b"{}"
@@ -58,8 +58,9 @@ def test_enviar_lote_dtes_envia_lote_y_registra_codigo(monkeypatch):
     resp = dte.enviar_lote_dtes(pendientes, db=db)
 
     assert len(captured["posts"]) == 1
-    url, body = captured["posts"][0]
+    url, headers, body = captured["posts"][0]
     assert url == "http://example/lote"
+    assert headers["Authorization"] == "Bearer TOKEN"
     assert body["cantidadDocumentos"] == 3
     assert db.reg == [
         (1, "lote", "RECIBIDO", "L123"),
@@ -75,7 +76,7 @@ def test_enviar_lote_dtes_divide_batches(monkeypatch):
     posts = []
 
     def fake_post(url, headers=None, json=None, timeout=None):
-        posts.append(json)
+        posts.append((headers, json))
 
         class Resp:
             content = b"{}"
@@ -96,8 +97,10 @@ def test_enviar_lote_dtes_divide_batches(monkeypatch):
     dte.enviar_lote_dtes(pendientes, db=DummyDB())
 
     assert len(posts) == 2
-    assert posts[0]["cantidadDocumentos"] == 100
-    assert posts[1]["cantidadDocumentos"] == 1
+    assert posts[0][0]["Authorization"] == "Bearer TOKEN"
+    assert posts[0][1]["cantidadDocumentos"] == 100
+    assert posts[1][0]["Authorization"] == "Bearer TOKEN"
+    assert posts[1][1]["cantidadDocumentos"] == 1
 
 
 def test_consultar_estado_lote(monkeypatch):
@@ -107,6 +110,7 @@ def test_consultar_estado_lote(monkeypatch):
 
     def fake_get(url, headers=None, timeout=None):
         captured["url"] = url
+        captured["headers"] = headers
 
         class Resp:
             def json(self):
@@ -119,4 +123,58 @@ def test_consultar_estado_lote(monkeypatch):
     resp = dte.consultar_estado_lote("ABC")
 
     assert captured["url"] == "http://example/lote/ABC"
+    assert captured["headers"]["Authorization"] == "Bearer TOKEN"
     assert resp["estado"] == "EN_PROCESO"
+
+
+def test_enviar_lote_dtes_reuses_bearer_prefix(monkeypatch):
+    pendientes = [(1, _make_dte(1))]
+
+    monkeypatch.setattr(jws, "sign_json", lambda data: "signed")
+
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+
+        class Resp:
+            content = b"{}"
+
+            def json(self):
+                return {"codigoLote": "L1", "estado": "RECIBIDO"}
+
+        return Resp()
+
+    monkeypatch.setattr(dte.requests, "post", fake_post)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer CLEAN")
+
+    class DummyDB:
+        def registrar_envio_dte(self, *a, **k):
+            pass
+
+    dte.enviar_lote_dtes(pendientes, db=DummyDB())
+
+    assert captured["headers"]["Authorization"] == "Bearer CLEAN"
+
+
+def test_consultar_estado_lote_reuses_bearer_prefix(monkeypatch):
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+    monkeypatch.setattr(auth, "get_token", lambda: "Bearer CLEAN")
+
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["headers"] = headers
+
+        class Resp:
+            def json(self):
+                return {"estado": "OK"}
+
+        return Resp()
+
+    monkeypatch.setattr(dte.requests, "get", fake_get)
+
+    dte.consultar_estado_lote("XYZ")
+
+    assert captured["headers"]["Authorization"] == "Bearer CLEAN"


### PR DESCRIPTION
## Summary
- normalize lote submission and status headers via build_auth_header so Authorization always uses a clean Bearer token
- extend lote DTE tests to assert Authorization headers for both prefixed and non-prefixed tokens

## Testing
- pytest tests/test_lote_dte.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e8ae940883238c14854d5f813523