### PR TITLE
Refine carta/ticket printing flow

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2419,10 +2419,13 @@ class FacturacionTab(QWidget):
             QMessageBox.warning(self, "Imprimir", "No se ha seleccionado ninguna factura.")
             return
 
-        preferred_format = None
         venta_id = entry.get("venta_id")
-        row_type = str(entry.get("row_type") or "").strip().lower()
-        if venta_id and row_type != "ticket":
+        base_pdf_path = self._resolve_pdf_path(entry)
+
+        supports_format_choice = bool(venta_id) and self._is_cf_or_ccf(entry)
+
+        preferred_format = None
+        if supports_format_choice:
             format_dialog = QMessageBox(self)
             format_dialog.setIcon(QMessageBox.Question)
             format_dialog.setWindowTitle("Formato de impresión")
@@ -2447,9 +2450,29 @@ class FacturacionTab(QWidget):
                 preferred_format = "carta"
             self._last_print_format = preferred_format
 
-        base_pdf_path = self._resolve_pdf_path(entry)
-        if preferred_format == "ticket":
-            pdf_path = self._resolve_ticket_pdf(entry, base_pdf_path)
+            carta_pdf_path = None
+            if preferred_format in ("carta", "ticket"):
+                try:
+                    carta_pdf_path = self.manager.db.get_factura_pdf(venta_id)
+                except Exception:
+                    carta_pdf_path = None
+                if not carta_pdf_path or not os.path.exists(carta_pdf_path):
+                    carta_pdf_path = self._generate_invoice_pdf(venta_id)
+
+            if preferred_format == "ticket":
+                pdf_path = self._resolve_ticket_pdf(entry, carta_pdf_path)
+            elif preferred_format == "carta":
+                if carta_pdf_path and os.path.exists(carta_pdf_path):
+                    pdf_path = carta_pdf_path
+                else:
+                    QMessageBox.warning(
+                        self,
+                        "Imprimir",
+                        "No se pudo generar la factura en carta.",
+                    )
+                    return
+            else:
+                return
         else:
             pdf_path = base_pdf_path
 
@@ -2458,9 +2481,10 @@ class FacturacionTab(QWidget):
             return
 
         preview_dialog = PdfPreviewDialog(pdf_path, self)
