### PR TITLE
Open generated PDFs with the default viewer

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -29,7 +29,6 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import QDate, Qt, QUrl, QTimer, QEvent, QSize
 from PyQt5.QtGui import QPixmap, QDesktopServices, QCursor, QImage
-from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
 import os
 import re
 import logging
@@ -57,7 +56,7 @@ from utils.jws import sign_and_save
 # ``sign_and_save`` generates both JSON and JWS files so no manual
 # stable JSON utilities are required here.
 from utils.sanitize import limpiar_doc, solo_digitos
-from utils.printing import send_pdf_to_printer, PrintError
+from utils.printing import open_pdf as open_pdf_file
 from utils import catalogos
 from paths import (
     DATOS_NEGOCIO_PATH,
@@ -2347,7 +2346,17 @@ class FacturacionTab(QWidget):
         pdf_path = self._resolve_pdf_path(entry)
 
         if pdf_path:
-            QDesktopServices.openUrl(QUrl.fromLocalFile(pdf_path))
+            absolute_path = os.path.abspath(pdf_path)
+            if not open_pdf_file(absolute_path):
+                QMessageBox.warning(
+                    self,
+                    "Abrir PDF",
+                    (
+                        "No se pudo abrir el archivo PDF automáticamente.\n"
+                        "Puedes abrirlo manualmente desde:\n"
+                        f"{absolute_path}"
+                    ),
+                )
         else:
             QMessageBox.warning(self, "Abrir PDF", "No se encontró el archivo PDF.")
 
@@ -2406,22 +2415,16 @@ class FacturacionTab(QWidget):
             )
             return
 
-        printer = QPrinter(QPrinter.HighResolution)
-        dialog = QPrintDialog(printer, self)
-        dialog.setWindowTitle("Imprimir factura")
-        if dialog.exec_() != QDialog.Accepted:
-            return
-
-        printer_name = (printer.printerName() or "").strip() or None
-        try:
-            send_pdf_to_printer(pdf_path, printer_name)
-        except PrintError as exc:
-            QMessageBox.critical(self, "Imprimir", str(exc))
-        else:
-            QMessageBox.information(
+        absolute_path = os.path.abspath(pdf_path)
+        if not open_pdf_file(absolute_path):
+            QMessageBox.warning(
                 self,
-                "Imprimir",
-                "El documento se envió a la impresora seleccionada.",
+                "Abrir PDF",
+                (
+                    "No se pudo abrir el archivo PDF automáticamente.\n"
+                    "Puedes abrirlo manualmente desde:\n"
+                    f"{absolute_path}"
+                ),
             )
 
     def _safe_remove(self, path: str | None) -> None:

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -22,14 +22,13 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QComboBox,
 )
-from PyQt5.QtCore import Qt, QDate, QUrl, QSize
-from PyQt5.QtGui import QDesktopServices, QPixmap
-from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
+from PyQt5.QtCore import Qt, QDate, QSize
+from PyQt5.QtGui import QPixmap
 from datetime import datetime, date, timedelta
 from utils.email_sender import EmailSender
 from utils.email_builder import build_email
 from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
-from utils.printing import send_pdf_to_printer, PrintError
+from utils.printing import open_pdf as open_pdf_file
 import tempfile
 import subprocess
 import shutil
@@ -679,7 +678,17 @@ class SalesTab(QWidget):
                 self, "Previsualizar", "No hay PDF guardado para esta venta."
             )
             return
-        QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.abspath(pdf_path)))
+        absolute_path = os.path.abspath(pdf_path)
+        if not open_pdf_file(absolute_path):
+            QMessageBox.warning(
+                self,
+                "Abrir PDF",
+                (
+                    "No se pudo abrir el archivo PDF automáticamente.\n"
+                    "Puedes abrirlo manualmente desde:\n"
+                    f"{absolute_path}"
+                ),
+            )
 
     def print_pdf(self):
         """Print the selected sale using the stored PDF file."""
@@ -720,24 +729,17 @@ class SalesTab(QWidget):
         if not pdf_path or not os.path.exists(pdf_path):
             return
 
-        printer = QPrinter(QPrinter.HighResolution)
-        dialog = QPrintDialog(printer, self)
-        dialog.setWindowTitle("Imprimir documento")
-        if dialog.exec_() != QDialog.Accepted:
-            return
-
-        printer_name = (printer.printerName() or "").strip() or None
-        try:
-            send_pdf_to_printer(pdf_path, printer_name)
-        except PrintError as exc:
-            QMessageBox.critical(self, title, str(exc))
-            return
-
-        QMessageBox.information(
-            self,
-            title,
-            "El documento se envió a la impresora seleccionada.",
-        )
+        absolute_path = os.path.abspath(pdf_path)
+        if not open_pdf_file(absolute_path):
+            QMessageBox.warning(
+                self,
+                "Abrir PDF",
+                (
+                    "No se pudo abrir el archivo PDF automáticamente.\n"
+                    "Puedes abrirlo manualmente desde:\n"
+                    f"{absolute_path}"
+                ),
+            )
 
     def send_email(self):
         """Send the selected document via email in a background thread."""

