### PR TITLE
Extender ajuste de DUI/NRC a notas de débito

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -30,6 +30,7 @@ from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 from utils.receptor import ensure_receptor_completo
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
+from utils.sanitize import solo_digitos
 
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,40 @@ Decimal_0 = Decimal("0")
 Decimal_1 = Decimal("1")
 Q4 = Decimal("0.0001")
 IVA = Decimal("0.13")
+
+
+def _normalize_dui(value: str | None) -> str | None:
+    """Return a 9-digit representation of ``value`` if possible."""
+
+    digits = solo_digitos(value)
+    if not digits:
+        return None
+    digits = digits[-9:]
+    return digits.zfill(9)
+
+
+def _search_dui(data: object) -> str | None:
+    """Search ``data`` recursively for a DUI (``tipoDocumento`` ``13``)."""
+
+    if isinstance(data, dict):
+        tipo_doc = data.get("tipoDocumento")
+        if tipo_doc is not None:
+            tipo_doc = str(tipo_doc).zfill(2)
+            if tipo_doc == "13":
+                for key in ("numDocumento", "numDoc", "numeroDocumento"):
+                    dui = _normalize_dui(data.get(key))
+                    if dui:
+                        return dui
+        for value in data.values():
+            dui = _search_dui(value)
+            if dui:
+                return dui
+    elif isinstance(data, (list, tuple)):
+        for item in data:
+            dui = _search_dui(item)
+            if dui:
+                return dui
+    return None
 
 
 def _pct_label(ratio: Decimal) -> str:
@@ -155,9 +190,10 @@ def generar_nce_desde_dte(
         "tipoMoneda": "USD",
     }
 
+    receptor_origen = dte_origen.get("receptor") or {}
     tipo_doc_rel = str(origen_ident.get("tipoDte") or "").zfill(2) if origen_ident.get("tipoDte") else None
     if not tipo_doc_rel:
-        tipo_doc_rel = "03" if (dte_origen.get("receptor") or {}).get("nrc") else "01"
+        tipo_doc_rel = "03" if receptor_origen.get("nrc") else "01"
     numero_documento = origen_ident.get("codigoGeneracion") or ""
     if isinstance(numero_documento, str):
         numero_documento = numero_documento.upper()
@@ -171,7 +207,21 @@ def generar_nce_desde_dte(
     ]
 
     emisor = deepcopy(dte_origen.get("emisor") or {})
-    receptor = ensure_receptor_completo(dte_origen.get("receptor"), ambiente)
+    receptor = ensure_receptor_completo(receptor_origen, ambiente)
+
+    preserve_nrc_null = False
+    if tipo_doc_rel == "01":
+        dui = (
+            _search_dui(receptor_origen)
+            or _search_dui(dte_origen.get("extension"))
+            or _search_dui(dte_origen.get("otrosDocumentos"))
+        )
+        if dui:
+            receptor["nit"] = dui
+        nrc_original = receptor_origen.get("nrc")
+        if not nrc_original or str(nrc_original).strip() in {"", "0"}:
+            receptor["nrc"] = None
+            preserve_nrc_null = True
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
@@ -415,5 +465,7 @@ def generar_nce_desde_dte(
     )
     schema = catalogos.get_dte_schema("05")
     result = sanitize_dte_payload(data, schema)
+    if preserve_nrc_null:
+        result.setdefault("receptor", {})["nrc"] = None
     return result
 

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -28,9 +28,44 @@ from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
 from utils.receptor import ensure_receptor_completo
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv
+from utils.sanitize import solo_digitos
 
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_dui(value: str | None) -> str | None:
+    """Return a 9-digit representation of ``value`` if possible."""
+
+    digits = solo_digitos(value)
+    if not digits:
+        return None
+    digits = digits[-9:]
+    return digits.zfill(9)
+
+
+def _search_dui(data: object) -> str | None:
+    """Search ``data`` recursively for a DUI (``tipoDocumento`` ``13``)."""
+
+    if isinstance(data, dict):
+        tipo_doc = data.get("tipoDocumento")
+        if tipo_doc is not None:
+            tipo_doc = str(tipo_doc).zfill(2)
+            if tipo_doc == "13":
+                for key in ("numDocumento", "numDoc", "numeroDocumento"):
+                    dui = _normalize_dui(data.get(key))
+                    if dui:
+                        return dui
+        for value in data.values():
+            dui = _search_dui(value)
+            if dui:
+                return dui
+    elif isinstance(data, (list, tuple)):
+        for item in data:
+            dui = _search_dui(item)
+            if dui:
+                return dui
+    return None
 
 def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
     """Genera una NDE basada en la nota registrada en ``notas``."""
@@ -122,7 +157,22 @@ def generar_nde_desde_dte(
     ]
 
     emisor = copy.deepcopy(dte_origen.get("emisor", {}))
