### PR TITLE
Reuse sales ticket generator for DTE tickets

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -36,7 +36,6 @@ import glob
 import hashlib
 
 from ticket_pdf import generar_ticket_personalizado
-from ticket_pdf import render_ticket_pdf
 from factura_sv import (
     generar_nota_credito_pdf,
     generar_nota_debito_pdf,
@@ -50,6 +49,7 @@ from nota_debito_electronica import generar_nde_desde_dte
 from nota_remision import generar_nota_remision_desde_db
 import nota_credito_electronica
 from utils.docs import get_document_paths, get_dte_document_paths, write_pdf_atomically
+from utils.ticket_adapters import dte_to_legacy_ticket_payload
 from utils.doc_generation import generate_invoice_pdf
 from utils.email_sender import EmailSender
 from utils.jws import sign_and_save
@@ -2583,6 +2583,13 @@ class FacturacionTab(QWidget):
                     if candidate and os.path.exists(candidate):
                         json_path = candidate
 
+        detalles_venta = []
+        if venta_id:
+            try:
+                detalles_venta = self.manager.db.get_detalles_venta(venta_id)
+            except Exception:
+                detalles_venta = []
+
         if not json_path or not os.path.exists(json_path):
             QMessageBox.warning(
                 self,
@@ -2616,6 +2623,7 @@ class FacturacionTab(QWidget):
             return None
 
         sello = None
+        firma = None
         if isinstance(payload_data, dict):
             sello = (
                 payload_data.get("selloRecibido")
@@ -2626,22 +2634,43 @@ class FacturacionTab(QWidget):
                 respuesta = payload_data.get("respuesta")
                 if isinstance(respuesta, dict):
                     sello = respuesta.get("selloRecibido") or respuesta.get("sello")
-        if not sello and extra_data:
-            sello = extra_data.get("selloRecibido") or extra_data.get("sello")
-        if not sello and isinstance(dte_payload, dict):
-            sello = dte_payload.get("selloRecibido") or dte_payload.get("acuseRecibo")
-
-        accepted = bool(sello)
+            firma = (
+                payload_data.get("firmaElectronica")
+                or payload_data.get("firma")
+                or payload_data.get("acuseFirma")
+            )
+            if not firma:
+                respuesta = payload_data.get("respuesta")
+                if isinstance(respuesta, dict):
+                    firma = respuesta.get("firmaElectronica") or respuesta.get("firma")
+        if extra_data:
+            if not sello:
+                sello = extra_data.get("selloRecibido") or extra_data.get("sello")
+            if not firma:
+                firma = extra_data.get("firmaElectronica") or extra_data.get("firma")
+        if isinstance(dte_payload, dict):
+            if not sello:
+                sello = dte_payload.get("selloRecibido") or dte_payload.get("acuseRecibo")
+            if not firma:
+                firma = dte_payload.get("firmaElectronica") or dte_payload.get("firma")
 
         try:
-            pdf_bytes = render_ticket_pdf(dte_payload, accepted, sello=sello)
-        except Exception as exc:
-            QMessageBox.critical(
-                self,
-                "Imprimir",
-                f"No se pudo generar el ticket en PDF: {exc}",
-            )
-            return None
+            datos_negocio = dte._load_datos_negocio() or {}
+        except Exception:
+            datos_negocio = {}
+
+        payload = dte_to_legacy_ticket_payload(
+            dte_payload,
+            venta or {},
+            detalles_venta,
+            datos_negocio,
+        )
+        dte_data = payload.get("dte_data") or {}
+        if sello:
+            dte_data.setdefault("selloRecibido", sello)
+        if firma:
+            dte_data.setdefault("firmaElectronica", firma)
+        payload["dte_data"] = dte_data
 
         venta_id = entry.get("venta_id")
         output_dir = None
@@ -2676,8 +2705,27 @@ class FacturacionTab(QWidget):
 
         output_path = os.path.join(output_dir, f"{ticket_base}.pdf")
 
+        def _render_ticket(tmp_path):
+            try:
+                generar_ticket_personalizado(
+                    payload.get("venta", {}),
+                    payload.get("detalles", []),
+                    archivo=str(tmp_path),
+                    datos_negocio=payload.get("datos_negocio"),
+                    dte_data=payload.get("dte_data"),
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                raise RuntimeError(str(exc)) from exc
+
         try:
-            write_pdf_atomically(output_path, lambda tmp: tmp.write_bytes(pdf_bytes))
+            write_pdf_atomically(output_path, _render_ticket)
+        except RuntimeError as exc:
+            QMessageBox.critical(
+                self,
+                "Imprimir",
+                f"No se pudo generar el ticket en PDF: {exc}",
+            )
+            return None
         except Exception as exc:
             QMessageBox.warning(
                 self,

--- a/utils/ticket_adapters.py
+++ b/utils/ticket_adapters.py
@@ -1,0 +1,215 @@
+"""Helpers to adapt DTE payloads into legacy ticket structures."""
+from __future__ import annotations
+
+from copy import deepcopy
+from decimal import Decimal, InvalidOperation
+from typing import Any, Iterable, Mapping
+
+from utils.catalogos import FORMA_PAGO
+
+# Replicate the mapping used by ``ticket_pdf`` to keep labels identical.
+_PAGO_LABELS = {code.zfill(2): value.upper() for code, value in FORMA_PAGO.items()}
+_PAGO_LABELS["01"] = "EFECTIVO"
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    """Safely convert *value* to :class:`Decimal`.
+
+    ``None`` and empty strings return ``None`` so callers can decide on
+    appropriate fallbacks without forcing a numeric zero.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        text = str(value).strip()
+        if not text:
+            return None
+        return Decimal(text)
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _line_total(entry: Mapping[str, Any]) -> Any:
+    """Return the best-effort line total for a DTE item entry."""
+
+    for key in (
+        "ventaGravada",
+        "ventaExenta",
+        "ventaNoSuj",
+        "montoTotalOperacion",
+        "montoTotal",
+        "subTotal",
+    ):
+        value = entry.get(key)
+        if value not in (None, "", 0):
+            return value
+    return None
+
+
+def _item_quantity(entry: Mapping[str, Any]) -> Any:
+    for key in ("cantidad", "cantidadUniMedida", "uniCantidad"):
+        value = entry.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _item_unit_price(entry: Mapping[str, Any]) -> Any:
+    for key in ("precio_unitario", "precioUnitario", "precioUnit", "precioUni", "precio"):
+        value = entry.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _item_description(entry: Mapping[str, Any]) -> str:
+    for key in ("descripcion", "descripcionProducto", "producto", "nombre"):
+        value = entry.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _map_items(entries: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    mapped: list[dict[str, Any]] = []
+    for entry in entries:
+        item: dict[str, Any] = {
+            "descripcion": _item_description(entry),
+        }
+        quantity = _item_quantity(entry)
+        if quantity is not None:
+            item["cantidad"] = quantity
+        unit_price = _item_unit_price(entry)
+        if unit_price is not None:
+            item["precio_unitario"] = unit_price
+        total = _line_total(entry)
+        if total is not None:
+            item["montoTotal"] = total
+        mapped.append(item)
+    return mapped
+
+
+def _map_forma_pago(resumen: Mapping[str, Any], venta: Mapping[str, Any]) -> tuple[str | None, Any | None]:
+    pagos = resumen.get("pagos") or []
+    if pagos:
+        pago = pagos[0]
+        codigo = str(pago.get("codigo") or "").zfill(2)
+        label = _PAGO_LABELS.get(codigo)
+        monto = pago.get("montoPago")
+        if label:
+            return label, monto
+    forma = venta.get("forma_pago")
+    if forma:
+        return str(forma), venta.get("monto_pago")
+    return None, None
+
+
+def dte_to_legacy_ticket_payload(
+    dte_json: Mapping[str, Any] | None,
+    venta: Mapping[str, Any] | None,
+    detalles: Iterable[Mapping[str, Any]] | None,
+    datos_negocio: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build a payload compatible with the legacy ticket generator.
+
+    The result mirrors the structure used when producing tickets for ventas:
+
+    ``{"venta": {...}, "detalles": [...], "datos_negocio": {...}, "dte_data": {...}}``
+    """
+
+    dte_json = deepcopy(dte_json or {})
+    venta_data: dict[str, Any] = dict(venta or {})
+    datos_negocio = dict(datos_negocio or {})
+
+    identificacion = dte_json.get("identificacion", {}) or {}
+    receptor = dte_json.get("receptor", {}) or {}
+    resumen = dte_json.get("resumen", {}) or {}
+
+    tipo_dte = str(identificacion.get("tipoDte") or "").zfill(2)
+    if tipo_dte == "01":
+        venta_data["tipo"] = "CF"
+    elif tipo_dte == "03":
+        venta_data["tipo"] = "CCF"
+
+    fecha = identificacion.get("fecEmi")
+    if fecha:
+        venta_data["fecha"] = fecha
+
+    numero_control = identificacion.get("numeroControl")
+    if numero_control:
+        venta_data["numero_control"] = numero_control
+
+    codigo_generacion = identificacion.get("codigoGeneracion")
+    if codigo_generacion:
+        venta_data["codigo_generacion"] = codigo_generacion
+
+    cliente_nombre = (
+        receptor.get("nombre")
+        or receptor.get("razonSocial")
+        or receptor.get("denominacionSocial")
+    )
+    if cliente_nombre and not venta_data.get("cliente"):
+        venta_data["cliente"] = cliente_nombre
+
+    documento = (
+        receptor.get("nit")
+        or receptor.get("dui")
+        or receptor.get("numDocumento")
+        or receptor.get("numeroDocumento")
+    )
+    if documento and not venta_data.get("documento"):
+        venta_data["documento"] = documento
+
+    subtotal = (
+        _to_decimal(resumen.get("sumas"))
+        or _to_decimal(resumen.get("subTotal"))
+        or _to_decimal(resumen.get("subTotalVentas"))
+        or _to_decimal(resumen.get("totalGravada"))
+    )
+
+    total = _to_decimal(resumen.get("totalPagar")) or _to_decimal(venta_data.get("total"))
+    if total is not None:
+        venta_data["total"] = total
+
+    iva = (
+        _to_decimal(resumen.get("iva"))
+        or _to_decimal(resumen.get("totalIva"))
+        or _to_decimal(resumen.get("ivaRete"))
+    )
+    if iva is None and subtotal is not None and total is not None:
+        iva_candidate = total - subtotal
+        if iva_candidate > Decimal("0"):
+            iva = iva_candidate
+    if iva is not None:
+        venta_data["iva"] = iva
+
+    if subtotal is not None:
+        venta_data.setdefault("sumas", subtotal)
+
+    forma_pago, monto_pago = _map_forma_pago(resumen, venta_data)
+    if forma_pago and not venta_data.get("forma_pago"):
+        venta_data["forma_pago"] = forma_pago
+    if monto_pago is not None and not venta_data.get("monto_pago"):
+        venta_data["monto_pago"] = monto_pago
+    elif not venta_data.get("forma_pago"):
+        venta_data["forma_pago"] = "Contado"
+
+    cuerpo = dte_json.get("cuerpoDocumento")
+    if cuerpo and isinstance(cuerpo, Iterable):
+        detalles_mapeados = _map_items(cuerpo)
+    else:
+        detalles_mapeados = _map_items(detalles or [])
+
+    dte_data = {
+        "dteJson": dte_json,
+    }
+
+    return {
+        "venta": venta_data,
+        "detalles": detalles_mapeados,
+        "datos_negocio": datos_negocio,
+        "dte_data": dte_data,
+    }


### PR DESCRIPTION
## Summary
- add a ticket adapter that maps DTE payloads into the legacy ticket generator structure
- update FacturacionTab ticket printing to reuse the sales ticket generator with the adapted payload and business data

## Testing
- pytest tests/test_ticket_format.py tests/test_ticket_renderer.py -q *(fails: repository snapshot is missing ticket_example.pdf)*

------
https://chatgpt.com/codex/tasks/task_e_68d98be453548323b395e33395ab5ba5