### PR TITLE
Remove otrosDocumentos from electronic note payloads

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -402,7 +402,6 @@ def generar_nce_desde_dte(
         "ventaTercero": None,
         "extension": None,
         "apendice": None,
-        "otrosDocumentos": None,
     }
 
     logger.info(
@@ -415,6 +414,5 @@ def generar_nce_desde_dte(
     )
     schema = catalogos.get_dte_schema("05")
     result = sanitize_dte_payload(data, schema)
-    result.setdefault("otrosDocumentos", None)
     return result
 

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -300,7 +300,6 @@ def generar_nde_desde_dte(
         "ventaTercero": None,
         "extension": None,
         "apendice": None,
-        "otrosDocumentos": None,
     }
 
     logger.info(
@@ -313,7 +312,6 @@ def generar_nde_desde_dte(
     )
     schema = catalogos.get_dte_schema("06")
     result = sanitize_dte_payload(data, schema)
-    result.setdefault("otrosDocumentos", None)
     return result
 
 

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -199,7 +199,7 @@ def test_generar_nce_receptor_placeholder_en_pruebas(monkeypatch):
     assert receptor["telefono"] == "00000000"
     assert receptor["direccion"]["departamento"] == "01"
     assert receptor["direccion"]["municipio"] == "01"
-    assert "otrosDocumentos" in nce
+    assert "otrosDocumentos" not in nce
 
 
 def test_generar_nce_receptor_incompleto_en_produccion(monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -182,7 +182,7 @@ def test_generar_nde_consumidor_final_sin_nit(monkeypatch):
     assert data["identificacion"]["tipoDte"] == "06"
     assert data["receptor"]["nit"] == "00000000000000"
     assert data["receptor"]["correo"] == "demo@example.com"
-    assert "otrosDocumentos" in data
+    assert "otrosDocumentos" not in data
 
 
 def test_generar_nde_receptor_placeholder_en_pruebas(monkeypatch):


### PR DESCRIPTION
## Summary
- stop adding `otrosDocumentos` to the sanitized payload of electronic credit and debit notes
- update regression tests to expect the field to be absent for those notes

## Testing
- pytest tests/test_nota_credito.py::test_generar_nce_receptor_placeholder_en_pruebas


------
https://chatgpt.com/codex/tasks/task_e_68d8d7b45aa88323950dbadd03b6335d