### PR TITLE
Extender la normalización de fechas para notas de débito

### DIFF
--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -106,12 +106,18 @@ def generar_nde_desde_dte(
     numero_documento = origen_ident.get("codigoGeneracion") or ""
     if isinstance(numero_documento, str):
         numero_documento = numero_documento.upper()
+    fecha_doc_rel = normalizar_fecha_iso(origen_ident.get("fecEmi"))
+    if fecha_doc_rel:
+        origen_ident["fecEmi"] = fecha_doc_rel
+    else:
+        fecha_doc_rel = origen_ident.get("fecEmi")
+
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,
             "tipoGeneracion": 2,
             "numeroDocumento": numero_documento,
-            "fechaEmision": origen_ident.get("fecEmi"),
+            "fechaEmision": fecha_doc_rel,
         }
     ]
 

--- a/tests/test_utils_fecha.py
+++ b/tests/test_utils_fecha.py
@@ -1,0 +1,16 @@
+from utils.fecha import normalizar_fecha_iso
+
+
+def test_normalizar_fecha_iso_dd_mm_yyyy_con_hora():
+    valor = "28/09/2025 10:31:54"
+    assert normalizar_fecha_iso(valor) == "2025-09-28"
+
+
+def test_normalizar_fecha_iso_dd_mm_yyyy_con_guiones():
+    valor = "28-09-2025"
+    assert normalizar_fecha_iso(valor) == "2025-09-28"
+
+
+def test_normalizar_fecha_iso_slash_iso():
+    valor = "2025/09/28"
+    assert normalizar_fecha_iso(valor) == "2025-09-28"

--- a/utils/fecha.py
+++ b/utils/fecha.py
@@ -36,9 +36,19 @@ def normalizar_fecha_iso(value: Union[str, datetime, date, None]) -> Optional[st
         fecha_dt = None
 
     if fecha_dt is None:
-        try:
-            fecha_dt = datetime.strptime(text[:10], "%Y-%m-%d")
-        except ValueError:
+        patrones = [
+            "%Y-%m-%d",
+            "%Y/%m/%d",
+            "%d/%m/%Y",
+            "%d-%m-%Y",
+        ]
+        for patron in patrones:
+            try:
+                fecha_dt = datetime.strptime(text[:10], patron)
+                break
+            except ValueError:
+                continue
+        else:
             return None
 
     return fecha_dt.date().isoformat()


### PR DESCRIPTION
## Summary
- actualizar `normalizar_fecha_iso` para aceptar fechas con separadores alternos y distintos formatos comunes
- agregar pruebas unitarias que cubren los nuevos formatos soportados

## Testing
- pytest tests/test_utils_fecha.py

------
https://chatgpt.com/codex/tasks/task_e_68d9613d51988323906a2ad275cf4fa3