### PR TITLE
Ensure notas reuse complete receptor data

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -4375,11 +4375,8 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
     venta_row = db.cursor.execute(
         "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
     ).fetchone()
-    tipo_doc = "01"
-    if venta_row:
-        venta = dict(venta_row)
-        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-            tipo_doc = "03"
+    credito_fiscal = db.get_venta_credito_fiscal(venta_id) if venta_row else None
+    tipo_doc = "03" if credito_fiscal else "01"
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc)
     detalles = None
     if nota.get("detalles"):

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -11,6 +11,7 @@ proyecto ``gestor-de-inventario``.
 """
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 import json
@@ -26,9 +27,9 @@ from dte import (
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
+from utils.receptor import ensure_receptor_completo
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
-from utils.sanitize import limpiar_documentos
 
 
 logger = logging.getLogger(__name__)
@@ -73,11 +74,8 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     ).fetchone()
     if not venta_row:
         raise ValueError("Venta no encontrada")
-    venta = dict(venta_row)
-    tipo_doc = "01"
-    if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-        # Se asume comprobante de crédito fiscal cuando no hay cliente asociado
-        tipo_doc = "03"
+    credito_fiscal = db.get_venta_credito_fiscal(venta_id)
+    tipo_doc = "03" if credito_fiscal else "01"
 
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
 
@@ -98,7 +96,14 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
             motivo=nota.get("motivo"),
         )
 
-    total_origen = Decimal(str(dte_origen.get("resumen", {}).get("montoTotalOperacion", 0)))
+    resumen_origen = dte_origen.get("resumen", {})
+    total_origen = Decimal(
+        str(
+            resumen_origen.get("montoTotalOperacion")
+            or resumen_origen.get("totalPagar")
+            or 0
+        )
+    )
     monto_nc = Decimal(str(nota.get("monto", 0)))
     if total_origen <= Decimal_0:
         raise ValueError("El documento de origen no tiene total válido")
@@ -139,7 +144,7 @@ def generar_nce_desde_dte(
         "ambiente": ambiente,
         "tipoDte": "05",
         "numeroControl": cabecera["numero_control"],
-        "codigoGeneracion": cabecera["codigo_generacion"],
+        "codigoGeneracion": cabecera["codigo_generacion"].upper(),
         "tipoModelo": cabecera["tipo_modelo"],
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
@@ -149,19 +154,23 @@ def generar_nce_desde_dte(
         "tipoMoneda": "USD",
     }
 
+    tipo_doc_rel = str(origen_ident.get("tipoDte") or "").zfill(2) if origen_ident.get("tipoDte") else None
+    if not tipo_doc_rel:
+        tipo_doc_rel = "03" if (dte_origen.get("receptor") or {}).get("nrc") else "01"
+    numero_documento = origen_ident.get("codigoGeneracion") or ""
+    if isinstance(numero_documento, str):
+        numero_documento = numero_documento.upper()
     doc_rel = [
         {
-            "tipoDocumento": origen_ident.get("tipoDte"),
+            "tipoDocumento": tipo_doc_rel,
             "tipoGeneracion": 2,
-            "numeroDocumento": origen_ident.get("codigoGeneracion"),
+            "numeroDocumento": numero_documento,
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]
 
-    emisor = dte_origen.get("emisor")
-    receptor = dte_origen.get("receptor")
-    limpiar_documentos(emisor)
-    limpiar_documentos(receptor)
+    emisor = deepcopy(dte_origen.get("emisor") or {})
+    receptor = ensure_receptor_completo(dte_origen.get("receptor"), ambiente)
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
@@ -346,7 +355,12 @@ def generar_nce_desde_dte(
                     }
                 )
             subtotal_ventas = (total_grav + total_exenta + total_nosuj).quantize(Q4)
-            orig_total = Decimal(str(orig_resumen.get("montoTotalOperacion", 0))) * ratio_val
+            orig_total_base = (
+                orig_resumen.get("montoTotalOperacion")
+                or orig_resumen.get("totalPagar")
+                or 0
+            )
+            orig_total = Decimal(str(orig_total_base)) * ratio_val
             iva_val = d2(orig_total - subtotal_ventas)
             monto_total_operacion = d2(orig_total)
 
@@ -388,6 +402,7 @@ def generar_nce_desde_dte(
         "ventaTercero": None,
         "extension": None,
         "apendice": None,
+        "otrosDocumentos": None,
     }
 
     logger.info(
@@ -399,5 +414,7 @@ def generar_nce_desde_dte(
         dte_origen.get("selloRecibido"),
     )
     schema = catalogos.get_dte_schema("05")
-    return sanitize_dte_payload(data, schema)
+    result = sanitize_dte_payload(data, schema)
+    result.setdefault("otrosDocumentos", None)
+    return result
 

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -25,9 +25,9 @@ from dte import (
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
+from utils.receptor import ensure_receptor_completo
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
-from utils.sanitize import limpiar_documentos
 
 
 logger = logging.getLogger(__name__)
@@ -45,11 +45,8 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     venta_row = db.cursor.execute(
         "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,),
     ).fetchone()
-    tipo_doc = "01"
-    if venta_row:
-        venta = dict(venta_row)
-        if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-            tipo_doc = "03"
+    credito_fiscal = db.get_venta_credito_fiscal(venta_id) if venta_row else None
+    tipo_doc = "03" if credito_fiscal else "01"
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
 
     detalles = None
@@ -88,7 +85,7 @@ def generar_nde_desde_dte(
         "ambiente": ambiente,
         "tipoDte": "06",
         "numeroControl": cabecera["numero_control"],
-        "codigoGeneracion": cabecera["codigo_generacion"],
+        "codigoGeneracion": cabecera["codigo_generacion"].upper(),
         "tipoModelo": cabecera["tipo_modelo"],
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
@@ -98,21 +95,23 @@ def generar_nde_desde_dte(
         "tipoMoneda": "USD",
     }
 
+    tipo_doc_rel = str(origen_ident.get("tipoDte") or "").zfill(2) if origen_ident.get("tipoDte") else None
+    if not tipo_doc_rel:
+        tipo_doc_rel = "03" if (dte_origen.get("receptor") or {}).get("nrc") else "01"
+    numero_documento = origen_ident.get("codigoGeneracion") or ""
+    if isinstance(numero_documento, str):
+        numero_documento = numero_documento.upper()
     doc_rel = [
         {
-            "tipoDocumento": origen_ident.get("tipoDte"),
+            "tipoDocumento": tipo_doc_rel,
             "tipoGeneracion": 2,
-            "numeroDocumento": origen_ident.get("codigoGeneracion"),
+            "numeroDocumento": numero_documento,
             "fechaEmision": origen_ident.get("fecEmi"),
         }
     ]
 
     emisor = copy.deepcopy(dte_origen.get("emisor", {}))
-    receptor = copy.deepcopy(dte_origen.get("receptor", {}))
-    receptor.setdefault("nombreComercial", None)
-    receptor.setdefault("nit", None)
-    limpiar_documentos(emisor)
-    limpiar_documentos(receptor)
+    receptor = ensure_receptor_completo(dte_origen.get("receptor"), ambiente)
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
@@ -301,6 +300,7 @@ def generar_nde_desde_dte(
         "ventaTercero": None,
         "extension": None,
         "apendice": None,
+        "otrosDocumentos": None,
     }
 
     logger.info(
@@ -312,7 +312,9 @@ def generar_nde_desde_dte(
         dte_origen.get("selloRecibido"),
     )
     schema = catalogos.get_dte_schema("06")
-    return sanitize_dte_payload(data, schema)
+    result = sanitize_dte_payload(data, schema)
+    result.setdefault("otrosDocumentos", None)
+    return result
 
 
 __all__ = ["generar_nde_desde_dte", "generar_nde_desde_nota"]

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -78,16 +78,190 @@ def test_generar_nota_credito_json_factura(tmp_path, monkeypatch):
         cliente_id, "2024-01-01", 10, "123", "06141407100012", "giro", descuentos=0
     )
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte="01")
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
     data = generar_nce_desde_dte(db, dte_origen, Decimal("1"), motivo="Dev")
-    assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
+    assert data["documentoRelacionado"][0]["tipoDocumento"] == "03"
     assert (
         data["documentoRelacionado"][0]["numeroDocumento"]
         == dte_origen["identificacion"]["codigoGeneracion"]
     )
-    assert "-" not in data["receptor"].get("nit", "")
+    receptor = data["receptor"]
+    assert "-" not in receptor.get("nit", "")
+    assert receptor.get("nit")
+    assert receptor.get("nrc") == "123"
+    assert receptor.get("nombreComercial") in {None, "Cliente"}
 
 
+def test_generar_nce_desde_nota_credito_fiscal(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente", "123", "06141407100012", "", "giro", "22223333", "cli@example.com", "Dir", "05", "24", nombreComercial="Cliente"
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-01-01",
+        10,
+        "123",
+        "06141407100012",
+        "giro",
+        descuentos=0,
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2024-01-02', 10, 'Dev')",
+        (venta_id,),
+    ).lastrowid
+
+    nce = generar_nce_desde_nota(db, nota_id)
+    doc_rel = nce["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"
+    receptor_nota = nce["receptor"]
+    assert receptor_nota["nit"] == "06141407100012"
+    assert receptor_nota["nrc"] == "123"
+    assert receptor_nota.get("nombreComercial") in {None, "Cliente"}
+
+
+def test_generar_nce_receptor_placeholder_en_pruebas(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": str(src.get("departamento", "05")).zfill(2), "municipio": str(src.get("municipio", "24")).zfill(2), "complemento": src.get("complemento", "Dir")},
+    )
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {"nombre": "Consumidor Final"},
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 1.0,
+                "montoDescu": 0.0,
+                "ventaGravada": 1.0,
+                "ventaExenta": 0.0,
+                "ventaNoSuj": 0.0,
+                "tributos": [],
+            }
+        ],
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    nce = generar_nce_desde_dte(db, dte_origen, Decimal("1"), ambiente="00")
+    receptor = nce["receptor"]
+    assert receptor["nit"] == "00000000000000"
+    assert receptor["nrc"] == "0"
+    assert receptor["correo"] == "demo@example.com"
+    assert receptor["telefono"] == "00000000"
+    assert receptor["direccion"]["departamento"] == "01"
+    assert receptor["direccion"]["municipio"] == "01"
+    assert "otrosDocumentos" in nce
+
+
+def test_generar_nce_receptor_incompleto_en_produccion(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": str(src.get("departamento", "05")).zfill(2), "municipio": str(src.get("municipio", "24")).zfill(2), "complemento": src.get("complemento", "Dir")},
+    )
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {"nombre": "Consumidor Final"},
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 1.0,
+                "montoDescu": 0.0,
+                "ventaGravada": 1.0,
+                "ventaExenta": 0.0,
+                "ventaNoSuj": 0.0,
+                "tributos": [],
+            }
+        ],
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    with pytest.raises(ValueError) as exc:
+        generar_nce_desde_dte(db, dte_origen, Decimal("1"), ambiente="01")
+
+    assert "nit" in str(exc.value)
+    assert "nrc" in str(exc.value)
 def test_nota_credito_total_nueve(monkeypatch):
     monkeypatch.setattr(
         "svfe.config.load_datos_negocio",

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,7 +1,8 @@
 import fitz
 from decimal import Decimal
+import pytest
 from db import DB
-from nota_debito_electronica import generar_nde_desde_dte
+from nota_debito_electronica import generar_nde_desde_dte, generar_nde_desde_nota
 from dte import generar_dte_json
 from nota_remision import generar_nota_remision_desde_db, generar_nota_remision
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
@@ -73,12 +74,12 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "1234567", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte="01")
+    dte_origen = generar_dte_json(db, venta_id, tipo_dte="03")
     data = generar_nde_desde_dte(db, dte_origen, None, 10, "Ajuste")
     assert data["identificacion"]["tipoDte"] == "06"
     assert data["resumen"]["montoTotalOperacion"] > 0
     doc_rel = data["documentoRelacionado"][0]
-    assert doc_rel["tipoDocumento"] == "01"
+    assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["fechaEmision"]
     assert (
@@ -87,6 +88,68 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     )
     assert doc_rel["numeroDocumento"] != data["identificacion"].get("numeroControl")
     assert "-" not in data["emisor"].get("nit", "")
+
+
+def test_generar_nde_desde_nota_credito_fiscal(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    db.add_cliente(
+        "Cliente",
+        "123",
+        "06141407100012",
+        "",
+        "giro",
+        "22223333",
+        "cli@example.com",
+        "Dir",
+        "05",
+        "24",
+        nombreComercial="Cliente",
+    )
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2024-01-01",
+        10,
+        "123",
+        "06141407100012",
+        "giro",
+        descuentos=0,
+    )
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'debito', '2024-01-02', 10, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    nde = generar_nde_desde_nota(db, nota_id)
+    doc_rel = nde["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"
+    receptor = nde["receptor"]
+    assert receptor["nit"] == "06141407100012"
+    assert receptor["nrc"] == "123"
+    assert receptor.get("nombreComercial") in {None, "Cliente"}
 
 
 def test_generar_nde_consumidor_final_sin_nit(monkeypatch):
@@ -117,7 +180,142 @@ def test_generar_nde_consumidor_final_sin_nit(monkeypatch):
     }
     data = generar_nde_desde_dte(db, dte_origen, None, 10, "Ajuste")
     assert data["identificacion"]["tipoDte"] == "06"
-    assert "nit" not in data["receptor"]
+    assert data["receptor"]["nit"] == "00000000000000"
+    assert data["receptor"]["correo"] == "demo@example.com"
+    assert "otrosDocumentos" in data
+
+
+def test_generar_nde_receptor_placeholder_en_pruebas(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {"nombre": "Consumidor Final"},
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 1.0,
+                "montoDescu": 0.0,
+                "ventaGravada": 1.0,
+                "ventaExenta": 0.0,
+                "ventaNoSuj": 0.0,
+                "tributos": [],
+            }
+        ],
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    nde = generar_nde_desde_dte(db, dte_origen, None, 1.0, "Ajuste", ambiente="00")
+    receptor = nde["receptor"]
+    assert receptor["nit"] == "00000000000000"
+    assert receptor["nrc"] == "0"
+    assert receptor["telefono"] == "00000000"
+    assert receptor["direccion"]["departamento"] == "01"
+
+
+def test_generar_nde_receptor_incompleto_en_produccion(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {"nombre": "Consumidor Final"},
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 1.0,
+                "montoDescu": 0.0,
+                "ventaGravada": 1.0,
+                "ventaExenta": 0.0,
+                "ventaNoSuj": 0.0,
+                "tributos": [],
+            }
+        ],
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    with pytest.raises(ValueError) as exc:
+        generar_nde_desde_dte(db, dte_origen, None, 1.0, "Ajuste", ambiente="01")
+
+    assert "nit" in str(exc.value)
+    assert "nrc" in str(exc.value)
 
 
 def test_generar_nde_ticket_minimo(monkeypatch):

--- a/utils/receptor.py
+++ b/utils/receptor.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List
+
+
+_PLACEHOLDERS_RECEPTOR = {
+    "nit": "00000000000000",
+    "nrc": "0",
+    "nombre": "CLIENTE DESCONOCIDO",
+    "codActividad": "00000",
+    "descActividad": "PENDIENTE",
+    "nombreComercial": None,
+    "telefono": "00000000",
+    "correo": "demo@example.com",
+}
+
+_PLACEHOLDERS_DIRECCION = {
+    "departamento": "01",
+    "municipio": "01",
+    "complemento": "DIRECCION PENDIENTE",
+}
+
+
+def ensure_receptor_completo(receptor: Dict[str, Any] | None, ambiente: str) -> Dict[str, Any]:
+    """Return a receptor dictionary that satisfies schema requirements for notas.
+
+    Parameters
+    ----------
+    receptor:
+        Receptor dictionary copied from the source DTE.
+    ambiente:
+        Ambiente value ("00" pruebas, "01" producción).
+    """
+
+    rec = deepcopy(receptor or {})
+    missing: List[str] = []
+
+    direccion = rec.get("direccion")
+    if not isinstance(direccion, dict):
+        direccion = {}
+    direccion = deepcopy(direccion)
+
+    for field, placeholder in _PLACEHOLDERS_RECEPTOR.items():
+        if _needs_placeholder(rec, field):
+            if ambiente == "01":
+                missing.append(field)
+            else:
+                rec[field] = placeholder
+        elif field == "correo":
+            correo = str(rec.get(field, ""))
+            if "@" not in correo:
+                if ambiente == "01":
+                    missing.append(field)
+                else:
+                    rec[field] = placeholder
+        elif field in {"nit", "nrc", "telefono", "codActividad"}:
+            value = rec.get(field)
+            if value is not None:
+                rec[field] = str(value)
+
+    for field, placeholder in _PLACEHOLDERS_DIRECCION.items():
+        if _needs_placeholder(direccion, field):
+            if ambiente == "01":
+                missing.append(f"direccion.{field}")
+            else:
+                direccion[field] = placeholder
+        else:
+            direccion[field] = str(direccion[field])
+
+    rec["direccion"] = direccion
+
+    if missing and ambiente == "01":
+        raise ValueError(
+            "Faltan campos obligatorios en receptor: " + ", ".join(sorted(missing))
+        )
+
+    # Asegura que las claves existan aunque sean None.
+    for field in _PLACEHOLDERS_RECEPTOR:
+        rec.setdefault(field, _PLACEHOLDERS_RECEPTOR[field])
+    for field in _PLACEHOLDERS_DIRECCION:
+        rec["direccion"].setdefault(field, _PLACEHOLDERS_DIRECCION[field])
+
+    return rec
+
+
+def _needs_placeholder(data: Dict[str, Any], field: str) -> bool:
+    if field not in data:
+        return True
+    value = data[field]
+    if field == "nombreComercial":
+        return False
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    return False


### PR DESCRIPTION
## Summary
- add a shared helper that fills missing receptor fields with schema-compliant placeholders in test environments and raises in production when data is incomplete
- update electronic credit and debit note generators to normalise related-document identifiers, preserve new receptor requirements, and keep optional top-level sections such as otrosDocumentos after sanitisation
- extend credit and debit note tests to cover receptor completion in ambiente 00 and validation failures in ambiente 01

## Testing
- pytest tests/test_nota_credito.py::test_generar_nce_receptor_placeholder_en_pruebas tests/test_nota_credito.py::test_generar_nce_receptor_incompleto_en_produccion tests/test_nota_debito_remision.py::test_generar_nde_receptor_placeholder_en_pruebas tests/test_nota_debito_remision.py::test_generar_nde_receptor_incompleto_en_produccion -q


------
https://chatgpt.com/codex/tasks/task_e_68d7a2dfd7e4832396ba632863306a78