### PR TITLE
Improve nota snapshot rehydration coverage

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -71,6 +71,13 @@ from paths import (
     DTES_DIR,
     DTE_FALLIDOS_DIR,
     DTES_PENDIENTES_DIR,
+    FACTURAS_CONSUMIDOR_FINAL_DIR,
+    FACTURAS_CREDITO_FISCAL_DIR,
+    TICKETS_OUTPUT_DIR,
+    NOTAS_CREDITO_DIR,
+    NOTAS_DEBITO_DIR,
+    FACTURAS_ARCHIVE_CF_DIR,
+    FACTURAS_ARCHIVE_CREDITO_DIR,
 )
 from xml.etree.ElementTree import Element, SubElement
 
@@ -5904,8 +5911,9 @@ def transmitir_dte(
     #     errors = _format_validation_errors(exc)
     #     raise DTEValidationError(errors, json_path) from exc
     resp = _enviar_documento(db, venta_id, data, modo)
-    if resp.get("sello"):
-        db.update_venta_extra(venta_id, {"selloRecibido": resp["sello"]})
+    sello = resp.get("sello")
+    if sello:
+        db.update_venta_extra(venta_id, {"selloRecibido": sello})
     return resp
 
 
@@ -6357,6 +6365,136 @@ def _enviar_documento(
     return res
 
 
+def _rehydrate_snapshot_from_fs(db: DB, nota_id: int, venta_id: int, expected_tipo: str | None) -> bool:
+    """Recrear el snapshot faltante buscando el DTE base en el disco."""
+
+    tipo = (expected_tipo or "").strip().lower()
+    if tipo not in {"credito", "debito"}:
+        return False
+
+    generator: Any
+    if tipo == "credito":
+        generator = generar_nota_credito_json
+    else:
+        generator = generar_nota_debito_json
+
+    try:
+        nota_json = generator(db, nota_id)
+    except Exception:
+        return False
+
+    referencias: list[dict[str, Any]] = []
+
+    def _collect_related(value: Any) -> None:
+        if isinstance(value, dict):
+            referencias.append(value)
+        elif isinstance(value, list) and value:
+            first = value[0]
+            if isinstance(first, dict):
+                referencias.append(first)
+
+    _collect_related(nota_json.get("documentoRelacionado"))
+    resumen = nota_json.get("resumen") or {}
+    if isinstance(resumen, dict):
+        _collect_related(resumen.get("documentoRelacionado"))
+
+    def _normalize(value: Any) -> str:
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if not text:
+            return ""
+        return text.upper()
+
+    target_code = ""
+    fallback_codes: list[str] = []
+    for ref in referencias:
+        codigo = _normalize(ref.get("codigoGeneracion") or ref.get("numeroDocumento"))
+        if codigo:
+            target_code = codigo
+            break
+        numero_control = _normalize(ref.get("numeroControl"))
+        if numero_control:
+            fallback_codes.append(numero_control)
+    if not target_code and fallback_codes:
+        target_code = fallback_codes[0]
+    if not target_code:
+        return False
+
+    search_keys = {target_code, *fallback_codes}
+
+    candidate_dirs: list[str] = []
+    for directory in (
+        DTES_DIR,
+        FACTURAS_CONSUMIDOR_FINAL_DIR,
+        FACTURAS_CREDITO_FISCAL_DIR,
+        TICKETS_OUTPUT_DIR,
+        NOTAS_CREDITO_DIR,
+        NOTAS_DEBITO_DIR,
+        FACTURAS_ARCHIVE_CF_DIR,
+        FACTURAS_ARCHIVE_CREDITO_DIR,
+    ):
+        if directory and directory not in candidate_dirs:
+            candidate_dirs.append(directory)
+
+    typed = [os.path.join(DTES_DIR, sub) for sub in ("fcf", "ccf", "nc", "nd") if DTES_DIR]
+    for t in typed:
+        if t and t not in candidate_dirs:
+            candidate_dirs.append(t)
+
+    for directory in candidate_dirs:
+        try:
+            base = Path(directory)
+        except TypeError:
+            continue
+        if not base.exists():
+            continue
+        try:
+            entries: list[Path] = []
+            for pattern in ("*.json", "*/*.json"):
+                entries.extend(base.glob(pattern))
+        except Exception:
+            continue
+        for entry in entries:
+            try:
+                with entry.open("r", encoding="utf-8") as fh:
+                    payload = json.load(fh)
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            ident = payload.get("identificacion") or {}
+            if not isinstance(ident, dict):
+                ident = {}
+            codigo = _normalize(ident.get("codigoGeneracion"))
+            numero_control = _normalize(ident.get("numeroControl"))
+            if codigo not in search_keys and numero_control not in search_keys:
+                continue
+            dest_dir = Path(DTES_DIR) / (codigo or target_code)
+            try:
+                dest_dir.mkdir(parents=True, exist_ok=True)
+            except Exception:
+                continue
+            dest_path = dest_dir / "documento.json"
+            try:
+                with dest_path.open("w", encoding="utf-8") as fh:
+                    json.dump(payload, fh, ensure_ascii=False)
+            except Exception:
+                continue
+            logger.info("SNAPSHOT: rehidratado %s → %s", entry, dest_path)
+            try:
+                setter = getattr(db, "set_snapshot_path")
+            except AttributeError:
+                setter = None
+            if callable(setter):
+                try:
+                    setter(venta_id, str(dest_path))
+                except Exception:
+                    pass
+            return True
+    return False
+
+
 def _ensure_nota_snapshot(db: DB, nota_id: int, *, expected_tipo: str | None = None) -> None:
     """Ensure that a stored snapshot exists for ``nota_id`` before sending."""
 
@@ -6393,6 +6531,9 @@ def _ensure_nota_snapshot(db: DB, nota_id: int, *, expected_tipo: str | None = N
         return
 
     if snapshot is None:
+        tipo_hint = expected_tipo or nota_tipo
+        if _rehydrate_snapshot_from_fs(db, nota_id, venta_id, tipo_hint):
+            return
         raise SnapshotNotFoundError(venta_id, nota_id)
 
 

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import logging
-import json
 import os
 import pytest
 import requests
@@ -189,6 +188,156 @@ def test_enviar_factura_rechazo_y_reenvio(monkeypatch, caplog, tmp_path):
         assert headers["Content-Type"] == "application/json"
         assert headers["Accept"] == "application/json"
         assert headers["User-Agent"] == "Vertex-DTE/1.0"
+
+
+def test_ensure_nota_snapshot_rehydrates_from_saved_json(tmp_path, monkeypatch):
+    base_code = "ABC123XYZ789"
+    origen_payload = {
+        "identificacion": {
+            "codigoGeneracion": base_code,
+            "numeroControl": "DTE-03-001",
+        }
+    }
+    source_dir = tmp_path / "facturas_credito_fiscal"
+    source_dir.mkdir()
+    (source_dir / "origen.json").write_text(json.dumps(origen_payload), encoding="utf-8")
+
+    dtes_dir = tmp_path / "dtes"
+    fcf_dir = tmp_path / "fcf"
+    consumidor_dir = tmp_path / "consumidor"
+    tickets_dir = tmp_path / "tickets"
+    notas_credito_dir = tmp_path / "notas_credito"
+    notas_debito_dir = tmp_path / "notas_debito"
+    archive_cf_dir = tmp_path / "archive_cf"
+    archive_credito_dir = tmp_path / "archive_credito"
+
+    for directory in (
+        dtes_dir,
+        fcf_dir,
+        consumidor_dir,
+        tickets_dir,
+        notas_credito_dir,
+        notas_debito_dir,
+        archive_cf_dir,
+        archive_credito_dir,
+    ):
+        directory.mkdir()
+
+    monkeypatch.setattr(dte, "DTES_DIR", str(dtes_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CONSUMIDOR_FINAL_DIR", str(consumidor_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CREDITO_FISCAL_DIR", str(source_dir))
+    monkeypatch.setattr(dte, "TICKETS_OUTPUT_DIR", str(tickets_dir))
+    monkeypatch.setattr(dte, "NOTAS_CREDITO_DIR", str(notas_credito_dir))
+    monkeypatch.setattr(dte, "NOTAS_DEBITO_DIR", str(notas_debito_dir))
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", str(archive_cf_dir))
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", str(archive_credito_dir))
+
+    monkeypatch.setattr(
+        dte,
+        "generar_nota_credito_json",
+        lambda db_obj, nota_ref: {"documentoRelacionado": [{"codigoGeneracion": base_code}]},
+    )
+
+    venta_id = 42
+    nota_id = 99
+
+    class DummyCursor:
+        def __init__(self, row):
+            self._row = row
+
+        def execute(self, *_args, **_kwargs):
+            return self
+
+        def fetchone(self):
+            return self._row
+
+    class DummyDB:
+        def __init__(self):
+            self.cursor = DummyCursor({"venta_id": venta_id, "tipo": "credito"})
+            self._snapshots = {}
+
+        def get_snapshot_by_venta(self, venta_ref):
+            return self._snapshots.get(venta_ref)
+
+        def set_snapshot_path(self, venta_ref, path):
+            self._snapshots[venta_ref] = path
+
+    db = DummyDB()
+    assert db.get_snapshot_by_venta(venta_id) is None
+
+    dte._ensure_nota_snapshot(db, nota_id, expected_tipo="credito")
+
+    stored_path = dtes_dir / base_code / "documento.json"
+    assert stored_path.exists()
+    with stored_path.open("r", encoding="utf-8") as fh:
+        persisted = json.load(fh)
+    assert persisted["identificacion"]["codigoGeneracion"] == base_code
+    assert db.get_snapshot_by_venta(venta_id) == str(stored_path)
+
+
+def test_ensure_nota_snapshot_rehydrates_from_typed_subdir(tmp_path, monkeypatch, caplog):
+    base_code = "TIPEDIR123"
+    payload = {
+        "identificacion": {
+            "codigoGeneracion": base_code,
+            "numeroControl": "DTE-04-001",
+        }
+    }
+
+    dtes_dir = tmp_path / "dtes"
+    source_path = dtes_dir / "fcf" / base_code / "documento.json"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(dte, "DTES_DIR", str(dtes_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CONSUMIDOR_FINAL_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_CREDITO_FISCAL_DIR", "")
+    monkeypatch.setattr(dte, "TICKETS_OUTPUT_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_CREDITO_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_DEBITO_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", "")
+
+    monkeypatch.setattr(
+        dte,
+        "generar_nota_credito_json",
+        lambda db_obj, nota_ref: {"documentoRelacionado": [{"codigoGeneracion": base_code}]},
+    )
+
+    venta_id = 314
+    nota_id = 2718
+
+    class DummyCursor:
+        def __init__(self, row):
+            self._row = row
+
+        def execute(self, *_args, **_kwargs):
+            return self
+
+        def fetchone(self):
+            return self._row
+
+    class DummyDB:
+        def __init__(self):
+            self.cursor = DummyCursor({"venta_id": venta_id, "tipo": "credito"})
+            self._snapshots = {}
+
+        def get_snapshot_by_venta(self, venta_ref):
+            return self._snapshots.get(venta_ref)
+
+        def set_snapshot_path(self, venta_ref, path):
+            self._snapshots[venta_ref] = path
+
+    db = DummyDB()
+    assert db.get_snapshot_by_venta(venta_id) is None
+
+    caplog.set_level(logging.INFO)
+    dte._ensure_nota_snapshot(db, nota_id, expected_tipo="credito")
+
+    stored_path = dtes_dir / base_code / "documento.json"
+    assert stored_path.exists()
+    assert db.get_snapshot_by_venta(venta_id) == str(stored_path)
+    assert any("SNAPSHOT: rehidratado" in rec.getMessage() for rec in caplog.records)
 
 
 def test_no_envia_si_validacion_falla(monkeypatch):


### PR DESCRIPTION
## Summary
- extend nota snapshot rehydration to scan typed DTE subdirectories, nested JSON files, and log recovered sources
- add a regression test that exercises rehydration when the source JSON lives under dtes/fcf/<codigo>/documento.json
- cache the factura sello lookup before persisting it to avoid referencing a transient dict value

## Testing
- pytest tests/test_envio_documentos.py::test_ensure_nota_snapshot_rehydrates_from_saved_json tests/test_envio_documentos.py::test_ensure_nota_snapshot_rehydrates_from_typed_subdir

------
https://chatgpt.com/codex/tasks/task_e_68da38088d208323a225cf245a6a9094