### PR TITLE
Normaliza fechas dd/mm/aaaa en notas relacionadas

### DIFF
--- a/db.py
+++ b/db.py
@@ -16,7 +16,7 @@ from utils.fiscal_extra import build_fiscal_extra, normalize_tipo_fiscal
 from utils.line_totals import compute_line_totals
 from utils.monto import d8
 from utils.snapshot import Snapshot
-from utils.fecha import normalizar_fecha_iso
+from utils.fecha import fecha_ddmmaaaa, normalizar_fecha_iso
 from paths import DTES_DIR, get_canonical_dte_dir, user_data_path
 
 logging.basicConfig(level=logging.INFO)
@@ -2715,7 +2715,7 @@ class DB:
             return {}
 
     def get_envio_fecha_emision(self, venta_id):
-        """Obtiene la fecha de emisión del último envío registrado para la venta."""
+        """Devuelve la fecha del último envío para ``venta_id`` en formato ``DD/MM/AAAA``."""
 
         self.ensure_column("dte_envios", "respuesta", "TEXT")
         row = self.cursor.execute(
@@ -2725,7 +2725,6 @@ class DB:
         if not row:
             return None
 
-        fh_procesamiento = None
         raw_respuesta = row["respuesta"] if isinstance(row, sqlite3.Row) else row[1]
         if raw_respuesta:
             try:
@@ -2738,13 +2737,12 @@ class DB:
                     body = respuesta.get("body")
                     if isinstance(body, dict):
                         fh_procesamiento = body.get("fhProcesamiento")
-        if fh_procesamiento:
-            fecha_procesada = normalizar_fecha_iso(fh_procesamiento)
-            if fecha_procesada:
-                return fecha_procesada
+                fecha_envio = fecha_ddmmaaaa(fh_procesamiento)
+                if fecha_envio:
+                    return fecha_envio
 
         fecha_hora = row["fecha_hora"] if isinstance(row, sqlite3.Row) else row[0]
-        return normalizar_fecha_iso(fecha_hora)
+        return fecha_ddmmaaaa(fecha_hora)
 
     def listar_dtes(self, fecha_inicio=None, fecha_fin=None, estado=None):
         """Lista registros de ``dte_envios`` filtrando por fecha y estado."""

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -32,7 +32,7 @@ from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
 from utils.env import env_flag
 from utils import metrics
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
 from utils.sanitize import solo_digitos
 from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
@@ -148,19 +148,31 @@ def generar_nce_desde_nota(
         uuid_origen = str(codigo_tmp).upper() if codigo_tmp else None
 
     fecha_origen = None
+    fecha_origen_source = None
     if snapshot and snapshot.fecha_emision:
-        fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
+        fecha_origen = fecha_ddmmaaaa(snapshot.fecha_emision)
+        if fecha_origen:
+            fecha_origen_source = "snapshot"
     if not fecha_origen and venta_id is not None:
         fecha_envio = db.get_envio_fecha_emision(venta_id)
         if fecha_envio:
-            fecha_origen = normalizar_fecha_iso(fecha_envio)
+            fecha_origen = fecha_envio
+            fecha_origen_source = "envio"
     if not fecha_origen and venta:
-        fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
+        fecha_origen = fecha_ddmmaaaa(venta.get("fecha"))
+        if fecha_origen:
+            fecha_origen_source = "venta"
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
         if isinstance(identificacion, dict):
             if identificacion.get("fecEmi") != fecha_origen:
                 identificacion["fecEmi"] = fecha_origen
+    logger.info(
+        "fecha relacionada para nota %s = %s (origen: %s)",
+        nota_id,
+        fecha_origen,
+        fecha_origen_source or "desconocido",
+    )
 
     detalles = None
     if nota.get("detalles"):
@@ -252,6 +264,7 @@ def generar_nce_desde_dte(
     origen_ident = dte_origen.get("identificacion", {})
     cabecera = generar_cabecera_dte_data(1, 1, "05", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
+    fecha_emision_por_defecto = fecha_ddmmaaaa(now) or fecha_emision_hoy_str(now)
     identificacion = {
         "version": DTE_VERSIONES["05"],
         "ambiente": ambiente,
@@ -262,7 +275,7 @@ def generar_nce_desde_dte(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_hoy_str(now),
+        "fecEmi": fecha_emision_por_defecto,
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
@@ -283,23 +296,26 @@ def generar_nce_desde_dte(
         tipo_doc_rel = "03" if receptor_origen.get("nrc") else "01"
 
     codigo_generacion = origen_ident.get("codigoGeneracion")
+    numero_control = origen_ident.get("numeroControl")
     if codigo_generacion:
         numero_documento = str(codigo_generacion).upper()
         tipo_generacion = 2
     else:
         tipo_generacion = 1
-        numero_documento = (
-            origen_ident.get("numeroDocumento")
-            or origen_ident.get("numeroControl")
-            or ""
-        )
-        numero_documento = str(numero_documento).strip()
+        numero_documento = str(numero_control or "").strip()
 
-    fecha_doc_rel = normalizar_fecha_iso(
+    fecha_doc_rel = fecha_ddmmaaaa(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
     if not fecha_doc_rel and fecha_origen:
-        fecha_doc_rel = normalizar_fecha_iso(fecha_origen)
+        fecha_doc_rel = fecha_ddmmaaaa(fecha_origen)
+
+    fecha_emision_nota = fecha_origen or fecha_doc_rel or fecha_emision_por_defecto
+    if fecha_emision_nota:
+        identificacion["fecEmi"] = fecha_emision_nota
+    if not fecha_doc_rel:
+        fecha_doc_rel = fecha_emision_nota
+
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -30,7 +30,7 @@ from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
 from utils.env import env_flag
 from utils import metrics
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
 from utils.sanitize import solo_digitos
 from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
@@ -126,19 +126,31 @@ def generar_nde_desde_nota(
         uuid_origen = str(codigo_tmp).upper() if codigo_tmp else None
 
     fecha_origen = None
+    fecha_origen_source = None
     if snapshot and snapshot.fecha_emision:
-        fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
+        fecha_origen = fecha_ddmmaaaa(snapshot.fecha_emision)
+        if fecha_origen:
+            fecha_origen_source = "snapshot"
     if not fecha_origen and venta_id is not None:
         fecha_envio = db.get_envio_fecha_emision(venta_id)
         if fecha_envio:
-            fecha_origen = normalizar_fecha_iso(fecha_envio)
+            fecha_origen = fecha_envio
+            fecha_origen_source = "envio"
     if not fecha_origen and venta:
-        fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
+        fecha_origen = fecha_ddmmaaaa(venta.get("fecha"))
+        if fecha_origen:
+            fecha_origen_source = "venta"
     if fecha_origen:
         identificacion = dte_origen.get("identificacion")
         if isinstance(identificacion, dict):
             if identificacion.get("fecEmi") != fecha_origen:
                 identificacion["fecEmi"] = fecha_origen
+    logger.info(
+        "fecha relacionada para nota %s = %s (origen: %s)",
+        nota_id,
+        fecha_origen,
+        fecha_origen_source or "desconocido",
+    )
 
     detalles = None
     if nota.get("detalles"):
@@ -201,6 +213,7 @@ def generar_nde_desde_dte(
 
     cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
+    fecha_emision_por_defecto = fecha_ddmmaaaa(now) or fecha_emision_hoy_str(now)
     identificacion = {
         "version": DTE_VERSIONES["06"],
         "ambiente": ambiente,
@@ -211,7 +224,7 @@ def generar_nde_desde_dte(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_hoy_str(now),
+        "fecEmi": fecha_emision_por_defecto,
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
@@ -231,23 +244,26 @@ def generar_nde_desde_dte(
         tipo_doc_rel = "03" if (dte_origen.get("receptor") or {}).get("nrc") else "01"
 
     codigo_generacion = origen_ident.get("codigoGeneracion")
+    numero_control = origen_ident.get("numeroControl")
     if codigo_generacion:
         numero_documento = str(codigo_generacion).upper()
         tipo_generacion = 2
     else:
         tipo_generacion = 1
-        numero_documento = (
-            origen_ident.get("numeroDocumento")
-            or origen_ident.get("numeroControl")
-            or ""
-        )
-        numero_documento = str(numero_documento).strip()
+        numero_documento = str(numero_control or "").strip()
 
-    fecha_doc_rel = normalizar_fecha_iso(
+    fecha_doc_rel = fecha_ddmmaaaa(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
     if not fecha_doc_rel and fecha_origen:
-        fecha_doc_rel = normalizar_fecha_iso(fecha_origen)
+        fecha_doc_rel = fecha_ddmmaaaa(fecha_origen)
+
+    fecha_emision_nota = fecha_origen or fecha_doc_rel or fecha_emision_por_defecto
+    if fecha_emision_nota:
+        identificacion["fecEmi"] = fecha_emision_nota
+    if not fecha_doc_rel:
+        fecha_doc_rel = fecha_emision_nota
+
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -22,10 +22,12 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Iterable, Optional
 
+import logging
+
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
 from utils.monto import monto_a_texto_sv, d2
 from utils.snapshot import normalize_snapshot
 import warnings
@@ -33,6 +35,9 @@ import warnings
 from utils.sanitize import limpiar_documentos, solo_digitos
 
 Decimal_0 = Decimal("0")
+
+
+logger = logging.getLogger(__name__)
 
 
 def _build_items(
@@ -141,16 +146,15 @@ def _normalizar_documento_relacionado(doc_rel: list[dict]) -> list[dict]:
         raise ValueError(
             "documento_relacionado requiere numeroDocumento y fechaEmision"
         )
-    try:
-        datetime.fromisoformat(fecha)
-    except Exception as exc:
-        raise ValueError("fechaEmision inválida en documento_relacionado") from exc
+    fecha_normalizada = fecha_ddmmaaaa(fecha)
+    if not fecha_normalizada:
+        raise ValueError("fechaEmision inválida en documento_relacionado")
     return [
         {
             "tipoDocumento": tipo,
             "tipoGeneracion": 2,
             "numeroDocumento": numero,
-            "fechaEmision": fecha,
+            "fechaEmision": fecha_normalizada,
         }
     ]
 
@@ -180,16 +184,26 @@ def generar_nota_remision(
         detalles = detalles or factura.get("cuerpoDocumento", [])
         if documento_relacionado is None:
             ident = factura.get("identificacion", {})
-            fecha_emision = normalizar_fecha_iso(ident.get("fecEmi"))
+            fecha_emision = fecha_ddmmaaaa(
+                ident.get("fecEmi") or ident.get("fechaEmision")
+            )
+            if not fecha_emision:
+                fecha_emision = fecha_ddmmaaaa(datetime.now(TZ_EL_SALVADOR))
             if fecha_emision:
                 ident["fecEmi"] = fecha_emision
+            codigo_generacion = ident.get("codigoGeneracion")
+            numero_control = ident.get("numeroControl")
+            if codigo_generacion:
+                numero_documento = str(codigo_generacion).upper()
+                tipo_generacion = 2
             else:
-                fecha_emision = ident.get("fecEmi")
+                numero_documento = str(numero_control or "").strip()
+                tipo_generacion = 1
             documento_relacionado = [
                 {
                     "tipoDocumento": ident.get("tipoDte"),
-                    "tipoGeneracion": 2,
-                    "numeroDocumento": ident.get("codigoGeneracion"),
+                    "tipoGeneracion": tipo_generacion,
+                    "numeroDocumento": numero_documento,
                     "fechaEmision": fecha_emision,
                 }
             ]
@@ -257,6 +271,7 @@ def generar_nota_remision(
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
+    fecha_emision_por_defecto = fecha_ddmmaaaa(now) or fecha_emision_hoy_str(now)
     identificacion = {
         "version": DTE_VERSIONES["04"],
         "ambiente": ambiente,
@@ -267,13 +282,16 @@ def generar_nota_remision(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_hoy_str(now),
+        "fecEmi": fecha_emision_por_defecto,
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
 
     if documento_relacionado:
         documento_relacionado = _normalizar_documento_relacionado(documento_relacionado)
+        fecha_relacionada = documento_relacionado[0].get("fechaEmision")
+        if fecha_relacionada:
+            identificacion["fecEmi"] = fecha_relacionada
     numero_doc = (
         documento_relacionado[0].get("numeroDocumento")
         if documento_relacionado
@@ -351,6 +369,7 @@ def generar_nota_remision_desde_db(
         from dte import generar_dte_json
 
         fecha_origen = None
+        fecha_origen_source = None
         snapshot = db.get_snapshot_by_venta(venta_id)
         if snapshot:
             try:
@@ -359,7 +378,9 @@ def generar_nota_remision_desde_db(
                 dte_origen = None
             else:
                 if snapshot.fecha_emision:
-                    fecha_origen = normalizar_fecha_iso(snapshot.fecha_emision)
+                    fecha_origen = fecha_ddmmaaaa(snapshot.fecha_emision)
+                    if fecha_origen:
+                        fecha_origen_source = "snapshot"
         else:
             dte_origen = None
 
@@ -371,15 +392,25 @@ def generar_nota_remision_desde_db(
         if not fecha_origen and venta_id is not None:
             fecha_envio = db.get_envio_fecha_emision(venta_id)
             if fecha_envio:
-                fecha_origen = normalizar_fecha_iso(fecha_envio)
+                fecha_origen = fecha_envio
+                fecha_origen_source = "envio"
 
         if not fecha_origen and venta:
-            fecha_origen = normalizar_fecha_iso(venta.get("fecha"))
+            fecha_origen = fecha_ddmmaaaa(venta.get("fecha"))
+            if fecha_origen:
+                fecha_origen_source = "venta"
 
         if fecha_origen and isinstance(dte_origen, dict):
             dte_ident = dte_origen.setdefault("identificacion", {})
             if isinstance(dte_ident, dict):
                 dte_ident["fecEmi"] = fecha_origen
+
+        logger.info(
+            "fecha relacionada para nota %s = %s (origen: %s)",
+            nota_id,
+            fecha_origen,
+            fecha_origen_source or "desconocido",
+        )
 
         extension = extra.get("extension") or {}
         return generar_nota_remision(

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -20,7 +20,7 @@ from typing import Iterable, Optional
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_emision_hoy_str, normalizar_fecha_iso
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
 from utils.monto import d2, monto_a_texto_sv
 import warnings
 
@@ -146,6 +146,7 @@ def _generar_base(
 
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
+    fecha_emision_por_defecto = fecha_ddmmaaaa(now) or fecha_emision_hoy_str(now)
     identificacion = {
         "version": DTE_VERSIONES["04"],
         "ambiente": ambiente,
@@ -156,11 +157,15 @@ def _generar_base(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_hoy_str(now),
+        "fecEmi": fecha_emision_por_defecto,
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
 
+    if documento_relacionado:
+        fecha_relacionada = documento_relacionado[0].get("fechaEmision")
+        if fecha_relacionada:
+            identificacion["fecEmi"] = fecha_relacionada
     numero_doc = documento_relacionado[0].get("numeroDocumento")
     items = _build_items(detalles, numero_doc)
 
@@ -231,22 +236,28 @@ def generar_nota_remision_desde_factura(
         factura["identificacion"] = ident
     fecha_emision = None
     if fecha_origen:
-        fecha_normalizada = normalizar_fecha_iso(fecha_origen)
-        if fecha_normalizada:
-            fecha_emision = fecha_normalizada
-            ident["fecEmi"] = fecha_emision
+        fecha_emision = fecha_ddmmaaaa(fecha_origen)
     if not fecha_emision:
-        fecha_normalizada = normalizar_fecha_iso(ident.get("fecEmi"))
-        if fecha_normalizada:
-            fecha_emision = fecha_normalizada
-            ident["fecEmi"] = fecha_emision
-        else:
-            fecha_emision = ident.get("fecEmi")
+        fecha_emision = fecha_ddmmaaaa(
+            ident.get("fecEmi") or ident.get("fechaEmision")
+        )
+    if not fecha_emision:
+        fecha_emision = fecha_ddmmaaaa(datetime.now(TZ_EL_SALVADOR))
+    if fecha_emision:
+        ident["fecEmi"] = fecha_emision
+    codigo_generacion = ident.get("codigoGeneracion")
+    numero_control = ident.get("numeroControl")
+    if codigo_generacion:
+        numero_documento = str(codigo_generacion).upper()
+        tipo_generacion = 2
+    else:
+        numero_documento = str(numero_control or "").strip()
+        tipo_generacion = 1
     doc_rel = [
         {
             "tipoDocumento": ident.get("tipoDte"),
-            "tipoGeneracion": 2,
-            "numeroDocumento": ident.get("codigoGeneracion"),
+            "tipoGeneracion": tipo_generacion,
+            "numeroDocumento": numero_documento,
             "fechaEmision": fecha_emision,
         }
     ]

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -133,6 +133,8 @@ def test_generar_nce_desde_nota_credito_fiscal(monkeypatch):
     nce = generar_nce_desde_nota(db, nota_id)
     doc_rel = nce["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
+    assert doc_rel["fechaEmision"] == "01/01/2024"
+    assert nce["identificacion"]["fecEmi"] == "01/01/2024"
     receptor_nota = nce["receptor"]
     assert receptor_nota["nit"] == "06141407100012"
     assert receptor_nota["nrc"] == "123"
@@ -173,18 +175,20 @@ def test_generar_nce_desde_nota_regenera_dte_fecha(monkeypatch):
         (venta_id,),
     ).lastrowid
 
-    fecha_envio = "2024-03-18"
+    fecha_envio_iso = "2024-03-18"
+    fecha_envio_ddmm = "18/03/2024"
     db.registrar_envio_dte(
         venta_id,
         "auto",
         "procesado",
         "SELLO",
-        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio}T12:34:56"}),
+        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio_iso}T12:34:56"}),
     )
 
     nce = generar_nce_desde_nota(db, nota_id, strict_snapshot=False)
     doc_rel = nce["documentoRelacionado"][0]
-    assert doc_rel["fechaEmision"] == fecha_envio
+    assert doc_rel["fechaEmision"] == fecha_envio_ddmm
+    assert nce["identificacion"]["fecEmi"] == fecha_envio_ddmm
 
 
 def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
@@ -274,7 +278,8 @@ def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         doc_rel["numeroDocumento"]
         == payload["identificacion"]["codigoGeneracion"].upper()
     )
-    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert doc_rel["fechaEmision"] == "01/08/2023"
+    assert nce["identificacion"]["fecEmi"] == "01/08/2023"
     assert metrics_calls == ["notes_source_used.snapshot"]
     assert payload["firma"] == "SIGNATURE"
 
@@ -358,7 +363,8 @@ def test_generar_nce_desde_nota_snapshot_dui(monkeypatch, tmp_path):
     assert doc_rel["tipoDocumento"] == "01"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
-    assert doc_rel["fechaEmision"] == "2023-09-01"
+    assert doc_rel["fechaEmision"] == "01/09/2023"
+    assert nce["identificacion"]["fecEmi"] == "01/09/2023"
 
 
 def test_generar_nce_desde_nota_strict_snapshot(monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -47,7 +47,7 @@ def _doc_rel():
             "tipoDocumento": "01",
             "tipoGeneracion": 2,
             "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
-            "fechaEmision": "2024-01-01",
+            "fechaEmision": "01/01/2024",
         }
     ]
 
@@ -162,6 +162,8 @@ def test_generar_nde_desde_nota_credito_fiscal(monkeypatch):
     nde = generar_nde_desde_nota(db, nota_id)
     doc_rel = nde["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
+    assert doc_rel["fechaEmision"] == "01/01/2024"
+    assert nde["identificacion"]["fecEmi"] == "01/01/2024"
     receptor = nde["receptor"]
     assert receptor["nit"] == "06141407100012"
     assert receptor["nrc"] == "123"
@@ -210,18 +212,20 @@ def test_generar_nde_desde_nota_regenera_dte_fecha(monkeypatch):
         (venta_id,),
     ).lastrowid
 
-    fecha_envio = "2024-04-12"
+    fecha_envio_iso = "2024-04-12"
+    fecha_envio_ddmm = "12/04/2024"
     db.registrar_envio_dte(
         venta_id,
         "auto",
         "procesado",
         "SELLO",
-        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio}T08:15:00"}),
+        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio_iso}T08:15:00"}),
     )
 
     nde = generar_nde_desde_nota(db, nota_id, strict_snapshot=False)
     doc_rel = nde["documentoRelacionado"][0]
-    assert doc_rel["fechaEmision"] == fecha_envio
+    assert doc_rel["fechaEmision"] == fecha_envio_ddmm
+    assert nde["identificacion"]["fecEmi"] == fecha_envio_ddmm
 
 
 def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
@@ -329,7 +333,8 @@ def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         doc_rel["numeroDocumento"]
         == payload["identificacion"]["codigoGeneracion"].upper()
     )
-    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert doc_rel["fechaEmision"] == "01/08/2023"
+    assert nde["identificacion"]["fecEmi"] == "01/08/2023"
     assert metrics_calls == ["notes_source_used.snapshot"]
     assert payload["firma"] == "SIGNATURE"
 
@@ -421,7 +426,8 @@ def test_generar_nde_desde_nota_snapshot_dui(monkeypatch, tmp_path):
     assert doc_rel["tipoDocumento"] == "01"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
-    assert doc_rel["fechaEmision"] == "2023-09-01"
+    assert doc_rel["fechaEmision"] == "01/09/2023"
+    assert nde["identificacion"]["fecEmi"] == "01/09/2023"
 
 
 def test_generar_nde_desde_nota_strict_snapshot(monkeypatch):
@@ -750,20 +756,22 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
         "remision", venta_id, "2024-01-02", 0, "Envio", detalles=extra
     )
 
-    fecha_envio = "2024-01-03"
+    fecha_envio_iso = "2024-01-03"
+    fecha_envio_ddmm = "03/01/2024"
     db.registrar_envio_dte(
         venta_id,
         "auto",
         "procesado",
         "SELLO",
-        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio}T08:00:00"}),
+        respuesta_json=json.dumps({"fhProcesamiento": f"{fecha_envio_iso}T08:00:00"}),
     )
 
     data = generar_nota_remision_desde_db(db, nota_id)
     assert data["identificacion"]["tipoDte"] == "04"
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert data["extension"]["nombEntrega"] == "Juan"
-    assert data["documentoRelacionado"][0]["fechaEmision"] == fecha_envio
+    assert data["documentoRelacionado"][0]["fechaEmision"] == fecha_envio_ddmm
+    assert data["identificacion"]["fecEmi"] == fecha_envio_ddmm
 
 
 def test_nota_debito_pdf(tmp_path):

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -38,7 +38,7 @@ def _sample_doc_rel():
             "tipoDocumento": "03",
             "tipoGeneracion": 2,
             "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
-            "fechaEmision": "2024-01-01",
+            "fechaEmision": "01/01/2024",
         }
     ]
 
@@ -69,8 +69,9 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
-    assert doc_rel["fechaEmision"] == "2024-01-01"
-    assert factura["identificacion"]["fecEmi"] == "2024-01-01"
+    assert doc_rel["fechaEmision"] == "01/01/2024"
+    assert factura["identificacion"]["fecEmi"] == "01/01/2024"
+    assert data["identificacion"]["fecEmi"] == "01/01/2024"
     item = data["cuerpoDocumento"][0]
     assert item["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
     assert item["codTributo"] is None

--- a/utils/fecha.py
+++ b/utils/fecha.py
@@ -52,3 +52,21 @@ def normalizar_fecha_iso(value: Union[str, datetime, date, None]) -> Optional[st
             return None
 
     return fecha_dt.date().isoformat()
+
+
+def fecha_ddmmaaaa(value: Union[str, datetime, date, None]) -> Optional[str]:
+    """Convierte ``value`` en una fecha ``DD/MM/AAAA``.
+
+    Acepta cadenas en formato ISO (con o sin hora), ``DD/MM/AAAA`` con o sin
+    hora y objetos :class:`datetime`/ :class:`date`.  Si la fecha no puede
+    interpretarse retorna ``None``.
+    """
+
+    fecha_iso = normalizar_fecha_iso(value)
+    if not fecha_iso:
+        return None
+    try:
+        fecha_obj = date.fromisoformat(fecha_iso)
+    except ValueError:
+        return None
+    return fecha_obj.strftime("%d/%m/%Y")


### PR DESCRIPTION
## Summary
- agrega `fecha_ddmmaaaa` para reutilizar el formateo DD/MM/AAAA y expone `DB.get_envio_fecha_emision` con la misma salida
- ajusta la generación de notas de crédito, débito y remisión para priorizar snapshot/envío/venta, copiar la fecha al documento relacionado y registrar la fuente utilizada
- actualiza las pruebas de NCE/NDE/NR para verificar el nuevo formato y los orígenes de fecha

## Testing
- pytest -q tests/test_nota_credito.py::test_generar_nce_desde_nota_regenera_dte_fecha
- pytest -q tests/test_nota_credito.py::test_generar_nce_desde_nota_prefiere_snapshot
- pytest -q tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_regenera_dte_fecha
- pytest -q tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_prefiere_snapshot
- pytest -q tests/test_nota_remision.py::test_nr_desde_factura_documento_relacionado


------
https://chatgpt.com/codex/tasks/task_e_68db01627eec83239dde0ba4a4e59919