### PR TITLE
Normalizar fechas dd/mm/aaaa en documentos relacionados de notas

### DIFF
--- a/db.py
+++ b/db.py
@@ -16,6 +16,7 @@ from utils.fiscal_extra import build_fiscal_extra, normalize_tipo_fiscal
 from utils.line_totals import compute_line_totals
 from utils.monto import d8
 from utils.snapshot import Snapshot
+from utils.fecha import normalizar_fecha_iso
 from paths import DTES_DIR, get_canonical_dte_dir, user_data_path
 
 logging.basicConfig(level=logging.INFO)
@@ -2712,6 +2713,38 @@ class DB:
             return json.loads(row[0])
         except Exception:
             return {}
+
+    def get_envio_fecha_emision(self, venta_id):
+        """Obtiene la fecha de emisión del último envío registrado para la venta."""
+
+        self.ensure_column("dte_envios", "respuesta", "TEXT")
+        row = self.cursor.execute(
+            "SELECT fecha_hora, respuesta FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
+            (venta_id,),
+        ).fetchone()
+        if not row:
+            return None
+
+        fh_procesamiento = None
+        raw_respuesta = row["respuesta"] if isinstance(row, sqlite3.Row) else row[1]
+        if raw_respuesta:
+            try:
+                respuesta = json.loads(raw_respuesta)
+            except Exception:
+                respuesta = None
+            if isinstance(respuesta, dict):
+                fh_procesamiento = respuesta.get("fhProcesamiento")
+                if not fh_procesamiento:
+                    body = respuesta.get("body")
+                    if isinstance(body, dict):
+                        fh_procesamiento = body.get("fhProcesamiento")
+        if fh_procesamiento:
+            fecha_procesada = normalizar_fecha_iso(fh_procesamiento)
+            if fecha_procesada:
+                return fecha_procesada
+
+        fecha_hora = row["fecha_hora"] if isinstance(row, sqlite3.Row) else row[0]
+        return normalizar_fecha_iso(fecha_hora)
 
     def listar_dtes(self, fecha_inicio=None, fecha_fin=None, estado=None):
         """Lista registros de ``dte_envios`` filtrando por fecha y estado."""

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -32,7 +32,12 @@ from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
 from utils.env import env_flag
 from utils import metrics
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import (
+    TZ_EL_SALVADOR,
+    fecha_ddmmaaaa,
+    fecha_emision_hoy_str,
+    normalizar_fecha_iso,
+)
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
 from utils.sanitize import solo_digitos
 from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