-        if preview_dialog.exec_() != QDialog.Accepted:
-            return
-        if preview_dialog.has_error():
+        if (
+            preview_dialog.exec_() != QDialog.Accepted
+            or preview_dialog.has_error()
+        ):
             QMessageBox.warning(
                 self,
                 "Imprimir",
@@ -2493,6 +2517,35 @@ class FacturacionTab(QWidget):
             os.remove(path)
         except OSError:
             pass
+
+    def _is_cf_or_ccf(self, entry: dict | None) -> bool:
+        if not entry:
+            return False
+
+        json_path = entry.get("json")
+        if json_path and os.path.exists(json_path):
+            try:
+                with open(json_path, "r", encoding="utf-8") as fh:
+                    payload = json.load(fh)
+                tipo_dte = str(
+                    payload.get("identificacion", {}).get("tipoDte", "")
+                ).zfill(2)
+                if tipo_dte in {"01", "03"}:
+                    return True
+            except Exception:
+                pass
+
+        tipo_codigo = entry.get("tipo_codigo")
+        if tipo_codigo is not None:
+            try:
+                tipo_codigo_str = str(tipo_codigo).zfill(2)
+            except Exception:
+                tipo_codigo_str = str(tipo_codigo)
+            if tipo_codigo_str in {"01", "03"}:
+                return True
+
+        tipo_desc = str(entry.get("tipo") or "").strip().lower()
+        return tipo_desc in {"consumidor final", "crédito fiscal", "credito fiscal"}
 
     def _build_ticket_format_pdf(
         self,

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -203,6 +203,211 @@ def test_resolve_ticket_pdf_builds_when_missing(monkeypatch, qt_app, tmp_path):
     assert flags.get("called") is True
 
 
+def test_print_invoice_ticket_entry_allows_format_selection(
+    monkeypatch, qt_app, tmp_path
+):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    carta_path = tmp_path / "invoice.pdf"
+    carta_path.write_text("pdf")
+    db.add_factura_pdf(venta_id, "Consumidor Final", str(carta_path))
+
+    tab = _make_tab(db, cid)
+    entry = {
+        "row_type": "ticket",
+        "venta_id": venta_id,
+        "codigo": "01",
+        "tipo": "Consumidor Final",
+    }
+    monkeypatch.setattr(tab, "_selected_entry", lambda: entry)
+
+    ticket_pdf = tmp_path / "ticket.pdf"
+    ticket_pdf.write_text("ticket")
+
+    ticket_calls = []
+
+    def fake_resolve_ticket(entry_arg, base_path):
+        ticket_calls.append((entry_arg, base_path))
+        return str(ticket_pdf)
+
+    monkeypatch.setattr(tab, "_resolve_ticket_pdf", fake_resolve_ticket)
+
+    preview_paths = []
+
+    class DummyPreview:
+        def __init__(self, path, parent=None):
+            preview_paths.append(path)
+
+        def exec_(self):
+            return facturacion_tab.QDialog.Accepted
+
+        def has_error(self):
+            return False
+
+    monkeypatch.setattr(facturacion_tab, "PdfPreviewDialog", DummyPreview)
+
+    opened_paths = []
+    monkeypatch.setattr(
+        facturacion_tab,
+        "open_pdf_file",
+        lambda path: opened_paths.append(path) or True,
+    )
+    monkeypatch.setattr(
+        facturacion_tab,
+        "resolve_user_visible_path",
+        lambda path: None,
+    )
+
+    class FakeMessageBox:
+        AcceptRole = object()
+        Question = object()
+        Cancel = object()
+        _next_choice = "carta"
+        warnings = []
+
+        def __init__(self, parent=None):
+            self._carta_button = None
+            self._ticket_button = None
+            self._cancel_button = None
+            self._clicked = None
+
+        def setIcon(self, icon):
+            pass
+
+        def setWindowTitle(self, title):
+            pass
+
+        def setText(self, text):
+            self.text = text
+
+        def addButton(self, text_or_button, role=None):
+            if text_or_button is self.Cancel:
+                button = SimpleNamespace(kind="cancel")
+                self._cancel_button = button
+            else:
+                button = SimpleNamespace(kind="text", text=text_or_button, role=role)
+                if text_or_button == "Carta":
+                    self._carta_button = button
+                elif text_or_button == "Ticket":
+                    self._ticket_button = button
+            return button
+
+        def setDefaultButton(self, button):
+            self._default = button
+
+        def exec_(self):
+            choice = self.__class__._next_choice
+            if choice == "ticket":
+                self._clicked = self._ticket_button
+            elif choice == "cancel":
+                self._clicked = self._cancel_button
+            else:
+                self._clicked = self._carta_button
+            return 0
+
+        def clickedButton(self):
+            return self._clicked
+
+        @classmethod
+        def warning(cls, *args, **kwargs):
+            cls.warnings.append((args, kwargs))
+            return None
+
+    monkeypatch.setattr(facturacion_tab, "QMessageBox", FakeMessageBox)
+
+    FakeMessageBox._next_choice = "carta"
+    tab.print_invoice()
+
+    assert preview_paths[-1] == str(carta_path)
+    assert opened_paths[-1] == str(carta_path)
+    assert ticket_calls == []
+
+    FakeMessageBox._next_choice = "ticket"
+    tab.print_invoice()
+
+    assert ticket_calls == [(entry, str(carta_path))]
+    assert preview_paths[-1] == str(ticket_pdf)
+    assert opened_paths[-1] == str(ticket_pdf)
+    assert FakeMessageBox.warnings == []
+
+
+def test_print_invoice_notes_skip_format_selection(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    nota_path = tmp_path / "nota.pdf"
+    nota_path.write_text("pdf")
+    db.add_factura_pdf(venta_id, "Nota de crédito", str(nota_path))
+
+    tab = _make_tab(db, cid)
+    entry = {
+        "row_type": "venta",
+        "venta_id": venta_id,
+        "codigo": "05",
+        "tipo": "Nota de crédito",
+    }
+    monkeypatch.setattr(tab, "_selected_entry", lambda: entry)
+
+    monkeypatch.setattr(tab, "_resolve_pdf_path", lambda e: str(nota_path))
+
+    def fail_get_factura(vid):
+        pytest.fail("get_factura_pdf no debe llamarse para notas")
+
+    def fail_generate(vid):
+        pytest.fail("_generate_invoice_pdf no debe llamarse para notas")
+
+    monkeypatch.setattr(tab.manager.db, "get_factura_pdf", fail_get_factura)
+    monkeypatch.setattr(tab, "_generate_invoice_pdf", fail_generate)
+
+    preview_paths = []
+
+    class DummyPreview:
+        def __init__(self, path, parent=None):
+            preview_paths.append(path)
+
+        def exec_(self):
+            return facturacion_tab.QDialog.Accepted
+
+        def has_error(self):
+            return False
+
+    monkeypatch.setattr(facturacion_tab, "PdfPreviewDialog", DummyPreview)
+
+    opened_paths = []
+    monkeypatch.setattr(
+        facturacion_tab,
+        "open_pdf_file",
+        lambda path: opened_paths.append(path) or True,
+    )
+    monkeypatch.setattr(
+        facturacion_tab,
+        "resolve_user_visible_path",
+        lambda path: None,
+    )
+
+    class TrackingMessageBox:
+        AcceptRole = object()
+        Question = object()
+        Cancel = object()
+        instances = []
+
+        def __init__(self, parent=None):
+            type(self).instances.append(self)
+
+        @classmethod
+        def warning(cls, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(facturacion_tab, "QMessageBox", TrackingMessageBox)
+
+    tab.print_invoice()
+
+    assert preview_paths
+    assert opened_paths
+    assert preview_paths[-1] == str(nota_path)
+    assert opened_paths[-1] == str(nota_path)
+    assert TrackingMessageBox.instances == []
+
+
 def test_send_selected_invoice(monkeypatch, qt_app, tmp_path):
     db = DB(":memory:")
     venta_id, cid = _create_sale(db)


### PR DESCRIPTION
## Summary
- resolve carta PDFs only when the carta/ticket dialog is used and fail gracefully if carta generation fails
- detect CF/CCF DTEs through JSON metadata or row hints before showing the format prompt
- tighten regression tests for ticket rows and ensure notes avoid triggering carta generation helpers

## Testing
- pytest tests/test_facturacion_tab_actions.py *(skipped: PyQt5 no disponible)*

------
https://chatgpt.com/codex/tasks/task_e_68d97b3e84a8832396bd5efa4c37b48b