### PR TITLE
Add ticket format option when printing invoices

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2338,6 +2338,27 @@ class FacturacionTab(QWidget):
             return pdf_path
         return None
 
+    def _resolve_ticket_pdf(
+        self,
+        entry: dict | None,
+        base_pdf_path: str | None = None,
+    ) -> str | None:
+        if not entry:
+            return None
+
+        venta_id = entry.get("venta_id")
+        if venta_id:
+            try:
+                stored_path = self.manager.db.get_ticket_pdf(venta_id)
+            except Exception:
+                stored_path = None
+            if stored_path:
+                canonical = os.fspath(stored_path)
+                if os.path.exists(canonical):
+                    return canonical
+
+        return self._build_ticket_format_pdf(entry, base_pdf_path)
+
     def open_pdf(self):
         entry = self._selected_entry()
         if not entry:
@@ -2403,7 +2424,7 @@ class FacturacionTab(QWidget):
 
         base_pdf_path = self._resolve_pdf_path(entry)
         if preferred_format == "ticket":
-            pdf_path = self._build_ticket_format_pdf(entry, base_pdf_path)
+            pdf_path = self._resolve_ticket_pdf(entry, base_pdf_path)
         else:
             pdf_path = base_pdf_path
 

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -155,6 +155,54 @@ def test_build_ticket_format_pdf_saves_alongside_invoice(monkeypatch, qt_app, tm
     assert not out_path.exists()
 
 
+def test_resolve_ticket_pdf_reuses_existing(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    existing = tmp_path / "existing.pdf"
+    existing.write_text("pdf")
+    db.add_ticket_pdf(venta_id, str(existing))
+
+    tab = _make_tab(db, cid)
+    entry = {"row_type": "venta", "venta_id": venta_id}
+
+    called = {}
+
+    def fake_build(entry_arg, base):
+        called["called"] = True
+        return "new"
+
+    monkeypatch.setattr(tab, "_build_ticket_format_pdf", fake_build)
+
+    resolved = tab._resolve_ticket_pdf(entry, None)
+
+    assert resolved == str(existing)
+    assert "called" not in called
+
+
+def test_resolve_ticket_pdf_builds_when_missing(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    missing = tmp_path / "missing.pdf"
+    db.add_ticket_pdf(venta_id, str(missing))
+
+    tab = _make_tab(db, cid)
+    entry = {"row_type": "venta", "venta_id": venta_id}
+
+    generated = tmp_path / "generated.pdf"
+    flags = {}
+
+    def fake_build(entry_arg, base):
+        flags["called"] = True
+        return str(generated)
+
+    monkeypatch.setattr(tab, "_build_ticket_format_pdf", fake_build)
+
+    resolved = tab._resolve_ticket_pdf(entry, None)
+
+    assert resolved == str(generated)
+    assert flags.get("called") is True
+
+
 def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)


### PR DESCRIPTION
## Summary
- reuse stored ticket PDFs when printing invoices and fall back to generating a new file on demand
- prompt the Facturación tab to resolve ticket PDFs through a dedicated helper when the ticket format is selected
- extend Facturación tab tests to cover ticket PDF resolution scenarios

## Testing
- pytest tests/test_facturacion_tab_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68d8eb3082a88323a8aab9176d6c4c26