### PR TITLE
Remove otrosDocumentos from notes and improve PDF diagnostics

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -71,6 +71,7 @@ from paths import (
     DTES_PENDIENTES_DIR,
     FACTURAS_ARCHIVE_CF_DIR,
     FACTURAS_ARCHIVE_CREDITO_DIR,
+    resolve_user_visible_path,
 )
 import tempfile
 import subprocess
@@ -2347,6 +2348,8 @@ class FacturacionTab(QWidget):
 
         if pdf_path:
             absolute_path = os.path.abspath(pdf_path)
+            display_path = resolve_user_visible_path(absolute_path)
+            logger.info("Intentando abrir PDF desde FacturacionTab.open_pdf: %s", absolute_path)
             if not open_pdf_file(absolute_path):
                 QMessageBox.warning(
                     self,
@@ -2354,7 +2357,7 @@ class FacturacionTab(QWidget):
                     (
                         "No se pudo abrir el archivo PDF automáticamente.\n"
                         "Puedes abrirlo manualmente desde:\n"
-                        f"{absolute_path}"
+                        f"{display_path}"
                     ),
                 )
         else:
@@ -2416,6 +2419,11 @@ class FacturacionTab(QWidget):
             return
 
         absolute_path = os.path.abspath(pdf_path)
+        display_path = resolve_user_visible_path(absolute_path)
+        logger.info(
+            "Intentando abrir PDF para impresión desde FacturacionTab.print_invoice: %s",
+            absolute_path,
+        )
         if not open_pdf_file(absolute_path):
             QMessageBox.warning(
                 self,
@@ -2423,7 +2431,7 @@ class FacturacionTab(QWidget):
                 (
                     "No se pudo abrir el archivo PDF automáticamente.\n"
                     "Puedes abrirlo manualmente desde:\n"
-                    f"{absolute_path}"
+                    f"{display_path}"
                 ),
             )
 

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -402,7 +402,6 @@ def generar_nce_desde_dte(
         "ventaTercero": None,
         "extension": None,
         "apendice": None,
-        "otrosDocumentos": None,
     }
 
     logger.info(
@@ -415,6 +414,5 @@ def generar_nce_desde_dte(
     )
     schema = catalogos.get_dte_schema("05")
     result = sanitize_dte_payload(data, schema)
-    result.setdefault("otrosDocumentos", None)
     return result
 

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -300,7 +300,6 @@ def generar_nde_desde_dte(
         "ventaTercero": None,
         "extension": None,
         "apendice": None,
-        "otrosDocumentos": None,
     }
 
     logger.info(
@@ -313,7 +312,6 @@ def generar_nde_desde_dte(
     )
     schema = catalogos.get_dte_schema("06")
     result = sanitize_dte_payload(data, schema)
-    result.setdefault("otrosDocumentos", None)
     return result
 
 

--- a/svfe/generators.py
+++ b/svfe/generators.py
@@ -370,13 +370,14 @@ def _generar(db: DB, tipo: str) -> Dict[str, Any]:
         "documentoRelacionado": _documento_relacionado(tipo),
         "emisor": _emisor(),
         "receptor": _receptor(tipo),
-        "otrosDocumentos": None,
         "ventaTercero": None,
         "cuerpoDocumento": _cuerpo_documento(tipo),
         "resumen": _resumen(tipo),
         "extension": None,
         "apendice": None,
     }
+    if "otrosDocumentos" in schema.get("properties", {}):
+        data["otrosDocumentos"] = None
     data["emisor"]["direccion"] = get_emisor_direccion()
     _validate_direccion(data["emisor"]["direccion"], "emisor")
     _validate_direccion(data["receptor"].get("direccion", {}), "receptor")

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -199,7 +199,7 @@ def test_generar_nce_receptor_placeholder_en_pruebas(monkeypatch):
     assert receptor["telefono"] == "00000000"
     assert receptor["direccion"]["departamento"] == "01"
     assert receptor["direccion"]["municipio"] == "01"
-    assert "otrosDocumentos" in nce
+    assert "otrosDocumentos" not in nce
 
 
 def test_generar_nce_receptor_incompleto_en_produccion(monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -182,7 +182,7 @@ def test_generar_nde_consumidor_final_sin_nit(monkeypatch):
     assert data["identificacion"]["tipoDte"] == "06"
     assert data["receptor"]["nit"] == "00000000000000"
     assert data["receptor"]["correo"] == "demo@example.com"
-    assert "otrosDocumentos" in data
+    assert "otrosDocumentos" not in data
 
 
 def test_generar_nde_receptor_placeholder_en_pruebas(monkeypatch):


### PR DESCRIPTION
## Summary
- stop attaching the otrosDocumentos property to credit and debit note payloads so they comply with the Hacienda JSON schema
- ensure the SVFE sample generators only add otrosDocumentos when the active schema allows it
- show end users the physical PDF path (with Windows Store remapping) and log the path before trying to open it from the facturación tab

## Testing
- pytest tests/test_nota_credito.py tests/test_nota_debito_remision.py *(fails: require sample data and patched dependencies to satisfy precio unitario/código de generación assertions in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d8dc93d42c8323a5ea06b596a76a1c