### PR TITLE
Tighten credit payment validation

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -1149,7 +1149,9 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
         self._backend_pago_plazo = ""
         self._backend_pago_periodo = ""
 
-        condicion = data.get("condicionOperacion")
+        condicion = data.get("condicion_operacion")
+        if condicion not in {1, 2, 3}:
+            condicion = data.get("condicionOperacion")
         if condicion in {1, 2, 3}:
             idx = self.condicion_pago_combo.findData(condicion)
             if idx >= 0:
@@ -2638,7 +2640,9 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         self._backend_pago_plazo = ""
         self._backend_pago_periodo = ""
 
-        condicion = data.get("condicionOperacion")
+        condicion = data.get("condicion_operacion")
+        if condicion not in {1, 2, 3}:
+            condicion = data.get("condicionOperacion")
         if condicion in {1, 2, 3}:
             idx = self.condicion_pago_combo.findData(condicion)
             if idx >= 0:

--- a/dte.py
+++ b/dte.py
@@ -831,6 +831,7 @@ _CONDICION_OPERACION_BY_NAME = {
     v.lower(): k for k, v in CONDICION_OPERACION_CATALOG.items()
 }
 _CONDICION_OPERACION_BY_NAME["credito"] = 2
+_CONDICION_OPERACION_BY_NAME["otros"] = 3
 
 
 def _parse_condicion_operacion(value):
