### PR TITLE
Update ticket payment condition handling

### DIFF
--- a/tests/test_ticket_fe_pdf.py
+++ b/tests/test_ticket_fe_pdf.py
@@ -9,7 +9,12 @@ from utils.doc_generation import generate_ticket_pdf
 
 
 def test_ticket_fe_pdf_clean(tmp_path):
-    venta = {"fecha": "2025-01-01", "total": 2.0}
+    venta = {
+        "fecha": "2025-01-01",
+        "total": 2.0,
+        "cliente": "Cliente Demo",
+        "documento": "00000000-0",
+    }
     detalles = [{"descripcion": "Acetaminofen 500mg", "cantidad": 1, "precio_unitario": 2.0}]
     dte_json = {
         "identificacion": {
@@ -60,11 +65,19 @@ def test_ticket_fe_pdf_clean(tmp_path):
     assert "DOCUMENTO TRIBUTARIO ELECTRÓNICO" in normalized
     assert "CONSUMIDOR FINAL" in normalized
     assert "TOTAL A PAGAR" in normalized or "Total a pagar" in text
-    assert "EFECTIVO" in text or "PAGOS" in text
+    lower_text = text.lower()
+    assert "condición de pago" in lower_text
+    assert "contado" in lower_text
 
 
 def test_generate_ticket_pdf_defaults_and_persists_es_ticket(tmp_path, monkeypatch):
-    venta = {"id": 1, "fecha": "2025-02-01", "total": 2.0}
+    venta = {
+        "id": 1,
+        "fecha": "2025-02-01",
+        "total": 2.0,
+        "cliente": "Cliente Demo",
+        "documento": "00000000-0",
+    }
     detalles = [
         {"cantidad": 1, "precio_unitario": 2.0, "descripcion": "Acetaminofen 500mg"}
     ]
@@ -179,4 +192,6 @@ def test_generate_ticket_pdf_defaults_and_persists_es_ticket(tmp_path, monkeypat
 
     assert "DOCUMENTO TRIBUTARIO ELECTRÓNICO" in normalized
     assert "CONSUMIDOR FINAL" in normalized
-    assert "EFECTIVO" in text or "PAGOS" in text
+    lower_text = text.lower()
+    assert "condición de pago" in lower_text
+    assert "contado" in lower_text

--- a/tests/test_ticket_renderer.py
+++ b/tests/test_ticket_renderer.py
@@ -33,6 +33,7 @@ def _sample_payload():
             "subTotal": Decimal("3.00"),
             "totalIva": Decimal("0.39"),
             "montoTotalOperacion": Decimal("3.39"),
+            "condicionOperacion": 1,
             "pagos": [{"codigo": "01", "montoPago": Decimal("3.39")}],
         },
         "extra": {"es_ticket": True},
@@ -54,7 +55,8 @@ def test_render_ticket_pdf_clean(tmp_path):
     assert "DOCUMENTO TRIBUTARIO" in text
     assert "ELECTRÓNICO — CONSUMIDOR FINAL" in normalized
     assert "DETALLE DE FACTURA" in text
-    assert "FORMA DE PAGO" in text or "Forma de pago" in text
+    assert "CONDICIÓN DE PAGO" in text or "Condición de pago" in text
+    assert "Contado" in text or "CONTADO" in text
     assert "Sello de Recepción: SEAL-123" in text
     assert "3.39" in text  # total
 

--- a/ticket_pdf.py
+++ b/ticket_pdf.py
@@ -17,7 +17,9 @@ from xml.sax.saxutils import escape
 import json
 import os
 
-from utils.catalogos import DTE_TIPOS, FORMA_PAGO
+import unicodedata
+
+from utils.catalogos import CONDICION_OPERACION, DTE_TIPOS
 
 from paths import DATOS_NEGOCIO_PATH
 from factura_sv import build_qr_url
@@ -217,6 +219,7 @@ def _build_ticket_flowables(
 
     ident = dte_json.get("identificacion", {}) or {}
     receptor = dte_json.get("receptor", {}) or {}
+    resumen = dte_json.get("resumen", {}) or {}
     titulo = document_title_label(ident)
 
     flowables.append(
@@ -428,25 +431,29 @@ def _build_ticket_flowables(
     )
     flowables.append(totals_table)
 
-    forma_pago = venta.get("forma_pago")
-    pago_monto = money(total)
-    pagos_resumen = dte_json.get("resumen", {}).get("pagos") or []
-    if not forma_pago and pagos_resumen:
-        pago = pagos_resumen[0]
-        code = str(pago.get("codigo") or "").zfill(2)
-        forma_pago = PAGO_LABELS.get(code, "Otro")
-        pago_monto = money(pago.get("montoPago") or total)
-    if forma_pago:
+    pagos_resumen = resumen.get("pagos") or []
+    condicion_pago = _resolve_condicion_pago(venta, resumen)
+    condicion_monto: Decimal | None = None
+    if condicion_pago:
+        if pagos_resumen:
+            pago = pagos_resumen[0]
+            condicion_monto = _to_decimal(pago.get("montoPago") or total)
+        else:
+            condicion_monto = total
+
+    if condicion_pago:
         flowables.append(Spacer(1, BLOCK_SPACING))
-        flowables.append(Paragraph("Pago", TICKET_STYLES["section_header"]))
+        flowables.append(Paragraph("Condición de pago", TICKET_STYLES["section_header"]))
+
+        monto_texto = money(condicion_monto) if condicion_monto is not None else ""
         pagos_table = Table(
             [
                 [
                     Paragraph(
-                        escape(f"Pago: {_with_falta(forma_pago)}"),
+                        escape(f"Condición: {_with_falta(condicion_pago)}"),
                         TICKET_STYLES["kv_label"],
                     ),
-                    Paragraph(escape(pago_monto), TICKET_STYLES["kv_value"]),
+                    Paragraph(escape(monto_texto), TICKET_STYLES["kv_value"]),
                 ]
             ],
             colWidths=[CONTENT_W * 0.55, CONTENT_W * 0.45],
@@ -564,8 +571,70 @@ def document_title_label(ident: Mapping[str, Any] | None) -> str:
     return "FACTURA"
 
 
-PAGO_LABELS = {code.zfill(2): value.upper() for code, value in FORMA_PAGO.items()}
-PAGO_LABELS["01"] = "EFECTIVO"
+
+def _normalize_condition_key(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return stripped.lower().strip()
+
+
+_CONDICION_OPERACION_LOOKUP: dict[str, int] = {}
+for _code, _label in CONDICION_OPERACION.items():
+    _CONDICION_OPERACION_LOOKUP[str(_code)] = _code
+    _CONDICION_OPERACION_LOOKUP[str(_code).zfill(2)] = _code
+    _CONDICION_OPERACION_LOOKUP[_normalize_condition_key(_label)] = _code
+
+if "otros" in _CONDICION_OPERACION_LOOKUP:
+    _CONDICION_OPERACION_LOOKUP.setdefault("otro", _CONDICION_OPERACION_LOOKUP["otros"])
+
+
+def _resolve_condicion_pago(
+    venta: Mapping[str, Any] | None = None,
+    resumen: Mapping[str, Any] | None = None,
+) -> str | None:
+    venta = venta or {}
+    resumen = resumen or {}
+
+    valor = venta.get("condicion_pago") or venta.get("condicionPago")
+    if valor is None:
+        valor = (
+            resumen.get("condicion_operacion")
+            or resumen.get("condicionOperacion")
+        )
+
+    if valor is None:
+        return None
+
+    code: int | None = None
+
+    if isinstance(valor, (int, float, Decimal)):
+        try:
+            code = int(valor)
+        except (TypeError, ValueError, ArithmeticError):
+            code = None
+    else:
+        texto = str(valor).strip()
+        if not texto:
+            return None
+
+        normalizado = _normalize_condition_key(texto)
+        code = _CONDICION_OPERACION_LOOKUP.get(normalizado)
+        if code is None:
+            if texto.isdigit():
+                code = int(texto)
+            elif normalizado.isdigit():
+                code = int(normalizado)
+
+    if code is not None:
+        etiqueta = CONDICION_OPERACION.get(code)
+        if etiqueta:
+            return etiqueta
+
+    if isinstance(valor, str):
+        texto = valor.strip()
+        return texto or None
+
+    return str(valor)
 
 
 def _calculate_item_total(entry: Mapping[str, Any]) -> Decimal:
@@ -779,22 +848,22 @@ def render_ticket_pdf(
     draw_left_right("IVA", money(iva))
     draw_left_right("Total a pagar", money(total), bold=True)
 
-    forma_pago = None
-    monto_pago = total
-    if pagos:
-        pago = pagos[0]
-        codigo = str(pago.get("codigo") or "").zfill(2)
-        forma_pago = PAGO_LABELS.get(codigo, "OTRO")
-        monto_pago = _to_decimal(pago.get("montoPago") or monto_pago)
+    condicion_pago = _resolve_condicion_pago(payload.get("venta"), resumen)
+    monto_pago = None
+    if condicion_pago:
+        if pagos:
+            pago = pagos[0]
+            monto_pago = _to_decimal(pago.get("montoPago") or total)
+        else:
+            monto_pago = total
 
-    if forma_pago or resumen.get("condicionOperacion"):
+    if condicion_pago:
         draw_rule()
-        draw_left("FORMA DE PAGO", bold=True)
-        if forma_pago:
-            draw_left_right(forma_pago, money(monto_pago))
-        condicion = resumen.get("condicionOperacion")
-        if condicion is not None:
-            draw_left(str(condicion).upper())
+        draw_left("CONDICIÓN DE PAGO", bold=True)
+        if monto_pago is not None:
+            draw_left_right(condicion_pago, money(monto_pago))
+        else:
+            draw_left(condicion_pago)
 
     if accepted and sello:
         draw_rule()


### PR DESCRIPTION
## Summary
- add a helper to normalize payment condition values from venta/resumen and map them to catalog labels
- update ticket PDF renderers to show a "Condición de pago" section using the helper and friendly labels
- adjust ticket PDF tests to expect the new wording and provide sample condition data

## Testing
- pytest tests/test_ticket_renderer.py tests/test_ticket_fe_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68da28e367548323bac7daca32d30982