### PR TITLE
Ensure PrintTo passes full argument list in PowerShell

### DIFF
--- a/utils/printing.py
+++ b/utils/printing.py
@@ -96,10 +96,17 @@ def _print_with_powershell(pdf_path: str, printer_name: str | None) -> None:
     quoted_path = _powershell_quote(os.path.abspath(pdf_path))
     script_parts = ["$ErrorActionPreference='Stop';"]
     if printer_name:
-        quoted_printer = _powershell_quote(printer_name)
+        quoted_arguments = ", ".join(
+            [
+                _powershell_quote(printer_name),
+                _powershell_quote(""),
+                _powershell_quote(""),
+                _powershell_quote(""),
+            ]
+        )
         command = (
             f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} "
-            f"-ArgumentList {quoted_printer} -PassThru"
+            f"-ArgumentList {quoted_arguments} -PassThru"
         )
     else:
         command = (


### PR DESCRIPTION
## Summary
- update the Windows PrintTo command to provide the full four-argument list expected by Start-Process

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6faea8bcc8323935eca6d9fcea076