### PR TITLE
Normalize nota debito related document date

### DIFF
--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -106,12 +106,18 @@ def generar_nde_desde_dte(
     numero_documento = origen_ident.get("codigoGeneracion") or ""
     if isinstance(numero_documento, str):
         numero_documento = numero_documento.upper()
+    fecha_doc_rel = normalizar_fecha_iso(origen_ident.get("fecEmi"))
+    if fecha_doc_rel:
+        origen_ident["fecEmi"] = fecha_doc_rel
+    else:
+        fecha_doc_rel = origen_ident.get("fecEmi")
+
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,
             "tipoGeneracion": 2,
             "numeroDocumento": numero_documento,
-            "fechaEmision": origen_ident.get("fecEmi"),
+            "fechaEmision": fecha_doc_rel,
         }
     ]
 


### PR DESCRIPTION
## Summary
- normalize the related document emission date when generating debit notes
- ensure the original document metadata retains the normalized emission date

## Testing
- pytest *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d9613d51988323906a2ad275cf4fa3