### PR TITLE
Relax geo validation fallback

### DIFF
--- a/tests/test_geo_validation.py
+++ b/tests/test_geo_validation.py
@@ -72,9 +72,11 @@ def test_validar_dep_muni_normaliza_codigos():
         ("03", "24"),
     ],
 )
-def test_validar_dep_muni_rejects_invalid_combinations(departamento, municipio):
-    with pytest.raises(GeoValidationError, match="no coincide por palabra"):
-        validar_dep_muni_por_catalogo(departamento, municipio)
+def test_validar_dep_muni_invalid_combinations_use_default(departamento, municipio):
+    with pytest.warns(UserWarning):
+        dep, muni = validar_dep_muni_por_catalogo(departamento, municipio)
+    assert dep == DEFAULT_ADDRESS["departamento"]
+    assert muni == DEFAULT_ADDRESS["municipio"]
 
 
 def test_validar_dep_muni_accepts_extranjeros():
@@ -98,10 +100,12 @@ def test_validar_dep_muni_shared_code_relies_on_name(monkeypatch):
         monkeypatch.setitem(CAT_MUNI44, "24", original)
 
 
-def test_norm_receptor_invalid_geo_raises():
+def test_norm_receptor_invalid_geo_uses_default():
     r = {"direccion": {"departamento": "05", "municipio": "20", "complemento": "abcdef"}}
-    with pytest.raises(GeoValidationError):
-        norm_receptor(r)
+    res = norm_receptor(r)
+    assert res["direccion"]["departamento"] == DEFAULT_ADDRESS["departamento"]
+    assert res["direccion"]["municipio"] == DEFAULT_ADDRESS["municipio"]
+    assert res["direccion"]["complemento"] == "abcdef"
 
 
 def test_norm_receptor_ticket_fallback():

--- a/utils/catalogos.py
+++ b/utils/catalogos.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import unicodedata
+import warnings
 from typing import Dict
 
 from utils import resource_path
@@ -691,24 +692,34 @@ def validar_dep_muni_por_catalogo(
         Códigos normalizados de departamento y municipio.
     """
 
+    def _fallback(reason: str) -> tuple[str, str]:
+        warnings.warn(
+            (
+                f"{reason}; utilizando valores por defecto de dirección "
+                "(06-San Salvador / 23-San Salvador Sur)"
+            ),
+            UserWarning,
+        )
+        return "06", "23"
+
     if dep is None:
-        raise GeoValidationError("Departamento inválido")
+        return _fallback("Departamento ausente")
     dep_raw = str(dep).strip()
     if not dep_raw.isdigit():
-        raise GeoValidationError("Departamento inválido")
+        return _fallback("Departamento inválido")
     dep_code = dep_raw.zfill(2)
     if dep_code not in CAT_DEPTOS:
-        raise GeoValidationError("Departamento no existe en CAT-012")
+        return _fallback("Departamento no existe en CAT-012")
 
     if muni is None:
-        raise GeoValidationError("Municipio inválido")
+        return _fallback("Municipio ausente")
     muni_raw = str(muni).strip()
     if not muni_raw.isdigit():
-        raise GeoValidationError("Municipio inválido")
+        return _fallback("Municipio inválido")
     muni_code = muni_raw.zfill(2)
     info = CAT_MUNI44.get(muni_code)
     if not info:
-        raise GeoValidationError("Municipio-44 no existe en CAT-013")
+        return _fallback("Municipio-44 no existe en CAT-013")
 
     dep_name = CAT_DEPTOS[dep_code]
     dept_tokens = _normalize_tokens(dep_name)
@@ -731,12 +742,17 @@ def validar_dep_muni_por_catalogo(
         f"{dep} ({CAT_DEPTOS.get(dep, dep)}: {name})"
         for dep, name in sorted(info.items())
     )
-    raise GeoValidationError(
-        "Municipio {muni} no coincide por palabra con el departamento {dep} "
-        "({dep_name}). Válido según catálogo para: {allowed}".format(
+    warnings.warn(
+        (
+            "Municipio {muni} no coincide por palabra con el departamento {dep} "
+            "({dep_name}). Válido según catálogo para: {allowed}; utilizando "
+            "valores por defecto de dirección (06-San Salvador / 23-San Salvador Sur)"
+        ).format(
             muni=muni_code, dep=dep_code, dep_name=dep_name, allowed=allowed
-        )
+        ),
+        UserWarning,
     )
+    return "06", "23"
 
 # Conjuntos derivados
 # Códigos permitidos en el resumen según el esquema oficial del DTE


### PR DESCRIPTION
## Summary
- allow `validar_dep_muni_por_catalogo` to fall back to default department/municipality codes instead of raising when data is missing or invalid
- update geo validation tests to expect the new fallback behaviour and assert the default address is used

## Testing
- pytest tests/test_geo_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d9759a38a88323948a0605b85ce3b2