### PR TITLE
Permite reenvío de DTE cuando cambia el identificador

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -5494,19 +5494,27 @@ def _enviar_documento(
     Si ``jws_token`` se proporciona, se reutiliza en lugar de firmar nuevamente.
     """
     print("DTE: START_enviar_documento", "modo=", modo)
+    ident = data.get("identificacion") or data.get("identificador") or {}
+    ident_codigo = (ident.get("codigoGeneracion") or "").upper()
+    ident_control = (ident.get("numeroControl") or "").upper()
     SUCCESS_STATES = ("TRANSMITIDO", "RECIBIDO", "PROCESADO", "ACEPTADO")
     if doc_id is not None:
+        db.ensure_column("dte_envios", "codigo_generacion", "TEXT")
+        db.ensure_column("dte_envios", "numero_control", "TEXT")
         row = db.cursor.execute(
             """
-            SELECT estado FROM dte_envios
+            SELECT estado, codigo_generacion, numero_control FROM dte_envios
             WHERE venta_id=? AND UPPER(estado) IN (?, ?, ?, ?)
             ORDER BY id DESC LIMIT 1
             """,
             (doc_id, *SUCCESS_STATES),
         ).fetchone()
         if row:
-            print("DTE: ALREADY_SENT_GUARD", row[0] if row else None)
-            raise ValueError("DTE ya enviado")
+            prev_codigo = (row[1] or "").upper()
+            prev_control = (row[2] or "").upper()
+            if prev_codigo == ident_codigo and prev_control == ident_control:
+                print("DTE: ALREADY_SENT_GUARD", row[0] if row else None)
+                raise ValueError("DTE ya enviado")
 
     config = _load_dte_api_config()
 
@@ -5514,7 +5522,6 @@ def _enviar_documento(
         raise ValueError("El total en letras es obligatorio")
 
     url = config["url"]
-    ident = data.get("identificacion") or data.get("identificador") or {}
     meta = {
         "ambiente": ident.get("ambiente"),
         "version": ident.get("version"),

--- a/tests/test_dte_resend_block.py
+++ b/tests/test_dte_resend_block.py
@@ -20,7 +20,14 @@ def create_sale(db: DB) -> int:
 def test_enviar_documento_rechaza_reenvio_exitoso(monkeypatch):
     db = DB(":memory:")
     venta = create_sale(db)
-    db.registrar_envio_dte(venta, "normal", "PROCESADO", "S")
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "PROCESADO",
+        "S",
+        codigo_generacion="ABC",
+        numero_control="NC1",
+    )
     db.registrar_envio_dte(venta, "normal", "Rechazado", "")
 
     called = {"sign": 0, "post": 0}
@@ -33,7 +40,7 @@ def test_enviar_documento_rechaza_reenvio_exitoso(monkeypatch):
         called["sign"] += 1
         return "token"
 
-    def fake_post(url, token, signed, meta):  # pragma: no cover - should not be called
+    def fake_post(url, documento, dte_data, *args, **kwargs):  # pragma: no cover - should not be called
         called["post"] += 1
         return {"estado": "Procesado"}
 
@@ -41,7 +48,11 @@ def test_enviar_documento_rechaza_reenvio_exitoso(monkeypatch):
     monkeypatch.setattr(dte, "_post_dte", fake_post)
 
     data = {
-        "identificacion": {"tipoDte": "01", "codigoGeneracion": "A"},
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "abc",
+            "numeroControl": "nc1",
+        },
         "resumen": {"totalLetras": "X"},
     }
     with pytest.raises(ValueError):
@@ -49,6 +60,53 @@ def test_enviar_documento_rechaza_reenvio_exitoso(monkeypatch):
 
     assert called["sign"] == 0
     assert called["post"] == 0
+
+
+def test_enviar_documento_reenvio_con_uuid_nuevo(monkeypatch):
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "PROCESADO",
+        "S",
+        codigo_generacion="OLD-UUID",
+        numero_control="NC-OLD",
+    )
+
+    called = {"sign": 0, "post": 0}
+
+    monkeypatch.setattr(auth, "get_token", lambda: "T")
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr(dte, "_load_dte_api_config", lambda: {"url": "http://example"})
+
+    def fake_sign(data):
+        called["sign"] += 1
+        return "token"
+
+    def fake_post(url, documento, dte_data, *args, **kwargs):
+        called["post"] += 1
+        return {"estado": "Procesado"}
+
+    data = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "NEW-uuid",
+            "numeroControl": "NC-NEW",
+        },
+        "resumen": {"totalLetras": "X"},
+    }
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
+    monkeypatch.setattr(dte, "_decode_jws_payload", lambda token: {"identificacion": data["identificacion"]})
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+    monkeypatch.setattr(dte, "_save_signed_dte", lambda *args, **kwargs: None)
+
+    resp = dte._enviar_documento(db, venta, data, "normal")
+
+    assert resp["estado"] == "Procesado"
+    assert called["sign"] == 1
+    assert called["post"] == 1
 
 
 def test_detectar_estado_factura_prioriza_exitosos(monkeypatch):


### PR DESCRIPTION
## Summary
- evita bloquear reenvíos de DTE cuando cambia el identificador comparando código de generación y número de control
- cubre con pruebas tanto el bloqueo cuando se reutiliza el mismo identificador como el envío cuando es uno nuevo

## Testing
- pytest tests/test_dte_resend_block.py

------
https://chatgpt.com/codex/tasks/task_e_68d79bc3f2788323a44c3d1a9ec5ff49