### PR TITLE
Corrige validación de pagos a crédito

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -1060,14 +1060,26 @@ def normalizar_pagos(pagos_raw, total, tipo_dte="01", condicion=1):
 
     if condicion == 2:
         first = pagos[0]
-        plazo_val = int(first.get("plazo") or 0)
-        periodo_val = str(first.get("periodo") or "").zfill(2)
-        if not plazo_val or periodo_val not in catalogos.PLAZO:
+        plazo_code = str(first.get("plazo") or "").zfill(2)
+        if plazo_code not in {"01", "02", "03"}:
             raise ValidationError(
-                "condicionOperacion=2 requiere pago con plazo>0 y periodo válido",
+                "Crédito: unidad inválida (01=días, 02=meses, 03=años)",
             )
-        first["plazo"] = plazo_val if not plazo_is_str else str(plazo_val).zfill(2)
-        first["periodo"] = periodo_val if periodo_is_str else int(periodo_val)
+
+        periodo_raw = first.get("periodo", 0)
+        try:
+            periodo_val = int(periodo_raw)
+        except (TypeError, ValueError):
+            raise ValidationError("Crédito: periodo debe ser entero > 0") from None
+        if periodo_val <= 0:
+            raise ValidationError("Crédito: periodo debe ser entero > 0")
+
+        first["plazo"] = (
+            plazo_code if plazo_is_str else int(plazo_code)
+        )
+        first["periodo"] = (
+            str(periodo_val) if periodo_is_str else periodo_val
+        )
 
     for p in pagos:
         p["montoPago"] = money(p["montoPago"])

--- a/utils/resumen.py
+++ b/utils/resumen.py
@@ -64,8 +64,8 @@ def validate_pagos_basico(resumen: dict, condicion: int) -> None:
     Verifica que los códigos de pago sean válidos según ``CAT-017`` y que la
     suma de ``montoPago`` coincida con ``totalPagar``.  Cuando la
     ``condicionOperacion`` es 2 (crédito) se requiere que el primer pago
-    contenga ``plazo`` mayor a cero y ``periodo`` perteneciente al catálogo
-    ``PLAZO``.
+    contenga ``plazo`` dentro de ``{"01", "02", "03"}`` (días, meses o años)
+    y que ``periodo`` sea un entero estrictamente positivo.
     """
 
     pagos: Iterable[dict] | None = resumen.get("pagos")


### PR DESCRIPTION
## Summary
- ajusta la normalización de pagos a crédito para aceptar periodos positivos y validar unidades de plazo según catálogo reducido
- actualiza la documentación del validador básico de pagos para reflejar las nuevas reglas

## Testing
- pytest tests/test_resumen_condicion_operacion.py


------
https://chatgpt.com/codex/tasks/task_e_68d9b5a032d48323a544a08fdca938a1