-    receptor = ensure_receptor_completo(dte_origen.get("receptor"), ambiente)
+    receptor_origen = dte_origen.get("receptor") or {}
+    receptor = ensure_receptor_completo(receptor_origen, ambiente)
+
+    preserve_nrc_null = False
+    if tipo_doc_rel == "01":
+        dui = (
+            _search_dui(receptor_origen)
+            or _search_dui(dte_origen.get("extension"))
+            or _search_dui(dte_origen.get("otrosDocumentos"))
+        )
+        if dui:
+            receptor["nit"] = dui
+        nrc_original = receptor_origen.get("nrc")
+        if not nrc_original or str(nrc_original).strip() in {"", "0"}:
+            receptor["nrc"] = None
+            preserve_nrc_null = True
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
@@ -323,6 +373,8 @@ def generar_nde_desde_dte(
     )
     schema = catalogos.get_dte_schema("06")
     result = sanitize_dte_payload(data, schema)
+    if preserve_nrc_null:
+        result.setdefault("receptor", {})["nrc"] = None
     return result
 
 

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -194,12 +194,83 @@ def test_generar_nce_receptor_placeholder_en_pruebas(monkeypatch):
     nce = generar_nce_desde_dte(db, dte_origen, Decimal("1"), ambiente="00")
     receptor = nce["receptor"]
     assert receptor["nit"] == "00000000000000"
-    assert receptor["nrc"] == "0"
+    assert "nrc" in receptor
+    assert receptor["nrc"] is None
     assert receptor["correo"] == "demo@example.com"
     assert receptor["telefono"] == "00000000"
     assert receptor["direccion"]["departamento"] == "01"
     assert receptor["direccion"]["municipio"] == "01"
     assert "otrosDocumentos" not in nce
+
+
+def test_generar_nce_consumidor_final_dui_en_nit(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {
+            "departamento": str(src.get("departamento", "05")).zfill(2),
+            "municipio": str(src.get("municipio", "24")).zfill(2),
+            "complemento": src.get("complemento", "Dir"),
+        },
+    )
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {
+            "nombre": "Consumidor Final",
+            "tipoDocumento": "13",
+            "numDocumento": "01234567-8",
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 1.0,
+                "montoDescu": 0.0,
+                "ventaGravada": 1.0,
+                "ventaExenta": 0.0,
+                "ventaNoSuj": 0.0,
+                "tributos": [],
+            }
+        ],
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    nce = generar_nce_desde_dte(db, dte_origen, Decimal("1"), ambiente="00")
+    receptor = nce["receptor"]
+    assert receptor["nit"] == "012345678"
+    assert "nrc" in receptor
+    assert receptor["nrc"] is None
 
 
 def test_generar_nce_receptor_incompleto_en_produccion(monkeypatch):

--- a/tests/test_nota_debito.py
+++ b/tests/test_nota_debito.py
@@ -1,0 +1,86 @@
+import pytest
+
+from db import DB
+from nota_debito_electronica import generar_nde_desde_dte
+
+
+def create_db():
+    return DB(":memory:")
+
+
+@pytest.fixture(autouse=True)
+def _mock_geo(monkeypatch):
+    monkeypatch.setattr(
+        "dte.validar_dep_muni_por_catalogo",
+        lambda d, m, strict=True: (str(d).zfill(2), str(m).zfill(2)),
+    )
+
+
+def test_generar_nde_consumidor_final_dui_en_nit(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {
+            "departamento": str(src.get("departamento", "05")).zfill(2),
+            "municipio": str(src.get("municipio", "24")).zfill(2),
+            "complemento": src.get("complemento", "Dir"),
+        },
+    )
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {},
+        "receptor": {
+            "nombre": "Consumidor Final",
+            "tipoDocumento": "13",
+            "numDocumento": "01234567-8",
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 1.0,
+                "montoDescu": 0.0,
+                "ventaGravada": 1.0,
+                "ventaExenta": 0.0,
+                "ventaNoSuj": 0.0,
+                "tributos": [],
+            }
+        ],
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    nde = generar_nde_desde_dte(db, dte_origen, None, 1.0, None, ambiente="00")
+    receptor = nde["receptor"]
+    assert receptor["nit"] == "012345678"
+    assert "nrc" in receptor
+    assert receptor["nrc"] is None


### PR DESCRIPTION
## Summary
- replicar la búsqueda y normalización del DUI para poblar el NIT en NDE derivadas de facturas de consumidor final
- conservar un NRC nulo cuando el documento de origen no lo provee y evitar que el saneador lo reemplace
- añadir una prueba específica para notas de débito que valida el nuevo tratamiento de NIT y NRC

## Testing
- `pytest tests/test_nota_credito.py::test_generar_nce_consumidor_final_dui_en_nit tests/test_nota_debito.py::test_generar_nde_consumidor_final_dui_en_nit -q`

------
https://chatgpt.com/codex/tasks/task_e_68d965d78f7c8323adff00f0e1c4d624