### PR TITLE
Normaliza fecha de emisión original al crear notas

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -28,7 +28,7 @@ from dte import (
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
 
 
@@ -69,15 +69,18 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     if venta_id is None:
         raise ValueError("La nota no está asociada a una venta")
 
-    venta_row = db.cursor.execute(
-        "SELECT cliente_id, total FROM ventas WHERE id=?", (venta_id,)
-    ).fetchone()
-    if not venta_row:
+    venta = db.get_venta_by_id(venta_id)
+    if not venta:
         raise ValueError("Venta no encontrada")
     credito_fiscal = db.get_venta_credito_fiscal(venta_id)
     tipo_doc = "03" if credito_fiscal else "01"
 
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+    fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
+    if fecha_origen:
+        identificacion = dte_origen.get("identificacion")
+        if isinstance(identificacion, dict):
+            identificacion["fecEmi"] = fecha_origen
 
     detalles = None
     if nota.get("detalles"):

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -26,7 +26,7 @@ from dte import (
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv
 
 
@@ -42,12 +42,17 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         raise ValueError("La nota indicada no es de débito")
 
     venta_id = nota.get("venta_id")
-    venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,),
-    ).fetchone()
-    credito_fiscal = db.get_venta_credito_fiscal(venta_id) if venta_row else None
+    venta = db.get_venta_by_id(venta_id) if venta_id is not None else None
+    if not venta:
+        raise ValueError("Venta no encontrada")
+    credito_fiscal = db.get_venta_credito_fiscal(venta_id)
     tipo_doc = "03" if credito_fiscal else "01"
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+    fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
+    if fecha_origen:
+        identificacion = dte_origen.get("identificacion")
+        if isinstance(identificacion, dict):
+            identificacion["fecEmi"] = fecha_origen
 
     detalles = None
     if nota.get("detalles"):

--- a/utils/fecha.py
+++ b/utils/fecha.py
@@ -1,5 +1,5 @@
-from datetime import datetime
-from typing import Optional
+from datetime import date, datetime
+from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
 TZ_EL_SALVADOR = ZoneInfo("America/El_Salvador")
@@ -11,3 +11,34 @@ def fecha_emision_hoy_str(now: Optional[datetime] = None) -> str:
     else:
         now = now.astimezone(TZ_EL_SALVADOR)
     return now.strftime("%Y-%m-%d")
+
+
+def normalizar_fecha_iso(value: Union[str, datetime, date, None]) -> Optional[str]:
+    """Convierte distintos formatos de fecha a ``YYYY-MM-DD``."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+
+    if isinstance(value, date):
+        return value.isoformat()
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    fecha_dt: Optional[datetime] = None
+    try:
+        fecha_dt = datetime.fromisoformat(text)
+    except ValueError:
+        fecha_dt = None
+
+    if fecha_dt is None:
+        try:
+            fecha_dt = datetime.strptime(text[:10], "%Y-%m-%d")
+        except ValueError:
+            return None
+
+    return fecha_dt.date().isoformat()


### PR DESCRIPTION
## Summary
- normaliza la fecha de emisión obtenida de la venta original antes de construir notas de crédito o débito
- añade un utilitario `normalizar_fecha_iso` para convertir valores heterogéneos a formato `YYYY-MM-DD`

## Testing
- pytest tests/test_nota_credito.py tests/test_nota_debito_remision.py *(falla: asserts existentes en la suite esperan datos adicionales no configurados en este entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e4898c388323b8f689dea4c7e646