### PR TITLE
Allow resending orphan notes without DB entry

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2259,18 +2259,43 @@ class FacturacionTab(QWidget):
         return self._reenviar_nota(entry, factura, "debito")
 
     def _reenviar_nota(self, entry: dict, factura: dict, expected_tipo: str) -> dict:
-        nota_id = self._buscar_nota_id(factura, expected_tipo)
-        if nota_id is None:
-            raise ValueError("No se encontró la nota asociada al documento seleccionado")
-        if expected_tipo == "credito":
-            resp = dte.enviar_nota_credito(self.manager.db, nota_id)
-        else:
-            resp = dte.enviar_nota_debito(self.manager.db, nota_id)
+        nota_id = None
+        nota_error: ValueError | None = None
         try:
-            self.load_invoices()
-        except Exception:
-            pass
-        return resp
+            nota_id = self._buscar_nota_id(factura, expected_tipo)
+        except ValueError as exc:
+            nota_error = exc
+
+        if nota_id is not None:
+            if expected_tipo == "credito":
+                resp = dte.enviar_nota_credito(self.manager.db, nota_id)
+            else:
+                resp = dte.enviar_nota_debito(self.manager.db, nota_id)
+            try:
+                self.load_invoices()
+            except Exception:
+                pass
+            return resp
+
+        json_path = factura.get("json") if factura else None
+        if json_path and os.path.exists(json_path):
+            if nota_error:
+                logger.warning(
+                    'No se pudo localizar la nota en la base de datos, se reenviará "%s" como DTE huérfano: %s',
+                    expected_tipo,
+                    nota_error,
+                )
+
+            resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
+            try:
+                self.load_invoices()
+            except Exception:
+                pass
+            return resp
+
+        if nota_error:
+            raise nota_error
+        raise ValueError("No se encontró la nota asociada al documento seleccionado")
 
     def _buscar_nota_id(self, factura: dict, expected_tipo: str) -> int | None:
         json_path = factura.get("json") if factura else None

--- a/tests/test_orphan_send.py
+++ b/tests/test_orphan_send.py
@@ -355,3 +355,42 @@ def test_resend_credit_note_regenerates_codigo(monkeypatch, qt_app, tmp_path):
     with open(json_path, "r", encoding="utf-8") as fh:
         refreshed = json.load(fh)
     assert refreshed["identificacion"]["codigoGeneracion"] == new_code
+
+
+def test_resend_credit_note_without_db_entry_transmits_orphan(
+    monkeypatch, qt_app, tmp_path
+):
+    monkeypatch.setattr(facturacion_tab.FacturacionTab, "load_invoices", lambda self: None)
+
+    db = DB(":memory:")
+    man = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+    tab = facturacion_tab.FacturacionTab(man)
+
+    json_path = tmp_path / "nota_credito.json"
+    json_path.write_text("{}", encoding="utf-8")
+
+    def fake_buscar(self, factura, expected):
+        raise ValueError("No se encontró la nota asociada al documento seleccionado")
+
+    monkeypatch.setattr(facturacion_tab.FacturacionTab, "_buscar_nota_id", fake_buscar)
+
+    def fail_enviar(*args, **kwargs):  # pragma: no cover - guard against regressions
+        pytest.fail("enviar_nota_credito no debe llamarse cuando falta la nota")
+
+    monkeypatch.setattr(facturacion_tab.dte, "enviar_nota_credito", fail_enviar)
+
+    called = {}
+
+    def fake_transmit(db_obj, path):
+        called["path"] = path
+        return {"estado": "Transmitido"}
+
+    monkeypatch.setattr(facturacion_tab.dte, "transmitir_dte_orphan", fake_transmit)
+
+    entry = {"row_type": "orphan", "tipo": "Nota de crédito"}
+    factura = {"json": str(json_path)}
+
+    resp = tab._reenviar_nota_credito(entry, factura)
+
+    assert called["path"] == str(json_path)
+    assert resp["estado"] == "Transmitido"


### PR DESCRIPTION
## Summary
- fall back to transmitting the stored JSON when a credit/debit note cannot be located in the database
- log the fallback and preserve the existing database-based resend path
- add a regression test that ensures orphan transmission is used when the database lookup fails

## Testing
- pytest tests/test_orphan_send.py -k without_db_entry_transmits_orphan *(fails: missing libGL.so.1 for PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_68d9705c42908323b78bea8e5102833e