### PR TITLE
Use ISO dates in electronic note payloads

### DIFF
--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -32,7 +32,7 @@ from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
 from utils.env import env_flag
 from utils import metrics
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str, fecha_iso
 from utils.monto import d2, monto_a_texto_sv, to_base_iva
 from utils.sanitize import solo_digitos
 from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
@@ -275,7 +275,7 @@ def generar_nce_desde_dte(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_por_defecto,
+        "fecEmi": fecha_iso(fecha_emision_por_defecto),
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
@@ -304,24 +304,26 @@ def generar_nce_desde_dte(
         tipo_generacion = 1
         numero_documento = str(numero_control or "").strip()
 
-    fecha_doc_rel = fecha_ddmmaaaa(
+    fecha_doc_rel_base = fecha_ddmmaaaa(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
-    if not fecha_doc_rel and fecha_origen:
-        fecha_doc_rel = fecha_ddmmaaaa(fecha_origen)
+    if not fecha_doc_rel_base and fecha_origen:
+        fecha_doc_rel_base = fecha_ddmmaaaa(fecha_origen)
 
-    fecha_emision_nota = fecha_origen or fecha_doc_rel or fecha_emision_por_defecto
-    if fecha_emision_nota:
-        identificacion["fecEmi"] = fecha_emision_nota
-    if not fecha_doc_rel:
-        fecha_doc_rel = fecha_emision_nota
+    fecha_emision_nota_base = (
+        fecha_origen or fecha_doc_rel_base or fecha_emision_por_defecto
+    )
+    if fecha_emision_nota_base:
+        identificacion["fecEmi"] = fecha_iso(fecha_emision_nota_base)
+    if not fecha_doc_rel_base:
+        fecha_doc_rel_base = fecha_emision_nota_base
 
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,
             "tipoGeneracion": tipo_generacion,
             "numeroDocumento": numero_documento,
-            "fechaEmision": fecha_doc_rel,
+            "fechaEmision": fecha_iso(fecha_doc_rel_base),
         }
     ]
 

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -30,7 +30,7 @@ from utils.identificacion import is_valid_nit, normalize_dui_to_nit9
 from utils.env import env_flag
 from utils import metrics
 from utils.receptor import ensure_receptor_completo
-from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str, fecha_iso
 from utils.monto import d2, monto_a_texto_sv
 from utils.sanitize import solo_digitos
 from utils.snapshot import SnapshotNotFoundError, normalize_snapshot
@@ -224,7 +224,7 @@ def generar_nde_desde_dte(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_por_defecto,
+        "fecEmi": fecha_iso(fecha_emision_por_defecto),
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
@@ -252,24 +252,26 @@ def generar_nde_desde_dte(
         tipo_generacion = 1
         numero_documento = str(numero_control or "").strip()
 
-    fecha_doc_rel = fecha_ddmmaaaa(
+    fecha_doc_rel_base = fecha_ddmmaaaa(
         origen_ident.get("fecEmi") or origen_ident.get("fechaEmision")
     )
-    if not fecha_doc_rel and fecha_origen:
-        fecha_doc_rel = fecha_ddmmaaaa(fecha_origen)
+    if not fecha_doc_rel_base and fecha_origen:
+        fecha_doc_rel_base = fecha_ddmmaaaa(fecha_origen)
 
-    fecha_emision_nota = fecha_origen or fecha_doc_rel or fecha_emision_por_defecto
-    if fecha_emision_nota:
-        identificacion["fecEmi"] = fecha_emision_nota
-    if not fecha_doc_rel:
-        fecha_doc_rel = fecha_emision_nota
+    fecha_emision_nota_base = (
+        fecha_origen or fecha_doc_rel_base or fecha_emision_por_defecto
+    )
+    if fecha_emision_nota_base:
+        identificacion["fecEmi"] = fecha_iso(fecha_emision_nota_base)
+    if not fecha_doc_rel_base:
+        fecha_doc_rel_base = fecha_emision_nota_base
 
     doc_rel = [
         {
             "tipoDocumento": tipo_doc_rel,
             "tipoGeneracion": tipo_generacion,
             "numeroDocumento": numero_documento,
-            "fechaEmision": fecha_doc_rel,
+            "fechaEmision": fecha_iso(fecha_doc_rel_base),
         }
     ]
 

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -27,7 +27,12 @@ import logging
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
+from utils.fecha import (
+    TZ_EL_SALVADOR,
+    fecha_ddmmaaaa,
+    fecha_emision_hoy_str,
+    fecha_iso,
+)
 from utils.monto import monto_a_texto_sv, d2
 from utils.snapshot import normalize_snapshot
 import warnings
@@ -154,7 +159,7 @@ def _normalizar_documento_relacionado(doc_rel: list[dict]) -> list[dict]:
             "tipoDocumento": tipo,
             "tipoGeneracion": 2,
             "numeroDocumento": numero,
-            "fechaEmision": fecha_normalizada,
+            "fechaEmision": fecha_iso(fecha_normalizada),
         }
     ]
 
@@ -204,7 +209,7 @@ def generar_nota_remision(
                     "tipoDocumento": ident.get("tipoDte"),
                     "tipoGeneracion": tipo_generacion,
                     "numeroDocumento": numero_documento,
-                    "fechaEmision": fecha_emision,
+                    "fechaEmision": fecha_iso(fecha_emision),
                 }
             ]
         # Para notas derivadas de factura la extensión puede omitirse
@@ -282,7 +287,7 @@ def generar_nota_remision(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_por_defecto,
+        "fecEmi": fecha_iso(fecha_emision_por_defecto),
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
@@ -291,7 +296,7 @@ def generar_nota_remision(
         documento_relacionado = _normalizar_documento_relacionado(documento_relacionado)
         fecha_relacionada = documento_relacionado[0].get("fechaEmision")
         if fecha_relacionada:
-            identificacion["fecEmi"] = fecha_relacionada
+            identificacion["fecEmi"] = fecha_iso(fecha_relacionada)
     numero_doc = (
         documento_relacionado[0].get("numeroDocumento")
         if documento_relacionado

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -20,7 +20,7 @@ from typing import Iterable, Optional
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
 from utils import catalogos
-from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str
+from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str, fecha_iso
 from utils.monto import d2, monto_a_texto_sv
 import warnings
 
@@ -157,7 +157,7 @@ def _generar_base(
         "tipoOperacion": cabecera["tipo_operacion"],
         "tipoContingencia": cabecera["tipo_contingencia"],
         "motivoContin": cabecera["motivo_contin"],
-        "fecEmi": fecha_emision_por_defecto,
+        "fecEmi": fecha_iso(fecha_emision_por_defecto),
         "horEmi": now.strftime("%H:%M:%S"),
         "tipoMoneda": "USD",
     }
@@ -165,7 +165,7 @@ def _generar_base(
     if documento_relacionado:
         fecha_relacionada = documento_relacionado[0].get("fechaEmision")
         if fecha_relacionada:
-            identificacion["fecEmi"] = fecha_relacionada
+            identificacion["fecEmi"] = fecha_iso(fecha_relacionada)
     numero_doc = documento_relacionado[0].get("numeroDocumento")
     items = _build_items(detalles, numero_doc)
 
@@ -258,7 +258,7 @@ def generar_nota_remision_desde_factura(
             "tipoDocumento": ident.get("tipoDte"),
             "tipoGeneracion": tipo_generacion,
             "numeroDocumento": numero_documento,
-            "fechaEmision": fecha_emision,
+            "fechaEmision": fecha_iso(fecha_emision),
         }
     ]
     ext = extension.copy() if extension else None

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -133,8 +133,8 @@ def test_generar_nce_desde_nota_credito_fiscal(monkeypatch):
     nce = generar_nce_desde_nota(db, nota_id)
     doc_rel = nce["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
-    assert doc_rel["fechaEmision"] == "01/01/2024"
-    assert nce["identificacion"]["fecEmi"] == "01/01/2024"
+    assert doc_rel["fechaEmision"] == "2024-01-01"
+    assert nce["identificacion"]["fecEmi"] == "2024-01-01"
     receptor_nota = nce["receptor"]
     assert receptor_nota["nit"] == "06141407100012"
     assert receptor_nota["nrc"] == "123"
@@ -176,7 +176,6 @@ def test_generar_nce_desde_nota_regenera_dte_fecha(monkeypatch):
     ).lastrowid
 
     fecha_envio_iso = "2024-03-18"
-    fecha_envio_ddmm = "18/03/2024"
     db.registrar_envio_dte(
         venta_id,
         "auto",
@@ -187,8 +186,8 @@ def test_generar_nce_desde_nota_regenera_dte_fecha(monkeypatch):
 
     nce = generar_nce_desde_nota(db, nota_id, strict_snapshot=False)
     doc_rel = nce["documentoRelacionado"][0]
-    assert doc_rel["fechaEmision"] == fecha_envio_ddmm
-    assert nce["identificacion"]["fecEmi"] == fecha_envio_ddmm
+    assert doc_rel["fechaEmision"] == fecha_envio_iso
+    assert nce["identificacion"]["fecEmi"] == fecha_envio_iso
 
 
 def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
@@ -250,7 +249,7 @@ def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         uuid=payload["identificacion"]["codigoGeneracion"],
         path=str(tmp_path / "documento.json"),
         tipo_documento="03",
-        fecha_emision="2023-08-01",
+        fecha_emision="01/08/2023",
         payload=payload,
     )
 
@@ -278,8 +277,8 @@ def test_generar_nce_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         doc_rel["numeroDocumento"]
         == payload["identificacion"]["codigoGeneracion"].upper()
     )
-    assert doc_rel["fechaEmision"] == "01/08/2023"
-    assert nce["identificacion"]["fecEmi"] == "01/08/2023"
+    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert nce["identificacion"]["fecEmi"] == "2023-08-01"
     assert metrics_calls == ["notes_source_used.snapshot"]
     assert payload["firma"] == "SIGNATURE"
 
@@ -343,7 +342,7 @@ def test_generar_nce_desde_nota_snapshot_dui(monkeypatch, tmp_path):
         uuid=payload["identificacion"]["codigoGeneracion"],
         path=str(tmp_path / "documento.json"),
         tipo_documento="01",
-        fecha_emision="2023-09-01",
+        fecha_emision="01/09/2023",
         payload=payload,
     )
 
@@ -363,8 +362,8 @@ def test_generar_nce_desde_nota_snapshot_dui(monkeypatch, tmp_path):
     assert doc_rel["tipoDocumento"] == "01"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
-    assert doc_rel["fechaEmision"] == "01/09/2023"
-    assert nce["identificacion"]["fecEmi"] == "01/09/2023"
+    assert doc_rel["fechaEmision"] == "2023-09-01"
+    assert nce["identificacion"]["fecEmi"] == "2023-09-01"
 
 
 def test_generar_nce_desde_nota_strict_snapshot(monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -47,7 +47,7 @@ def _doc_rel():
             "tipoDocumento": "01",
             "tipoGeneracion": 2,
             "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
-            "fechaEmision": "01/01/2024",
+            "fechaEmision": "2024-01-01",
         }
     ]
 
@@ -162,8 +162,8 @@ def test_generar_nde_desde_nota_credito_fiscal(monkeypatch):
     nde = generar_nde_desde_nota(db, nota_id)
     doc_rel = nde["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
-    assert doc_rel["fechaEmision"] == "01/01/2024"
-    assert nde["identificacion"]["fecEmi"] == "01/01/2024"
+    assert doc_rel["fechaEmision"] == "2024-01-01"
+    assert nde["identificacion"]["fecEmi"] == "2024-01-01"
     receptor = nde["receptor"]
     assert receptor["nit"] == "06141407100012"
     assert receptor["nrc"] == "123"
@@ -213,7 +213,6 @@ def test_generar_nde_desde_nota_regenera_dte_fecha(monkeypatch):
     ).lastrowid
 
     fecha_envio_iso = "2024-04-12"
-    fecha_envio_ddmm = "12/04/2024"
     db.registrar_envio_dte(
         venta_id,
         "auto",
@@ -224,8 +223,8 @@ def test_generar_nde_desde_nota_regenera_dte_fecha(monkeypatch):
 
     nde = generar_nde_desde_nota(db, nota_id, strict_snapshot=False)
     doc_rel = nde["documentoRelacionado"][0]
-    assert doc_rel["fechaEmision"] == fecha_envio_ddmm
-    assert nde["identificacion"]["fecEmi"] == fecha_envio_ddmm
+    assert doc_rel["fechaEmision"] == fecha_envio_iso
+    assert nde["identificacion"]["fecEmi"] == fecha_envio_iso
 
 
 def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
@@ -305,7 +304,7 @@ def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         uuid=payload["identificacion"]["codigoGeneracion"],
         path=str(tmp_path / "documento.json"),
         tipo_documento="03",
-        fecha_emision="2023-08-01",
+        fecha_emision="01/08/2023",
         payload=payload,
     )
 
@@ -333,8 +332,8 @@ def test_generar_nde_desde_nota_prefiere_snapshot(monkeypatch, tmp_path):
         doc_rel["numeroDocumento"]
         == payload["identificacion"]["codigoGeneracion"].upper()
     )
-    assert doc_rel["fechaEmision"] == "01/08/2023"
-    assert nde["identificacion"]["fecEmi"] == "01/08/2023"
+    assert doc_rel["fechaEmision"] == "2023-08-01"
+    assert nde["identificacion"]["fecEmi"] == "2023-08-01"
     assert metrics_calls == ["notes_source_used.snapshot"]
     assert payload["firma"] == "SIGNATURE"
 
@@ -406,7 +405,7 @@ def test_generar_nde_desde_nota_snapshot_dui(monkeypatch, tmp_path):
         uuid=payload["identificacion"]["codigoGeneracion"],
         path=str(tmp_path / "documento.json"),
         tipo_documento="01",
-        fecha_emision="2023-09-01",
+        fecha_emision="01/09/2023",
         payload=payload,
     )
 
