### PR TITLE
Harden nota snapshot rehydration edge cases

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -6372,32 +6372,6 @@ def _rehydrate_snapshot_from_fs(db: DB, nota_id: int, venta_id: int, expected_ti
     if tipo not in {"credito", "debito"}:
         return False
 
-    generator: Any
-    if tipo == "credito":
-        generator = generar_nota_credito_json
-    else:
-        generator = generar_nota_debito_json
-
-    try:
-        nota_json = generator(db, nota_id)
-    except Exception:
-        return False
-
-    referencias: list[dict[str, Any]] = []
-
-    def _collect_related(value: Any) -> None:
-        if isinstance(value, dict):
-            referencias.append(value)
-        elif isinstance(value, list) and value:
-            first = value[0]
-            if isinstance(first, dict):
-                referencias.append(first)
-
-    _collect_related(nota_json.get("documentoRelacionado"))
-    resumen = nota_json.get("resumen") or {}
-    if isinstance(resumen, dict):
-        _collect_related(resumen.get("documentoRelacionado"))
-
     def _normalize(value: Any) -> str:
         if value is None:
             return ""
@@ -6406,22 +6380,120 @@ def _rehydrate_snapshot_from_fs(db: DB, nota_id: int, venta_id: int, expected_ti
             return ""
         return text.upper()
 
-    target_code = ""
-    fallback_codes: list[str] = []
-    for ref in referencias:
-        codigo = _normalize(ref.get("codigoGeneracion") or ref.get("numeroDocumento"))
-        if codigo:
-            target_code = codigo
-            break
-        numero_control = _normalize(ref.get("numeroControl"))
-        if numero_control:
-            fallback_codes.append(numero_control)
-    if not target_code and fallback_codes:
-        target_code = fallback_codes[0]
-    if not target_code:
+    def _row_get(row_obj: Any, key: str, idx: int) -> Any:
+        if row_obj is None:
+            return None
+        if isinstance(row_obj, Mapping):
+            return row_obj.get(key)
+        try:
+            return row_obj[key]  # type: ignore[index]
+        except Exception:
+            pass
+        try:
+            return row_obj[idx]
+        except Exception:
+            return None
+
+    codigo_generacion = ""
+    numero_control = ""
+
+    cursor = getattr(db, "cursor", None)
+    if cursor is None:
         return False
 
-    search_keys = {target_code, *fallback_codes}
+    try:
+        row = cursor.execute(
+            """
+            SELECT codigo_generacion, numero_control
+            FROM dte_envios
+            WHERE venta_id = ?
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (venta_id,),
+        ).fetchone()
+    except Exception:
+        row = None
+
+    if row:
+        codigo_generacion = _row_get(row, "codigo_generacion", 0)
+        numero_control = _row_get(row, "numero_control", 1)
+
+    codigo_generacion_norm = _normalize(codigo_generacion)
+    numero_control_norm = _normalize(numero_control)
+
+    search_keys_ordered: list[str] = []
+    if codigo_generacion_norm:
+        search_keys_ordered.append(codigo_generacion_norm)
+    if numero_control_norm and numero_control_norm not in search_keys_ordered:
+        search_keys_ordered.append(numero_control_norm)
+
+    def _extend_from_related(source: Any) -> None:
+        if not source:
+            return
+        containers: list[Any] = []
+        if isinstance(source, (list, tuple, set)):
+            containers.extend(source)
+        else:
+            containers.append(source)
+        for item in containers:
+            if isinstance(item, dict):
+                codigo_val = _normalize(item.get("codigoGeneracion") or item.get("codigo_generacion"))
+                numero_val = _normalize(item.get("numeroControl") or item.get("numero_control"))
+                for value in (codigo_val, numero_val):
+                    if value and value not in search_keys_ordered:
+                        search_keys_ordered.append(value)
+
+    if not search_keys_ordered:
+        detalles_row = None
+        try:
+            detalles_row = cursor.execute(
+                "SELECT detalles FROM notas WHERE id=?",
+                (nota_id,),
+            ).fetchone()
+        except Exception:
+            detalles_row = None
+
+        detalles_payload: Any = None
+        if detalles_row:
+            detalles_value: Any = None
+            if isinstance(detalles_row, dict):
+                detalles_value = detalles_row.get("detalles")
+            else:
+                detalles_value = _row_get(detalles_row, "detalles", 0)
+            if isinstance(detalles_value, (bytes, bytearray)):
+                try:
+                    detalles_value = detalles_value.decode("utf-8")
+                except Exception:
+                    detalles_value = None
+            if isinstance(detalles_value, str):
+                try:
+                    detalles_payload = json.loads(detalles_value)
+                except Exception:
+                    detalles_payload = None
+            elif isinstance(detalles_value, dict):
+                detalles_payload = detalles_value
+
+        if isinstance(detalles_payload, dict):
+            related_candidates: list[Any] = []
+            for key in (
+                "documentoRelacionado",
+                "documentosRelacionados",
+                "documento_relacionado",
+                "documentos_relacionados",
+            ):
+                rel = detalles_payload.get(key)
+                if rel:
+                    related_candidates.append(rel)
+            for rel in related_candidates:
+                _extend_from_related(rel)
+
+    search_keys_ordered = [value for value in search_keys_ordered if value]
+    if not search_keys_ordered:
+        return False
+
+    search_keys = set(search_keys_ordered)
+    canonical_code = codigo_generacion_norm or search_keys_ordered[0]
 
     candidate_dirs: list[str] = []
     for directory in (
@@ -6441,6 +6513,11 @@ def _rehydrate_snapshot_from_fs(db: DB, nota_id: int, venta_id: int, expected_ti
     for t in typed:
         if t and t not in candidate_dirs:
             candidate_dirs.append(t)
+
+    try:
+        setter = getattr(db, "set_snapshot_path")
+    except AttributeError:
+        setter = None
 
     for directory in candidate_dirs:
         try:
@@ -6470,28 +6547,74 @@ def _rehydrate_snapshot_from_fs(db: DB, nota_id: int, venta_id: int, expected_ti
             numero_control = _normalize(ident.get("numeroControl"))
             if codigo not in search_keys and numero_control not in search_keys:
                 continue
-            dest_dir = Path(DTES_DIR) / (codigo or target_code)
+            dest_code = _normalize(ident.get("codigoGeneracion")) or canonical_code
+            if not dest_code:
+                dest_code = _normalize(ident.get("numeroControl"))
+            if not dest_code and search_keys_ordered:
+                dest_code = search_keys_ordered[0]
+            if not dest_code:
+                continue
+            dest_dir = Path(DTES_DIR) / dest_code
             try:
                 dest_dir.mkdir(parents=True, exist_ok=True)
             except Exception:
                 continue
             dest_path = dest_dir / "documento.json"
+            entry_resolved = entry
+            dest_resolved = dest_path
             try:
-                with dest_path.open("w", encoding="utf-8") as fh:
-                    json.dump(payload, fh, ensure_ascii=False)
+                entry_resolved = entry.resolve()
             except Exception:
+                pass
+            try:
+                dest_resolved = dest_path.resolve()
+            except FileNotFoundError:
+                dest_resolved = dest_path
+            except Exception:
+                dest_resolved = dest_path
+            if entry_resolved == dest_resolved:
+                logger.info("SNAPSHOT: ya existía %s", dest_path)
+                if callable(setter):
+                    try:
+                        setter(venta_id, str(dest_path))
+                    except Exception:
+                        pass
+                return True
+            tmp_path = dest_path.with_suffix(".json.tmp")
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except Exception:
+                pass
+            try:
+                shutil.copyfile(entry, tmp_path)
+                os.replace(tmp_path, dest_path)
+            except shutil.SameFileError:
+                if callable(setter):
+                    try:
+                        setter(venta_id, str(dest_path))
+                    except Exception:
+                        pass
+                return True
+            except Exception:
+                try:
+                    if tmp_path.exists():
+                        tmp_path.unlink()
+                except Exception:
+                    pass
                 continue
             logger.info("SNAPSHOT: rehidratado %s → %s", entry, dest_path)
-            try:
-                setter = getattr(db, "set_snapshot_path")
-            except AttributeError:
-                setter = None
             if callable(setter):
                 try:
                     setter(venta_id, str(dest_path))
                 except Exception:
                     pass
             return True
+    logger.warning(
+        "SNAPSHOT: no se encontró JSON para claves=%s en %d dirs",
+        search_keys_ordered,
+        len(candidate_dirs),
+    )
     return False
 
 

--- a/tests/test_envio_documentos.py
+++ b/tests/test_envio_documentos.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 import os
+import sqlite3
 import pytest
 import requests
 
@@ -232,35 +233,46 @@ def test_ensure_nota_snapshot_rehydrates_from_saved_json(tmp_path, monkeypatch):
     monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", str(archive_cf_dir))
     monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", str(archive_credito_dir))
 
-    monkeypatch.setattr(
-        dte,
-        "generar_nota_credito_json",
-        lambda db_obj, nota_ref: {"documentoRelacionado": [{"codigoGeneracion": base_code}]},
-    )
-
     venta_id = 42
     nota_id = 99
 
     class DummyCursor:
-        def __init__(self, row):
-            self._row = row
+        def __init__(self, nota_row, envio_row, detalles_row=None):
+            self._nota_row = nota_row
+            self._envio_row = envio_row
+            self._detalles_row = detalles_row if detalles_row is not None else nota_row
+            self._last_query = ""
 
         def execute(self, *_args, **_kwargs):
+            query = _args[0] if _args else ""
+            if isinstance(query, str):
+                self._last_query = query
             return self
 
         def fetchone(self):
-            return self._row
+            if "FROM notas" in self._last_query:
+                if "detalles" in self._last_query.lower():
+                    return self._detalles_row
+                return self._nota_row
+            if "FROM dte_envios" in self._last_query:
+                return self._envio_row
+            return None
 
     class DummyDB:
         def __init__(self):
-            self.cursor = DummyCursor({"venta_id": venta_id, "tipo": "credito"})
+            nota_row = {"venta_id": venta_id, "tipo": "credito"}
+            detalles_row = {"detalles": json.dumps({"documentoRelacionado": [{"codigoGeneracion": base_code}]})}
+            envio_row = {"codigo_generacion": base_code, "numero_control": "NC-001"}
+            self.cursor = DummyCursor(nota_row, envio_row, detalles_row)
             self._snapshots = {}
+            self.set_calls: list[tuple[int, str]] = []
 
         def get_snapshot_by_venta(self, venta_ref):
             return self._snapshots.get(venta_ref)
 
         def set_snapshot_path(self, venta_ref, path):
             self._snapshots[venta_ref] = path
+            self.set_calls.append((venta_ref, path))
 
     db = DummyDB()
     assert db.get_snapshot_by_venta(venta_id) is None
@@ -273,6 +285,98 @@ def test_ensure_nota_snapshot_rehydrates_from_saved_json(tmp_path, monkeypatch):
         persisted = json.load(fh)
     assert persisted["identificacion"]["codigoGeneracion"] == base_code
     assert db.get_snapshot_by_venta(venta_id) == str(stored_path)
+    assert db.set_calls == [(venta_id, str(stored_path))]
+
+
+def test_ensure_nota_snapshot_fallbacks_to_nota_detalles(tmp_path, monkeypatch):
+    base_code = "FALLBACK123456"
+    origen_payload = {
+        "identificacion": {
+            "codigoGeneracion": base_code,
+            "numeroControl": "DTE-07-001",
+        }
+    }
+
+    source_dir = tmp_path / "facturas_credito_fiscal"
+    source_dir.mkdir()
+    (source_dir / "legacy.json").write_text(json.dumps(origen_payload), encoding="utf-8")
+
+    dtes_dir = tmp_path / "dtes"
+    consumidor_dir = tmp_path / "consumidor"
+    notas_credito_dir = tmp_path / "notas_credito"
+    for directory in (dtes_dir, consumidor_dir, notas_credito_dir):
+        directory.mkdir()
+
+    monkeypatch.setattr(dte, "DTES_DIR", str(dtes_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CONSUMIDOR_FINAL_DIR", str(consumidor_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CREDITO_FISCAL_DIR", str(source_dir))
+    monkeypatch.setattr(dte, "TICKETS_OUTPUT_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_CREDITO_DIR", str(notas_credito_dir))
+    monkeypatch.setattr(dte, "NOTAS_DEBITO_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", "")
+
+    venta_id = 2112
+    nota_id = 1225
+
+    class DummyCursor:
+        def __init__(self, nota_row, envio_row, detalles_row=None):
+            self._nota_row = nota_row
+            self._envio_row = envio_row
+            self._detalles_row = detalles_row if detalles_row is not None else nota_row
+            self._last_query = ""
+
+        def execute(self, *_args, **_kwargs):
+            query = _args[0] if _args else ""
+            if isinstance(query, str):
+                self._last_query = query
+            return self
+
+        def fetchone(self):
+            if "FROM notas" in self._last_query:
+                if "detalles" in self._last_query.lower():
+                    return self._detalles_row
+                return self._nota_row
+            if "FROM dte_envios" in self._last_query:
+                return self._envio_row
+            return None
+
+    class DummyDB:
+        def __init__(self):
+            nota_row = {"venta_id": venta_id, "tipo": "credito"}
+            detalles_row = {
+                "detalles": json.dumps(
+                    {
+                        "documentoRelacionado": [
+                            {
+                                "codigoGeneracion": base_code,
+                                "numeroControl": "FALL-001",
+                            }
+                        ]
+                    }
+                )
+            }
+            envio_row = None
+            self.cursor = DummyCursor(nota_row, envio_row, detalles_row)
+            self._snapshots = {}
+            self.set_calls: list[tuple[int, str]] = []
+
+        def get_snapshot_by_venta(self, venta_ref):
+            return self._snapshots.get(venta_ref)
+
+        def set_snapshot_path(self, venta_ref, path):
+            self._snapshots[venta_ref] = path
+            self.set_calls.append((venta_ref, path))
+
+    db = DummyDB()
+    assert db.get_snapshot_by_venta(venta_id) is None
+
+    dte._ensure_nota_snapshot(db, nota_id, expected_tipo="credito")
+
+    stored_path = dtes_dir / base_code / "documento.json"
+    assert stored_path.exists()
+    assert db.get_snapshot_by_venta(venta_id) == str(stored_path)
+    assert db.set_calls == [(venta_id, str(stored_path))]
 
 
 def test_ensure_nota_snapshot_rehydrates_from_typed_subdir(tmp_path, monkeypatch, caplog):
@@ -298,35 +402,46 @@ def test_ensure_nota_snapshot_rehydrates_from_typed_subdir(tmp_path, monkeypatch
     monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", "")
     monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", "")
 
-    monkeypatch.setattr(
-        dte,
-        "generar_nota_credito_json",
-        lambda db_obj, nota_ref: {"documentoRelacionado": [{"codigoGeneracion": base_code}]},
-    )
-
     venta_id = 314
     nota_id = 2718
 
     class DummyCursor:
-        def __init__(self, row):
-            self._row = row
+        def __init__(self, nota_row, envio_row, detalles_row=None):
+            self._nota_row = nota_row
+            self._envio_row = envio_row
+            self._detalles_row = detalles_row if detalles_row is not None else nota_row
+            self._last_query = ""
 
         def execute(self, *_args, **_kwargs):
+            query = _args[0] if _args else ""
+            if isinstance(query, str):
+                self._last_query = query
             return self
 
         def fetchone(self):
-            return self._row
+            if "FROM notas" in self._last_query:
+                if "detalles" in self._last_query.lower():
+                    return self._detalles_row
+                return self._nota_row
+            if "FROM dte_envios" in self._last_query:
+                return self._envio_row
+            return None
 
     class DummyDB:
         def __init__(self):
-            self.cursor = DummyCursor({"venta_id": venta_id, "tipo": "credito"})
+            nota_row = {"venta_id": venta_id, "tipo": "credito"}
+            detalles_row = {"detalles": json.dumps({"documentoRelacionado": [{"codigoGeneracion": base_code}]})}
+            envio_row = {"codigo_generacion": base_code, "numero_control": "NC-002"}
+            self.cursor = DummyCursor(nota_row, envio_row, detalles_row)
             self._snapshots = {}
+            self.set_calls: list[tuple[int, str]] = []
 
         def get_snapshot_by_venta(self, venta_ref):
             return self._snapshots.get(venta_ref)
 
         def set_snapshot_path(self, venta_ref, path):
             self._snapshots[venta_ref] = path
+            self.set_calls.append((venta_ref, path))
 
     db = DummyDB()
     assert db.get_snapshot_by_venta(venta_id) is None
@@ -338,6 +453,185 @@ def test_ensure_nota_snapshot_rehydrates_from_typed_subdir(tmp_path, monkeypatch
     assert stored_path.exists()
     assert db.get_snapshot_by_venta(venta_id) == str(stored_path)
     assert any("SNAPSHOT: rehidratado" in rec.getMessage() for rec in caplog.records)
+    assert db.set_calls == [(venta_id, str(stored_path))]
+
+
+def test_ensure_nota_snapshot_handles_sqlite_row_metadata(tmp_path, monkeypatch):
+    base_code = "ROWMETA321"
+    payload = {
+        "identificacion": {
+            "codigoGeneracion": base_code,
+            "numeroControl": "DTE-05-009",
+        }
+    }
+
+    source_dir = tmp_path / "facturas_credito_fiscal"
+    source_dir.mkdir()
+    (source_dir / "legacy.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    dtes_dir = tmp_path / "dtes"
+    dtes_dir.mkdir()
+
+    monkeypatch.setattr(dte, "DTES_DIR", str(dtes_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CONSUMIDOR_FINAL_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_CREDITO_FISCAL_DIR", str(source_dir))
+    monkeypatch.setattr(dte, "TICKETS_OUTPUT_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_CREDITO_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_DEBITO_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", "")
+
+    venta_id = 918
+    nota_id = 273
+
+    sql_conn = sqlite3.connect(":memory:")
+    sql_conn.row_factory = sqlite3.Row
+    sql_cur = sql_conn.cursor()
+    sql_cur.execute(
+        "select ? as codigo_generacion, ? as numero_control",
+        (base_code, "NC-ROW-001"),
+    )
+    envio_row = sql_cur.fetchone()
+
+    sql_cur.execute(
+        "select ? as detalles",
+        (
+            json.dumps(
+                {
+                    "documentoRelacionado": [
+                        {
+                            "codigoGeneracion": base_code,
+                            "numeroControl": "ROW-CTRL-1",
+                        }
+                    ]
+                }
+            ),
+        ),
+    )
+    detalles_row = sql_cur.fetchone()
+    sql_conn.close()
+
+    class DummyCursor:
+        def __init__(self, nota_row, envio_row_obj, detalles_row_obj):
+            self._nota_row = nota_row
+            self._envio_row = envio_row_obj
+            self._detalles_row = detalles_row_obj
+            self._last_query = ""
+
+        def execute(self, *_args, **_kwargs):
+            query = _args[0] if _args else ""
+            if isinstance(query, str):
+                self._last_query = query
+            return self
+
+        def fetchone(self):
+            if "FROM notas" in self._last_query:
+                if "detalles" in self._last_query.lower():
+                    return self._detalles_row
+                return self._nota_row
+            if "FROM dte_envios" in self._last_query:
+                return self._envio_row
+            return None
+
+    class DummyDB:
+        def __init__(self):
+            nota_row = {"venta_id": venta_id, "tipo": "credito"}
+            self.cursor = DummyCursor(nota_row, envio_row, detalles_row)
+            self._snapshots = {}
+            self.set_calls: list[tuple[int, str]] = []
+
+        def get_snapshot_by_venta(self, venta_ref):
+            return self._snapshots.get(venta_ref)
+
+        def set_snapshot_path(self, venta_ref, path):
+            self._snapshots[venta_ref] = path
+            self.set_calls.append((venta_ref, path))
+
+    db = DummyDB()
+    assert db.get_snapshot_by_venta(venta_id) is None
+
+    dte._ensure_nota_snapshot(db, nota_id, expected_tipo="credito")
+
+    stored_path = dtes_dir / base_code / "documento.json"
+    assert stored_path.exists()
+    assert db.get_snapshot_by_venta(venta_id) == str(stored_path)
+    assert db.set_calls == [(venta_id, str(stored_path))]
+
+
+def test_ensure_nota_snapshot_when_canonical_exists(tmp_path, monkeypatch, caplog):
+    base_code = "EXISTE555"
+    payload = {
+        "identificacion": {
+            "codigoGeneracion": base_code,
+            "numeroControl": "DTE-06-444",
+        }
+    }
+
+    dtes_dir = tmp_path / "dtes"
+    canonical_path = dtes_dir / base_code / "documento.json"
+    canonical_path.parent.mkdir(parents=True, exist_ok=True)
+    canonical_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(dte, "DTES_DIR", str(dtes_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CONSUMIDOR_FINAL_DIR", str(dtes_dir))
+    monkeypatch.setattr(dte, "FACTURAS_CREDITO_FISCAL_DIR", "")
+    monkeypatch.setattr(dte, "TICKETS_OUTPUT_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_CREDITO_DIR", "")
+    monkeypatch.setattr(dte, "NOTAS_DEBITO_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CF_DIR", "")
+    monkeypatch.setattr(dte, "FACTURAS_ARCHIVE_CREDITO_DIR", "")
+
+    venta_id = 551
+    nota_id = 552
+
+    class DummyCursor:
+        def __init__(self, nota_row, envio_row):
+            self._nota_row = nota_row
+            self._envio_row = envio_row
+            self._last_query = ""
+
+        def execute(self, *_args, **_kwargs):
+            query = _args[0] if _args else ""
+            if isinstance(query, str):
+                self._last_query = query
+            return self
+
+        def fetchone(self):
+            if "FROM notas" in self._last_query:
+                return self._nota_row
+            if "FROM dte_envios" in self._last_query:
+                return self._envio_row
+            return None
+
+    class DummyDB:
+        def __init__(self):
+            nota_row = {"venta_id": venta_id, "tipo": "credito"}
+            envio_row = {"codigo_generacion": base_code, "numero_control": "NC-EXISTE"}
+            self.cursor = DummyCursor(nota_row, envio_row)
+            self._snapshots = {}
+            self.set_calls: list[tuple[int, str]] = []
+
+        def get_snapshot_by_venta(self, venta_ref):
+            return self._snapshots.get(venta_ref)
+
+        def set_snapshot_path(self, venta_ref, path):
+            self._snapshots[venta_ref] = path
+            self.set_calls.append((venta_ref, path))
+
+    db = DummyDB()
+    assert db.get_snapshot_by_venta(venta_id) is None
+
+    def fail_copy(src, dst):  # pragma: no cover - should not be called
+        raise AssertionError("copyfile should not be called when canonical exists")
+
+    monkeypatch.setattr(dte.shutil, "copyfile", fail_copy)
+
+    caplog.set_level(logging.INFO)
+    dte._ensure_nota_snapshot(db, nota_id, expected_tipo="credito")
+
+    assert db.get_snapshot_by_venta(venta_id) == str(canonical_path)
+    assert db.set_calls == [(venta_id, str(canonical_path))]
+    assert any("SNAPSHOT: ya existía" in rec.getMessage() for rec in caplog.records)
 
 
 def test_no_envia_si_validacion_falla(monkeypatch):


### PR DESCRIPTION
## Summary
- add a defensive `_row_get` helper so `_rehydrate_snapshot_from_fs` can read sqlite3.Row results and nota detalle payloads without `.get`
- copy matching snapshots atomically, detect already-canonical files, persist the canonical path, and emit a warning when no candidates match
- extend envio document tests with sqlite row coverage and a canonical-file scenario to ensure `set_snapshot_path` is called without copying

## Testing
- pytest tests/test_envio_documentos.py -k snapshot -q

------
https://chatgpt.com/codex/tasks/task_e_68dac0a4156c8323bccbe78194dff677