### PR TITLE
Ensure notas reuse original emission dates

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -154,8 +154,9 @@ def generar_nce_desde_nota(
         fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
-        if isinstance(identificacion, dict) and not identificacion.get("fecEmi"):
-            identificacion["fecEmi"] = fecha_origen
+        if isinstance(identificacion, dict):
+            if identificacion.get("fecEmi") != fecha_origen:
+                identificacion["fecEmi"] = fecha_origen
 
     detalles = None
     if nota.get("detalles"):
@@ -172,6 +173,7 @@ def generar_nce_desde_nota(
             detalles=detalles,
             ambiente=ambiente,
             motivo=nota.get("motivo"),
+            fecha_origen=fecha_origen,
         )
     else:
         resumen_origen = dte_origen.get("resumen", {})
@@ -195,6 +197,7 @@ def generar_nce_desde_nota(
             ambiente=ambiente,
             motivo=nota.get("motivo"),
             monto=monto_nc,
+            fecha_origen=fecha_origen,
         )
 
     doc_rel = resultado.get("documentoRelacionado") or []
@@ -235,6 +238,7 @@ def generar_nce_desde_dte(
     ambiente: str = "00",
     motivo: Optional[str] = None,
     monto: Decimal | None = None,
+    fecha_origen: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una NCE."""
     if detalles is None:
@@ -290,6 +294,8 @@ def generar_nce_desde_dte(
     fecha_doc_rel = normalizar_fecha_iso(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
+    if not fecha_doc_rel and fecha_origen:
+        fecha_doc_rel = normalizar_fecha_iso(fecha_origen)
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -132,8 +132,9 @@ def generar_nde_desde_nota(
         fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
-        if isinstance(identificacion, dict) and not identificacion.get("fecEmi"):
-            identificacion["fecEmi"] = fecha_origen
+        if isinstance(identificacion, dict):
+            if identificacion.get("fecEmi") != fecha_origen:
+                identificacion["fecEmi"] = fecha_origen
 
     detalles = None
     if nota.get("detalles"):
@@ -149,6 +150,7 @@ def generar_nde_desde_nota(
         nota.get("monto"),
         nota.get("motivo"),
         ambiente=ambiente,
+        fecha_origen=fecha_origen,
     )
 
     doc_rel = resultado.get("documentoRelacionado") or []
@@ -188,6 +190,7 @@ def generar_nde_desde_dte(
     motivo: str | None = None,
     *,
     ambiente: str = "00",
+    fecha_origen: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
     origen_ident = dte_origen.get("identificacion", {})
@@ -239,6 +242,8 @@ def generar_nde_desde_dte(
     fecha_doc_rel = normalizar_fecha_iso(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
+    if not fecha_doc_rel and fecha_origen:
+        fecha_doc_rel = normalizar_fecha_iso(fecha_origen)
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -1,4 +1,5 @@
 import fitz
+from copy import deepcopy
 from decimal import Decimal, ROUND_HALF_UP
 from db import DB
 from dte import generar_dte_json
@@ -135,6 +136,45 @@ def test_generar_nce_desde_nota_credito_fiscal(monkeypatch):
     assert receptor_nota["nit"] == "06141407100012"
     assert receptor_nota["nrc"] == "123"
     assert receptor_nota.get("nombreComercial") in {None, "Cliente"}
+
+
+def test_generar_nce_desde_nota_regenera_dte_fecha(monkeypatch):
+    monkeypatch.setattr(
+        "svfe.config.load_datos_negocio",
+        lambda: {"direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"}},
+    )
+    monkeypatch.setattr("dte.validate_dte_json", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_fecha = "2024-03-15"
+    venta_id = db.add_venta(venta_fecha, 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    dte_base = generar_dte_json(db, venta_id, tipo_dte="01")
+    dte_alterado = deepcopy(dte_base)
+    dte_alterado["identificacion"]["fecEmi"] = "2024-03-18"
+
+    monkeypatch.setattr(
+        "nota_credito_electronica.generar_dte_json",
+        lambda *args, **kwargs: deepcopy(dte_alterado),
+    )
+
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'credito', '2024-03-20', 10, 'Dev')",
+        (venta_id,),
+    ).lastrowid
+
+    nce = generar_nce_desde_nota(db, nota_id, strict_snapshot=False)
+    doc_rel = nce["documentoRelacionado"][0]
+    assert doc_rel["fechaEmision"] == venta_fecha
 
 
 def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,4 +1,5 @@
 import fitz
+from copy import deepcopy
 from decimal import Decimal
 import pytest
 from db import DB
@@ -152,6 +153,53 @@ def test_generar_nde_desde_nota_credito_fiscal(monkeypatch):
     assert receptor["nit"] == "06141407100012"
     assert receptor["nrc"] == "123"
     assert receptor.get("nombreComercial") in {None, "Cliente"}
+
+
+def test_generar_nde_desde_nota_regenera_dte_fecha(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    }
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(
+        "dte._build_receptor_direccion",
+        lambda src: {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+    )
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vid = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vid, None, 0, 0, 0, 10)
+    pid = db.cursor.lastrowid
+    venta_fecha = "2024-04-10"
+    venta_id = db.add_venta(venta_fecha, 10)
+    db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
+
+    dte_base = generar_dte_json(db, venta_id, tipo_dte="01")
+    dte_alterado = deepcopy(dte_base)
+    dte_alterado["identificacion"]["fecEmi"] = "2024-04-12"
+
+    monkeypatch.setattr(
+        "nota_debito_electronica.generar_dte_json",
+        lambda *args, **kwargs: deepcopy(dte_alterado),
+    )
+
+    nota_id = db.cursor.execute(
+        "INSERT INTO notas (venta_id, tipo, fecha, monto, motivo) VALUES (?, 'debito', '2024-04-15', 10, 'Ajuste')",
+        (venta_id,),
+    ).lastrowid
+
+    nde = generar_nde_desde_nota(db, nota_id, strict_snapshot=False)
+    doc_rel = nde["documentoRelacionado"][0]
+    assert doc_rel["fechaEmision"] == venta_fecha
 
 
 def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- align nota crédito/débito generators to always override the origin DTE emission date and reuse it for related document metadata
- add regression coverage that exercises the regenerated DTE path and asserts the related document keeps the original sale date

## Testing
- pytest tests/test_nota_credito.py::test_generar_nce_desde_nota_regenera_dte_fecha -q
- pytest tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_regenera_dte_fecha -q

------
https://chatgpt.com/codex/tasks/task_e_68daebe51fcc8323af6c36c0ce3bf083