@@ -426,8 +425,8 @@ def test_generar_nde_desde_nota_snapshot_dui(monkeypatch, tmp_path):
     assert doc_rel["tipoDocumento"] == "01"
     assert doc_rel["tipoGeneracion"] == 2
     assert doc_rel["numeroDocumento"] == payload["identificacion"]["codigoGeneracion"].upper()
-    assert doc_rel["fechaEmision"] == "01/09/2023"
-    assert nde["identificacion"]["fecEmi"] == "01/09/2023"
+    assert doc_rel["fechaEmision"] == "2023-09-01"
+    assert nde["identificacion"]["fecEmi"] == "2023-09-01"
 
 
 def test_generar_nde_desde_nota_strict_snapshot(monkeypatch):
@@ -757,7 +756,6 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
     )
 
     fecha_envio_iso = "2024-01-03"
-    fecha_envio_ddmm = "03/01/2024"
     db.registrar_envio_dte(
         venta_id,
         "auto",
@@ -770,8 +768,8 @@ def test_generar_nota_remision_factura(tmp_path, monkeypatch):
     assert data["identificacion"]["tipoDte"] == "04"
     assert data["documentoRelacionado"][0]["tipoDocumento"] == "01"
     assert data["extension"]["nombEntrega"] == "Juan"
-    assert data["documentoRelacionado"][0]["fechaEmision"] == fecha_envio_ddmm
-    assert data["identificacion"]["fecEmi"] == fecha_envio_ddmm
+    assert data["documentoRelacionado"][0]["fechaEmision"] == fecha_envio_iso
+    assert data["identificacion"]["fecEmi"] == fecha_envio_iso
 
 
 def test_nota_debito_pdf(tmp_path):

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -38,7 +38,7 @@ def _sample_doc_rel():
             "tipoDocumento": "03",
             "tipoGeneracion": 2,
             "numeroDocumento": "12345678-ABCD-1234-ABCD-1234567890AB",
-            "fechaEmision": "01/01/2024",
+            "fechaEmision": "2024-01-01",
         }
     ]
 
