### PR TITLE
Use DTE snapshots for credit/debit notes

### DIFF
--- a/db.py
+++ b/db.py
@@ -11,10 +11,12 @@ from pathlib import Path
 from decimal import Decimal
 from typing import Any
 
+from utils import versioned_dte
 from utils.fiscal_extra import build_fiscal_extra, normalize_tipo_fiscal
 from utils.line_totals import compute_line_totals
 from utils.monto import d8
-from paths import get_canonical_dte_dir, user_data_path
+from utils.snapshot import Snapshot
+from paths import DTES_DIR, get_canonical_dte_dir, user_data_path
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -1327,6 +1329,64 @@ class DB:
                     pass
             return data
         return None
+
+    def get_snapshot_by_venta(self, venta_id: int | None) -> Snapshot | None:
+        """Return the stored snapshot for ``venta_id`` if available."""
+
+        if venta_id is None:
+            return None
+        self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
+        with self.lock:
+            self.cursor.execute(
+                "SELECT codigo_generacion FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+                (venta_id,),
+            )
+            row = self.cursor.fetchone()
+        if not row:
+            return None
+        codigo = row[0] if isinstance(row, tuple) else row["codigo_generacion"]
+        codigo = (codigo or "").strip()
+        if not codigo:
+            return None
+        try:
+            version_dir = versioned_dte.resolve_version_dir(DTES_DIR, codigo)
+        except ValueError:
+            return None
+        json_path = os.path.join(version_dir, "documento.json")
+        if not os.path.exists(json_path):
+            return None
+        try:
+            with open(json_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            logger.exception(
+                "No se pudo leer snapshot %s para venta %s", codigo, venta_id
+            )
+            return None
+        if not isinstance(data, dict):
+            return None
+        ident = data.get("identificacion") or {}
+        tipo_raw = ident.get("tipoDte")
+        if isinstance(tipo_raw, int):
+            tipo_doc = f"{tipo_raw:02d}"
+        elif isinstance(tipo_raw, str):
+            tipo_str = tipo_raw.strip()
+            if tipo_str.isdigit() and len(tipo_str) <= 2:
+                tipo_doc = f"{int(tipo_str):02d}"
+            elif tipo_str:
+                tipo_doc = tipo_str
+            else:
+                tipo_doc = None
+        else:
+            tipo_doc = None
+        fecha = ident.get("fecEmi") or ident.get("fechaEmision")
+        return Snapshot(
+            uuid=str(codigo).upper(),
+            path=json_path,
+            tipo_documento=tipo_doc,
+            fecha_emision=fecha,
+            payload=data,
+        )
 
     def get_compras(self):
         self.cursor.execute("SELECT * FROM compras")

--- a/dte.py
+++ b/dte.py
@@ -4369,34 +4369,9 @@ def generar_nde_desde_dte(
 
 def generar_nota_debito_json(db: DB, nota_id: int) -> dict:
     """Genera la estructura JSON para una nota de débito."""
-    row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
-    if not row:
-        raise ValueError("Nota no encontrada")
-    nota = dict(row)
-    if nota.get("tipo") != "debito":
-        raise ValueError("La nota indicada no es de débito")
+    from nota_debito_electronica import generar_nde_desde_nota
 
-    venta_id = nota.get("venta_id")
-    venta_row = None
-    if venta_id is not None:
-        venta_row = db.cursor.execute(
-            "SELECT cliente_id FROM ventas WHERE id=?", (venta_id,)
-        ).fetchone()
-    credito_fiscal = db.get_venta_credito_fiscal(venta_id) if venta_row else None
-    tipo_doc = "03" if credito_fiscal else "01"
-    dte_origen = generar_dte_json(
-        db,
-        venta_id,
-        tipo_dte=tipo_doc,
-        _allow_missing_venta=True,
-    )
-    detalles = None
-    if nota.get("detalles"):
-        try:
-            detalles = json.loads(nota["detalles"])
-        except Exception:
-            detalles = None
-    return generar_nde_desde_dte(db, dte_origen, detalles, nota.get("monto"), nota.get("motivo"))
+    return generar_nde_desde_nota(db, nota_id)
 
 
 def generar_nota_remision_json(

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -11,6 +11,7 @@ proyecto ``gestor-de-inventario``.
 """
 from __future__ import annotations
 
+import time
 from copy import deepcopy
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
@@ -27,10 +28,14 @@ from dte import (
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
+from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
+from utils.env import env_flag
+from utils import metrics
 from utils.receptor import ensure_receptor_completo
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
 from utils.sanitize import solo_digitos
+from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
 
 
 logger = logging.getLogger(__name__)
@@ -41,15 +46,21 @@ Decimal_1 = Decimal("1")
 Q4 = Decimal("0.0001")
 IVA = Decimal("0.13")
 
+STRICT_SNAPSHOT_DEFAULT = env_flag("STRICT_SNAPSHOT", default=True)
+
 
 def _normalize_dui(value: str | None) -> str | None:
     """Return a 9-digit representation of ``value`` if possible."""
 
-    digits = solo_digitos(value)
-    if not digits:
+    if value is None:
         return None
-    digits = digits[-9:]
-    return digits.zfill(9)
+    try:
+        return normalize_dui_to_nit9(value)
+    except ValueError:
+        digits = solo_digitos(value)
+        if len(digits) == 9:
+            return digits
+    return None
 
 
 def _search_dui(data: object) -> str | None:
@@ -81,7 +92,13 @@ def _pct_label(ratio: Decimal) -> str:
     return str((ratio * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
-def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
+def generar_nce_desde_nota(
+    db: DB,
+    nota_id: int,
+    *,
+    ambiente: str = "00",
+    strict_snapshot: bool | None = None,
+) -> dict:
     """Genera una NCE basada en la nota registrada en ``notas``.
 
     Parameters
@@ -93,6 +110,9 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
     ambiente:
         Código de ambiente (``00`` pruebas, ``01`` producción).
     """
+
+    strict = STRICT_SNAPSHOT_DEFAULT if strict_snapshot is None else bool(strict_snapshot)
+    start = time.perf_counter()
     row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
     if not row:
         raise ValueError("Nota no encontrada")
@@ -101,24 +121,40 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         raise ValueError("La nota indicada no es de crédito")
 
     venta_id = nota.get("venta_id")
-
     venta = db.get_venta_by_id(venta_id) if venta_id is not None else None
     credito_fiscal = (
         db.get_venta_credito_fiscal(venta_id) if venta_id is not None else None
     )
     tipo_doc = "03" if credito_fiscal else "01"
 
-    dte_origen = generar_dte_json(
-        db,
-        venta_id,
-        tipo_dte=tipo_doc,
-        ambiente=ambiente,
-        _allow_missing_venta=True,
-    )
-    fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
+    snapshot = db.get_snapshot_by_venta(venta_id) if venta_id is not None else None
+    source_used = "db"
+    if snapshot:
+        dte_origen = normalize_snapshot(snapshot.payload)
+        source_used = "snapshot"
+        uuid_origen = snapshot.uuid.upper() if snapshot.uuid else None
+    else:
+        if strict and venta_id is not None:
+            raise SnapshotNotFoundError(venta_id, nota_id)
+        dte_origen = generar_dte_json(
+            db,
+            venta_id,
+            tipo_dte=tipo_doc,
+            ambiente=ambiente,
+            _allow_missing_venta=True,
+        )
+        origen_ident_tmp = dte_origen.get("identificacion") or {}
+        codigo_tmp = origen_ident_tmp.get("codigoGeneracion")
+        uuid_origen = str(codigo_tmp).upper() if codigo_tmp else None
+
+    fecha_origen = None
+    if snapshot and snapshot.fecha_emision:
+        fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
+    elif venta:
+        fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
-        if isinstance(identificacion, dict):
+        if isinstance(identificacion, dict) and not identificacion.get("fecEmi"):
             identificacion["fecEmi"] = fecha_origen
 
     detalles = None
@@ -129,7 +165,7 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
             detalles = None
 
     if detalles:
-        return generar_nce_desde_dte(
+        resultado = generar_nce_desde_dte(
             db,
             dte_origen,
             None,
@@ -137,30 +173,46 @@ def generar_nce_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
             ambiente=ambiente,
             motivo=nota.get("motivo"),
         )
-
-    resumen_origen = dte_origen.get("resumen", {})
-    total_origen = Decimal(
-        str(
-            resumen_origen.get("montoTotalOperacion")
-            or resumen_origen.get("totalPagar")
-            or 0
+    else:
+        resumen_origen = dte_origen.get("resumen", {})
+        total_origen = Decimal(
+            str(
+                resumen_origen.get("montoTotalOperacion")
+                or resumen_origen.get("totalPagar")
+                or 0
+            )
         )
-    )
-    monto_nc = Decimal(str(nota.get("monto", 0)))
-    if total_origen <= Decimal_0:
-        raise ValueError("El documento de origen no tiene total válido")
-    if monto_nc > total_origen:
-        raise ValueError("Monto excede total del documento de origen")
-    ratio = (monto_nc / total_origen).quantize(Decimal("0.0001"))
+        monto_nc = Decimal(str(nota.get("monto", 0)))
+        if total_origen <= Decimal_0:
+            raise ValueError("El documento de origen no tiene total válido")
+        if monto_nc > total_origen:
+            raise ValueError("Monto excede total del documento de origen")
+        ratio = (monto_nc / total_origen).quantize(Decimal("0.0001"))
+        resultado = generar_nce_desde_dte(
+            db,
+            dte_origen,
+            ratio,
+            ambiente=ambiente,
+            motivo=nota.get("motivo"),
+            monto=monto_nc,
+        )
 
-    return generar_nce_desde_dte(
-        db,
-        dte_origen,
-        ratio,
-        ambiente=ambiente,
-        motivo=nota.get("motivo"),
-        monto=monto_nc,
+    doc_rel = resultado.get("documentoRelacionado") or []
+    rel = doc_rel[0] if doc_rel else {}
+    duration_ms = (time.perf_counter() - start) * 1000
+    metrics.inc(f"notes_source_used.{source_used}")
+    logger.info(
+        "NCE relaciona tipo=%s uuid=%s num=%s fec=%s fuente=%s nota_id=%s venta_id=%s dur_ms=%.3f",
+        rel.get("tipoDocumento"),
+        uuid_origen,
+        rel.get("numeroDocumento"),
+        rel.get("fechaEmision"),
+        source_used,
+        nota_id,
+        venta_id,
+        duration_ms,
     )
+    return resultado
 
 
 def generar_nce_desde_dte(
@@ -197,37 +249,74 @@ def generar_nce_desde_dte(
     }
 
     receptor_origen = dte_origen.get("receptor") or {}
-    tipo_doc_rel = str(origen_ident.get("tipoDte") or "").zfill(2) if origen_ident.get("tipoDte") else None
+    tipo_raw = origen_ident.get("tipoDte")
+    if isinstance(tipo_raw, int):
+        tipo_doc_rel = f"{tipo_raw:02d}"
+    elif isinstance(tipo_raw, str):
+        tipo_str = tipo_raw.strip()
+        if tipo_str.isdigit() and len(tipo_str) <= 2:
+            tipo_doc_rel = f"{int(tipo_str):02d}"
+        else:
+            tipo_doc_rel = tipo_str or None
+    else:
+        tipo_doc_rel = None
     if not tipo_doc_rel:
         tipo_doc_rel = "03" if receptor_origen.get("nrc") else "01"
-    numero_documento = origen_ident.get("codigoGeneracion") or ""
-    if isinstance(numero_documento, str):
-        numero_documento = numero_documento.upper()
+
+    codigo_generacion = origen_ident.get("codigoGeneracion")
+    if codigo_generacion:
+        numero_documento = str(codigo_generacion).upper()
+        tipo_generacion = 2
+    else:
+        tipo_generacion = 1
+        numero_documento = (
+            origen_ident.get("numeroDocumento")
+            or origen_ident.get("numeroControl")
+            or ""
+        )
+        numero_documento = str(numero_documento).strip()
+
+    fecha_doc_rel = normalizar_fecha_iso(
+        origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
+    )
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,
-            "tipoGeneracion": 2,
+            "tipoGeneracion": tipo_generacion,
             "numeroDocumento": numero_documento,
-            "fechaEmision": origen_ident.get("fecEmi"),
+            "fechaEmision": fecha_doc_rel,
         }
     ]
 
     emisor = deepcopy(dte_origen.get("emisor") or {})
-    receptor = ensure_receptor_completo(receptor_origen, ambiente)
-
-    preserve_nrc_null = False
-    if tipo_doc_rel == "01":
+    receptor_base = deepcopy(receptor_origen)
+    nit_digits = solo_digitos(receptor_base.get("nit"))
+    if nit_digits and is_valid_nit(nit_digits):
+        receptor_base["nit"] = nit_digits
+    else:
+        receptor_base.pop("nit", None)
+    if not (nit_digits and is_valid_nit(nit_digits)):
         dui = (
             _search_dui(receptor_origen)
             or _search_dui(dte_origen.get("extension"))
             or _search_dui(dte_origen.get("otrosDocumentos"))
         )
         if dui:
-            receptor["nit"] = dui
-        nrc_original = receptor_origen.get("nrc")
-        if not nrc_original or str(nrc_original).strip() in {"", "0"}:
-            receptor["nrc"] = None
-            preserve_nrc_null = True
+            receptor_base["nit"] = dui
+    receptor = ensure_receptor_completo(receptor_base, ambiente)
+    final_nit = solo_digitos(receptor.get("nit"))
+    if final_nit and is_valid_nit(final_nit):
+        receptor["nit"] = final_nit
+
+    nrc_original = receptor_origen.get("nrc")
+    preserve_nrc_null = False
+    if (
+        tipo_doc_rel == "01"
+        or not nrc_original
+        or str(nrc_original).strip() in {"", "0"}
+    ):
+        receptor["nrc"] = None
+        preserve_nrc_null = True
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -8,6 +8,7 @@ proporciones del documento original.
 """
 from __future__ import annotations
 
+import time
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 import copy
@@ -25,10 +26,14 @@ from dte import (
 )
 from utils import catalogos
 from utils.catalogos import TRIBUTO_IVA, TRIBUTOS
+from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
+from utils.env import env_flag
+from utils import metrics
 from utils.receptor import ensure_receptor_completo
 from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
 from utils.monto import d2, monto_a_texto_sv
 from utils.sanitize import solo_digitos
+from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
 
 
 logger = logging.getLogger(__name__)
@@ -37,11 +42,15 @@ logger = logging.getLogger(__name__)
 def _normalize_dui(value: str | None) -> str | None:
     """Return a 9-digit representation of ``value`` if possible."""
 
-    digits = solo_digitos(value)
-    if not digits:
+    if value is None:
         return None
-    digits = digits[-9:]
-    return digits.zfill(9)
+    try:
+        return normalize_dui_to_nit9(value)
+    except ValueError:
+        digits = solo_digitos(value)
+        if len(digits) == 9:
+            return digits
+    return None
 
 
 def _search_dui(data: object) -> str | None:
@@ -67,8 +76,21 @@ def _search_dui(data: object) -> str | None:
                 return dui
     return None
 
-def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dict:
+
+STRICT_SNAPSHOT_DEFAULT = env_flag("STRICT_SNAPSHOT", default=True)
+
+
+def generar_nde_desde_nota(
+    db: DB,
+    nota_id: int,
+    *,
+    ambiente: str = "00",
+    strict_snapshot: bool | None = None,
+) -> dict:
     """Genera una NDE basada en la nota registrada en ``notas``."""
+
+    strict = STRICT_SNAPSHOT_DEFAULT if strict_snapshot is None else bool(strict_snapshot)
+    start = time.perf_counter()
     row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
     if not row:
         raise ValueError("Nota no encontrada")
@@ -82,17 +104,35 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         db.get_venta_credito_fiscal(venta_id) if venta_id is not None else None
     )
     tipo_doc = "03" if credito_fiscal else "01"
-    dte_origen = generar_dte_json(
-        db,
-        venta_id,
-        tipo_dte=tipo_doc,
-        ambiente=ambiente,
-        _allow_missing_venta=True,
-    )
-    fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
+
+    snapshot = db.get_snapshot_by_venta(venta_id) if venta_id is not None else None
+    source_used = "db"
+    if snapshot:
+        dte_origen = normalize_snapshot(snapshot.payload)
+        source_used = "snapshot"
+        uuid_origen = snapshot.uuid.upper() if snapshot.uuid else None
+    else:
+        if strict and venta_id is not None:
+            raise SnapshotNotFoundError(venta_id, nota_id)
+        dte_origen = generar_dte_json(
+            db,
+            venta_id,
+            tipo_dte=tipo_doc,
+            ambiente=ambiente,
+            _allow_missing_venta=True,
+        )
+        origen_ident_tmp = dte_origen.get("identificacion") or {}
+        codigo_tmp = origen_ident_tmp.get("codigoGeneracion")
+        uuid_origen = str(codigo_tmp).upper() if codigo_tmp else None
+
+    fecha_origen = None
+    if snapshot and snapshot.fecha_emision:
+        fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
+    elif venta:
+        fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
-        if isinstance(identificacion, dict):
+        if isinstance(identificacion, dict) and not identificacion.get("fecEmi"):
             identificacion["fecEmi"] = fecha_origen
 
     detalles = None
@@ -102,7 +142,7 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         except Exception:
             detalles = None
 
-    return generar_nde_desde_dte(
+    resultado = generar_nde_desde_dte(
         db,
         dte_origen,
         detalles,
@@ -110,6 +150,23 @@ def generar_nde_desde_nota(db: DB, nota_id: int, *, ambiente: str = "00") -> dic
         nota.get("motivo"),
         ambiente=ambiente,
     )
+
+    doc_rel = resultado.get("documentoRelacionado") or []
+    rel = doc_rel[0] if doc_rel else {}
+    duration_ms = (time.perf_counter() - start) * 1000
+    metrics.inc(f"notes_source_used.{source_used}")
+    logger.info(
+        "NDE relaciona tipo=%s uuid=%s num=%s fec=%s fuente=%s nota_id=%s venta_id=%s dur_ms=%.3f",
+        rel.get("tipoDocumento"),
+        uuid_origen,
+        rel.get("numeroDocumento"),
+        rel.get("fechaEmision"),
+        source_used,
+        nota_id,
+        venta_id,
+        duration_ms,
+    )
+    return resultado
 
 
 def generar_nde_desde_dte(
@@ -141,22 +198,40 @@ def generar_nde_desde_dte(
         "tipoMoneda": "USD",
     }
 
-    tipo_doc_rel = str(origen_ident.get("tipoDte") or "").zfill(2) if origen_ident.get("tipoDte") else None
+    tipo_raw = origen_ident.get("tipoDte")
+    if isinstance(tipo_raw, int):
+        tipo_doc_rel = f"{tipo_raw:02d}"
+    elif isinstance(tipo_raw, str):
+        tipo_str = tipo_raw.strip()
+        if tipo_str.isdigit() and len(tipo_str) <= 2:
+            tipo_doc_rel = f"{int(tipo_str):02d}"
+        else:
+            tipo_doc_rel = tipo_str or None
+    else:
+        tipo_doc_rel = None
     if not tipo_doc_rel:
         tipo_doc_rel = "03" if (dte_origen.get("receptor") or {}).get("nrc") else "01"
-    numero_documento = origen_ident.get("codigoGeneracion") or ""
-    if isinstance(numero_documento, str):
-        numero_documento = numero_documento.upper()
-    fecha_doc_rel = normalizar_fecha_iso(origen_ident.get("fecEmi"))
-    if fecha_doc_rel:
-        origen_ident["fecEmi"] = fecha_doc_rel
-    else:
-        fecha_doc_rel = origen_ident.get("fecEmi")
 
+    codigo_generacion = origen_ident.get("codigoGeneracion")
+    if codigo_generacion:
+        numero_documento = str(codigo_generacion).upper()
+        tipo_generacion = 2
+    else:
+        tipo_generacion = 1
+        numero_documento = (
+            origen_ident.get("numeroDocumento")
+            or origen_ident.get("numeroControl")
+            or ""
+        )
+        numero_documento = str(numero_documento).strip()
+
+    fecha_doc_rel = normalizar_fecha_iso(
+        origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
+    )
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,
-            "tipoGeneracion": 2,
+            "tipoGeneracion": tipo_generacion,
             "numeroDocumento": numero_documento,
             "fechaEmision": fecha_doc_rel,
         }
@@ -164,25 +239,38 @@ def generar_nde_desde_dte(
 
     emisor = copy.deepcopy(dte_origen.get("emisor", {}))
     receptor_origen = dte_origen.get("receptor") or {}
-    receptor = ensure_receptor_completo(receptor_origen, ambiente)
-
-    preserve_nrc_null = False
-    if tipo_doc_rel == "01":
+    receptor_base = copy.deepcopy(receptor_origen)
+    nit_digits = solo_digitos(receptor_base.get("nit"))
+    if nit_digits and is_valid_nit(nit_digits):
+        receptor_base["nit"] = nit_digits
+    else:
+        receptor_base.pop("nit", None)
+    if not (nit_digits and is_valid_nit(nit_digits)):
         dui = (
             _search_dui(receptor_origen)
             or _search_dui(dte_origen.get("extension"))
             or _search_dui(dte_origen.get("otrosDocumentos"))
         )
         if dui:
-            receptor["nit"] = dui
-        nrc_original = receptor_origen.get("nrc")
-        if not nrc_original or str(nrc_original).strip() in {"", "0"}:
-            receptor["nrc"] = None
-            preserve_nrc_null = True
+            receptor_base["nit"] = dui
+    receptor = ensure_receptor_completo(receptor_base, ambiente)
+    final_nit = solo_digitos(receptor.get("nit"))
+    if final_nit and is_valid_nit(final_nit):
+        receptor["nit"] = final_nit
+
+    nrc_original = receptor_origen.get("nrc")
+    preserve_nrc_null = False
+    if (
+        tipo_doc_rel == "01"
+        or not nrc_original
+        or str(nrc_original).strip() in {"", "0"}
+    ):
+        receptor["nrc"] = None
+        preserve_nrc_null = True
 
     orig_resumen = dte_origen.get("resumen", {})
     items: list[dict] = []
-    uuid_origen = origen_ident.get("codigoGeneracion", "")
+    uuid_origen = numero_documento if tipo_generacion == 2 else ""
     tipo_doc_desc = catalogos.DTE_TIPOS.get(origen_ident.get("tipoDte", ""), "documento")
     extra_desc = f": {motivo}" if motivo else ""
 

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -6,6 +6,7 @@ from nota_credito_electronica import generar_nce_desde_dte, generar_nce_desde_no
 import pytest
 from factura_sv import generar_nota_credito_pdf
 import utils.catalogos as catalogos
+from utils.snapshot import Snapshot, SnapshotNotFoundError
 
 
 def create_db():
@@ -134,6 +135,208 @@ def test_generar_nce_desde_nota_credito_fiscal(monkeypatch):
     assert receptor_nota["nit"] == "06141407100012"
     assert receptor_nota["nrc"] == "123"
     assert receptor_nota.get("nombreComercial") in {None, "Cliente"}
+
+
+def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    venta_id = db.add_venta("2023-08-01", 100)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2023-08-05', 10, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    payload = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fecEmi": "2023-08-01",
+            "numeroControl": "DTE-03-00100001",
+        },
+        "emisor": {"nombre": "Emisor"},
+        "receptor": {
+            "nombre": "Cliente Snapshot",
+            "nit": "0614-140710-001-2",
+            "nrc": None,
+            "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Producto",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 100,
+                "montoDescu": 0,
+                "ventaGravada": 100,
+                "ventaExenta": 0,
+                "ventaNoSuj": 0,
+                "tributos": [catalogos.TRIBUTO_IVA],
+            }
+        ],
+        "resumen": {
+            "totalGravada": 100,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+            "montoTotalOperacion": 100,
+        },
+        "firma": "SIGNATURE",
+    }
+    snapshot = Snapshot(
+        uuid=payload["identificacion"]["codigoGeneracion"],
+        path=str(tmp_path / "documento.json"),
+        tipo_documento="03",
+        fecha_emision="2023-08-01",
+        payload=payload,
+    )
+
+    monkeypatch.setattr(db, "get_snapshot_by_venta", lambda vid: snapshot if vid == venta_id else None)
+
+    def _fail_generar_dte(*_args, **_kwargs):
+        raise AssertionError("No se debe regenerar desde la base de datos")
+
+    monkeypatch.setattr("nota_credito_electronica.generar_dte_json", _fail_generar_dte)
+    metrics_calls = []
+    monkeypatch.setattr(
+        "nota_credito_electronica.metrics.inc", lambda name: metrics_calls.append(name)
+    )
+
+    nce = generar_nce_desde_nota(db, nota_id)
+
+    receptor = nce["receptor"]
+    assert receptor["nit"] == "06141407100012"
+    assert receptor["nrc"] is None
+
+    doc_rel = nce["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"
+    assert doc_rel["tipoGeneracion"] == 2
+    assert (
+        doc_rel["numeroDocumento"]
+        == payload["identificacion"]["codigoGeneracion"].upper()
+    )
+    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert metrics_calls == ["notes_source_used.snapshot"]
+    assert payload["firma"] == "SIGNATURE"
+
+
+def test_generar_nce_desde_nota_snapshot_dui(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    venta_id = db.add_venta("2023-09-01", 40)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2023-09-03', 8, 'Devolución')",
+        (venta_id,),
+    ).lastrowid
+
+    payload = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-DCBA-4321-DCBA-0987654321FF",
+            "fecEmi": "2023-09-01",
+            "numeroControl": "DTE-01-00001234",
+        },
+        "emisor": {"nombre": "Emisor"},
+        "receptor": {
+            "nombre": "Consumidor Final",
+            "tipoDocumento": "13",
+            "numDocumento": "01234567-8",
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 40,
+                "montoDescu": 0,
+                "ventaGravada": 40,
+                "ventaExenta": 0,
+                "ventaNoSuj": 0,
+                "tributos": [catalogos.TRIBUTO_IVA],
+            }
+        ],
+        "resumen": {
+            "totalGravada": 40,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+            "montoTotalOperacion": 40,
+        },
+        "firma": "ORIGINAL-FIRMA",
+    }
+
+    snapshot = Snapshot(
+        uuid=payload["identificacion"]["codigoGeneracion"],
+        path=str(tmp_path / "documento.json"),
+        tipo_documento="01",
+        fecha_emision="2023-09-01",
+        payload=payload,
+    )
+
+    monkeypatch.setattr(db, "get_snapshot_by_venta", lambda vid: snapshot if vid == venta_id else None)
+    monkeypatch.setattr(
+        "nota_credito_electronica.generar_dte_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("Debe usar snapshot")),
+    )
+
+    nce = generar_nce_desde_nota(db, nota_id)
+
+    receptor = nce["receptor"]
+    assert receptor["nit"] == "012345678"
+    assert receptor["nrc"] is None
+
+    doc_rel = nce["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "01"
+    assert doc_rel["tipoGeneracion"] == 2
+    assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
+    assert doc_rel["fechaEmision"] == "2023-09-01"
+
+
+def test_generar_nce_desde_nota_strict_snapshot(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    venta_id = db.add_venta("2023-08-01", 50)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2023-08-05', 5, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    monkeypatch.setattr(db, "get_snapshot_by_venta", lambda _vid: None)
+
+    with pytest.raises(SnapshotNotFoundError) as exc:
+        generar_nce_desde_nota(db, nota_id, strict_snapshot=True)
+
+    message = str(exc.value)
+    assert str(venta_id) in message
+    assert str(nota_id) in message
 
 
 def test_generar_nce_receptor_placeholder_en_pruebas(monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -6,6 +6,8 @@ from nota_debito_electronica import generar_nde_desde_dte, generar_nde_desde_not
 from dte import generar_dte_json
 from nota_remision import generar_nota_remision_desde_db, generar_nota_remision
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
+from utils.snapshot import Snapshot, SnapshotNotFoundError
+import utils.catalogos as catalogos
 
 
 def create_db():
@@ -150,6 +152,252 @@ def test_generar_nde_desde_nota_credito_fiscal(monkeypatch):
     assert receptor["nit"] == "06141407100012"
     assert receptor["nrc"] == "123"
     assert receptor.get("nombreComercial") in {None, "Cliente"}
+
+
+def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    db.add_cliente("Cliente", "123", "06141407100012", "", "giro", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2023-08-01",
+        100,
+        "123",
+        "06141407100012",
+        "giro",
+        descuentos=0,
+    )
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'debito', '2023-08-05', 10, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    payload = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "12345678-ABCD-1234-ABCD-1234567890AB",
+            "fecEmi": "2023-08-01",
+            "numeroControl": "DTE-03-00100001",
+        },
+        "emisor": {"nombre": "Emisor"},
+        "receptor": {
+            "nombre": "Cliente Snapshot",
+            "nit": "0614-140710-001-2",
+            "nrc": None,
+            "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Producto",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 100,
+                "montoDescu": 0,
+                "ventaGravada": 100,
+                "ventaExenta": 0,
+                "ventaNoSuj": 0,
+                "tributos": [catalogos.TRIBUTO_IVA],
+            }
+        ],
+        "resumen": {
+            "totalGravada": 100,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+            "montoTotalOperacion": 100,
+        },
+        "firma": "SIGNATURE",
+    }
+    snapshot = Snapshot(
+        uuid=payload["identificacion"]["codigoGeneracion"],
+        path=str(tmp_path / "documento.json"),
+        tipo_documento="03",
+        fecha_emision="2023-08-01",
+        payload=payload,
+    )
+
+    monkeypatch.setattr(db, "get_snapshot_by_venta", lambda vid: snapshot if vid == venta_id else None)
+
+    def _fail_generar_dte(*_args, **_kwargs):
+        raise AssertionError("No se debe regenerar desde la base de datos")
+
+    monkeypatch.setattr("nota_debito_electronica.generar_dte_json", _fail_generar_dte)
+    metrics_calls = []
+    monkeypatch.setattr(
+        "nota_debito_electronica.metrics.inc", lambda name: metrics_calls.append(name)
+    )
+
+    nde = generar_nde_desde_nota(db, nota_id)
+
+    receptor = nde["receptor"]
+    assert receptor["nit"] == "06141407100012"
+    assert receptor["nrc"] is None
+
+    doc_rel = nde["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"
+    assert doc_rel["tipoGeneracion"] == 2
+    assert (
+        doc_rel["numeroDocumento"]
+        == payload["identificacion"]["codigoGeneracion"].upper()
+    )
+    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert metrics_calls == ["notes_source_used.snapshot"]
+    assert payload["firma"] == "SIGNATURE"
+
+
+def test_generar_nde_desde_nota_snapshot_dui(monkeypatch, tmp_path):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    venta_id = db.add_venta("2023-09-01", 40)
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'debito', '2023-09-03', 8, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    payload = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "87654321-ABCD-4321-ABCD-112233445566",
+            "fecEmi": "2023-09-01",
+            "numeroControl": "DTE-01-00004567",
+        },
+        "emisor": {"nombre": "Emisor"},
+        "receptor": {
+            "nombre": "Consumidor Final",
+            "tipoDocumento": "13",
+            "numDocumento": "12345678-9",
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "tipoItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 40,
+                "montoDescu": 0,
+                "ventaGravada": 40,
+                "ventaExenta": 0,
+                "ventaNoSuj": 0,
+                "tributos": [catalogos.TRIBUTO_IVA],
+            }
+        ],
+        "resumen": {
+            "totalGravada": 40,
+            "totalExenta": 0,
+            "totalNoSuj": 0,
+            "montoTotalOperacion": 40,
+        },
+        "firma": "ORIGINAL-FIRMA",
+    }
+
+    snapshot = Snapshot(
+        uuid=payload["identificacion"]["codigoGeneracion"],
+        path=str(tmp_path / "documento.json"),
+        tipo_documento="01",
+        fecha_emision="2023-09-01",
+        payload=payload,
+    )
+
+    monkeypatch.setattr(db, "get_snapshot_by_venta", lambda vid: snapshot if vid == venta_id else None)
+    monkeypatch.setattr(
+        "nota_debito_electronica.generar_dte_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("Debe usar snapshot")),
+    )
+
+    nde = generar_nde_desde_nota(db, nota_id)
+
+    receptor = nde["receptor"]
+    assert receptor["nit"] == "123456789"
+    assert receptor["nrc"] is None
+
+    doc_rel = nde["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "01"
+    assert doc_rel["tipoGeneracion"] == 2
+    assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
+    assert doc_rel["fechaEmision"] == "2023-09-01"
+
+
+def test_generar_nde_desde_nota_strict_snapshot(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    db.add_cliente("Cliente", "123", "06141407100012", "", "giro", "", "", "", "", "")
+    cliente_id = db.cursor.lastrowid
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id,
+        "2023-08-01",
+        50,
+        "123",
+        "06141407100012",
+        "giro",
+        descuentos=0,
+    )
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'debito', '2023-08-05', 5, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    monkeypatch.setattr(db, "get_snapshot_by_venta", lambda _vid: None)
+
+    with pytest.raises(SnapshotNotFoundError) as exc:
+        generar_nde_desde_nota(db, nota_id, strict_snapshot=True)
+
+    message = str(exc.value)
+    assert str(venta_id) in message
+    assert str(nota_id) in message
 
 
 def test_generar_nde_consumidor_final_sin_nit(monkeypatch):

--- a/utils/env.py
+++ b/utils/env.py
@@ -1,0 +1,25 @@
+"""Helpers for reading environment configuration values."""
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+__all__ = ["env_flag"]
+
+
+_TRUTHY: Iterable[str] = {"1", "true", "yes", "on"}
+_FALSY: Iterable[str] = {"0", "false", "no", "off"}
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    """Return ``True`` when environment variable ``name`` is truthy."""
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default

--- a/utils/identificacion.py
+++ b/utils/identificacion.py
@@ -1,0 +1,30 @@
+"""Helpers for validating and normalising identification documents."""
+from __future__ import annotations
+
+import re
+
+__all__ = ["is_valid_nit", "normalize_dui_to_nit9"]
+
+_NIT_RE = re.compile(r"^(?:\d{9}|\d{14})$")
+_DUI_RE = re.compile(r"^\d{9}$")
+
+
+def is_valid_nit(nit: str | None) -> bool:
+    """Return ``True`` if ``nit`` represents a valid NIT (9 or 14 digits)."""
+
+    if nit is None:
+        return False
+    value = str(nit).strip()
+    if not value:
+        return False
+    digits = value if value.isdigit() else value.replace("-", "")
+    return bool(_NIT_RE.fullmatch(digits))
+
+
+def normalize_dui_to_nit9(dui: str | None) -> str:
+    """Normalise ``dui`` removing separators and validating length."""
+
+    cleaned = (dui or "").replace("-", "").strip()
+    if not _DUI_RE.fullmatch(cleaned):
+        raise ValueError("DUI inválido para normalizar a NIT-9")
+    return cleaned

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,43 @@
+"""Lightweight helpers for emitting instrumentation metrics.
+
+The project historically didn't collect metrics, however several new
+workflows expect an ``inc`` helper to be present.  This module keeps the
+interface intentionally small so call sites can record counters without
+introducing an external dependency.  The current implementation simply
+logs the event at ``DEBUG`` level which is sufficient for unit tests.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+__all__ = ["inc"]
+
+_logger = logging.getLogger("metrics")
+
+
+def inc(name: str, value: int = 1, **labels: Any) -> None:
+    """Increment counter ``name``.
+
+    Parameters
+    ----------
+    name:
+        Metric identifier.  Empty names are ignored so callers can pass
+        dynamic values without additional guards.
+    value:
+        Increment amount.  Non-integer values are coerced to ``int`` when
+        possible.
+    labels:
+        Optional keyword labels attached to the event.
+    """
+
+    if not name:
+        return
+    try:
+        amount = int(value)
+    except (TypeError, ValueError):
+        amount = 1
+    if labels:
+        _logger.debug("metric_inc %s=%s labels=%s", name, amount, labels)
+    else:
+        _logger.debug("metric_inc %s=%s", name, amount)

--- a/utils/snapshot.py
+++ b/utils/snapshot.py
@@ -1,0 +1,90 @@
+"""Helpers for working with persisted DTE snapshots."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+__all__ = ["Snapshot", "SnapshotNotFoundError", "normalize_snapshot"]
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """Metadata for a stored DTE snapshot."""
+
+    uuid: str
+    path: str
+    tipo_documento: str | None
+    fecha_emision: str | None
+    payload: dict[str, Any]
+
+
+class SnapshotNotFoundError(RuntimeError):
+    """Raised when the expected snapshot is not available."""
+
+    def __init__(self, venta_id: int, nota_id: int | None = None):
+        message = f"No se encontró snapshot para venta {venta_id}"
+        if nota_id is not None:
+            message += f" (nota {nota_id})"
+        super().__init__(message)
+        self.venta_id = venta_id
+        self.nota_id = nota_id
+
+
+_TRANSIENT_ROOT_KEYS = {
+    "acuse",
+    "acuseRecibo",
+    "acuseRecepcion",
+    "acuseRecepcionMH",
+    "acuseMH",
+    "acuseDte",
+    "firma",
+    "firmaElectronica",
+    "firmaDigital",
+    "sello",
+    "selloRecepcion",
+    "selloRecibido",
+    "selloMH",
+    "estado",
+    "estadoDte",
+    "estadoTransmision",
+    "estadoEnvio",
+    "respuesta",
+    "respuestaMH",
+}
+
+
+def _clean_identificacion(data: Mapping[str, Any]) -> dict[str, Any]:
+    ident = dict(data)
+    tipo = ident.get("tipoDte")
+    if isinstance(tipo, int):
+        ident["tipoDte"] = f"{tipo:02d}"
+    elif isinstance(tipo, str):
+        stripped = tipo.strip()
+        if stripped.isdigit() and len(stripped) <= 2:
+            ident["tipoDte"] = f"{int(stripped):02d}"
+        elif stripped:
+            ident["tipoDte"] = stripped
+    codigo = ident.get("codigoGeneracion")
+    if isinstance(codigo, str):
+        ident["codigoGeneracion"] = codigo.strip().upper()
+    fecha = ident.get("fechaEmision")
+    if fecha and not ident.get("fecEmi"):
+        ident["fecEmi"] = fecha
+    if ident.get("fechaEmision") in {None, ""}:
+        ident.pop("fechaEmision", None)
+    return ident
+
+
+def normalize_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a sanitised copy of ``payload`` suitable for reuse."""
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("snapshot payload debe ser un mapeo")
+    data = deepcopy(payload)
+    for key in _TRANSIENT_ROOT_KEYS:
+        data.pop(key, None)
+    ident = data.get("identificacion")
+    if isinstance(ident, Mapping):
+        data["identificacion"] = _clean_identificacion(ident)
+    return data

--- a/utils/versioned_dte.py
+++ b/utils/versioned_dte.py
@@ -20,6 +20,16 @@ def decode_jws_payload(token: str) -> dict:
     return json.loads(data.decode("utf-8"))
 
 
+def resolve_version_dir(base_dir: str | None, codigo: str) -> str:
+    """Return the directory that stores ``codigo`` within ``base_dir``."""
+
+    base = os.path.abspath(base_dir or DTES_DIR)
+    codigo = (codigo or "").strip()
+    if not codigo:
+        raise ValueError("codigo_generacion inválido para snapshot")
+    return os.path.join(base, codigo)
+
+
 def ensure_version(dte_json: dict, base_dir: str | None = None) -> tuple[str, str]:
     """Ensure a directory for the given ``dte_json`` exists.
 
@@ -31,8 +41,7 @@ def ensure_version(dte_json: dict, base_dir: str | None = None) -> tuple[str, st
     ident = dte_json.get("identificacion", {})
     codigo = ident.get("codigoGeneracion") or "SIN-CODIGO"
     json_hash = hash_json(dte_json)
-    base_dir = os.path.abspath(base_dir or DTES_DIR)
-    version_dir = os.path.join(base_dir, codigo)
+    version_dir = resolve_version_dir(base_dir, codigo)
     os.makedirs(version_dir, exist_ok=True)
     save_file(
         os.path.join(version_dir, "documento.json"),
@@ -80,4 +89,5 @@ __all__ = [
     "save_estado",
     "decode_jws_payload",
     "hash_json",
+    "resolve_version_dir",
 ]


### PR DESCRIPTION
## Summary
- add snapshot lookup and normalization utilities, including DUI/NIT helpers
- generate credit and debit notes from stored DTE snapshots with strict fallback handling, normalized receptor data, and source metrics
- extend note generation tests to cover snapshot preference and strict snapshot errors
- default STRICT_SNAPSHOT to true via an env helper and add DUI-only snapshot regression tests

## Testing
- pytest tests/test_nota_credito.py::test_generar_nce_desde_nota_prefiere_snapshot tests/test_nota_credito.py::test_generar_nce_desde_nota_snapshot_dui tests/test_nota_credito.py::test_generar_nce_desde_nota_strict_snapshot tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_prefiere_snapshot tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_snapshot_dui tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_strict_snapshot

------
https://chatgpt.com/codex/tasks/task_e_68d9a3eea4148323a8b0b1427c329e34