@@ -841,19 +842,13 @@ def _parse_condicion_operacion(value):
     the catalog is normalized to ``1`` without raising an exception.
     """
 
-    if value in (None, ""):
-        code = 1
-    elif isinstance(value, (int, float)):
-        code = int(value)
-    else:
-        val = str(value).strip().lower().replace("...", "")
-        if val.isdigit():
-            code = int(val)
-        else:
-            code = _CONDICION_OPERACION_BY_NAME.get(val, 1)
-    if code not in CONDICION_OPERACION_CATALOG:
-        code = 1
-    return code
+    try:
+        return normalize_condicion_operacion(value)
+    except ValueError:
+        logger.warning(
+            "condicionOperacion inválida %r detectada en DTE; usando Contado", value
+        )
+        return 1
 
 
 # Valores por defecto del resumen según el tipo de DTE

--- a/tests/test_resumen_condicion_operacion.py
+++ b/tests/test_resumen_condicion_operacion.py
@@ -1,24 +1,35 @@
 import pytest
 
-from dte import _parse_condicion_operacion as normalize_condicion_operacion
-from utils.resumen import validate_pagos_basico
+from dte import _parse_condicion_operacion as parse_condicion_operacion
+from utils.doc_generation import normalize_payment_condition
+from utils.resumen import (
+    normalize_condicion_operacion as normalize_condicion_operacion_extra,
+    sync_condicion_operacion_flags,
+    validate_pagos_basico,
+)
 
 
 def test_normalize_condicion_operacion_variants():
     """normalize_condicion_operacion should accept multiple representations."""
-    assert normalize_condicion_operacion(1) == 1
-    assert normalize_condicion_operacion("1") == 1
-    assert normalize_condicion_operacion("contado") == 1
-    assert normalize_condicion_operacion("Crédito") == 2
-    assert normalize_condicion_operacion("credito") == 2
-    assert normalize_condicion_operacion("OTRO") == 3
-    assert normalize_condicion_operacion("3") == 3
+    assert parse_condicion_operacion(1) == 1
+    assert parse_condicion_operacion("1") == 1
+    assert parse_condicion_operacion("contado") == 1
+    assert parse_condicion_operacion("Crédito") == 2
+    assert parse_condicion_operacion("credito") == 2
+    assert parse_condicion_operacion("OTRO") == 3
+    assert parse_condicion_operacion("3") == 3
 
 
 def test_normalize_condicion_operacion_invalid():
     """Values outside the catalog should normalize to 1 (contado)."""
-    assert normalize_condicion_operacion(4) == 1
-    assert normalize_condicion_operacion("invalida") == 1
+    assert parse_condicion_operacion(4) == 1
+    assert parse_condicion_operacion("invalida") == 1
+
+
+def test_normalize_condicion_operacion_alias_otros():
+    """Both helper variants must accept the plural alias 'Otros'."""
+    assert parse_condicion_operacion("otros") == 3
+    assert normalize_condicion_operacion_extra("Otros") == 3
 
 
 def test_validate_pagos_basico_condicion1():
@@ -32,4 +43,148 @@ def test_validate_pagos_basico_requires_plazo_periodo():
     resumen = {"totalPagar": 10.0, "pagos": [{"codigo": "01", "montoPago": 10.0}]}
     with pytest.raises(ValueError):
         validate_pagos_basico(resumen, 2)
+
+
+def test_validate_pagos_basico_credito_acepta_periodos_largos():
+    """Credit operations allow arbitrary positive periods (e.g. 12 meses)."""
+
+    resumen = {
+        "totalPagar": 10.0,
+        "pagos": [
+            {"codigo": "01", "montoPago": 10.0, "plazo": "02", "periodo": 12},
+        ],
+    }
+
+    validate_pagos_basico(resumen, 2)
+
+
+def test_validate_pagos_basico_credito_rechaza_periodo_invalido():
+    """Periodo no numérico o <=0 debe generar error explícito."""
+
+    resumen = {
+        "totalPagar": 10.0,
+        "pagos": [
+            {"codigo": "01", "montoPago": 10.0, "plazo": "02", "periodo": "12x"},
+        ],
+    }
+
+    with pytest.raises(ValueError, match="periodo debe ser entero > 0"):
+        validate_pagos_basico(resumen, 2)
+
+
+def test_validate_pagos_basico_credito_rechaza_plazo_fuera_catalogo():
+    """Plazos distintos de 01/02/03 se rechazan con mensaje claro."""
+
+    resumen = {
+        "totalPagar": 10.0,
+        "pagos": [
+            {"codigo": "01", "montoPago": 10.0, "plazo": "05", "periodo": 6},
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Crédito: unidad inválida"):
+        validate_pagos_basico(resumen, 2)
+
+
+def test_sync_condicion_operacion_flags_sets_both_keys():
+    """sync helper should write both camelCase and snake_case keys."""
+    extra = {}
+    code = sync_condicion_operacion_flags(extra, "Crédito")
+    assert code == 2
+    assert extra["condicion_operacion"] == 2
+    assert extra["condicionOperacion"] == 2
+
+
+def test_normalize_payment_condition_credit_variants():
+    """Credit operations normalize plazo/periodo while keeping integers."""
+    payload = {
+        "condicion_operacion": 2,
+        "pago_plazo": "M",
+        "pago_periodo": "3",
+    }
+    result = normalize_payment_condition(payload)
+    assert result["pago_plazo"] == "02"
+    assert result["pago_periodo"] == 3
+
+
+def test_normalize_payment_condition_non_credit_blanks_fields():
+    """Non credit operations must drop plazo/periodo content."""
+    payload = {
+        "condicion_operacion": 1,
+        "pago_plazo": "02",
+        "pago_periodo": "5",
+    }
+    result = normalize_payment_condition(payload)
+    assert result["pago_plazo"] is None
+    assert result["pago_periodo"] is None
+
+
+def test_normalize_payment_condition_credit_errors_on_invalid_periodo():
+    """Invalid periodo raises before reaching the generator layer."""
+    payload = {
+        "condicion_operacion": 2,
+        "pago_plazo": "M",
+        "pago_periodo": 0,
+    }
+    with pytest.raises(ValueError):
+        normalize_payment_condition(payload)
+
+
+def test_normalize_payment_condition_credit_errors_on_invalid_plazo():
+    """Invalid plazo catalog value should be rejected."""
+    payload = {
+        "condicion_operacion": 2,
+        "pago_plazo": "ZZ",
+        "pago_periodo": 5,
+    }
+    with pytest.raises(ValueError):
+        normalize_payment_condition(payload)
+
+
+@pytest.mark.parametrize(
+    "condicion, plazo, periodo, esperado_plazo, esperado_periodo",
+    [
+        (2, "M", "3", "02", 3),
+        (2, "02", 7, "02", 7),
+        (1, "A", 12, None, None),
+        (3, "01", "9", None, None),
+    ],
+)
+def test_normalize_payment_condition_matches_schema_examples(
+    condicion, plazo, periodo, esperado_plazo, esperado_periodo
+):
+    """La normalización respeta los casos representativos del esquema DTE."""
+
+    payload = {
+        "condicion_operacion": condicion,
+        "pago_plazo": plazo,
+        "pago_periodo": periodo,
+        "pago_referencia": "OC-1234",
+        "otros": "no tocar",
+    }
+
+    result = normalize_payment_condition(payload)
+
+    assert result["condicion_operacion"] in {1, 2, 3}
+    assert result["pago_plazo"] == esperado_plazo
+    assert result["pago_periodo"] == esperado_periodo
+    assert result["pago_referencia"] == "OC-1234"
+    assert result["otros"] == "no tocar"
+
+
+def test_normalize_payment_condition_is_idempotent():
+    """Invocar la función varias veces no altera un resultado ya normalizado."""
+
+    payload = {
+        "condicion_operacion": 2,
+        "pago_plazo": "d",
+        "pago_periodo": "15",
+    }
+
+    first = normalize_payment_condition(payload)
+    second = normalize_payment_condition(first)
+
+    assert second is first
+    assert second["pago_plazo"] == "01"
+    assert second["pago_periodo"] == 15
 

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -34,6 +34,7 @@ from num2words import num2words  # Instala las dependencias con: pip install -r 
 from factura_sv import generar_factura_electronica_pdf
 from decimal import Decimal, ROUND_HALF_UP
 from utils.fiscal_extra import build_fiscal_extra
+from utils.resumen import sync_condicion_operacion_flags
 from utils.monto import monto_a_texto_sv
 from utils.jws import sign_json
 from utils.firmador import iniciar_firmador, detener_firmador, firmador_activo
@@ -50,7 +51,8 @@ def build_payment_condition_extra(data):
     if condicion not in {1, 2, 3}:
         return {}
 
-    extra = {"condicionOperacion": condicion}
+    extra: dict = {}
+    sync_condicion_operacion_flags(extra, condicion)
     if condicion == 2:
         plazo = data.get("pago_plazo")
         periodo = data.get("pago_periodo")
@@ -66,6 +68,10 @@ def build_payment_condition_extra(data):
         if referencia:
             pago["referencia"] = referencia
         extra["pagos"] = [pago]
+        extra["pago_plazo"] = plazo
+        extra["pago_periodo"] = periodo
+        if referencia:
+            extra["pago_referencia"] = referencia
     return extra
 
 

--- a/utils/doc_generation.py
+++ b/utils/doc_generation.py
@@ -15,12 +15,61 @@ from utils.monto import D, d2, monto_a_texto_sv, iva_item, to_base_iva
 from utils.docs import get_document_paths, build_invoice_json, write_pdf_atomically
 from utils.jws import sign_and_save
 from utils import versioned_dte
-from utils.resumen import normalize_condicion_operacion, validate_pagos_basico
+from utils.resumen import (
+    normalize_condicion_operacion,
+    sync_condicion_operacion_flags,
+    validate_pagos_basico,
+)
 from utils.sanitize import limpiar_documentos
 from utils.stable_json import save_file, stable_stringify
 
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_payment_condition(data: dict) -> dict:
+    """Normalize credit payment fields prior to DTE generation.
+
+    The function ensures the UI supplied ``pago_plazo``/``pago_periodo`` values
+    adhere to the MH schema expectations. Only the relevant keys are touched so
+    the caller can update the persisted ``extra`` payload without affecting any
+    other structure.
+    """
+
+    cond_raw = data.get("condicion_operacion")
+    try:
+        condicion = normalize_condicion_operacion(cond_raw)
+    except ValueError:
+        logger.warning(
+            "condicion_operacion inválida %r; normalizando a Contado", cond_raw
+        )
+        condicion = 1
+
+    data["condicion_operacion"] = condicion
+    if condicion == 2:
+        unidad_raw = data.get("pago_plazo")
+        unidad = str(unidad_raw or "").strip().upper()
+        letras_a_codigo = {"D": "01", "M": "02", "A": "03"}
+        if unidad in letras_a_codigo:
+            data["pago_plazo"] = letras_a_codigo[unidad]
+        elif unidad in {"01", "02", "03"}:
+            data["pago_plazo"] = unidad
+        else:
+            raise ValueError("Crédito: unidad inválida (esperado D/M/A o 01/02/03)")
+
+        cantidad_raw = data.get("pago_periodo")
+        try:
+            cantidad = int(cantidad_raw)
+        except (TypeError, ValueError):
+            raise ValueError("Crédito: periodo debe ser entero > 0") from None
+        if cantidad <= 0:
+            raise ValueError("Crédito: periodo debe ser entero > 0")
+        data["pago_periodo"] = cantidad
+    else:
+        data["pago_plazo"] = None
+        data["pago_periodo"] = None
+
+    return data
 
 
 def _path_missing(path: Path) -> bool:
@@ -253,6 +302,105 @@ def generate_invoice_pdf(manager, venta_id):
             extra = {}
     venta_data["extra"] = extra
     precios_incluyen_iva = bool(extra.get("precios_incluyen_iva"))
+
+    condicion_operacion = (
+        extra.get("condicion_operacion")
+        or extra.get("condicionOperacion")
+        or venta_data.get("condicion_operacion")
+    )
+    pagos_raw = extra.get("pagos")
+    pago_plazo = extra.get("pago_plazo")
+    pago_periodo = extra.get("pago_periodo")
+    if isinstance(pagos_raw, list) and pagos_raw:
+        first_pago = pagos_raw[0]
+        if isinstance(first_pago, dict):
+            if pago_plazo in (None, ""):
+                pago_plazo = first_pago.get("plazo")
+            if pago_periodo in (None, ""):
+                pago_periodo = first_pago.get("periodo")
+    try:
+        normalized_payment = normalize_payment_condition(
+            {
+                "condicion_operacion": condicion_operacion,
+                "pago_plazo": pago_plazo,
+                "pago_periodo": pago_periodo,
+            }
+        )
+    except ValueError as exc:
+        logger.error("Validación de condición de pago inválida: %s", exc)
+        raise
+
+    condicion_norm = normalized_payment.get("condicion_operacion", 1)
+    if condicion_norm not in {1, 2, 3}:
+        condicion_norm = 1
+    original_cond_camel = extra.get("condicionOperacion")
+    original_cond_snake = extra.get("condicion_operacion")
+    condicion_changed = (
+        original_cond_snake != condicion_norm
+        or original_cond_camel != condicion_norm
+    )
+    if condicion_changed:
+        sync_condicion_operacion_flags(extra, condicion_norm)
+    pagos_updated = False
+    payment_fields_changed = False
+    if condicion_norm == 2:
+        if not (isinstance(pagos_raw, list) and pagos_raw and isinstance(pagos_raw[0], dict)):
+            raise ValueError("Crédito: pagos no detallados correctamente")
+        plazo_code = normalized_payment["pago_plazo"]
+        periodo_val = normalized_payment["pago_periodo"]
+        if extra.get("pago_plazo") != plazo_code:
+            extra["pago_plazo"] = plazo_code
+            payment_fields_changed = True
+        if extra.get("pago_periodo") != periodo_val:
+            extra["pago_periodo"] = periodo_val
+            payment_fields_changed = True
+        first_pago = pagos_raw[0]
+        if first_pago.get("plazo") != plazo_code:
+            first_pago["plazo"] = plazo_code
+            pagos_updated = True
+        if first_pago.get("periodo") != periodo_val:
+            first_pago["periodo"] = periodo_val
+            pagos_updated = True
+        referencia_val = first_pago.get("referencia")
+        if extra.get("pago_referencia") != referencia_val:
+            extra["pago_referencia"] = referencia_val
+            payment_fields_changed = True
+    else:
+        if extra.get("pago_plazo") not in (None, ""):
+            extra["pago_plazo"] = None
+            payment_fields_changed = True
+        if extra.get("pago_periodo") not in (None, ""):
+            extra["pago_periodo"] = None
+            payment_fields_changed = True
+        if extra.get("pago_referencia") not in (None, ""):
+            extra["pago_referencia"] = None
+            payment_fields_changed = True
+        if isinstance(pagos_raw, list) and pagos_raw and isinstance(pagos_raw[0], dict):
+            first_pago = pagos_raw[0]
+            if first_pago.get("plazo") not in (None, ""):
+                first_pago["plazo"] = None
+                pagos_updated = True
+            if first_pago.get("periodo") not in (None, ""):
+                first_pago["periodo"] = None
+                pagos_updated = True
+            if first_pago.get("referencia") not in (None, ""):
+                first_pago["referencia"] = None
+                pagos_updated = True
+    if condicion_changed or pagos_updated or payment_fields_changed:
+        try:
+            manager.db.update_venta_extra(
+                venta_id,
+                {
+                    "condicionOperacion": extra.get("condicionOperacion"),
+                    "condicion_operacion": extra.get("condicion_operacion"),
+                    "pagos": extra.get("pagos"),
+                    "pago_plazo": extra.get("pago_plazo"),
+                    "pago_periodo": extra.get("pago_periodo"),
+                    "pago_referencia": extra.get("pago_referencia"),
+                },
+            )
+        except Exception:
+            logger.debug("No se pudo actualizar pagos normalizados", exc_info=True)
 
     if venta_data.get("vendedor_id"):
         trabajador = manager.db.get_trabajador(venta_data["vendedor_id"])

--- a/utils/resumen.py
+++ b/utils/resumen.py
@@ -16,6 +16,7 @@ _CONDICION_OPERACION_BY_NAME = {
     "credito": 2,
     "crédito": 2,
     "otro": 3,
+    "otros": 3,
 }
 
 
@@ -37,6 +38,23 @@ def normalize_condicion_operacion(value: Any) -> int:
             code = _CONDICION_OPERACION_BY_NAME.get(val)
     if code not in CONDICION_OPERACION_CATALOG:
         raise ValueError(f"condicionOperacion inválida: {value}")
+    return code
+
+
+def sync_condicion_operacion_flags(extra: dict | None, value: Any) -> int:
+    """Store ``value`` under both camelCase and snake_case keys.
+
+    The canonical representation inside ``extra`` uses ``condicion_operacion``
+    while the camelCase variant is preserved for legacy payloads that expect
+    it.  The helper returns the normalized catalog code so callers can reuse
+    it without recomputing.
+    """
+
+    if extra is None:
+        extra = {}
+    code = normalize_condicion_operacion(value)
+    extra["condicion_operacion"] = code
+    extra["condicionOperacion"] = code
     return code
 
 
@@ -69,9 +87,16 @@ def validate_pagos_basico(resumen: dict, condicion: int) -> None:
 
     if condicion == 2:
         first = pagos[0]
-        plazo = first.get("plazo") or 0
-        periodo = str(first.get("periodo") or "").zfill(2)
-        if not plazo or periodo not in catalogos.PLAZO:
+        plazo_code = str(first.get("plazo", "")).zfill(2)
+        if plazo_code not in {"01", "02", "03"}:
             raise ValueError(
-                "Para operaciones a crédito, pagos[0] requiere plazo>0 y periodo válido"
+                "Crédito: unidad inválida (01=días, 02=meses, 03=años)"
             )
+
+        periodo_raw = first.get("periodo", 0)
+        try:
+            periodo = int(periodo_raw)
+        except (TypeError, ValueError):
+            raise ValueError("Crédito: periodo debe ser entero > 0") from None
+        if periodo <= 0:
+            raise ValueError("Crédito: periodo debe ser entero > 0")


### PR DESCRIPTION
## Summary
- ensure resumen credit validations check the plazo catalog and positive integer periodo values
- add regression tests covering long credit periods, invalid periods, and invalid plazo codes

## Testing
- pytest tests/test_resumen_condicion_operacion.py

------
https://chatgpt.com/codex/tasks/task_e_68d8eee3769c8323a121629e5eb7dfea