### PR TITLE
Fix Windows printing argument validation error

### DIFF
--- a/utils/printing.py
+++ b/utils/printing.py
@@ -96,14 +96,7 @@ def _print_with_powershell(pdf_path: str, printer_name: str | None) -> None:
     quoted_path = _powershell_quote(os.path.abspath(pdf_path))
     script_parts = ["$ErrorActionPreference='Stop';"]
     if printer_name:
-        quoted_arguments = ", ".join(
-            [
-                _powershell_quote(printer_name),
-                _powershell_quote(""),
-                _powershell_quote(""),
-                _powershell_quote(""),
-            ]
-        )
+        quoted_arguments = _powershell_quote(printer_name)
         command = (
             f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} "
             f"-ArgumentList {quoted_arguments} -PassThru"


### PR DESCRIPTION
## Summary
- simplify the PowerShell command used for Windows printing
- avoid passing empty Start-Process arguments that cause validation failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d707ca1a008323bfc4e646fa40c542