@@ -129,10 +134,19 @@ def generar_nce_desde_nota(
 
     snapshot = db.get_snapshot_by_venta(venta_id) if venta_id is not None else None
     source_used = "db"
+    fecha_relacionada_ddmmaa = None
     if snapshot:
         dte_origen = normalize_snapshot(snapshot.payload)
         source_used = "snapshot"
         uuid_origen = snapshot.uuid.upper() if snapshot.uuid else None
+        ident_snapshot = (
+            snapshot.payload.get("identificacion") if isinstance(snapshot.payload, dict) else None
+        )
+        if isinstance(ident_snapshot, dict):
+            base_fec_snapshot = (
+                ident_snapshot.get("fecEmi") or ident_snapshot.get("fechaEmision")
+            )
+            fecha_relacionada_ddmmaa = fecha_ddmmaaaa(base_fec_snapshot)
     else:
         if strict and venta_id is not None:
             raise SnapshotNotFoundError(venta_id, nota_id)
@@ -150,13 +164,19 @@ def generar_nce_desde_nota(
     fecha_origen = None
     if snapshot and snapshot.fecha_emision:
         fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
-    elif venta:
+    if not fecha_origen and venta_id is not None:
+        fecha_envio = db.get_envio_fecha_emision(venta_id)
+        if fecha_envio:
+            fecha_origen = normalizar_fecha_iso(fecha_envio)
+    if not fecha_origen and venta:
         fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
         if isinstance(identificacion, dict):
             if identificacion.get("fecEmi") != fecha_origen:
                 identificacion["fecEmi"] = fecha_origen
+    if not fecha_relacionada_ddmmaa:
+        fecha_relacionada_ddmmaa = fecha_ddmmaaaa(fecha_origen)
 
     detalles = None
     if nota.get("detalles"):
@@ -174,6 +194,7 @@ def generar_nce_desde_nota(
             ambiente=ambiente,
             motivo=nota.get("motivo"),
             fecha_origen=fecha_origen,
+            fecha_relacionada_ddmmaa=fecha_relacionada_ddmmaa,
         )
     else:
         resumen_origen = dte_origen.get("resumen", {})
@@ -198,23 +219,29 @@ def generar_nce_desde_nota(
             motivo=nota.get("motivo"),
             monto=monto_nc,
             fecha_origen=fecha_origen,
+            fecha_relacionada_ddmmaa=fecha_relacionada_ddmmaa,
         )
 
     doc_rel = resultado.get("documentoRelacionado") or []
     rel = doc_rel[0] if doc_rel else {}
     duration_ms = (time.perf_counter() - start) * 1000
     metrics.inc(f"notes_source_used.{source_used}")
-    if (
-        fecha_origen
-        and rel.get("fechaEmision")
-        and rel.get("fechaEmision") != fecha_origen
-    ):
-        logger.warning(
-            "documentoRelacionado.fechaEmision: valor no verificable localmente nota_id=%s venta_id=%s uuid=%s",
-            nota_id,
-            venta_id,
-            uuid_origen,
-        )
+    if fecha_origen and rel.get("fechaEmision"):
+        rel_iso = normalizar_fecha_iso(rel.get("fechaEmision"))
+        if rel_iso and rel_iso != fecha_origen:
+            logger.warning(
+                "documentoRelacionado.fechaEmision: valor no verificable localmente nota_id=%s venta_id=%s uuid=%s",
+                nota_id,
+                venta_id,
+                uuid_origen,
+            )
+        elif not rel_iso:
+            logger.warning(
+                "documentoRelacionado.fechaEmision no se pudo normalizar nota_id=%s venta_id=%s uuid=%s",
+                nota_id,
+                venta_id,
+                uuid_origen,
+            )
     logger.info(
         "NCE relaciona tipo=%s uuid=%s num=%s fec=%s fuente=%s nota_id=%s venta_id=%s dur_ms=%.3f",
         rel.get("tipoDocumento"),
@@ -239,6 +266,7 @@ def generar_nce_desde_dte(
     motivo: Optional[str] = None,
     monto: Decimal | None = None,
     fecha_origen: Optional[str] = None,
+    fecha_relacionada_ddmmaa: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una NCE."""
     if detalles is None:
@@ -291,11 +319,11 @@ def generar_nce_desde_dte(
         )
         numero_documento = str(numero_documento).strip()
 
-    fecha_doc_rel = normalizar_fecha_iso(
+    fecha_doc_rel = fecha_relacionada_ddmmaa or fecha_ddmmaaaa(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
     if not fecha_doc_rel and fecha_origen:
-        fecha_doc_rel = normalizar_fecha_iso(fecha_origen)
+        fecha_doc_rel = fecha_ddmmaaaa(fecha_origen)
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -30,7 +30,12 @@ from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
 from utils.env import env_flag
 from utils import metrics
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import (
+    TZ_EL_SALVADOR,
+    fecha_ddmmaaaa,
+    fecha_emision_hoy_str,
+    normalizar_fecha_iso,
+)
 from utils.monto import d2, monto_a_texto_sv
 from utils.sanitize import solo_digitos
 from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
@@ -107,10 +112,19 @@ def generar_nde_desde_nota(
 
     snapshot = db.get_snapshot_by_venta(venta_id) if venta_id is not None else None
     source_used = "db"
+    fecha_relacionada_ddmmaa = None
     if snapshot:
         dte_origen = normalize_snapshot(snapshot.payload)
         source_used = "snapshot"
         uuid_origen = snapshot.uuid.upper() if snapshot.uuid else None
+        ident_snapshot = (
+            snapshot.payload.get("identificacion") if isinstance(snapshot.payload, dict) else None
+        )
+        if isinstance(ident_snapshot, dict):
+            base_fec_snapshot = (
+                ident_snapshot.get("fecEmi") or ident_snapshot.get("fechaEmision")
+            )
+            fecha_relacionada_ddmmaa = fecha_ddmmaaaa(base_fec_snapshot)
     else:
         if strict and venta_id is not None:
             raise SnapshotNotFoundError(venta_id, nota_id)
@@ -128,13 +142,19 @@ def generar_nde_desde_nota(
     fecha_origen = None
     if snapshot and snapshot.fecha_emision:
         fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
-    elif venta:
+    if not fecha_origen and venta_id is not None:
+        fecha_envio = db.get_envio_fecha_emision(venta_id)
+        if fecha_envio:
+            fecha_origen = normalizar_fecha_iso(fecha_envio)
+    if not fecha_origen and venta:
         fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
         if isinstance(identificacion, dict):
             if identificacion.get("fecEmi") != fecha_origen:
                 identificacion["fecEmi"] = fecha_origen
+    if not fecha_relacionada_ddmmaa:
+        fecha_relacionada_ddmmaa = fecha_ddmmaaaa(fecha_origen)
 
     detalles = None
     if nota.get("detalles"):
@@ -151,23 +171,29 @@ def generar_nde_desde_nota(
         nota.get("motivo"),
         ambiente=ambiente,
         fecha_origen=fecha_origen,
+        fecha_relacionada_ddmmaa=fecha_relacionada_ddmmaa,
     )
 
     doc_rel = resultado.get("documentoRelacionado") or []
     rel = doc_rel[0] if doc_rel else {}
     duration_ms = (time.perf_counter() - start) * 1000
     metrics.inc(f"notes_source_used.{source_used}")
-    if (
-        fecha_origen
-        and rel.get("fechaEmision")
-        and rel.get("fechaEmision") != fecha_origen
-    ):
-        logger.warning(
-            "documentoRelacionado.fechaEmision: valor no verificable localmente nota_id=%s venta_id=%s uuid=%s",
-            nota_id,
-            venta_id,
-            uuid_origen,
-        )
+    if fecha_origen and rel.get("fechaEmision"):
+        rel_iso = normalizar_fecha_iso(rel.get("fechaEmision"))
+        if rel_iso and rel_iso != fecha_origen:
+            logger.warning(
+                "documentoRelacionado.fechaEmision: valor no verificable localmente nota_id=%s venta_id=%s uuid=%s",
+                nota_id,
+                venta_id,
+                uuid_origen,
+            )
+        elif not rel_iso:
+            logger.warning(
+                "documentoRelacionado.fechaEmision no se pudo normalizar nota_id=%s venta_id=%s uuid=%s",
+                nota_id,
+                venta_id,
+                uuid_origen,
+            )
     logger.info(
         "NDE relaciona tipo=%s uuid=%s num=%s fec=%s fuente=%s nota_id=%s venta_id=%s dur_ms=%.3f",
         rel.get("tipoDocumento"),
@@ -191,6 +217,7 @@ def generar_nde_desde_dte(
     *,
     ambiente: str = "00",
     fecha_origen: Optional[str] = None,
+    fecha_relacionada_ddmmaa: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
     origen_ident = dte_origen.get("identificacion", {})
@@ -239,11 +266,11 @@ def generar_nde_desde_dte(
         )
         numero_documento = str(numero_documento).strip()
 
-    fecha_doc_rel = normalizar_fecha_iso(
+    fecha_doc_rel = fecha_relacionada_ddmmaa or fecha_ddmmaaaa(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
     if not fecha_doc_rel and fecha_origen:
-        fecha_doc_rel = normalizar_fecha_iso(fecha_origen)
+        fecha_doc_rel = fecha_ddmmaaaa(fecha_origen)
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -25,8 +25,14 @@ from typing import Iterable, Optional
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import (
+    TZ_EL_SALVADOR,
+    fecha_ddmmaaaa,
+    fecha_emision_hoy_str,
+    normalizar_fecha_iso,
+)
 from utils.monto import monto_a_texto_sv, d2
+from utils.snapshot import normalize_snapshot
 import warnings
 
 from utils.sanitize import limpiar_documentos, solo_digitos
@@ -140,16 +146,15 @@ def _normalizar_documento_relacionado(doc_rel: list[dict]) -> list[dict]:
         raise ValueError(
             "documento_relacionado requiere numeroDocumento y fechaEmision"
         )
-    try:
-        datetime.fromisoformat(fecha)
-    except Exception as exc:
-        raise ValueError("fechaEmision inválida en documento_relacionado") from exc
+    fecha_formateada = fecha_ddmmaaaa(fecha)
+    if not fecha_formateada:
+        raise ValueError("fechaEmision inválida en documento_relacionado")
     return [
         {
             "tipoDocumento": tipo,
             "tipoGeneracion": 2,
             "numeroDocumento": numero,
-            "fechaEmision": fecha,
+            "fechaEmision": fecha_formateada,
         }
     ]
 
@@ -179,17 +184,23 @@ def generar_nota_remision(
         detalles = detalles or factura.get("cuerpoDocumento", [])
         if documento_relacionado is None:
             ident = factura.get("identificacion", {})
-            fecha_emision = normalizar_fecha_iso(ident.get("fecEmi"))
+            fecha_base = ident.get("fecEmi") or ident.get("fechaEmision")
+            fecha_emision = normalizar_fecha_iso(fecha_base)
             if fecha_emision:
                 ident["fecEmi"] = fecha_emision
             else:
                 fecha_emision = ident.get("fecEmi")
+            fecha_doc_rel = (
+                fecha_ddmmaaaa(fecha_base)
+                or fecha_ddmmaaaa(fecha_emision)
+                or fecha_emision
+            )
             documento_relacionado = [
                 {
                     "tipoDocumento": ident.get("tipoDte"),
                     "tipoGeneracion": 2,
                     "numeroDocumento": ident.get("codigoGeneracion"),
-                    "fechaEmision": fecha_emision,
+                    "fechaEmision": fecha_doc_rel,
                 }
             ]
         # Para notas derivadas de factura la extensión puede omitirse
@@ -349,14 +360,43 @@ def generar_nota_remision_desde_db(
 
         from dte import generar_dte_json
 
-        fecha_origen = normalizar_fecha_iso(venta.get("fecha")) if venta else None
-        dte_origen = generar_dte_json(db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente)
-        if fecha_origen:
+        fecha_origen = None
+        snapshot = db.get_snapshot_by_venta(venta_id)
+        if snapshot:
+            try:
+                dte_origen = normalize_snapshot(snapshot.payload)
+            except Exception:
+                dte_origen = None
+            else:
+                if snapshot.fecha_emision:
+                    fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
+        else:
+            dte_origen = None
+
+        if dte_origen is None:
+            dte_origen = generar_dte_json(
+                db, venta_id, tipo_dte=tipo_doc, ambiente=ambiente
+            )
+
+        if not fecha_origen and venta_id is not None:
+            fecha_envio = db.get_envio_fecha_emision(venta_id)
+            if fecha_envio:
+                fecha_origen = normalizar_fecha_iso(fecha_envio)
+
+        if not fecha_origen and venta:
+            fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
+
+        if fecha_origen and isinstance(dte_origen, dict):
             dte_ident = dte_origen.setdefault("identificacion", {})
-            dte_ident["fecEmi"] = fecha_origen
+            if isinstance(dte_ident, dict):
+                dte_ident["fecEmi"] = fecha_origen
+
         extension = extra.get("extension") or {}
         return generar_nota_remision(
-            db, factura=dte_origen, extension=extension, ambiente=ambiente
+            db,
+            factura=dte_origen,
+            extension=extension,
+            ambiente=ambiente,
         )
 
     factura = extra.get("factura")

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -20,7 +20,12 @@ from typing import Iterable, Optional
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import (
+    TZ_EL_SALVADOR,
+    fecha_ddmmaaaa,
+    fecha_emision_hoy_str,
+    normalizar_fecha_iso,
+)
 from utils.monto import d2, monto_a_texto_sv
 import warnings
 
@@ -217,6 +222,7 @@ def generar_nota_remision_desde_factura(
     detalles: Optional[Iterable[dict]] = None,
     extension: Optional[dict] = None,
     ambiente: str = "00",
+    fecha_origen: Optional[str] = None,
 ) -> dict:
     """Genera una NR reutilizando los datos de una factura ``factura``."""
 
@@ -224,18 +230,34 @@ def generar_nota_remision_desde_factura(
     receptor = factura.get("receptor", {})
     receptor.setdefault("bienTitulo", "01")
     detalles = detalles or factura.get("cuerpoDocumento", [])
-    ident = factura.get("identificacion", {})
-    fecha_emision = normalizar_fecha_iso(ident.get("fecEmi"))
-    if fecha_emision:
-        ident["fecEmi"] = fecha_emision
-    else:
-        fecha_emision = ident.get("fecEmi")
+    ident = factura.get("identificacion") or {}
+    if not isinstance(ident, dict):
+        ident = {}
+        factura["identificacion"] = ident
+    fecha_emision = None
+    if fecha_origen:
+        fecha_normalizada = normalizar_fecha_iso(fecha_origen)
+        if fecha_normalizada:
+            fecha_emision = fecha_normalizada
+            ident["fecEmi"] = fecha_emision
+    if not fecha_emision:
+        fecha_normalizada = normalizar_fecha_iso(ident.get("fecEmi"))
+        if fecha_normalizada:
+            fecha_emision = fecha_normalizada
+            ident["fecEmi"] = fecha_emision
+        else:
+            fecha_emision = ident.get("fecEmi")
+    fecha_doc_rel = (
+        fecha_ddmmaaaa(fecha_emision)
+        or fecha_ddmmaaaa(ident.get("fecEmi"))
+        or fecha_emision
+    )
     doc_rel = [
         {
             "tipoDocumento": ident.get("tipoDte"),
             "tipoGeneracion": 2,
             "numeroDocumento": ident.get("codigoGeneracion"),
-            "fechaEmision": fecha_emision,
+            "fechaEmision": fecha_doc_rel,
         }
     ]
     ext = extension.copy() if extension else None

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -1,5 +1,6 @@
 import fitz
 from copy import deepcopy
+import json
 from decimal import Decimal, ROUND_HALF_UP
 from db import DB
 from dte import generar_dte_json
@@ -8,6 +9,7 @@ import pytest
 from factura_sv import generar_nota_credito_pdf
 import utils.catalogos as catalogos
 from utils.snapshot import Snapshot, SnapshotNotFoundError
+from utils.fecha import fecha_ddmmaaaa
 
 
 def create_db():
@@ -172,9 +174,18 @@ def test_generar_nce_desde_nota_regenera_dte_fecha(monkeypatch):
         (venta_id,),
     ).lastrowid
 
+    fecha_envio = "2024-03-18"
+    db.registrar_envio_dte(
+        venta_id,
+        "auto",
+        "procesado",
+        "SELLO",
+        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio}T12:34:56"}),
+    )
+
     nce = generar_nce_desde_nota(db, nota_id, strict_snapshot=False)
     doc_rel = nce["documentoRelacionado"][0]
-    assert doc_rel["fechaEmision"] == venta_fecha
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa(fecha_envio)
 
 
 def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
@@ -264,7 +275,7 @@ def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         doc_rel["numeroDocumento"]
         == payload["identificacion"]["codigoGeneracion"].upper()
     )
-    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa("2023-08-01")
     assert metrics_calls == ["notes_source_used.snapshot"]
     assert payload["firma"] == "SIGNATURE"
 
@@ -348,7 +359,7 @@ def test_generar_nce_desde_nota_snapshot_dui(monkeypatch, tmp_path):
     assert doc_rel["tipoDocumento"] == "01"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
-    assert doc_rel["fechaEmision"] == "2023-09-01"
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa("2023-09-01")
 
 
 def test_generar_nce_desde_nota_strict_snapshot(monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -1,6 +1,8 @@
-import fitz
 from copy import deepcopy
 from decimal import Decimal
+import json
+
+import fitz
 import pytest
 from db import DB
 from nota_debito_electronica import generar_nde_desde_dte, generar_nde_desde_nota
@@ -8,6 +10,7 @@ from dte import generar_dte_json
 from nota_remision import generar_nota_remision_desde_db, generar_nota_remision
 from factura_sv import generar_nota_debito_pdf, generar_nota_remision_pdf
 from utils.snapshot import Snapshot, SnapshotNotFoundError
+from utils.fecha import fecha_ddmmaaaa
 import utils.catalogos as catalogos
 
 
@@ -73,7 +76,18 @@ def test_generar_nota_debito_json_ticket(tmp_path, monkeypatch):
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", None,  vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "1234567", "06141407100012", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "1234567",
+        "06141407100012",
+        "",
+        "giro",
+        "22223456",
+        "cliente@example.com",
+        "",
+        "",
+        "",
+    )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "1234567", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
@@ -197,9 +211,18 @@ def test_generar_nde_desde_nota_regenera_dte_fecha(monkeypatch):
         (venta_id,),
     ).lastrowid
 
+    fecha_envio = "2024-04-12"
+    db.registrar_envio_dte(
+        venta_id,
+        "auto",
+        "procesado",
+        "SELLO",
+        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio}T08:15:00"}),
+    )
+
     nde = generar_nde_desde_nota(db, nota_id, strict_snapshot=False)
     doc_rel = nde["documentoRelacionado"][0]
-    assert doc_rel["fechaEmision"] == venta_fecha
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa(fecha_envio)
 
 
 def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
@@ -307,7 +330,7 @@ def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         doc_rel["numeroDocumento"]
         == payload["identificacion"]["codigoGeneracion"].upper()
     )
-    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa("2023-08-01")
     assert metrics_calls == ["notes_source_used.snapshot"]
     assert payload["firma"] == "SIGNATURE"
 
@@ -399,7 +422,7 @@ def test_generar_nde_desde_nota_snapshot_dui(monkeypatch, tmp_path):
     assert doc_rel["tipoDocumento"] == "01"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
-    assert doc_rel["fechaEmision"] == "2023-09-01"
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa("2023-09-01")
 
 
 def test_generar_nde_desde_nota_strict_snapshot(monkeypatch):
@@ -701,7 +724,18 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
     vid = db.cursor.lastrowid
     db.add_producto("Prod", "P1", None,  vid, None, 0, 0, 0, 10)
     pid = db.cursor.lastrowid
-    db.add_cliente("Cliente", "1234567", "06141407100012", "", "giro", "", "", "", "", "")
+    db.add_cliente(
+        "Cliente",
+        "1234567",
+        "06141407100012",
+        "",
+        "giro",
+        "22223456",
+        "cliente@example.com",
+        "",
+        "",
+        "",
+    )
     cliente_id = db.cursor.lastrowid
     venta_id = db.add_venta_credito_fiscal(cliente_id, "2024-01-01", 10, "1234567", "06141407100012", "giro", descuentos=0)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
@@ -717,10 +751,20 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
         "remision", venta_id, "2024-01-02", 0, "Envio", detalles=extra
     )
 
+    fecha_envio = "2024-01-03"
+    db.registrar_envio_dte(
+        venta_id,
+        "auto",
+        "procesado",
+        "SELLO",
+        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio}T08:00:00"}),
+    )
+
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "04"
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert data["extension"]["nombEntrega"] == "Juan"
+    assert data["documentoRelacionado"][0]["fechaEmision"] == fecha_ddmmaaaa(fecha_envio)
 
 
 def test_nota_debito_pdf(tmp_path):

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -6,6 +6,7 @@ from nota_remision_electronica import (
     generar_nota_remision_desde_factura,
     generar_nota_remision_independiente,
 )
+from utils.fecha import fecha_ddmmaaaa
 import dte
 
 
@@ -69,7 +70,7 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
-    assert doc_rel["fechaEmision"] == "2024-01-01"
+    assert doc_rel["fechaEmision"] == fecha_ddmmaaaa("2024-01-01")
     assert factura["identificacion"]["fecEmi"] == "2024-01-01"
     item = data["cuerpoDocumento"][0]
     assert item["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"

--- a/utils/fecha.py
+++ b/utils/fecha.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+import re
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -52,3 +53,36 @@ def normalizar_fecha_iso(value: Union[str, datetime, date, None]) -> Optional[st
             return None
 
     return fecha_dt.date().isoformat()
+
+
+def fecha_ddmmaaaa(value: Union[str, datetime, date, None]) -> Optional[str]:
+    """Convierte ``value`` al formato ``dd/mm/aaaa`` si es posible."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return value.strftime("%d/%m/%Y")
+
+    if isinstance(value, date):
+        return value.strftime("%d/%m/%Y")
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    # Remove time portions such as ``HH:MM:SS`` or ISO ``T`` separators.
+    text = text.split("T", 1)[0]
+    text = text.split(" ", 1)[0]
+
+    for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d", "%Y/%m/%d"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.strftime("%d/%m/%Y")
+        except ValueError:
+            continue
+
+    if re.fullmatch(r"\d{2}/\d{2}/\d{4}", text):
+        return text
+
+    return None


### PR DESCRIPTION
## Summary
- agregar el helper `fecha_ddmmaaaa` y usarlo en las notas de crédito y débito para copiar la fecha del DTE base en formato dd/mm/aaaa en `documentoRelacionado`
- actualizar la generación de notas de remisión (directa y desde DTE) para reutilizar la fecha del DTE origen en dd/mm/aaaa y aceptar entradas normalizadas
- ajustar las pruebas de NCE, NDE y NR para validar que las fechas relacionadas provienen del DTE original en el formato esperado

## Testing
- COV_CORE_DISABLE=1 pytest tests/test_nota_credito.py::test_generar_nce_desde_nota_regenera_dte_fecha tests/test_nota_credito.py::test_generar_nce_desde_nota_prefiere_snapshot tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_regenera_dte_fecha tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_prefiere_snapshot
- COV_CORE_DISABLE=1 pytest tests/test_nota_remision.py::test_nr_desde_factura_documento_relacionado tests/test_nota_debito_remision.py::test_generar_nota_remision_factura

------
https://chatgpt.com/codex/tasks/task_e_68daf0bdc42c8323b9050e0c2fbf3194