### PR TITLE
Implement direct PDF printing

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -27,8 +27,8 @@ from PyQt5.QtWidgets import (
     QAction,
     QFormLayout,
 )
-from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent, QSize, QRectF
-from PyQt5.QtGui import QPixmap, QDesktopServices, QCursor, QImage, QPainter
+from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent, QSize
+from PyQt5.QtGui import QPixmap, QDesktopServices, QCursor
 from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
 import os
 import re
@@ -57,6 +57,7 @@ from utils.jws import sign_and_save
 # ``sign_and_save`` generates both JSON and JWS files so no manual
 # stable JSON utilities are required here.
 from utils.sanitize import limpiar_doc, solo_digitos
+from utils.printing import send_pdf_to_printer, PrintError
 from utils import catalogos
 from paths import (
     DATOS_NEGOCIO_PATH,
@@ -2232,18 +2233,6 @@ class FacturacionTab(QWidget):
             QMessageBox.warning(self, "Imprimir", "No se encontró el archivo PDF.")
             return
 
-        try:
-            import fitz
-        except ImportError:
-            if cleanup_path:
-                self._safe_remove(cleanup_path)
-            QMessageBox.critical(
-                self,
-                "Imprimir",
-                "La funcionalidad de impresión requiere la biblioteca PyMuPDF.",
-            )
-            return
-
         printer = QPrinter(QPrinter.HighResolution)
         dialog = QPrintDialog(printer, self)
         dialog.setWindowTitle("Imprimir factura")
@@ -2252,60 +2241,18 @@ class FacturacionTab(QWidget):
                 self._safe_remove(cleanup_path)
             return
 
-        document = None
-        painter = QPainter()
+        printer_name = (printer.printerName() or "").strip() or None
         try:
-            document = fitz.open(pdf_path)
-        except Exception as exc:
-            if cleanup_path:
-                self._safe_remove(cleanup_path)
-            QMessageBox.critical(self, "Imprimir", f"No se pudo abrir el PDF: {exc}")
-            return
-
-        if not painter.begin(printer):
-            document.close()
-            if cleanup_path:
-                self._safe_remove(cleanup_path)
-            QMessageBox.warning(self, "Imprimir", "No se pudo iniciar la impresión.")
-            return
-
-        painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
-        try:
-            page_count = document.page_count
-            for index in range(page_count):
-                page = document.load_page(index)
-                zoom = max(printer.resolution(), 72) / 72
-                matrix = fitz.Matrix(zoom, zoom)
-                pix = page.get_pixmap(matrix=matrix, alpha=False)
-                image_format = QImage.Format_RGB888
-                image = QImage(pix.samples, pix.width, pix.height, pix.stride, image_format)
-                if image.isNull():
-                    raise RuntimeError("No se pudo preparar la página para impresión.")
-
-                page_rect = printer.pageRect(QPrinter.DevicePixel)
-                scale = min(
-                    page_rect.width() / image.width(),
-                    page_rect.height() / image.height(),
-                )
-                target_width = image.width() * scale
-                target_height = image.height() * scale
-                x_offset = page_rect.x() + (page_rect.width() - target_width) / 2
-                y_offset = page_rect.y() + (page_rect.height() - target_height) / 2
-                target_rect = QRectF(
-                    x_offset,
-                    y_offset,
-                    target_width,
-                    target_height,
-                )
-                painter.drawImage(target_rect, image)
-                if index < page_count - 1:
-                    if not printer.newPage():
-                        raise RuntimeError("No se pudo crear una nueva página de impresión.")
-        except Exception as exc:
-            QMessageBox.critical(self, "Imprimir", f"Error al imprimir la factura: {exc}")
+            send_pdf_to_printer(pdf_path, printer_name)
+        except PrintError as exc:
+            QMessageBox.critical(self, "Imprimir", str(exc))
+        else:
+            QMessageBox.information(
+                self,
+                "Imprimir",
+                "El documento se envió a la impresora seleccionada.",
+            )
         finally:
-            painter.end()
-            document.close()
             if cleanup_path:
                 self._safe_remove(cleanup_path)
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -24,10 +24,12 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt, QDate, QUrl, QSize
 from PyQt5.QtGui import QDesktopServices, QPixmap
+from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
 from datetime import datetime, date, timedelta
 from utils.email_sender import EmailSender
 from utils.email_builder import build_email
 from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
+from utils.printing import send_pdf_to_printer, PrintError
 import tempfile
 import subprocess
 import shutil
@@ -680,12 +682,62 @@ class SalesTab(QWidget):
         QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(pdf_path)))
 
     def print_pdf(self):
-        """Print the selected sale using the saved PDF."""
+        """Print the selected sale using the stored PDF file."""
+
         if self.sales_table.currentRow() < 0:
             QMessageBox.warning(self, "Imprimir", "Seleccione una factura primero.")
             return
