### PR TITLE
Ensure EmailConfigDialog keeps default SMTP when missing

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -3469,8 +3469,15 @@ class EmailConfigDialog(QDialog):
 
     def set_data(self, datos):
         self.combo_email_provider.setCurrentText(datos.get("email_provider", "Gmail"))
-        self.smtp_server.setText(datos.get("smtp_server", ""))
-        self.smtp_port.setText(str(datos.get("smtp_port", "")))
+
+        smtp_server = datos.get("smtp_server")
+        if smtp_server:
+            self.smtp_server.setText(smtp_server)
+
+        smtp_port = datos.get("smtp_port")
+        if smtp_port:
+            self.smtp_port.setText(str(smtp_port))
+
         self.email_usuario.setText(datos.get("email_usuario", ""))
         self.email_contrasena.setText(datos.get("email_contrasena", ""))
 

--- a/tests/test_sales_tab_email.py
+++ b/tests/test_sales_tab_email.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import QTableWidgetItem, QMessageBox
 
 import sales_tab
 from sales_tab import SalesTab
+from dialogs.dialogs import EmailConfigDialog
 
 warnings.filterwarnings(
     "ignore", message="Credenciales SMTP incompletas.*"
@@ -73,6 +74,17 @@ def _setup_tab(venta, cliente, producto, monkeypatch=None):
     tab.sales_table.setRowCount(1)
     tab.sales_table.setItem(0, 0, QTableWidgetItem(str(venta["id"])))
     return db, tab
+
+
+def test_email_config_dialog_uses_defaults_without_smtp_data(qt_app):
+    dialog = EmailConfigDialog(datos={
+        "email_provider": "Gmail",
+        "smtp_server": "",
+        "smtp_port": "",
+    })
+
+    assert dialog.smtp_server.text() == "smtp.gmail.com"
+    assert dialog.smtp_port.text() == "587"
 
 
 def test_send_email_builds_message_and_marks_status(


### PR DESCRIPTION
## Summary
- keep the default SMTP host and port provided by EmailConfigDialog when stored values are empty
- add a regression test that opens the dialog without SMTP data and checks the default Gmail settings

## Testing
- pytest tests/test_sales_tab_email.py -k defaults_without_smtp -q

------
https://chatgpt.com/codex/tasks/task_e_68d8e8c5e4ec8323a907d4a7e82452ea