### PR TITLE
Adjust token warning tests to patch auth headers

### DIFF
--- a/tests/test_token_warning.py
+++ b/tests/test_token_warning.py
@@ -49,7 +49,7 @@ def test_post_dte_token_invalid(monkeypatch):
     monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda doc, data: {})
     monkeypatch.setattr(dte, "format_cliente_id_from_dui", lambda dui: "cid")
     monkeypatch.setattr(dte, "detect_user_agent", lambda ua, opts, app_version, client_id: "UA")
-    monkeypatch.setattr(dte, "build_auth_header", lambda auth, app_version, client_id: {})
+    monkeypatch.setattr(dte, "auth_headers", lambda extra=None: {})
 
     class Resp:
         status_code = 401
@@ -61,7 +61,7 @@ def test_post_dte_token_invalid(monkeypatch):
     assert resp == {
         "estado": "Rechazado",
         "http_status": 401,
-        "detalle": "Token expirado en Hacienda",
+        "detalle": "Token inválido o caducado. Obtenga un nuevo token en Configuración > Facturación Electrónica y reintente.",
     }
 
 
@@ -69,7 +69,7 @@ def test_post_dte_token_invalid_without_detail(monkeypatch):
     monkeypatch.setattr(dte, "construir_sobre_recepcion", lambda doc, data: {})
     monkeypatch.setattr(dte, "format_cliente_id_from_dui", lambda dui: "cid")
     monkeypatch.setattr(dte, "detect_user_agent", lambda ua, opts, app_version, client_id: "UA")
-    monkeypatch.setattr(dte, "build_auth_header", lambda auth, app_version, client_id: {})
+    monkeypatch.setattr(dte, "auth_headers", lambda extra=None: {})
 
     class Resp:
         status_code = 403
@@ -82,7 +82,7 @@ def test_post_dte_token_invalid_without_detail(monkeypatch):
     assert resp == {
         "estado": "Rechazado",
         "http_status": 403,
-        "detalle": "Token inválido o caducado",
+        "detalle": "Token inválido o caducado. Obtenga un nuevo token en Configuración > Facturación Electrónica y reintente.",
     }
 
 


### PR DESCRIPTION
## Summary
- update token warning tests to stub `dte.auth_headers` instead of `build_auth_header`
- align token rejection expectations with the standardized detail message

## Testing
- pytest tests/test_token_warning.py *(fails: ImportError: libGL.so.1 missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d78e23da0083239b4355cd26f9faf3