### PR TITLE
Limit missing venta bypass to debit note generation

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2071,9 +2071,12 @@ def generar_dte_json(
     ``kwargs`` se acepta para compatibilidad con parámetros obsoletos.
     """
     row = db.cursor.execute("SELECT * FROM ventas WHERE id=?", (venta_id,)).fetchone()
-    if not row:
+    if row is not None:
+        venta = dict(row)
+    elif kwargs.get("_allow_missing_venta"):
+        venta = {}
+    else:
         raise ValueError("Venta no encontrada")
-    venta = dict(row)
 
     if tipo_operacion is None:
         modo = get_default_modo_transmision()

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -47,7 +47,13 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         db.get_venta_credito_fiscal(venta_id) if venta_id is not None else None
     )
     tipo_doc = "03" if credito_fiscal else "01"
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+    dte_origen = generar_dte_json(
+        db,
+        venta_id,
+        tipo_dte=tipo_doc,
+        ambiente=ambiente,
+        _allow_missing_venta=True,
+    )
     fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")


### PR DESCRIPTION
## Summary
- restore the venta lookup validation in generar_dte_json except when explicitly bypassed
- allow nota_debito_electronica to request the bypass so debit notes can be sent without the venta record

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d966d17f3c8323abfccd4124d64737