### PR TITLE
Ensure PDF helpers use user-visible paths

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2347,17 +2347,21 @@ class FacturacionTab(QWidget):
         pdf_path = self._resolve_pdf_path(entry)
 
         if pdf_path:
-            absolute_path = os.path.abspath(pdf_path)
-            display_path = resolve_user_visible_path(absolute_path)
-            logger.info("Intentando abrir PDF desde FacturacionTab.open_pdf: %s", absolute_path)
-            if not open_pdf_file(absolute_path):
+            logical_path = os.path.abspath(pdf_path)
+            visible_path = resolve_user_visible_path(logical_path)
+            path_to_open = visible_path or logical_path
+            logger.info(
+                "Intentando abrir PDF desde FacturacionTab.open_pdf: %s",
+                logical_path,
+            )
+            if not open_pdf_file(path_to_open):
                 QMessageBox.warning(
                     self,
                     "Abrir PDF",
                     (
                         "No se pudo abrir el archivo PDF automáticamente.\n"
                         "Puedes abrirlo manualmente desde:\n"
-                        f"{display_path}"
+                        f"{path_to_open}"
                     ),
                 )
         else:
@@ -2418,20 +2422,21 @@ class FacturacionTab(QWidget):
             )
             return
 
-        absolute_path = os.path.abspath(pdf_path)
-        display_path = resolve_user_visible_path(absolute_path)
+        logical_path = os.path.abspath(pdf_path)
+        visible_path = resolve_user_visible_path(logical_path)
+        path_to_open = visible_path or logical_path
         logger.info(
             "Intentando abrir PDF para impresión desde FacturacionTab.print_invoice: %s",
-            absolute_path,
+            logical_path,
         )
-        if not open_pdf_file(absolute_path):
+        if not open_pdf_file(path_to_open):
             QMessageBox.warning(
                 self,
                 "Abrir PDF",
                 (
                     "No se pudo abrir el archivo PDF automáticamente.\n"
                     "Puedes abrirlo manualmente desde:\n"
-                    f"{display_path}"
+                    f"{path_to_open}"
                 ),
             )
 

--- a/utils/printing.py
+++ b/utils/printing.py
@@ -7,6 +7,8 @@ import sys
 import webbrowser
 from pathlib import Path
 
+from paths import resolve_user_visible_path
+
 
 def open_pdf_with_default_viewer(path: str) -> bool:
     """Try to open ``path`` using ``QDesktopServices`` if Qt is available."""
@@ -46,15 +48,31 @@ def open_pdf_cross_platform(path: str) -> bool:
 def open_pdf(path: str) -> bool:
     """Open the PDF located at ``path`` with the user's preferred application."""
 
-    if not path or not Path(path).exists():
+    if not path:
+        return False
+
+    physical_path = resolve_user_visible_path(path)
+    candidate_path = physical_path if physical_path != path else path
+
+    def _path_exists(target: str) -> bool:
+        try:
+            return Path(target).exists()
+        except OSError:
+            return False
+
+    if candidate_path and _path_exists(candidate_path):
+        usable_path = candidate_path
+    elif candidate_path != path and path and _path_exists(path):
+        usable_path = path
+    else:
         return False
 
     try:
-        if open_pdf_with_default_viewer(path):
+        if open_pdf_with_default_viewer(usable_path):
             return True
     except Exception:
         # If Qt is available but fails, continue with the fallback strategy.
         pass
 
-    return open_pdf_cross_platform(path)
+    return open_pdf_cross_platform(usable_path)
 


### PR DESCRIPTION
## Summary
- resolve logical PDF paths to user-visible locations before opening them
- use the physical path returned by resolve_user_visible_path when opening or printing invoices while logging the logical path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8e91011708323866335e2cd75d837