### PR TITLE
Ensure PowerShell print command terminates before waiting

### DIFF
--- a/utils/printing.py
+++ b/utils/printing.py
@@ -99,11 +99,11 @@ def _print_with_powershell(pdf_path: str, printer_name: str | None) -> None:
         quoted_arguments = _powershell_quote(printer_name)
         command = (
             f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} "
-            f"-ArgumentList {quoted_arguments} -PassThru"
+            f"-ArgumentList {quoted_arguments} -PassThru;"
         )
     else:
         command = (
-            f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} -PassThru"
+            f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} -PassThru;"
         )
     script_parts.append(command)
     script_parts.append("Wait-Process -Id $process.Id")


### PR DESCRIPTION
## Summary
- append a terminating semicolon to the PowerShell Start-Process command
- prevent positional parameter errors by ensuring Wait-Process runs as a separate statement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d708e5212c832389fb21e89be2006a