### PR TITLE
Auth warm-up and 401 retry reauth adjustments

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -512,6 +512,45 @@ def _post_json(url: str, headers: Mapping[str, Any], body: Any, *, tag: str):
         else:
             last_no_www = False
 
+        should_force_refresh = (
+            retry_401_enabled
+            and last_resp is not None
+            and last_resp.status_code == 401
+            and last_resp.text == ""
+            and last_no_www
+            and resp.status_code == 401
+            and text_body == ""
+            and no_www_auth
+            and attempt == 2
+        )
+
+        if should_force_refresh:
+            host_text = (host or "").lower()
+            ambiente_detectado = "apitest" if "apitest" in host_text else "produccion"
+            try:
+                from mh_auth import ensure_valid_bearer  # Lazy import to avoid cycles
+
+                refreshed = ensure_valid_bearer(
+                    ambiente_detectado,
+                    headers_dict.get("Authorization"),
+                    force=True,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "AUTH: no se pudo refrescar token para retry tag=%s: %s",
+                    tag,
+                    exc,
+                )
+            else:
+                if refreshed:
+                    logger.info(
+                        "AUTH: refreshed token for retry (fp=%s)",
+                        _fp_auth(refreshed),
+                    )
+                    headers_dict["Authorization"] = refreshed
+                    last_resp = resp
+                    continue
+
         if (
             last_resp is not None
             and last_resp.status_code == 401

--- a/mh_auth.py
+++ b/mh_auth.py
@@ -1,13 +1,23 @@
 import base64
+import hashlib
 import json
 import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
 
-from paths import DATOS_NEGOCIO_PATH
+import requests
+
+from paths import CONFIG_NEGOCIO_PATH, DATOS_NEGOCIO_PATH
+from utils.env import env_flag
 
 log = logging.getLogger(__name__)
 
 
 _TOKEN_CACHE: dict[str, str | None] = {}
+_AUTO_TOKEN_CACHE: dict[str, str] = {}
+_WARMUP_DONE: set[str] = set()
 
 
 def _normalize_environment(ambiente: str | None) -> str:
@@ -30,6 +40,173 @@ def _normalize_environment(ambiente: str | None) -> str:
 def _read_negocio_json():
     with open(DATOS_NEGOCIO_PATH, "r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def _read_config_json() -> dict[str, Any]:
+    try:
+        with open(CONFIG_NEGOCIO_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:  # pragma: no cover - logged for observability
+        log.warning("AUTH: no se pudo leer config_negocio.json: %s", exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+_ENV_KEY_ALIASES = {
+    "apitest": ["apitest", "pruebas", "00", "0", "test"],
+    "produccion": ["produccion", "01", "1", "prod", "production"],
+}
+
+
+def _resolve_env_config(env: str, config: dict[str, Any]) -> dict[str, Any]:
+    candidates = _ENV_KEY_ALIASES.get(env, [])
+    for key in candidates:
+        value = config.get(key)
+        if isinstance(value, dict):
+            return value
+    ambiente_raw = config.get("ambiente")
+    normalized = _normalize_environment(ambiente_raw) if ambiente_raw else None
+    if normalized and normalized != env:
+        for key in _ENV_KEY_ALIASES.get(normalized, []):
+            value = config.get(key)
+            if isinstance(value, dict):
+                return value
+    return {}
+
+
+def _decode_secret(raw: Any) -> str:
+    if not isinstance(raw, str):
+        return ""
+    text = raw.strip()
+    if not text:
+        return ""
+    try:
+        decoded = base64.b64decode(text.encode("utf-8"), validate=True)
+        return decoded.decode("utf-8")
+    except Exception:
+        return text
+
+
+def _fingerprint(token: str | None) -> str:
+    if not token:
+        return "MISSING"
+    return hashlib.sha1(token.encode("utf-8")).hexdigest()[:10]
+
+
+def _normalize_bearer_value(token_raw: Any) -> str:
+    from dte import _normalize_bearer as _dte_normalize_bearer  # Lazy import
+
+    return _dte_normalize_bearer(str(token_raw or ""))
+
+
+def _to_timestamp(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        if text.isdigit():
+            try:
+                return float(text)
+            except Exception:
+                return None
+        try:
+            dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except Exception:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    return None
+
+
+def _token_ttl_seconds(token: str | None) -> float | None:
+    if not token:
+        return None
+    claims = decode_jwt_claims(token)
+    if not claims:
+        return None
+    exp_ts = _to_timestamp(claims.get("exp"))
+    if exp_ts is None:
+        return None
+    return exp_ts - time.time()
+
+
+def _resolve_auth_params(env: str) -> tuple[str, str, str]:
+    config = _read_config_json()
+    env_conf = _resolve_env_config(env, config) if isinstance(config, dict) else {}
+    if not isinstance(env_conf, dict):
+        env_conf = {}
+    auth_conf = env_conf.get("auth") if isinstance(env_conf, dict) else None
+    if not isinstance(auth_conf, dict):
+        auth_conf = {}
+    top_auth = config.get("auth") if isinstance(config, dict) else None
+    if not isinstance(top_auth, dict):
+        top_auth = {}
+
+    def _first_non_empty(values: list[Any]) -> str:
+        for value in values:
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    user = _first_non_empty(
+        [
+            auth_conf.get("nitUsuario"),
+            auth_conf.get("user"),
+            auth_conf.get("nit"),
+            env_conf.get("api_user") if isinstance(env_conf, dict) else None,
+            top_auth.get("nitUsuario"),
+            top_auth.get("user"),
+            top_auth.get("nit"),
+            config.get("api_user") if isinstance(config, dict) else None,
+        ]
+    )
+
+    pwd = _first_non_empty(
+        [
+            auth_conf.get("pwd"),
+            auth_conf.get("password"),
+            env_conf.get("api_pwd") if isinstance(env_conf, dict) else None,
+            top_auth.get("pwd"),
+            top_auth.get("password"),
+            config.get("api_pwd") if isinstance(config, dict) else None,
+        ]
+    )
+
+    user = _decode_secret(user)
+    pwd = _decode_secret(pwd)
+
+    auth_url = None
+    if isinstance(env_conf, dict):
+        auth_url = env_conf.get("auth_url") or env_conf.get("authUrl")
+    if not auth_url and isinstance(config, dict):
+        auth_url = config.get("auth_url") or config.get("authUrl")
+    if isinstance(auth_url, str):
+        auth_url = auth_url.strip()
+    if not auth_url:
+        try:
+            datos = _read_negocio_json()
+        except Exception:
+            datos = {}
+        if isinstance(datos, dict):
+            dte_api = datos.get("dte_api")
+            if isinstance(dte_api, dict):
+                base_url = dte_api.get("url") or dte_api.get("endpoint")
+                if isinstance(base_url, str):
+                    base = base_url.strip().rstrip("/")
+                    if base:
+                        auth_url = f"{base}/seguridad/auth"
+    if not auth_url:
+        raise RuntimeError("URL de autenticación no configurada para Hacienda")
+    if not user or not pwd:
+        raise RuntimeError("Credenciales API no configuradas para Hacienda")
+    return auth_url, user, pwd
 
 
 def _load_tokens_from_file() -> dict[str, str]:
@@ -62,6 +239,8 @@ def _load_tokens_from_file() -> dict[str, str]:
 
 def invalidate_token_cache() -> None:
     _TOKEN_CACHE.clear()
+    _AUTO_TOKEN_CACHE.clear()
+    _WARMUP_DONE.clear()
 
 
 def get_manual_token(ambiente: str | None = None) -> str | None:
@@ -79,22 +258,162 @@ def get_manual_token(ambiente: str | None = None) -> str | None:
     return _TOKEN_CACHE[env]
 
 
-def auth_headers(extra: dict | None = None, *, ambiente: str | None = None) -> dict:
-    """Construye headers para MH usando EXCLUSIVAMENTE el token manual guardado."""
-
+def acquire_token(ambiente: str) -> str:
     env = _normalize_environment(ambiente)
-    token = get_manual_token(env)
+    url, user, pwd = _resolve_auth_params(env)
+    try:
+        resp = requests.post(url, data={"user": user, "pwd": pwd}, timeout=20)
+    except Exception as exc:  # pragma: no cover - network failure
+        raise RuntimeError("No se pudo conectar con el servicio de autenticación") from exc
+
+    status_code = getattr(resp, "status_code", None)
+    if isinstance(status_code, int) and status_code >= 400:
+        log.warning("AUTH: respuesta HTTP %s al solicitar token", status_code)
+    try:
+        resp.raise_for_status()
+    except Exception as exc:  # pragma: no cover - bubbled for observabilidad
+        raise RuntimeError("La autenticación con Hacienda fue rechazada") from exc
+
+    try:
+        payload = resp.json()
+    except Exception as exc:
+        raise RuntimeError("Respuesta de autenticación no es JSON válido") from exc
+
+    if isinstance(payload, dict):
+        status = payload.get("status")
+        if status and str(status).upper() not in {"OK", "200"}:
+            message = payload.get("message") or payload.get("error") or payload.get("detalle")
+            if message:
+                raise RuntimeError(f"Autenticación rechazada ({status}): {message}")
+            raise RuntimeError(f"Autenticación rechazada ({status})")
+        body = payload.get("body") if isinstance(payload.get("body"), dict) else None
+        if isinstance(body, dict):
+            token_raw = body.get("token") or body.get("access_token")
+            token_type = body.get("tokenType") or body.get("token_type")
+        else:
+            token_raw = payload.get("token") or payload.get("access_token")
+            token_type = payload.get("tokenType") or payload.get("token_type")
+    else:
+        token_raw = None
+        token_type = None
+
+    if not token_raw and isinstance(payload, dict):
+        body = payload.get("body")
+        if isinstance(body, dict):
+            token_raw = body.get("token") or body.get("access_token")
+            token_type = body.get("tokenType") or body.get("token_type")
+
+    if not token_raw:
+        raise RuntimeError("Respuesta de autenticación sin token válido")
+
+    if isinstance(token_type, str) and token_type.lower() == "bearer" and isinstance(token_raw, str):
+        token_raw = f"Bearer {token_raw}"
+
+    normalized = _normalize_bearer_value(token_raw)
+    ttl = _token_ttl_seconds(normalized)
+    log.info("AUTH: acquired token env=%s fp=%s ttl_s=%s", env, _fingerprint(normalized), int(ttl) if ttl is not None else None)
+    return normalized
+
+
+def _is_token_valid(token: str | None, threshold: int) -> bool:
     if not token:
+        return False
+    ttl = _token_ttl_seconds(token)
+    if ttl is None:
+        return False
+    return ttl > threshold
+
+
+def ensure_valid_bearer(
+    ambiente: str,
+    current: str | None,
+    *,
+    min_ttl_s: int = 300,
+    force: bool = False,
+) -> str:
+    env = _normalize_environment(ambiente)
+    try:
+        threshold = max(0, int(min_ttl_s))
+    except Exception:
+        try:
+            threshold = max(0, int(float(min_ttl_s)))
+        except Exception:
+            threshold = 300
+
+    normalized_current = None
+    if current is not None:
+        try:
+            normalized_current = _normalize_bearer_value(current)
+        except Exception:
+            normalized_current = None
+
+    cached = _AUTO_TOKEN_CACHE.get(env)
+
+    if not force and _is_token_valid(normalized_current, threshold):
+        _AUTO_TOKEN_CACHE[env] = normalized_current  # type: ignore[arg-type]
+        _TOKEN_CACHE[env] = normalized_current
+        return normalized_current  # type: ignore[return-value]
+
+    if not force and cached and _is_token_valid(cached, threshold):
+        return cached
+
+    try:
+        refreshed = acquire_token(env)
+    except Exception as exc:
+        fallback = normalized_current or cached
+        if fallback:
+            log.warning("AUTH: no se pudo renovar token env=%s, se reutiliza fp=%s (%s)", env, _fingerprint(fallback), exc)
+            _AUTO_TOKEN_CACHE[env] = fallback
+            _TOKEN_CACHE[env] = fallback
+            return fallback
+        raise
+
+    normalized = _normalize_bearer_value(refreshed)
+    _AUTO_TOKEN_CACHE[env] = normalized
+    _TOKEN_CACHE[env] = normalized
+    return normalized
+
+
+def auth_headers(extra: dict | None = None, *, ambiente: str | None = None) -> dict:
+    env = _normalize_environment(ambiente)
+    manual_token = get_manual_token(env)
+    cached = _AUTO_TOKEN_CACHE.get(env)
+    current = manual_token or cached
+
+    raw_min_ttl = os.getenv("DTE_TOKEN_MIN_TTL_S", "300")
+    try:
+        min_ttl = max(0, int(raw_min_ttl))
+    except Exception:
+        try:
+            min_ttl = max(0, int(float(raw_min_ttl)))
+        except Exception:
+            min_ttl = 300
+
+    warmup_enabled = env_flag("DTE_AUTH_WARMUP", default=True)
+    needs_warmup = warmup_enabled and env not in _WARMUP_DONE
+    initial_normalized = _normalize_bearer_value(current) if current else None
+
+    try:
+        token = ensure_valid_bearer(env, current, min_ttl_s=min_ttl, force=needs_warmup)
+    except Exception as exc:
+        if manual_token:
+            raise
         raise RuntimeError(
             "Token manual no configurado. Use 'Obtener token' en Configuración de Facturación Electrónica."
-        )
+        ) from exc
+
+    if needs_warmup:
+        _WARMUP_DONE.add(env)
+        if token != initial_normalized:
+            log.info("AUTH: warmup reauth (fp=%s)", _fingerprint(token))
 
     headers = {"Authorization": token}
     if extra:
         headers.update(extra)
 
-    fingerprint = token[-8:] if len(token) >= 8 else token
-    log.info("AUTH: USING MANUAL TOKEN (amb=%s fp=%s)", env, fingerprint)
+    _TOKEN_CACHE[env] = token
+    _AUTO_TOKEN_CACHE[env] = token
+    log.info("AUTH: ready token (amb=%s fp=%s)", env, _fingerprint(token))
     return headers
 
 

--- a/tests/test_dte_http_wrapper.py
+++ b/tests/test_dte_http_wrapper.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 from datetime import timedelta
+from typing import Any
 from types import SimpleNamespace
 from unittest import mock
 
@@ -149,6 +150,51 @@ def test_post_json_retry_on_empty_401(requests_mock, monkeypatch, caplog):
     assert second_request.headers.get("Connection") == "close"
     retry_msgs = [rec.message for rec in caplog.records if "401 vacío" in rec.message]
     assert len(retry_msgs) >= 2
+
+
+@pytest.mark.parametrize("host", ["apitest.dtes.mh.gob.sv", "api.dtes.mh.gob.sv"])
+def test_post_json_refreshes_token_on_persistent_empty_401(requests_mock, monkeypatch, caplog, host):
+    url = f"https://{host}/fesv/recepciondte"
+    headers = _base_headers()
+    body = {"ambiente": "00"}
+    monkeypatch.setenv("DTE_BACKOFF_MS", "0")
+    caplog.set_level(logging.INFO, logger="dte")
+
+    ensure_calls: dict[str, Any] = {}
+
+    def fake_ensure(env, current, *, min_ttl_s=300, force):
+        ensure_calls.setdefault("count", 0)
+        ensure_calls["count"] += 1
+        ensure_calls["env"] = env
+        ensure_calls["current"] = current
+        ensure_calls["min_ttl_s"] = min_ttl_s
+        ensure_calls["force"] = force
+        return "Bearer REFRESHED"
+
+    monkeypatch.setattr("mh_auth.ensure_valid_bearer", fake_ensure)
+
+    requests_mock.post(
+        url,
+        [
+            {"status_code": 401, "text": "", "headers": {}},
+            {"status_code": 401, "text": "", "headers": {}},
+            {"status_code": 200, "json": {"estado": "RECIBIDO"}},
+        ],
+    )
+
+    resp, data, _ = _post_json(url, headers, body, tag="test_retry_refresh")
+
+    assert resp.status_code == 200
+    assert data == {"estado": "RECIBIDO"}
+    assert len(requests_mock.request_history) == 3
+    assert requests_mock.request_history[2].headers.get("Authorization") == "Bearer REFRESHED"
+    expected_env = "apitest" if "apitest" in host else "produccion"
+    assert ensure_calls["env"] == expected_env
+    assert ensure_calls["current"] == "Bearer token"
+    assert ensure_calls["force"] is True
+    assert ensure_calls["min_ttl_s"] == 300
+    assert ensure_calls["count"] == 1
+    assert any("AUTH: refreshed token for retry" in rec.message for rec in caplog.records)
 
 
 def test_post_json_normalizes_authorization(requests_mock, caplog):

--- a/tests/test_mh_auth_manual_token.py
+++ b/tests/test_mh_auth_manual_token.py
@@ -1,6 +1,16 @@
+import base64
 import json
+import time
 
 import mh_auth
+
+
+def _make_token(sub: str, ttl: int = 3600) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode("utf-8")).rstrip(b"=")
+    now = int(time.time())
+    payload = {"sub": sub, "iat": now, "exp": now + ttl}
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=")
+    return f"Bearer {header.decode()}" + "." + body.decode() + "."
 
 
 def test_get_manual_token_per_environment(tmp_path, monkeypatch):
@@ -43,22 +53,25 @@ def test_get_manual_token_uses_cache(tmp_path, monkeypatch):
 
 def test_auth_headers_uses_environment_token(tmp_path, monkeypatch):
     datos_path = tmp_path / "datos_negocio.json"
+    prod_token = _make_token("PROD")
+    test_token = _make_token("TEST")
     datos_path.write_text(
         json.dumps(
             {
                 "dte_api": {
-                    "token_pruebas": "aaa",
-                    "token_produccion": "Bearer PROD",
+                    "token_pruebas": test_token,
+                    "token_produccion": prod_token,
                 }
             }
         )
     )
     monkeypatch.setattr(mh_auth, "DATOS_NEGOCIO_PATH", str(datos_path))
+    monkeypatch.setenv("DTE_AUTH_WARMUP", "0")
     mh_auth.invalidate_token_cache()
 
     headers_prod = mh_auth.auth_headers(ambiente="produccion")
-    assert headers_prod["Authorization"] == "Bearer PROD"
+    assert headers_prod["Authorization"] == prod_token
 
     headers_test = mh_auth.auth_headers({"X": "1"}, ambiente="pruebas")
-    assert headers_test["Authorization"] == "aaa"
+    assert headers_test["Authorization"] == test_token
     assert headers_test["X"] == "1"


### PR DESCRIPTION
## Summary
- add centralized token acquisition with TTL-aware caching, warm-up, and manual-token fallback to mh_auth
- normalize Authorization headers via ensure_valid_bearer and refresh tokens on persistent empty 401 responses in dte
- extend unit tests to cover manual token handling and forced reauth retry behaviour

## Testing
- pytest tests/test_mh_auth_manual_token.py tests/test_dte_http_wrapper.py


------
https://chatgpt.com/codex/tasks/task_e_68da26bbb01883239bd265b13e606a04