### PR TITLE
Guardar ticket PDF junto a factura

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2219,17 +2219,13 @@ class FacturacionTab(QWidget):
                 preferred_format = "carta"
             self._last_print_format = preferred_format
 
-        cleanup_path = None
         base_pdf_path = self._resolve_pdf_path(entry)
         if preferred_format == "ticket":
             pdf_path = self._build_ticket_format_pdf(entry, base_pdf_path)
-            cleanup_path = pdf_path
         else:
             pdf_path = base_pdf_path
 
         if not pdf_path or not os.path.exists(pdf_path):
-            if cleanup_path:
-                self._safe_remove(cleanup_path)
             QMessageBox.warning(self, "Imprimir", "No se encontró el archivo PDF.")
             return
 
@@ -2237,8 +2233,6 @@ class FacturacionTab(QWidget):
         dialog = QPrintDialog(printer, self)
         dialog.setWindowTitle("Imprimir factura")
         if dialog.exec_() != QDialog.Accepted:
-            if cleanup_path:
-                self._safe_remove(cleanup_path)
             return
 
         printer_name = (printer.printerName() or "").strip() or None
@@ -2252,9 +2246,6 @@ class FacturacionTab(QWidget):
                 "Imprimir",
                 "El documento se envió a la impresora seleccionada.",
             )
-        finally:
-            if cleanup_path:
-                self._safe_remove(cleanup_path)
 
     def _safe_remove(self, path: str | None) -> None:
         if not path:
@@ -2358,23 +2349,54 @@ class FacturacionTab(QWidget):
             )
             return None
 
+        venta_id = entry.get("venta_id")
+        output_dir = None
+        ticket_base = None
+        if base_pdf_path:
+            output_dir = os.path.dirname(base_pdf_path)
+            ticket_base = os.path.splitext(os.path.basename(base_pdf_path))[0]
+        if not output_dir:
+            tipo_entry = str(entry.get("tipo") or "").strip().lower()
+            if tipo_entry == "consumidor final":
+                output_dir = CF_DIR
+            elif tipo_entry in {"crédito fiscal", "credito fiscal"}:
+                output_dir = CREDITO_DIR
+        if not output_dir:
+            output_dir = TICKETS_DIR
+
         try:
-            os.makedirs(TICKETS_DIR, exist_ok=True)
+            os.makedirs(output_dir, exist_ok=True)
         except OSError:
             pass
 
-        filename = f"ticket_print_{uuid.uuid4().hex}.pdf"
-        output_path = os.path.join(TICKETS_DIR, filename)
+        if ticket_base:
+            lower_name = ticket_base.lower()
+            for suffix in ("_consumidorfinal", "_creditofiscal", "_ticket"):
+                if lower_name.endswith(suffix):
+                    ticket_base = ticket_base[: -len(suffix)] + "_Ticket"
+                    break
+            else:
+                ticket_base = f"{ticket_base}_Ticket"
+        else:
+            ticket_base = f"ticket_print_{uuid.uuid4().hex}"
+
+        output_path = os.path.join(output_dir, f"{ticket_base}.pdf")
+
         try:
-            with open(output_path, "wb") as fh:
-                fh.write(pdf_bytes)
-        except OSError as exc:
+            write_pdf_atomically(output_path, lambda tmp: tmp.write_bytes(pdf_bytes))
+        except Exception as exc:
             QMessageBox.warning(
                 self,
                 "Imprimir",
-                f"No se pudo escribir el ticket temporal: {exc}",
+                f"No se pudo escribir el ticket: {exc}",
             )
             return None
+
+        if venta_id and output_dir != TICKETS_DIR:
+            try:
+                self.manager.db.add_ticket_pdf(venta_id, output_path)
+            except Exception:
+                pass
 
         return output_path
 

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -92,7 +92,7 @@ def test_create_ticket_saves_files(qt_app, tmp_path, monkeypatch):
     assert save_path.with_suffix(".json").exists()
 
 
-def test_build_ticket_format_pdf_generates_temp_file(monkeypatch, qt_app, tmp_path):
+def test_build_ticket_format_pdf_saves_alongside_invoice(monkeypatch, qt_app, tmp_path):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)
     cf_dir = tmp_path / "facturas_consumidor_final"
@@ -138,9 +138,7 @@ def test_build_ticket_format_pdf_generates_temp_file(monkeypatch, qt_app, tmp_pa
     json_path = pdf_path.with_suffix(".json")
     json_path.write_text(json.dumps(dte_payload))
     db.add_factura_pdf(venta_id, "Consumidor Final", str(pdf_path))
-
-    tickets_dir = tmp_path / "tickets"
-    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(tickets_dir))
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(cf_dir))
 
     tab = _make_tab(db, cid)
     entry = {"row_type": "venta", "venta_id": venta_id, "tipo": "Consumidor Final"}
@@ -149,8 +147,10 @@ def test_build_ticket_format_pdf_generates_temp_file(monkeypatch, qt_app, tmp_pa
     assert output is not None
     out_path = Path(output)
     assert out_path.exists()
-    assert out_path.parent == tickets_dir
+    assert out_path.parent == cf_dir
     assert out_path.stat().st_size > 0
+    stored = db.get_ticket_pdf(venta_id)
+    assert stored == str(out_path)
     tab._safe_remove(output)
     assert not out_path.exists()
 


### PR DESCRIPTION
## Summary
- store generated ticket PDFs for crédito fiscal and consumidor final invoices alongside their original documents instead of temporary ticket folders
- update printing workflow to keep the saved ticket file and register it in the database for future use
- adjust the ticket generation test to expect the new storage location and persisted record

## Testing
- pytest tests/test_facturacion_tab_actions.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6fa8510c08323908cf8f1127ed9d1