### PR TITLE
Permitir envío de notas sin venta asociada

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -2070,10 +2070,12 @@ def generar_dte_json(
 
     ``kwargs`` se acepta para compatibilidad con parámetros obsoletos.
     """
+    allow_missing_venta = kwargs.get("_allow_missing_venta")
+
     row = db.cursor.execute("SELECT * FROM ventas WHERE id=?", (venta_id,)).fetchone()
     if row is not None:
         venta = dict(row)
-    elif kwargs.get("_allow_missing_venta"):
+    elif allow_missing_venta:
         venta = {}
     else:
         raise ValueError("Venta no encontrada")
@@ -2090,7 +2092,7 @@ def generar_dte_json(
         total = venta.get("total")
         if total is not None:
             venta["total_letras"] = numero_a_letras(total)
-    if not venta.get("total_letras"):
+    if not venta.get("total_letras") and not allow_missing_venta:
         raise ValueError("El total en letras es obligatorio")
 
     detalles = db.get_detalles_venta(venta_id)
@@ -4375,12 +4377,19 @@ def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
         raise ValueError("La nota indicada no es de débito")
 
     venta_id = nota.get("venta_id")
-    venta_row = db.cursor.execute(
-        "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
-    ).fetchone()
+    venta_row = None
+    if venta_id is not None:
+        venta_row = db.cursor.execute(
+            "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
+        ).fetchone()
     credito_fiscal = db.get_venta_credito_fiscal(venta_id) if venta_row else None
     tipo_doc = "03" if credito_fiscal else "01"
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc)
+    dte_origen = generar_dte_json(
+        db,
+        venta_id,
+        tipo_dte=tipo_doc,
+        _allow_missing_venta=True,
+    )
     detalles = None
     if nota.get("detalles"):
         try:

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -108,7 +108,13 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     )
     tipo_doc = "03" if credito_fiscal else "01"
 
-    dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
+    dte_origen = generar_dte_json(
+        db,
+        venta_id,
+        tipo_dte=tipo_doc,
+        ambiente=ambiente,
+        _allow_missing_venta=True,
+    )
     fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")


### PR DESCRIPTION
## Summary
- allow `generar_dte_json` to skip the "Venta no encontrada" and total-en-letras validation when a note is built without una venta asociada
- ensure generation of notas de crédito y débito solicite el DTE de origen con la bandera de permitir ventas ausentes y evite consultas innecesarias

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68d96ced69148323bb601273eb5bda81