### PR TITLE
Normaliza fechas en notas de remisión derivadas de DTE

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -25,7 +25,7 @@ from typing import Iterable, Optional
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import monto_a_texto_sv, d2
 import warnings
 
@@ -179,12 +179,17 @@ def generar_nota_remision(
         detalles = detalles or factura.get("cuerpoDocumento", [])
         if documento_relacionado is None:
             ident = factura.get("identificacion", {})
+            fecha_emision = normalizar_fecha_iso(ident.get("fecEmi"))
+            if fecha_emision:
+                ident["fecEmi"] = fecha_emision
+            else:
+                fecha_emision = ident.get("fecEmi")
             documento_relacionado = [
                 {
                     "tipoDocumento": ident.get("tipoDte"),
                     "tipoGeneracion": 2,
                     "numeroDocumento": ident.get("codigoGeneracion"),
-                    "fechaEmision": ident.get("fecEmi"),
+                    "fechaEmision": fecha_emision,
                 }
             ]
         # Para notas derivadas de factura la extensión puede omitirse
@@ -335,18 +340,20 @@ def generar_nota_remision_desde_db(
 
     venta_id = nota.get("venta_id")
     if venta_id:
-        venta_row = db.cursor.execute(
-            "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
-        ).fetchone()
+        venta = db.get_venta_by_id(venta_id)
         tipo_doc = "01"
-        if venta_row:
-            venta = dict(venta_row)
-            if not db.get_venta_credito_fiscal(venta_id) and not venta.get("cliente_id"):
-                tipo_doc = "03"
+        if venta and not db.get_venta_credito_fiscal(venta_id) and not venta.get(
+            "cliente_id"
+        ):
+            tipo_doc = "03"
 
         from dte import generar_dte_json
 
+        fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
         dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+        if fecha_origen:
+            dte_ident = dte_origen.setdefault("identificacion", {})
+            dte_ident["fecEmi"] = fecha_origen
         extension = extra.get("extension") or {}
         return generar_nota_remision(
             db, factura=dte_origen, extension=extension, ambiente=ambiente

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -20,7 +20,7 @@ from typing import Iterable, Optional
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv
 import warnings
 
@@ -225,12 +225,17 @@ def generar_nota_remision_desde_factura(
     receptor.setdefault("bienTitulo", "01")
     detalles = detalles or factura.get("cuerpoDocumento", [])
     ident = factura.get("identificacion", {})
+    fecha_emision = normalizar_fecha_iso(ident.get("fecEmi"))
+    if fecha_emision:
+        ident["fecEmi"] = fecha_emision
+    else:
+        fecha_emision = ident.get("fecEmi")
     doc_rel = [
         {
             "tipoDocumento": ident.get("tipoDte"),
             "tipoGeneracion": 2,
             "numeroDocumento": ident.get("codigoGeneracion"),
-            "fechaEmision": ident.get("fecEmi"),
+            "fechaEmision": fecha_emision,
         }
     ]
     ext = extension.copy() if extension else None

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -50,7 +50,7 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
         "identificacion": {
             "tipoDte": "03",
             "codigoGeneracion": "12345678-ABCD-1234-ABCD-1234567890AB",
-            "fecEmi": "2024-01-01",
+            "fecEmi": "2024-01-01T08:15:30",
         },
         "emisor": _sample_emisor(),
         "receptor": _sample_receptor(),
@@ -58,11 +58,19 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
             {"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}
         ],
     }
-    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
+    assert doc_rel["fechaEmision"] == "2024-01-01"
+    assert factura["identificacion"]["fecEmi"] == "2024-01-01"
     item = data["cuerpoDocumento"][0]
     assert item["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
     assert item["codTributo"] is None
@@ -311,7 +319,13 @@ def test_receptor_dui_sin_nrc(monkeypatch):
         "receptor": receptor,
         "cuerpoDocumento": [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}],
     }
-    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     with warnings.catch_warnings(record=True) as w:
         data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     rec = data["receptor"]
@@ -368,7 +382,13 @@ def test_receptor_campo_obligatorio_faltante(monkeypatch, campo):
     receptor = _sample_receptor()
     receptor.pop(campo)
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
-    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     with pytest.raises(ValueError, match=f"receptor requiere {campo}"):
         generar_nota_remision_independiente(
             db,
@@ -387,7 +407,13 @@ def test_receptor_direccion_complemento_faltante(monkeypatch):
     receptor = _sample_receptor()
     receptor["direccion"].pop("complemento")
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
-    extension = {"docuEntrega": "123", "docuRecibe": "456"}
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
     with pytest.raises(ValueError, match="receptor requiere direccion.complemento"):
         generar_nota_remision_independiente(
             db,


### PR DESCRIPTION
## Summary
- normaliza `fecEmi` con `normalizar_fecha_iso` al construir el documento relacionado de las notas de remisión basadas en facturas
- sincroniza la fecha de emisiones generadas desde la base de datos reutilizando `db.get_venta_by_id`
- ajusta las pruebas de notas de remisión para validar el formato `YYYY-MM-DD` y mantener la estructura del resultado

## Testing
- pytest tests/test_nota_remision.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e87bf6588323a970721b0e4d8115