--- a/utils/printing.py
+++ b/utils/printing.py
@@ -1,123 +1,58 @@
-"""Utilities to send PDF documents to the system print spooler."""
+"""Helpers to open PDF files with the system's default viewer."""
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import sys
+import webbrowser
+from pathlib import Path
 
 
-class PrintError(RuntimeError):
-    """Raised when a PDF could not be sent to the printer."""
-
-
-def send_pdf_to_printer(pdf_path: str, printer_name: str | None = None) -> None:
-    """Send ``pdf_path`` to the print spooler.
-
-    Args:
-        pdf_path: Absolute path to the PDF file that should be printed.
-        printer_name: Optional printer name selected by the user.
-
-    Raises:
-        PrintError: If the command required to print the file could not be
-            executed or returned an error status.
-    """
-
-    if not pdf_path or not os.path.exists(pdf_path):
-        raise PrintError("No se encontró el archivo PDF para imprimir.")
-
-    if sys.platform.startswith("win"):
-        _print_with_powershell(pdf_path, printer_name)
-        return
-
-    command = _build_unix_print_command(pdf_path, printer_name)
-    if not command:
-        raise PrintError(
-            "No se encontró un comando de impresión compatible (lp o lpr)."
-        )
-    _run_print_command(command)
-
-
-def _build_unix_print_command(
-    pdf_path: str, printer_name: str | None = None
-) -> list[str] | None:
-    """Build the printing command for Unix-like systems."""
-
-    if shutil.which("lp"):
-        command = ["lp"]
-        if printer_name:
-            command.extend(["-d", printer_name])
-        command.append(pdf_path)
-        return command
-
-    if shutil.which("lpr"):
-        command = ["lpr"]
-        if printer_name:
-            command.extend(["-P", printer_name])
-        command.append(pdf_path)
-        return command
-
-    return None
-
-
-def _run_print_command(command: list[str]) -> None:
-    """Execute a system command and raise ``PrintError`` on failure."""
+def open_pdf_with_default_viewer(path: str) -> bool:
+    """Try to open ``path`` using ``QDesktopServices`` if Qt is available."""
 
     try:
-        subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError as exc:  # pragma: no cover - defensive branch
-        raise PrintError(f"No se encontró el comando de impresión: {exc}") from exc
-    except subprocess.CalledProcessError as exc:
-        stderr = exc.stderr.strip() if exc.stderr else ""
-        stdout = exc.stdout.strip() if exc.stdout else ""
-        details = stderr or stdout or str(exc)
-        raise PrintError(f"Error al enviar el PDF a la impresora: {details}") from exc
+        from PyQt5.QtCore import QUrl
+        from PyQt5.QtGui import QDesktopServices
+    except ImportError:
+        return False
+
+    url = QUrl.fromLocalFile(path)
+    return bool(QDesktopServices.openUrl(url))
 
 
-def _powershell_quote(value: str) -> str:
-    """Return a PowerShell-escaped literal string."""
+def open_pdf_cross_platform(path: str) -> bool:
+    """Open ``path`` using the platform's default mechanism."""
 
-    return "'" + value.replace("'", "''") + "'"
-
-
-def _print_with_powershell(pdf_path: str, printer_name: str | None) -> None:
-    """Send the PDF to Windows' print system using PowerShell."""
-
-    powershell = shutil.which("powershell") or shutil.which("powershell.exe")
-    if not powershell:
-        raise PrintError("No se encontró PowerShell para imprimir el documento.")
-
-    verb = "PrintTo" if printer_name else "Print"
-    quoted_path = _powershell_quote(os.path.abspath(pdf_path))
-    script_parts = ["$ErrorActionPreference='Stop';"]
-    if printer_name:
-        quoted_arguments = _powershell_quote(printer_name)
-        command = (
-            f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} "
-            f"-ArgumentList {quoted_arguments} -PassThru;"
-        )
-    else:
-        command = (
-            f"$process = Start-Process -FilePath {quoted_path} -Verb {verb!r} -PassThru;"
-        )
-    script_parts.append(command)
-    script_parts.append("Wait-Process -Id $process.Id")
-    script = " ".join(script_parts)
+    absolute_path = os.fspath(Path(path).resolve())
 
     try:
-        subprocess.run(
-            [powershell, "-NoProfile", "-Command", script],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        stderr = exc.stderr.strip() if exc.stderr else ""
-        stdout = exc.stdout.strip() if exc.stdout else ""
-        details = stderr or stdout or str(exc)
-        raise PrintError(f"Error al imprimir el documento: {details}") from exc
+        if sys.platform.startswith("win"):
+            os.startfile(absolute_path)  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", absolute_path])
+        else:
+            subprocess.Popen(["xdg-open", absolute_path])
+        return True
+    except Exception:
+        try:
+            return webbrowser.open(f"file://{absolute_path}", new=2)
+        except Exception:
+            return False
+
+
+def open_pdf(path: str) -> bool:
+    """Open the PDF located at ``path`` with the user's preferred application."""
+
+    if not path or not Path(path).exists():
+        return False
+
+    try:
+        if open_pdf_with_default_viewer(path):
+            return True
+    except Exception:
+        # If Qt is available but fails, continue with the fallback strategy.
+        pass
+
+    return open_pdf_cross_platform(path)
+


### PR DESCRIPTION
## Summary
- replace the PowerShell/print based workflow with helpers that open PDFs in the system viewer
- use the new PDF opening helper from the invoicing and sales tabs and show a manual-open warning if the viewer cannot be launched

## Testing
- pytest *(fails: ImportError: libGL.so.1 missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8caa6fbdc8323873449bb40054fe6