@@ -69,9 +69,9 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
     assert doc_rel["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
-    assert doc_rel["fechaEmision"] == "01/01/2024"
+    assert doc_rel["fechaEmision"] == "2024-01-01"
     assert factura["identificacion"]["fecEmi"] == "01/01/2024"
-    assert data["identificacion"]["fecEmi"] == "01/01/2024"
+    assert data["identificacion"]["fecEmi"] == "2024-01-01"
     item = data["cuerpoDocumento"][0]
     assert item["numeroDocumento"] == "12345678-ABCD-1234-ABCD-1234567890AB"
     assert item["codTributo"] is None

--- a/tests/test_utils_fecha.py
+++ b/tests/test_utils_fecha.py
@@ -1,4 +1,4 @@
-from utils.fecha import normalizar_fecha_iso
+from utils.fecha import fecha_iso, normalizar_fecha_iso
 
 
 def test_normalizar_fecha_iso_dd_mm_yyyy_con_hora():
@@ -14,3 +14,19 @@ def test_normalizar_fecha_iso_dd_mm_yyyy_con_guiones():
 def test_normalizar_fecha_iso_slash_iso():
     valor = "2025/09/28"
     assert normalizar_fecha_iso(valor) == "2025-09-28"
+
+
+def test_fecha_iso_dd_mm_yyyy():
+    assert fecha_iso("28/09/2025") == "2025-09-28"
+
+
+def test_fecha_iso_iso_con_timezone_z():
+    assert fecha_iso("2025-09-28T10:31:54Z") == "2025-09-28"
+
+
+def test_fecha_iso_iso_con_offset():
+    assert fecha_iso("2025-09-28T05:15:00-06:00") == "2025-09-28"
+
+
+def test_fecha_iso_invalida_retorna_original():
+    assert fecha_iso("fecha no valida") == "fecha no valida"

--- a/utils/fecha.py
+++ b/utils/fecha.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
-from typing import Optional, Union
+from email.utils import parsedate_to_datetime
+from typing import Any, Optional, Union
 from zoneinfo import ZoneInfo
 
 TZ_EL_SALVADOR = ZoneInfo("America/El_Salvador")
@@ -52,6 +53,49 @@ def normalizar_fecha_iso(value: Union[str, datetime, date, None]) -> Optional[st
             return None
 
     return fecha_dt.date().isoformat()
+
+
+def fecha_iso(value: Any) -> str:
+    """Return ``value`` formatted as ``YYYY-MM-DD`` when possible.
+
+    ``value`` can be a string in ``DD/MM/AAAA`` format, ISO strings with or without
+    time components, :class:`datetime` or :class:`date` instances.  When the value
+    cannot be interpreted as a date the original ``value`` is returned so other
+    validations can surface the error.
+    """
+
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+
+    if isinstance(value, date):
+        return value.isoformat()
+
+    if value is None:
+        return value
+
+    text = str(value).strip()
+    if not text:
+        return value
+
+    normalized = normalizar_fecha_iso(text)
+    if normalized:
+        return normalized
+
+    if text.endswith("Z"):
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+        except ValueError:
+            pass
+
+    try:
+        parsed = parsedate_to_datetime(text)
+    except (TypeError, ValueError, IndexError):
+        parsed = None
+
+    if parsed is not None:
+        return parsed.date().isoformat()
+
+    return value
 
 
 def fecha_ddmmaaaa(value: Union[str, datetime, date, None]) -> Optional[str]:


### PR DESCRIPTION
## Summary
- add a `fecha_iso` helper that normalizes DD/MM/YYYY strings and ISO timestamps (including timezone suffixes) to YYYY-MM-DD while preserving unparseable values
- ensure electronic credit, debit, and remisión note payloads populate `identificacion.fecEmi` and related document dates with ISO strings instead of human-formatted dates
- update note-related tests to assert ISO-formatted dates and cover the new `fecha_iso` behavior

## Testing
- STRICT_SNAPSHOT=0 pytest tests/test_nota_credito.py::test_generar_nce_desde_nota_credito_fiscal
- STRICT_SNAPSHOT=0 pytest tests/test_nota_credito.py::test_generar_nce_desde_nota_regenera_dte_fecha tests/test_nota_credito.py::test_generar_nce_desde_nota_prefiere_snapshot
- STRICT_SNAPSHOT=0 pytest tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_credito_fiscal tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_regenera_dte_fecha tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_prefiere_snapshot tests/test_nota_debito_remision.py::test_generar_nde_desde_nota_snapshot_dui tests/test_nota_debito_remision.py::test_generar_nota_remision_factura
- STRICT_SNAPSHOT=0 pytest tests/test_nota_remision.py::test_nr_desde_factura_documento_relacionado
- pytest tests/test_utils_fecha.py

------
https://chatgpt.com/codex/tasks/task_e_68db0ad8fb948323ad9a5926fe9d88c0