-        # Reuse preview_pdf to open the file
-        self.preview_pdf()
+
+        row = self.sales_table.currentRow()
+        venta_id = int(self.sales_table.item(row, 0).text())
+        venta = self.manager.db.get_venta_by_id(venta_id)
+        if not venta or int(venta.get("id", 0)) != venta_id:
+            QMessageBox.warning(self, "Imprimir", "No se encontró la venta seleccionada.")
+            return
+
+        title = "Imprimir"
+        if self._is_ticket_sale(venta):
+            pdf_path = self.manager.db.get_ticket_pdf(venta_id)
+            failure_message = "No se pudo generar el ticket."
+            if not pdf_path or not os.path.exists(pdf_path):
+                pdf_path = self._safe_generate(
+                    self._generate_ticket_pdf,
+                    venta_id,
+                    title,
+                    failure_message,
+                )
+        else:
+            pdf_path = self.manager.db.get_factura_pdf(venta_id)
+            failure_message = "No se pudo generar la factura."
+            if not pdf_path or not os.path.exists(pdf_path):
+                pdf_path = self._safe_generate(
+                    self._generate_invoice_pdf,
+                    venta_id,
+                    title,
+                    failure_message,
+                )
+
+        if not pdf_path or not os.path.exists(pdf_path):
+            return
+
+        printer = QPrinter(QPrinter.HighResolution)
+        dialog = QPrintDialog(printer, self)
+        dialog.setWindowTitle("Imprimir documento")
+        if dialog.exec_() != QDialog.Accepted:
+            return
+
+        printer_name = (printer.printerName() or "").strip() or None
+        try:
+            send_pdf_to_printer(pdf_path, printer_name)
+        except PrintError as exc:
+            QMessageBox.critical(self, title, str(exc))
+            return
+
+        QMessageBox.information(
+            self,
+            title,
+            "El documento se envió a la impresora seleccionada.",
+        )
 
     def send_email(self):
         """Send the selected document via email in a background thread."""

--- a/utils/printing.py
+++ b/utils/printing.py
@@ -1,0 +1,123 @@
+"""Utilities to send PDF documents to the system print spooler."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+class PrintError(RuntimeError):
+    """Raised when a PDF could not be sent to the printer."""
+
+
+def send_pdf_to_printer(pdf_path: str, printer_name: str | None = None) -> None:
+    """Send ``pdf_path`` to the print spooler.
+
+    Args:
+        pdf_path: Absolute path to the PDF file that should be printed.
+        printer_name: Optional printer name selected by the user.
+
+    Raises:
+        PrintError: If the command required to print the file could not be
+            executed or returned an error status.
+    """
+
+    if not pdf_path or not os.path.exists(pdf_path):
+        raise PrintError("No se encontró el archivo PDF para imprimir.")
+
+    if sys.platform.startswith("win"):
+        _print_with_powershell(pdf_path, printer_name)
+        return
+
+    command = _build_unix_print_command(pdf_path, printer_name)
+    if not command:
+        raise PrintError(
+            "No se encontró un comando de impresión compatible (lp o lpr)."
+        )
+    _run_print_command(command)
+
+
+def _build_unix_print_command(
+    pdf_path: str, printer_name: str | None = None
+) -> list[str] | None:
+    """Build the printing command for Unix-like systems."""
+
+    if shutil.which("lp"):
+        command = ["lp"]
+        if printer_name:
+            command.extend(["-d", printer_name])
+        command.append(pdf_path)
+        return command
+
+    if shutil.which("lpr"):
+        command = ["lpr"]
+        if printer_name:
+            command.extend(["-P", printer_name])
+        command.append(pdf_path)
+        return command
+
+    return None
+
+
+def _run_print_command(command: list[str]) -> None:
+    """Execute a system command and raise ``PrintError`` on failure."""
+
+    try:
+        subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - defensive branch
+        raise PrintError(f"No se encontró el comando de impresión: {exc}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else ""
+        stdout = exc.stdout.strip() if exc.stdout else ""
+        details = stderr or stdout or str(exc)
+        raise PrintError(f"Error al enviar el PDF a la impresora: {details}") from exc
+
+
+def _powershell_quote(value: str) -> str:
+    """Return a PowerShell-escaped literal string."""
+
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _print_with_powershell(pdf_path: str, printer_name: str | None) -> None:
+    """Send the PDF to Windows' print system using PowerShell."""
+
+    powershell = shutil.which("powershell") or shutil.which("powershell.exe")
+    if not powershell:
+        raise PrintError("No se encontró PowerShell para imprimir el documento.")
+
+    verb = "PrintTo" if printer_name else "Print"
+    quoted_path = _powershell_quote(os.path.abspath(pdf_path))
+    script_parts = ["$ErrorActionPreference='Stop';"]
+    if printer_name:
+        quoted_printer = _powershell_quote(printer_name)
+        command = (
+            f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} "
+            f"-ArgumentList {quoted_printer} -PassThru"
+        )
+    else:
+        command = (
+            f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} -PassThru"
+        )
+    script_parts.append(command)
+    script_parts.append("Wait-Process -Id $process.Id")
+    script = " ".join(script_parts)
+
+    try:
+        subprocess.run(
+            [powershell, "-NoProfile", "-Command", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else ""
+        stdout = exc.stdout.strip() if exc.stdout else ""
+        details = stderr or stdout or str(exc)
+        raise PrintError(f"Error al imprimir el documento: {details}") from exc


### PR DESCRIPTION
## Summary
- add a cross-platform printing helper that sends saved PDFs to the operating system spooler
- update factura printing to rely on the stored PDF (including temporary tickets) and report success or errors
- allow the sales tab to regenerate missing PDFs and print them through the selected printer

## Testing
- python -m compileall utils/printing.py facturacion_tab.py sales_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f3fe7d948323841f780c20ed5fe4