### PR TITLE
Remove unused build_auth_header import from anulacion

### DIFF
--- a/anulacion.py
+++ b/anulacion.py
@@ -24,7 +24,6 @@ from dte import (
     _decode_jws_payload,
     format_cliente_id_from_dui,
     detect_user_agent,
-    build_auth_header,
     _parse_error_response,
     APP_VERSION,
 )


### PR DESCRIPTION
## Summary
- remove the outdated `build_auth_header` import from `anulacion.py` now that the helper no longer exists

## Testing
- python - <<'PY'
import anulacion
print('ok')
PY


------
https://chatgpt.com/codex/tasks/task_e_68d78e21d3e88323beea3364ce93a0b0