### PR TITLE
Remove sale association requirement from note generators

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -66,13 +66,11 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         raise ValueError("La nota indicada no es de crédito")
 
     venta_id = nota.get("venta_id")
-    if venta_id is None:
-        raise ValueError("La nota no está asociada a una venta")
 
-    venta = db.get_venta_by_id(venta_id)
-    if not venta:
-        raise ValueError("Venta no encontrada")
-    credito_fiscal = db.get_venta_credito_fiscal(venta_id)
+    venta = db.get_venta_by_id(venta_id) if venta_id is not None else None
+    credito_fiscal = (
+        db.get_venta_credito_fiscal(venta_id) if venta_id is not None else None
+    )
     tipo_doc = "03" if credito_fiscal else "01"
 
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -43,9 +43,9 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
 
     venta_id = nota.get("venta_id")
     venta = db.get_venta_by_id(venta_id) if venta_id is not None else None
-    if not venta:
-        raise ValueError("Venta no encontrada")
-    credito_fiscal = db.get_venta_credito_fiscal(venta_id)
+    credito_fiscal = (
+        db.get_venta_credito_fiscal(venta_id) if venta_id is not None else None
+    )
     tipo_doc = "03" if credito_fiscal else "01"
     dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
     fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None


### PR DESCRIPTION
## Summary
- remove the ValueError raised when a credit note lacks an associated sale
- drop the analogous sale validation in the debit note generator while keeping existing generation logic

## Testing
- pytest tests/test_nota_credito.py::test_generar_nce_desde_nota_credito_fiscal -q
- pytest tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_credito_fiscal -q

------
https://chatgpt.com/codex/tasks/task_e_68d95d5a6d0483239871b2aa66d47eaf