### PR TITLE
Use manual MH token for Hacienda requests

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import requests
 
 import auth
+from mh_auth import auth_headers
 from db import DB
 from utils import stable_json
 from utils import resource_path
@@ -722,7 +723,6 @@ def _quick_invalidacion_checks(
 
 def _post_invalidacion(
     url: str,
-    token: str,
     evento_data: dict,
     *,
     ambiente_config: str | None = None,
@@ -733,7 +733,6 @@ def _post_invalidacion(
     dui: str | None = None,
     client_id: str | None = None,
 ) -> dict:
-    token = token or ""
     pu = urlparse(url)
     assert pu.netloc in {
         "apitest.dtes.mh.gob.sv",
@@ -830,31 +829,39 @@ def _post_invalidacion(
 
     client_id = client_id or format_cliente_id_from_dui(dui)
     ua = detect_user_agent(user_agent, opts, app_version or APP_VERSION, client_id)
-    auth_headers = build_auth_header(
-        auth if auth is not None else {"access_token": token},
-        app_version=app_version or APP_VERSION,
-        client_id=client_id,
+    headers = auth_headers(
+        {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": ua,
+            "app-version": str(app_version or APP_VERSION),
+        }
     )
-    headers = {
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "User-Agent": ua,
-        **auth_headers,
-    }
+    if client_id:
+        headers.setdefault("cliente-id", str(client_id))
 
     try:
         resp = requests.post(url, headers=headers, json=body, timeout=20)
     except requests.RequestException as exc:
         return {"estado": "Error", "detalle": str(exc)}
 
-    text = getattr(resp, "text", "")
+    text_body = getattr(resp, "text", "")
     try:
         data = resp.json()
     except Exception:
         data = None
 
+    if resp.status_code in {401, 403}:
+        result = {
+            "estado": "Rechazado",
+            "http_status": resp.status_code,
+            "detalle": "Token inválido o caducado. Obtenga un nuevo token en Configuración > Facturación Electrónica y reintente.",
+        }
+        print(json.dumps(result, ensure_ascii=False))
+        return result
+
     if isinstance(resp.status_code, int) and resp.status_code >= 400:
-        detalle = data if data is not None else text
+        detalle = data if data is not None else text_body
         result = {"estado": "Rechazado", "http_status": resp.status_code, "detalle": detalle}
         if isinstance(data, dict):
             detalle_info = data.get("detalle") if isinstance(data.get("detalle"), dict) else data
@@ -867,10 +874,9 @@ def _post_invalidacion(
         print(json.dumps(result, ensure_ascii=False))
         return result
 
-    result = data if data is not None else {"estado": "Recibido", "detalle": text}
+    result = data if data is not None else {"estado": "Recibido", "detalle": text_body}
     print(json.dumps(result, ensure_ascii=False))
     return result
-
 
 def build_invalidacion_json(
     factura: dict, ui_motivo: dict, *, ambiente: str, db: DB | None = None
@@ -1226,12 +1232,10 @@ def enviar_invalidacion(db: DB, data: dict) -> dict:
                 "No se pudo guardar el evento de anulación %s",
                 codigo_generacion or "",
             )
-    token = auth.get_token()
     ambiente_cfg = config.get("ambiente")
     _quick_invalidacion_checks(data, ambiente_raiz=ambiente_cfg, db=db)
     respuesta = _post_invalidacion(
         url,
-        token,
         data,
         ambiente_config=ambiente_cfg,
     )

--- a/auth.py
+++ b/auth.py
@@ -1,442 +1,66 @@
-import os
+from __future__ import annotations
+
 import json
-import sqlite3
-import time
-import base64
 import logging
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import urlparse
 
-import requests
+from mh_auth import get_manual_token
+from paths import CONFIG_NEGOCIO_PATH, DATOS_NEGOCIO_PATH
 
-from paths import CONFIG_NEGOCIO_PATH, user_data_path
-
-logger = logging.getLogger(__name__)
-
-DEFAULT_AUTH_URL = "https://apitest.dtes.mh.gob.sv/seguridad/auth"
-# URL de producción proporcionada por el MH
-PRODUCTION_AUTH_URL = "https://api.dtes.mh.gob.sv/seguridad/auth"
-CONFIG_PATH = CONFIG_NEGOCIO_PATH
-DB_PATH = str(user_data_path("inventario.db"))
-
-_access_token: Optional[str] = None
-_expires_at: float = 0.0
-_obtained_at: float = 0.0
-_token_type: str = ""
-_token_len: int = 0
-# Credenciales actualmente asociadas al token en caché
-_current_user: Optional[str] = None
-_current_pwd: Optional[str] = None
-_last_auth_url: Optional[str] = None
-_last_auth_host: Optional[str] = None
+log = logging.getLogger(__name__)
 
 
-def _read_db_credentials() -> Tuple[Optional[str], Optional[str]]:
-    """Intenta obtener NIT y contraseña desde la tabla 'tokens'."""
-    nit = pwd = None
+def _read_json(path: str) -> dict:
     try:
-        with sqlite3.connect(DB_PATH) as conn:
-            cur = conn.cursor()
-            cur.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'"
-            )
-            if cur.fetchone():
-                cur.execute("SELECT value FROM tokens WHERE key='nit'")
-                row = cur.fetchone()
-                nit = row[0] if row else None
-                cur.execute("SELECT value FROM tokens WHERE key='pwd'")
-                row = cur.fetchone()
-                pwd = row[0] if row else None
-    except sqlite3.Error:
-        pass
-    return nit, pwd
-
-
-def _read_config_credentials() -> Tuple[Optional[str], Optional[str]]:
-    """Lee NIT y contraseña de ``config_negocio.json``."""
-    nit = pwd = None
-    try:
-        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
-
-        ambiente = data.get("ambiente", "pruebas")
-        env_conf = data.get(ambiente, {})
-        firma_conf = env_conf.get("firma_electronica", {})
-        auth_conf = env_conf.get("auth", {})
-
-        nit = (
-            auth_conf.get("nitUsuario")
-            or auth_conf.get("nit")
-            or auth_conf.get("user")
-            or auth_conf.get("usuario")
-            or env_conf.get("api_nit")
-            or env_conf.get("api_user")
-            or env_conf.get("api_usuario")
-            or env_conf.get("nit")
-            or env_conf.get("NIT")
-            or env_conf.get("user")
-            or env_conf.get("usuario")
-            or env_conf.get("api", {}).get("nit")
-            or env_conf.get("api", {}).get("user")
-            or env_conf.get("dte_api", {}).get("nit")
-            or env_conf.get("dte_api", {}).get("user")
-            or firma_conf.get("nit")
-            or firma_conf.get("NIT")
-            or firma_conf.get("user")
-            or firma_conf.get("usuario")
-            or data.get("nit")
-            or data.get("NIT")
-            or data.get("user")
-            or data.get("usuario")
-            or data.get("api_nit")
-            or data.get("api_user")
-            or data.get("api_usuario")
-            or data.get("api", {}).get("nit")
-            or data.get("api", {}).get("user")
-            or data.get("dte_api", {}).get("nit")
-            or data.get("dte_api", {}).get("user")
-        )
-        pwd = (
-            auth_conf.get("pwd")
-            or auth_conf.get("password")
-            or env_conf.get("api_pwd")
-            or env_conf.get("api_password")
-            or env_conf.get("clave")
-            or env_conf.get("api", {}).get("pwd")
-            or env_conf.get("dte_api", {}).get("pwd")
-            or firma_conf.get("pwd")
-            or firma_conf.get("password")
-            or firma_conf.get("passwordPri")
-            or data.get("api_pwd")
-            or data.get("api_password")
-            or data.get("clave")
-            or data.get("api", {}).get("pwd")
-            or data.get("dte_api", {}).get("pwd")
-        )
-        if pwd:
-            try:
-                pwd = base64.b64decode(pwd).decode()
-            except Exception:
-                pass
-    except (OSError, json.JSONDecodeError):
-        pass
-    return nit, pwd
+    except Exception as exc:  # pragma: no cover - logged for diagnostics
+        log.debug("No se pudo leer %s: %s", path, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
-def _get_config_nit_and_url() -> Tuple[Optional[str], Optional[str]]:
-    """Obtiene ``nitUsuario`` y ``auth_url`` de ``config_negocio.json``."""
-    try:
-        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        ambiente = data.get("ambiente", "pruebas")
-        env_conf = data.get(ambiente, {})
-        auth_conf = env_conf.get("auth", {})
-        nit = auth_conf.get("nitUsuario")
-        url = env_conf.get("auth_url") or data.get("auth_url")
-        if url:
-            url = url.strip()
-        return nit, url
-    except (OSError, json.JSONDecodeError):
-        return None, None
+def _guess_auth_url() -> Optional[str]:
+    data = _read_json(CONFIG_NEGOCIO_PATH)
+    ambiente = data.get("ambiente", "pruebas") if isinstance(data, dict) else "pruebas"
+    env_conf = data.get(ambiente, {}) if isinstance(data, dict) else {}
+    if isinstance(env_conf, dict):
+        auth_url = env_conf.get("auth_url")
+        if auth_url:
+            return str(auth_url).strip() or None
+    if isinstance(data, dict):
+        auth_url = data.get("auth_url")
+        if auth_url:
+            return str(auth_url).strip() or None
+
+    negocio = _read_json(DATOS_NEGOCIO_PATH)
+    base_url = None
+    if isinstance(negocio, dict):
+        dte_api = negocio.get("dte_api")
+        if isinstance(dte_api, dict):
+            base_url = dte_api.get("url")
+    if base_url:
+        base = str(base_url).strip().rstrip("/")
+        if base:
+            return f"{base}/seguridad/auth"
+    return None
 
 
-def _get_credentials() -> Tuple[str, str]:
-    """Obtiene NIT y contraseña de base de datos o de archivo de configuración."""
-    nit, pwd = _read_db_credentials()
-    if not nit or not pwd:
-        nit2, pwd2 = _read_config_credentials()
-        nit = nit or nit2
-        pwd = pwd or pwd2
-    if not nit or not pwd:
-        raise RuntimeError("Credenciales de API no configuradas")
-    return nit, pwd
-
-
-def _get_auth_url() -> str:
-    """Obtiene la URL de autenticación según el ambiente configurado."""
-    try:
-        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        ambiente = data.get("ambiente", "pruebas")
-        env_conf = data.get(ambiente, {})
-        url = env_conf.get("auth_url") or data.get("auth_url")
-        if url:
-            url = url.strip()
-        return url or DEFAULT_AUTH_URL
-    except (OSError, json.JSONDecodeError):
-        return DEFAULT_AUTH_URL
-
-
-def _check_and_update_token_len(token: str) -> int:
-    """Valida la estructura del JWT y actualiza metadatos globales.
-
-    Hacienda devuelve ``body.token`` con la cadena completa ``Bearer <jwt>`` y
-    ``tokenType`` igual a ``"Bearer"``. La longitud del JWT depende de las
-    claves y claims, por lo que aquí se valida el formato en lugar de imponer un
-    tamaño fijo.
-    """
-
-    global _token_len, _expires_at, _obtained_at
-
-    token = token.strip()
-    if token.lower().startswith("bearer "):
-        token = token[7:].strip()
-
-    parts = token.split(".")
-    if len(parts) != 3 or any(not p for p in parts):
-        raise ValueError("Token JWT mal formado")
-
-    token_len = len(token)
-    if token_len < 100:
-        raise ValueError(f"Longitud de token inesperada: {token_len}")
-
-    if _token_len and token_len != _token_len:
-        raise ValueError("La longitud del token no coincide con la almacenada")
-
-    # Intentar decodificar header y payload sin verificar firma
-    try:
-        def _b64decode(seg: str) -> dict:
-            padding = "=" * (-len(seg) % 4)
-            return json.loads(base64.urlsafe_b64decode(seg + padding))
-
-        payload = _b64decode(parts[1])
-        exp = payload.get("exp")
-        iat = payload.get("iat")
-        if isinstance(exp, (int, float)):
-            _expires_at = float(exp)
-        if isinstance(iat, (int, float)):
-            _obtained_at = float(iat)
-    except Exception:
-        pass
-
-    _token_len = token_len
-    return token_len
-
-
-def _request_new_token(nit: str, pwd: str, url: Optional[str] = None) -> Tuple[str, int, str]:
-    """Solicita un nuevo token de acceso a la API."""
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    data = {"user": nit, "pwd": pwd}
-    url = url or _get_auth_url()
-    global _last_auth_url, _last_auth_host
-    _last_auth_url = url
-    _last_auth_host = urlparse(url).netloc
-    try:
-        resp = requests.post(url, data=data, headers=headers, timeout=20)
-        status_code = getattr(resp, "status_code", "N/A")
-        resp_text = getattr(resp, "text", "")
-        print(status_code)
-        print(resp_text)
-        if isinstance(status_code, int) and status_code >= 400:
-            logger.error("Respuesta de Hacienda %s: %s", status_code, resp_text)
-        else:
-            logger.debug("Respuesta de Hacienda %s: %s", status_code, resp_text)
-        resp.raise_for_status()
-        info = resp.json()
-        body = info.get("body", {}) if isinstance(info, dict) else {}
-        token = body.get("token") if info.get("status") == "OK" else None
-        token_type = body.get("tokenType", "") if body else ""
-        expires_in = int(body.get("expiresIn", 0)) if body else 0
-        if not token:
-            response_text = resp.text
-            raise ValueError(
-                f"Respuesta de autenticación sin token: {response_text[:200]}"
-            )
-        if token_type.lower() == "bearer":
-            token_type = "Bearer"
-        return token, expires_in, token_type
-    except requests.HTTPError as exc:
-        status_code = exc.response.status_code if exc.response is not None else None
-        if status_code in {401, 403}:
-            raise RuntimeError("Token inválido o caducado") from exc
-        report = f"Error de autenticación al solicitar token en {url}: {exc}"
-        if exc.response is not None:
-            report += f"\nRespuesta: {exc.response.text[:200]}"
-        print(report)
-        raise
-    except Exception as exc:
-        report = f"Error de autenticación al solicitar token en {url}: {exc}"
-        print(report)
-        raise
-
-
-def _save_token(token: str, expires_in: int, obtained_at: float, token_len: int) -> None:
-    """Guarda el token y metadatos en la tabla 'tokens' si es posible."""
-    try:
-        with sqlite3.connect(DB_PATH) as conn:
-            cur = conn.cursor()
-            cur.execute(
-                "CREATE TABLE IF NOT EXISTS tokens (key TEXT PRIMARY KEY, value TEXT)"
-            )
-            cur.execute(
-                "INSERT OR REPLACE INTO tokens(key, value) VALUES('access_token', ?)",
-                (token,),
-            )
-            cur.execute(
-                "INSERT OR REPLACE INTO tokens(key, value) VALUES('expires_in', ?)",
-                (str(expires_in),),
-            )
-            cur.execute(
-                "INSERT OR REPLACE INTO tokens(key, value) VALUES('obtained_at', ?)",
-                (str(obtained_at),),
-            )
-            cur.execute(
-                "INSERT OR REPLACE INTO tokens(key, value) VALUES('token_len', ?)",
-                (str(token_len),),
-            )
-            conn.commit()
-        try:
-            os.chmod(DB_PATH, 0o600)
-        except OSError:
-            pass
-    except sqlite3.Error:
-        pass
-
-
-def _load_cached_token() -> None:
-    """Carga token almacenado en disco y lo reutiliza sin importar su vigencia."""
-
-    global _access_token, _expires_at, _obtained_at, _token_len
-
-    if _access_token:
-        return
-
-    try:
-        with sqlite3.connect(DB_PATH) as conn:
-            cur = conn.cursor()
-            cur.execute(
-                "SELECT key, value FROM tokens WHERE key IN "
-                "('access_token', 'expires_in', 'obtained_at', 'token_len')"
-            )
-            rows = cur.fetchall()
-    except sqlite3.Error:
-        return
-
-    if not rows:
-        return
-
-    cached = {key: value for key, value in rows}
-    token = cached.get("access_token")
-    if not token:
-        return
-
-    expires_in = cached.get("expires_in")
-    obtained_at = cached.get("obtained_at")
-
-    try:
-        expires_in_value = float(expires_in) if expires_in is not None else 0.0
-    except (TypeError, ValueError):
-        expires_in_value = 0.0
-
-    try:
-        obtained_at_value = float(obtained_at) if obtained_at is not None else 0.0
-    except (TypeError, ValueError):
-        obtained_at_value = 0.0
-
-    _access_token = token
-    _obtained_at = obtained_at_value
-    _expires_at = obtained_at_value + expires_in_value if expires_in_value else 0.0
-
-    token_len_value = cached.get("token_len")
-    try:
-        _token_len = int(token_len_value) if token_len_value is not None else 0
-    except (TypeError, ValueError):
-        _token_len = 0
-
-    try:
-        _check_and_update_token_len(token)
-    except Exception:
-        _access_token = None
-        _obtained_at = 0.0
-        _expires_at = 0.0
-        _token_len = 0
-
-
-
-def delete_token() -> None:
-    """Elimina el token almacenado y limpia la caché."""
-    global _access_token, _expires_at, _obtained_at, _token_type, _token_len
-    try:
-        with sqlite3.connect(DB_PATH) as conn:
-            cur = conn.cursor()
-            cur.execute(
-                "DELETE FROM tokens WHERE key IN ('access_token', 'expires_in', 'obtained_at', 'token_len')"
-            )
-            conn.commit()
-    except sqlite3.Error:
-        pass
-    _access_token = None
-    _token_type = ""
-    _expires_at = 0.0
-    _obtained_at = 0.0
-    _token_len = 0
-
-
-def get_token(
-    refresh: bool = False,
-    nit: Optional[str] = None,
-    pwd: Optional[str] = None,
-) -> str:
-    """Devuelve un token válido. Puede recibir credenciales explícitas."""
-    global _access_token, _expires_at, _obtained_at, _token_type, _current_user, _current_pwd
-
-    if not _access_token:
-        _load_cached_token()
-
-    if nit is not None and pwd is not None:
-        if nit != _current_user or pwd != _current_pwd:
-            refresh = True
-            _access_token = None
-            _expires_at = 0.0
-            _current_user, _current_pwd = nit, pwd
-    else:
-        nit, pwd = _get_credentials()
-        if nit != _current_user or pwd != _current_pwd:
-            _current_user, _current_pwd = nit, pwd
-
-    if not refresh and _access_token:
-        try:
-            _check_and_update_token_len(_access_token)
-        except Exception:
-            _access_token = None
-            _expires_at = 0.0
-            _obtained_at = 0.0
-            _token_len = 0
-        else:
-            return _access_token
-
-    url = _get_auth_url()
-    global _last_auth_url, _last_auth_host
-    _last_auth_url = url
-    _last_auth_host = urlparse(url).netloc
-    conf_nit, conf_url = _get_config_nit_and_url()
-    if conf_nit and nit != conf_nit:
-        raise ValueError(
-            f"NIT utilizado {nit} difiere del configurado {conf_nit}"
-        )
-    if conf_url and url != conf_url:
-        raise ValueError(
-            f"URL de auth {url} difiere de la configurada {conf_url}"
-        )
-    logger.info("Reautenticando con NIT %s y URL %s", nit, url)
-    try:
-        token, expires_in, token_type = _request_new_token(nit, pwd, url)
-    except Exception as exc:
-        print(f"No se pudo obtener token: {exc}")
-        raise
-    token_len = _check_and_update_token_len(token)
-    obtained_at = time.time()
-    _access_token = token
-    _token_type = token_type
-    _obtained_at = obtained_at
-    _expires_at = obtained_at + expires_in
-    _save_token(token, expires_in, obtained_at, token_len)
-    return token
+def get_token(*_args, **_kwargs) -> str:
+    manual = get_manual_token()
+    if manual:
+        return manual
+    raise RuntimeError(
+        "Token manual no configurado. Use 'Obtener token' en Configuración de Facturación Electrónica."
+    )
 
 
 def get_last_auth_host() -> Optional[str]:
-    """Devuelve el host utilizado en la última autenticación."""
-    if _last_auth_host:
-        return _last_auth_host
-    url = _get_auth_url()
-    return urlparse(url).netloc
+    url = _guess_auth_url()
+    if not url:
+        return None
+    try:
+        return urlparse(url).netloc or None
+    except Exception:  # pragma: no cover - urlparse should handle strings gracefully
+        return None

--- a/dte.py
+++ b/dte.py
@@ -19,6 +19,7 @@ from utils import jws
 from utils import versioned_dte
 from utils.stable_json import stable_stringify, save_file, hash_json
 import auth
+from mh_auth import auth_headers
 from jsonschema import ValidationError, RefResolver
 from utils import catalogos
 from utils.catalogos import (
@@ -4998,63 +4999,17 @@ def detect_user_agent(
     return base
 
 
-def build_auth_header(
-    auth: dict | None,
-    app_version: str | None = None,
-    client_id: str | None = None,
-) -> dict:
-    headers: dict = {}
-    if auth:
-        # 1) Authorization explícito
-        if auth.get("authorization"):
-            headers["Authorization"] = str(auth["authorization"])
-        # 2) Bearer
-        elif auth.get("access_token") or auth.get("bearer"):
-            token = auth.get("access_token") or auth.get("bearer")
-            token = str(token).strip()
-            if token.lower().startswith("bearer "):
-                headers["Authorization"] = token
-            else:
-                headers["Authorization"] = f"Bearer {token}" if token else ""
-        # 3) Basic
-        elif auth.get("basic_user") and auth.get("basic_password"):
-            creds = f"{auth['basic_user']}:{auth['basic_password']}"
-            b64 = base64.b64encode(creds.encode()).decode()
-            headers["Authorization"] = f"Basic {b64}"
-        # 4) Esquema personalizado
-        elif auth.get("scheme") and auth.get("credentials"):
-            headers["Authorization"] = f"{auth['scheme']} {auth['credentials']}"
-
-        # 5) Mezclar headers extra
-        if isinstance(auth.get("headers"), dict):
-            headers.update(auth["headers"])
-
-    # Metadatos de trazabilidad:
-    if app_version:
-        headers.setdefault("app-version", str(app_version))
-    if client_id:
-        headers.setdefault("cliente-id", str(client_id))
-    return headers
-
-
 def _post_dte(
     url: str,
-    token: str,
     documento: str,
     dte_data: dict | None = None,
     user_agent: str | None = None,
-    auth: dict | None = None,
     opts: dict | None = None,
     app_version: str | None = None,
     dui: str | None = None,
     client_id: str | None = None,
 ) -> dict:
     print("HTTP: POST_ENTER")
-    token = token or ""
-    if token:
-        logger.debug("Token: %s...%s", token[:5], token[-5:])
-    else:
-        logger.debug("Token: <empty>")
 
     pu = urlparse(url)
     assert pu.netloc in {
@@ -5069,17 +5024,16 @@ def _post_dte(
 
     client_id = client_id or format_cliente_id_from_dui(dui)
     ua = detect_user_agent(user_agent, opts, app_version or APP_VERSION, client_id)
-    auth_headers = build_auth_header(
-        auth if auth is not None else {"access_token": token},
-        app_version=app_version or APP_VERSION,
-        client_id=client_id,
+    headers = auth_headers(
+        {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": ua,
+            "app-version": str(app_version or APP_VERSION),
+        }
     )
-    headers = {
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "User-Agent": ua,
-        **auth_headers,
-    }
+    if client_id:
+        headers.setdefault("cliente-id", str(client_id))
 
     try:
         print(json.dumps(sobre, ensure_ascii=False))
@@ -5089,40 +5043,23 @@ def _post_dte(
     except requests.RequestException as exc:
         return {"estado": "Error", "detalle": str(exc)}
 
-    text = getattr(resp, "text", "")
+    text_body = getattr(resp, "text", "")
     try:
         data = resp.json()
     except Exception:
         data = None
 
     if resp.status_code in {401, 403}:
-        detalle: Any
-        if isinstance(data, dict):
-            detalle = data.get("detalle") or data
-        elif data is not None:
-            detalle = data
-        else:
-            detalle = text
-
-        detalle_val = detalle
-        if isinstance(detalle_val, str):
-            detalle_val = detalle_val.strip() or None
-        elif isinstance(detalle_val, dict) and not detalle_val:
-            detalle_val = None
-
-        if detalle_val in (None, ""):
-            detalle_val = "Token inválido o caducado"
-
         result = {
             "estado": "Rechazado",
             "http_status": resp.status_code,
-            "detalle": detalle_val,
+            "detalle": "Token inválido o caducado. Obtenga un nuevo token en Configuración > Facturación Electrónica y reintente.",
         }
         print(json.dumps(result, ensure_ascii=False))
         return result
 
     if isinstance(resp.status_code, int) and resp.status_code >= 400:
-        detalle = data if data is not None else text
+        detalle = data if data is not None else text_body
         result = {
             "estado": "Rechazado",
             "http_status": resp.status_code,
@@ -5139,29 +5076,20 @@ def _post_dte(
         print(json.dumps(result, ensure_ascii=False))
         return result
 
-    result = data if data is not None else {"estado": "Recibido", "detalle": text}
+    result = data if data is not None else {"estado": "Recibido", "detalle": text_body}
     print(json.dumps(result, ensure_ascii=False))
     return result
 
-
 def _post_evento(
     url: str,
-    token: str,
     evento: str,
     evento_data: dict | None = None,
     user_agent: str | None = None,
-    auth: dict | None = None,
     opts: dict | None = None,
     app_version: str | None = None,
     dui: str | None = None,
     client_id: str | None = None,
 ) -> dict:
-    token = token or ""
-    if token:
-        logger.debug("Token: %s...%s", token[:5], token[-5:])
-    else:
-        logger.debug("Token: <empty>")
-
     pu = urlparse(url)
     assert pu.netloc in {
         "apitest.dtes.mh.gob.sv",
@@ -5181,17 +5109,16 @@ def _post_evento(
 
     client_id = client_id or format_cliente_id_from_dui(dui)
     ua = detect_user_agent(user_agent, opts, app_version or APP_VERSION, client_id)
-    auth_headers = build_auth_header(
-        auth if auth is not None else {"access_token": token},
-        app_version=app_version or APP_VERSION,
-        client_id=client_id,
+    headers = auth_headers(
+        {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": ua,
+            "app-version": str(app_version or APP_VERSION),
+        }
     )
-    headers = {
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "User-Agent": ua,
-        **auth_headers,
-    }
+    if client_id:
+        headers.setdefault("cliente-id", str(client_id))
 
     try:
         print(json.dumps(body, ensure_ascii=False))
@@ -5199,22 +5126,30 @@ def _post_evento(
     except requests.RequestException as exc:
         return {"estado": "Error", "detalle": str(exc)}
 
-    text = getattr(resp, "text", "")
+    text_body = getattr(resp, "text", "")
     try:
         data = resp.json()
     except Exception:
         data = None
 
+    if resp.status_code in {401, 403}:
+        result = {
+            "estado": "Rechazado",
+            "http_status": resp.status_code,
+            "detalle": "Token inválido o caducado. Obtenga un nuevo token en Configuración > Facturación Electrónica y reintente.",
+        }
+        print(json.dumps(result, ensure_ascii=False))
+        return result
+
     if isinstance(resp.status_code, int) and resp.status_code >= 400:
-        detalle = data if data is not None else text
+        detalle = data if data is not None else text_body
         result = {"estado": "Rechazado", "http_status": resp.status_code, "detalle": detalle}
         print(json.dumps(result, ensure_ascii=False))
         return result
 
-    result = data if data is not None else {"estado": "Recibido", "detalle": text}
+    result = data if data is not None else {"estado": "Recibido", "detalle": text_body}
     print(json.dumps(result, ensure_ascii=False))
     return result
-
 
 def transmitir_dte(
     db: DB, venta_id: int, modo: str | None = None, tipo_dte: str = "01"
@@ -5344,7 +5279,6 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
     }
     config = _load_dte_api_config()
     url = config["url"]
-    token = auth.get_token()
     auth_host = auth.get_last_auth_host()
     recep_host = urlparse(url).netloc
     if auth_host and recep_host != auth_host:
@@ -5354,7 +5288,7 @@ def transmitir_dte_orphan(db: DB, json_path: str) -> dict:
             recep_host,
         )
     try:
-        respuesta = _post_dte(url, token, jws_token, meta)
+        respuesta = _post_dte(url, jws_token, meta)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = (
             respuesta.get("estado")
@@ -5417,8 +5351,7 @@ def enviar_dte_a_hacienda(jws_token: str) -> dict:
         "tipoDte": ident.get("tipoDte") or ident.get("tipoDocumento"),
         "codigoGeneracion": ident.get("codigoGeneracion"),
     }
-    token = auth.get_token()
-    respuesta = _post_dte(url, token, jws_token, meta)
+    respuesta = _post_dte(url, jws_token, meta)
     estado = (
         respuesta.get("estado")
         or respuesta.get("estadoDte")
@@ -5446,7 +5379,6 @@ def enviar_lote_dtes(pendientes, db: DB | None = None):
 
     cfg = _load_dte_api_config()
     url = cfg["url"].rstrip("/") + "/lote"
-    token = auth.get_token()
 
     resultados = []
     for i in range(0, len(pendientes), 100):
@@ -5483,12 +5415,12 @@ def enviar_lote_dtes(pendientes, db: DB | None = None):
             ],
         }
 
-        auth_headers = build_auth_header({"access_token": token})
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            **auth_headers,
-        }
+        headers = auth_headers(
+            {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
 
         try:
             resp = requests.post(url, headers=headers, json=body, timeout=20)
@@ -5519,12 +5451,7 @@ def consultar_estado_lote(codigo_lote: str) -> dict:
 
     cfg = _load_dte_api_config()
     url = cfg["url"].rstrip("/") + f"/lote/{codigo_lote}"
-    token = auth.get_token()
-    auth_headers = build_auth_header({"access_token": token})
-    headers = {
-        "Accept": "application/json",
-        **auth_headers,
-    }
+    headers = auth_headers({"Accept": "application/json"})
     try:
         resp = requests.get(url, headers=headers, timeout=20)
         return resp.json()
@@ -5600,9 +5527,6 @@ def _enviar_documento(
         data["identificacion"] = ident
     elif "identificador" in data:
         data["identificador"] = ident
-    manual_token = False
-    token = auth.get_token()
-    print("AUTH: USING", "MANUAL" if manual_token else "AUTO")
     auth_host = auth.get_last_auth_host()
     recep_host = urlparse(url).netloc
     if auth_host and recep_host != auth_host:
@@ -5661,7 +5585,7 @@ def _enviar_documento(
 
     try:
         print("DTE: BEFORE_POST")
-        respuesta = _post_dte(url, token, signed, meta)
+        respuesta = _post_dte(url, signed, meta)
         sello = (
             respuesta.get("sello")
             or respuesta.get("selloRecepcion")
@@ -5863,11 +5787,10 @@ def _enviar_evento(db: DB, evento_id: int, data: dict) -> dict:
     pu = urlparse(config["url"])
     url = f"{pu.scheme}://{pu.netloc}/fesv/contingencia"
     signed = jws.sign_json(data)
-    token = auth.get_token()
     ident = data.get("identificacion") or data.get("identificador") or {}
 
     try:
-        respuesta = _post_evento(url, token, signed, data)
+        respuesta = _post_evento(url, signed, data)
         sello = respuesta.get("sello") or respuesta.get("selloRecepcion") or ""
         estado = (
             respuesta.get("estado")

--- a/mh_auth.py
+++ b/mh_auth.py
@@ -1,0 +1,37 @@
+import json
+import logging
+
+from paths import DATOS_NEGOCIO_PATH
+
+log = logging.getLogger(__name__)
+
+
+def _read_negocio_json():
+    with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_manual_token() -> str | None:
+    """Lee datos_negocio.json y retorna dte_api.token (string con 'Bearer ...') si existe."""
+    try:
+        data = _read_negocio_json()
+        token = (((data or {}).get("dte_api") or {}).get("token"))
+        token = str(token).strip() if token is not None else None
+        return token or None
+    except Exception as e:  # pragma: no cover - logged for observability
+        log.warning("No se pudo leer token manual de datos_negocio.json: %s", e)
+        return None
+
+
+def auth_headers(extra: dict | None = None) -> dict:
+    """Construye headers para MH usando EXCLUSIVAMENTE el token manual guardado."""
+    token = get_manual_token()
+    if not token:
+        raise RuntimeError(
+            "Token manual no configurado. Use 'Obtener token' en Configuración de Facturación Electrónica."
+        )
+    headers = {"Authorization": token}
+    if extra:
+        headers.update(extra)
+    log.info("AUTH: USING MANUAL TOKEN (fp=%s)", token[-8:] if len(token) >= 8 else token)
+    return headers

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -1,301 +1,48 @@
-import json
-import time
-import os
-import logging
+from types import SimpleNamespace
+
 import pytest
-import requests
+
 import auth
-import sqlite3
+import dte
 
-LONG_TOKEN = "a" * 120 + "." + "b" * 120 + "." + "c" * 120
-
-
-def write_config(tmp_path, nit="123", pwd="pwd"):
-    cfg = tmp_path / "config.json"
-    cfg.write_text(json.dumps({"nit": nit, "api_pwd": pwd}))
-    return cfg
+def test_get_token_returns_manual(monkeypatch):
+    monkeypatch.setattr(auth, "get_manual_token", lambda: "Bearer TOKEN")
+    monkeypatch.setattr("mh_auth.get_manual_token", lambda: "Bearer TOKEN")
+    assert auth.get_token() == "Bearer TOKEN"
 
 
-def setup_paths(monkeypatch, tmp_path):
-    cfg = write_config(tmp_path)
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
-
-
-def test_get_credentials_missing(monkeypatch, tmp_path):
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(tmp_path / "missing.json"))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "missing.db"))
+def test_get_token_missing_raises(monkeypatch):
+    monkeypatch.setattr(auth, "get_manual_token", lambda: None)
+    monkeypatch.setattr("mh_auth.get_manual_token", lambda: None)
     with pytest.raises(RuntimeError):
-        auth._get_credentials()
+        auth.get_token()
 
 
-def test_get_token_caching_and_refresh(monkeypatch, tmp_path):
-    setup_paths(monkeypatch, tmp_path)
-    calls = {"n": 0}
+def test_post_dte_uses_manual_token(monkeypatch):
+    captured = {}
 
-    def fake_request(nit, pwd, url):
-        calls["n"] += 1
-        return f"Bearer {LONG_TOKEN}{calls['n']}", 120, "Bearer"
+    def fake_post(url, headers, json=None, timeout=None):
+        captured["headers"] = headers
+        return SimpleNamespace(status_code=200, json=lambda: {"estado": "Recibido"}, text="OK")
 
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-    t1 = auth.get_token(refresh=True)
-    assert t1 == f"Bearer {LONG_TOKEN}1"
-    t2 = auth.get_token()
-    assert t2 == f"Bearer {LONG_TOKEN}1"
-    assert calls["n"] == 1
-    t3 = auth.get_token(refresh=True)
-    assert t3 == f"Bearer {LONG_TOKEN}2"
-    assert calls["n"] == 2
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    monkeypatch.setattr(auth, "get_manual_token", lambda: "Bearer TOKEN")
+    monkeypatch.setattr("mh_auth.get_manual_token", lambda: "Bearer TOKEN")
+    meta = {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "A" * 36}
+    response = dte._post_dte(dte.DEFAULT_RECEPCION_URL, "payload", meta)
+    assert response["estado"] == "Recibido"
+    assert captured["headers"]["Authorization"] == "Bearer TOKEN"
 
 
-def test_get_token_reuses_cached_on_new_process(monkeypatch, tmp_path):
-    setup_paths(monkeypatch, tmp_path)
+def test_post_dte_401_returns_manual_message(monkeypatch):
+    def fake_post(url, headers, json=None, timeout=None):
+        return SimpleNamespace(status_code=401, json=lambda: {"detalle": "Unauthorized"}, text="Unauthorized")
 
-    auth._access_token = None
-    auth._expires_at = 0.0
-    auth._obtained_at = 0.0
-    auth._token_len = 0
-    auth._token_type = ""
-    auth._current_user = None
-    auth._current_pwd = None
-
-    def fake_request(nit, pwd, url):
-        return "Bearer " + LONG_TOKEN, 300, "Bearer"
-
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-
-    first_token = auth.get_token(refresh=True)
-    assert first_token == "Bearer " + LONG_TOKEN
-
-    auth._access_token = None
-    auth._expires_at = 0.0
-    auth._obtained_at = 0.0
-    auth._token_len = 0
-    auth._token_type = ""
-    auth._current_user = None
-    auth._current_pwd = None
-
-    def unexpected_request(*args, **kwargs):
-        raise AssertionError("_request_new_token should not be called")
-
-    monkeypatch.setattr(auth, "_request_new_token", unexpected_request)
-
-    reused_token = auth.get_token()
-    assert reused_token == first_token
-
-    auth._access_token = None
-    auth._expires_at = 0.0
-    auth._obtained_at = 0.0
-    auth._token_len = 0
-    auth._token_type = ""
-    auth._current_user = None
-    auth._current_pwd = None
-
-
-def test_get_token_expired_keeps_cached(monkeypatch, tmp_path):
-    setup_paths(monkeypatch, tmp_path)
-
-    def fake_request(nit, pwd, url):
-        return f"Bearer {LONG_TOKEN}x", 1, "Bearer"
-
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-    token1 = auth.get_token(refresh=True)
-    auth._expires_at = time.time() - 1
-
-    def unexpected_request(*args, **kwargs):
-        raise AssertionError("_request_new_token should not be called automatically")
-
-    monkeypatch.setattr(auth, "_request_new_token", unexpected_request)
-    token2 = auth.get_token()
-    assert token2 == token1
-
-
-def test_request_error(monkeypatch, tmp_path):
-    setup_paths(monkeypatch, tmp_path)
-
-    def fake_post(url, data, headers, timeout):
-        raise requests.HTTPError("boom")
-
-    monkeypatch.setattr(auth.requests, "post", fake_post)
-    with pytest.raises(requests.HTTPError):
-        auth.get_token(refresh=True)
-
-
-def test_missing_token_includes_response(monkeypatch):
-    def fake_post(url, data, headers, timeout):
-        class Resp:
-            status_code = 200
-            text = '{"status":"OK","body":{"mensaje":"sin token"}}'
-
-            def raise_for_status(self):
-                return None
-
-            def json(self):
-                return {"status": "OK", "body": {"mensaje": "sin token"}}
-
-        return Resp()
-
-    monkeypatch.setattr(auth.requests, "post", fake_post)
-    monkeypatch.setattr(auth, "_get_auth_url", lambda: "http://fake")
-    with pytest.raises(ValueError) as excinfo:
-        auth._request_new_token("nit", "pwd")
-    msg = str(excinfo.value)
-    assert "sin token" in msg
-    assert "Respuesta de autenticación sin token" in msg
-
-
-def test_request_new_token_preserves_bearer(monkeypatch):
-    """El token devuelto mantiene el prefijo Bearer cuando está presente."""
-
-    def fake_post(url, data, headers, timeout):
-        class Resp:
-            status_code = 200
-
-            def raise_for_status(self):
-                return None
-
-            def json(self):
-                return {
-                    "status": "OK",
-                    "body": {
-                        "token": "Bearer ABC.DEF.GHI",
-                        "tokenType": "Bearer",
-                        "expiresIn": 60,
-                    },
-                }
-
-        return Resp()
-
-    monkeypatch.setattr(auth.requests, "post", fake_post)
-    monkeypatch.setattr(auth, "_get_auth_url", lambda: "http://fake")
-    token, expires_in, token_type = auth._request_new_token("nit", "pwd")
-    assert token == "Bearer ABC.DEF.GHI"
-    assert token_type == "Bearer"
-    assert expires_in == 60
-
-
-def test_env_specific_credentials(monkeypatch, tmp_path):
-    data = {
-        "ambiente": "pruebas",
-        "pruebas": {
-            "firma_electronica": {
-                "nit": "env_nit",
-                "passwordPri": "env_pwd",
-            }
-        },
-    }
-    cfg = tmp_path / "config_env.json"
-    cfg.write_text(json.dumps(data))
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
-    nit, pwd = auth._read_config_credentials()
-    assert nit == "env_nit"
-    assert pwd == "env_pwd"
-
-
-def test_read_config_api_user(monkeypatch, tmp_path):
-    data = {"api_user": "user1", "api_pwd": "pass1"}
-    cfg = tmp_path / "cfg.json"
-    cfg.write_text(json.dumps(data))
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
-    nit, pwd = auth._read_config_credentials()
-    assert nit == "user1"
-    assert pwd == "pass1"
-
-
-def test_get_token_with_explicit_credentials(monkeypatch):
-    calls = {"n": 0}
-
-    def fake_request(nit, pwd, url):
-        calls["n"] += 1
-        return f"Bearer {LONG_TOKEN}{calls['n']}", 120, "Bearer"
-
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-    monkeypatch.setattr(auth, "_get_config_nit_and_url", lambda: (None, None))
-    t1 = auth.get_token(refresh=True, nit="u", pwd="p")
-    assert t1 == f"Bearer {LONG_TOKEN}1"
-    t2 = auth.get_token(nit="u", pwd="p")
-    assert t2 == f"Bearer {LONG_TOKEN}1"
-    assert calls["n"] == 1
-    auth.get_token(nit="u2", pwd="p2")
-    assert calls["n"] == 2
-
-
-def test_delete_token(monkeypatch, tmp_path):
-    setup_paths(monkeypatch, tmp_path)
-    calls = {"n": 0}
-
-    def fake_request(nit, pwd, url):
-        calls["n"] += 1
-        return f"Bearer {LONG_TOKEN}{calls['n']}", 120, "Bearer"
-
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-    auth.get_token(refresh=True)
-    auth.delete_token()
-    with sqlite3.connect(auth.DB_PATH) as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT value FROM tokens WHERE key='access_token'")
-        assert cur.fetchone() is None
-    t2 = auth.get_token()
-    assert t2 == f"Bearer {LONG_TOKEN}2"
-    assert calls["n"] == 2
-
-
-def test_reauth_logs_nit_and_url(monkeypatch, tmp_path, caplog):
-    data = {
-        "ambiente": "pruebas",
-        "pruebas": {
-            "auth_url": "http://auth.example",
-            "auth": {"nitUsuario": "123", "pwd": "pwd"},
-        },
-    }
-    cfg = tmp_path / "cfg.json"
-    cfg.write_text(json.dumps(data))
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
-    caplog.set_level(logging.INFO)
-
-    def fake_request(nit, pwd, url):
-        assert nit == "123"
-        assert url == "http://auth.example"
-        return f"Bearer {LONG_TOKEN}1", 120, "Bearer"
-
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-    token = auth.get_token(refresh=True)
-    assert token == f"Bearer {LONG_TOKEN}1"
-    assert "Reautenticando con NIT 123 y URL http://auth.example" in caplog.text
-
-
-def test_reauth_mismatch_nit(monkeypatch, tmp_path):
-    data = {
-        "ambiente": "pruebas",
-        "pruebas": {
-            "auth_url": "http://auth.example",
-            "auth": {"nitUsuario": "123", "pwd": "pwd"},
-        },
-    }
-    cfg = tmp_path / "cfg.json"
-    cfg.write_text(json.dumps(data))
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
-
-    def fake_request(nit, pwd, url):
-        return f"Bearer {LONG_TOKEN}1", 120, "Bearer"
-
-    monkeypatch.setattr(auth, "_request_new_token", fake_request)
-    with pytest.raises(ValueError):
-        auth.get_token(refresh=True, nit="999", pwd="pwd")
-
-
-def test_records_last_auth_host(monkeypatch, tmp_path):
-    data = {"ambiente": "pruebas", "pruebas": {"auth_url": "http://auth.example"}}
-    cfg = tmp_path / "cfg.json"
-    cfg.write_text(json.dumps(data))
-    monkeypatch.setattr(auth, "CONFIG_PATH", str(cfg))
-    monkeypatch.setattr(auth, "DB_PATH", str(tmp_path / "db.sqlite"))
-    monkeypatch.setattr(
-        auth, "_request_new_token", lambda nit, pwd, url: (f"Bearer {LONG_TOKEN}1", 120, "Bearer")
-    )
-    auth.get_token(refresh=True, nit="user", pwd="pwd")
-    assert auth.get_last_auth_host() == "auth.example"
+    monkeypatch.setattr("dte.requests.post", fake_post)
+    monkeypatch.setattr(auth, "get_manual_token", lambda: "Bearer TOKEN")
+    monkeypatch.setattr("mh_auth.get_manual_token", lambda: "Bearer TOKEN")
+    meta = {"ambiente": "00", "version": 1, "tipoDte": "01", "codigoGeneracion": "A" * 36}
+    result = dte._post_dte(dte.DEFAULT_RECEPCION_URL, "payload", meta)
+    assert result["estado"] == "Rechazado"
+    assert result["http_status"] == 401
+    assert "Token inválido" in result["detalle"]


### PR DESCRIPTION
## Summary
- add a dedicated `mh_auth` helper to read the persisted Hacienda token and construct Authorization headers
- simplify `auth.get_token`/`get_last_auth_host` to rely exclusively on the manual token configuration
- update DTE and invalidation flows to use the shared headers helper and return clear guidance on 401/403 responses
- refresh the authentication module tests to assert manual-token behaviour and error handling

## Testing
- pytest tests/test_auth_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d708c14c788323818f1ee71ed2b6af