### PR TITLE
Use file URI when opening PDFs via webbrowser

### DIFF
--- a/tests/test_open_pdf.py
+++ b/tests/test_open_pdf.py
@@ -1,3 +1,4 @@
+from pathlib import PureWindowsPath
 from types import SimpleNamespace
 
 import facturacion_tab
@@ -25,3 +26,32 @@ def test_open_pdf(monkeypatch, qt_app, tmp_path):
     tab.open_pdf()
 
     assert opened["path"] == str(pdf_path)
+
+
+def test_open_pdf_windows_fallback(monkeypatch):
+    from utils import printing
+
+    class DummyWindowsPath(PureWindowsPath):
+        def resolve(self):  # type: ignore[override]
+            return self
+
+    monkeypatch.setattr(printing, "Path", DummyWindowsPath)
+    monkeypatch.setattr(printing.sys, "platform", "win32")
+
+    def failing_startfile(path):
+        raise OSError("boom")
+
+    monkeypatch.setattr(printing.os, "startfile", failing_startfile, raising=False)
+
+    opened = {}
+
+    def fake_webbrowser_open(url, new=0):
+        opened["url"] = url
+        opened["new"] = new
+        return True
+
+    monkeypatch.setattr(printing.webbrowser, "open", fake_webbrowser_open)
+
+    assert printing.open_pdf_cross_platform("C:/Users/test/doc.pdf") is True
+    assert opened["url"] == "file:///C:/Users/test/doc.pdf"
+    assert opened["new"] == 2

--- a/utils/printing.py
+++ b/utils/printing.py
@@ -24,7 +24,9 @@ def open_pdf_with_default_viewer(path: str) -> bool:
 def open_pdf_cross_platform(path: str) -> bool:
     """Open ``path`` using the platform's default mechanism."""
 
-    absolute_path = os.fspath(Path(path).resolve())
+    resolved_path = Path(path).resolve()
+    absolute_path = os.fspath(resolved_path)
+    file_uri = resolved_path.as_uri()
 
     try:
         if sys.platform.startswith("win"):
@@ -36,7 +38,7 @@ def open_pdf_cross_platform(path: str) -> bool:
         return True
     except Exception:
         try:
-            return webbrowser.open(f"file://{absolute_path}", new=2)
+            return webbrowser.open(file_uri, new=2)
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary
- build a file URI via Path.as_uri() when preparing to open PDFs
- reuse the computed URI inside the fallback webbrowser.open call
- add a regression test that simulates the Windows fallback behaviour

## Testing
- pytest tests/test_open_pdf.py *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d1ee35d48323a6272d5792f3ebd0