### PR TITLE
Limitar override de fecEmi y agregar prueba de factura

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -6210,7 +6210,9 @@ def _enviar_documento(
     print("DTE: START_enviar_documento", "modo=", modo)
     ident = data.get("identificacion") or data.get("identificador") or {}
     doc_ref = ident.get("numeroControl") or ident.get("codigoGeneracion") or doc_id
-    tipo_dte = ident.get("tipoDte") or ident.get("tipoDocumento")
+    raw_tipo_dte = ident.get("tipoDte") or ident.get("tipoDocumento")
+    tipo_dte = str(raw_tipo_dte or "").strip()
+    tipo_dte_norm = tipo_dte.zfill(2) if tipo_dte.isdigit() else tipo_dte
     nota_types = {"04", "05", "06"}
     ident_codigo = (ident.get("codigoGeneracion") or "").upper()
     ident_control = (ident.get("numeroControl") or "").upper()
@@ -6246,7 +6248,7 @@ def _enviar_documento(
         "codigoGeneracion": ident.get("codigoGeneracion"),
     }
     today_str = None
-    if tipo_dte in nota_types:
+    if tipo_dte_norm in nota_types:
         today_str = fecha_emision_hoy_str()
         if ident.get("fecEmi") != today_str:
             ident["fecEmi"] = today_str
@@ -6994,6 +6996,7 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str | None = None) -> dict:
     )
     jws_path = os.path.splitext(json_path)[0] + ".jws"
     jws_token = None
+    cached_payload: dict[str, Any] | None = None
     if os.path.exists(jws_path):
         try:
             with open(jws_path, "r", encoding="utf-8") as fh:
@@ -7009,13 +7012,41 @@ def enviar_nota_credito(db: DB, nota_id: int, modo: str | None = None) -> dict:
                     and payload_ident.get("fecEmi") == ident.get("fecEmi")
                 ):
                     jws_token = cached_token
+                    cached_payload = payload
         except Exception:
             jws_token = None
+            cached_payload = None
+    payload_json = stable_stringify(data, indent=2)
+    save_file(json_path, payload_json)
     if jws_token is None:
-        save_file(json_path, stable_stringify(data, indent=2))
         token = sign_json(data)
         jws_token = token.rstrip("\n")
         save_file(jws_path, jws_token, add_final_newline=False)
+    signed_payload: dict[str, Any] | None = cached_payload
+    if signed_payload is None and jws_token:
+        try:
+            signed_payload = _decode_jws_payload(jws_token)
+        except Exception:
+            signed_payload = None
+    if signed_payload is not None:
+        assert (signed_payload.get("identificacion") or {}).get("fecEmi") == ident.get(
+            "fecEmi"
+        )
+    primary_ident = data.get("identificacion") or {}
+    related = data.get("documentoRelacionado")
+    related_entry: Mapping[str, Any] | None = None
+    if isinstance(related, list):
+        for candidate in related:
+            if isinstance(candidate, Mapping):
+                related_entry = candidate
+                break
+    elif isinstance(related, Mapping):
+        related_entry = related
+    logger.info(
+        "SAVE->SEND fecEmi=%s rel.fechaEmision=%s",
+        primary_ident.get("fecEmi"),
+        (related_entry or {}).get("fechaEmision"),
+    )
     resp = _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
     if resp.get("sello"):
         db.update_venta_extra(nota_id, {"selloRecibido": resp["sello"]})
@@ -7144,6 +7175,7 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str | None = None) -> dict:
     )
     jws_path = os.path.splitext(json_path)[0] + ".jws"
     jws_token = None
+    cached_payload: dict[str, Any] | None = None
     if os.path.exists(jws_path):
         try:
             with open(jws_path, "r", encoding="utf-8") as fh:
@@ -7159,13 +7191,41 @@ def enviar_nota_debito(db: DB, nota_id: int, modo: str | None = None) -> dict:
                     and payload_ident.get("fecEmi") == ident.get("fecEmi")
                 ):
                     jws_token = cached_token
+                    cached_payload = payload
         except Exception:
             jws_token = None
+            cached_payload = None
+    payload_json = stable_stringify(data, indent=2)
+    save_file(json_path, payload_json)
     if jws_token is None:
-        save_file(json_path, stable_stringify(data, indent=2))
         token = sign_json(data)
         jws_token = token.rstrip("\n")
         save_file(jws_path, jws_token, add_final_newline=False)
+    signed_payload: dict[str, Any] | None = cached_payload
+    if signed_payload is None and jws_token:
+        try:
+            signed_payload = _decode_jws_payload(jws_token)
+        except Exception:
+            signed_payload = None
+    if signed_payload is not None:
+        assert (signed_payload.get("identificacion") or {}).get("fecEmi") == ident.get(
+            "fecEmi"
+        )
+    primary_ident = data.get("identificacion") or {}
+    related = data.get("documentoRelacionado")
+    related_entry: Mapping[str, Any] | None = None
+    if isinstance(related, list):
+        for candidate in related:
+            if isinstance(candidate, Mapping):
+                related_entry = candidate
+                break
+    elif isinstance(related, Mapping):
+        related_entry = related
+    logger.info(
+        "SAVE->SEND fecEmi=%s rel.fechaEmision=%s",
+        primary_ident.get("fecEmi"),
+        (related_entry or {}).get("fechaEmision"),
+    )
     resp = _enviar_documento(db, nota_id, data, modo, jws_token=jws_token)
     if resp.get("sello"):
         db.update_venta_extra(nota_id, {"selloRecibido": resp["sello"]})
@@ -7210,6 +7270,32 @@ def enviar_nota_remision(db: DB, nota_id: int, modo: str | None = None) -> dict:
         )
     ident["fecEmi"] = hoy_fec
     data["identificacion"] = ident
+    from utils.docs import get_dte_document_paths
+    from utils.stable_json import save_file, stable_stringify
+
+    receptor = data.get("receptor", {}) or {}
+    _, json_path = get_dte_document_paths(
+        ident.get("fecEmi"),
+        receptor.get("nombre") or receptor.get("nombreComercial") or "",
+        ident.get("numeroControl"),
+        "NotaRemision",
+    )
+    payload_json = stable_stringify(data, indent=2)
+    save_file(json_path, payload_json)
+    related = data.get("documentoRelacionado")
+    related_entry: Mapping[str, Any] | None = None
+    if isinstance(related, list):
+        for candidate in related:
+            if isinstance(candidate, Mapping):
+                related_entry = candidate
+                break
+    elif isinstance(related, Mapping):
+        related_entry = related
+    logger.info(
+        "SAVE->SEND fecEmi=%s rel.fechaEmision=%s",
+        ident.get("fecEmi"),
+        (related_entry or {}).get("fechaEmision"),
+    )
     resp = _enviar_documento(db, nota_id, data, modo)
     if resp.get("sello"):
         db.update_venta_extra(nota_id, {"selloRecibido": resp["sello"]})

--- a/tests/test_enviar_documento_fecemi.py
+++ b/tests/test_enviar_documento_fecemi.py
@@ -1,0 +1,57 @@
+import copy
+
+import auth
+import dte
+from db import DB
+
+
+def test_enviar_documento_preserva_fecemi_factura(monkeypatch):
+    db = DB(":memory:")
+    controlled_date = "2024-01-15"
+    data = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "UUID-123",
+            "numeroControl": "DTE-01-ABC-000000000000001",
+            "fecEmi": controlled_date,
+        },
+        "resumen": {"totalLetras": "DIEZ"},
+    }
+
+    calls = {"sign": 0, "post": 0}
+    captured: dict[str, dict] = {}
+
+    monkeypatch.setattr(auth, "get_last_auth_host", lambda: None)
+    monkeypatch.setattr(
+        dte,
+        "_load_dte_api_config",
+        lambda: {"url": "https://apitest.dtes.mh.gob.sv/fesv/recepciondte"},
+    )
+    monkeypatch.setattr(dte, "_save_signed_dte", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dte, "fecha_emision_hoy_str", lambda now=None: "2077-07-07")
+
+    def fake_sign(payload):
+        calls["sign"] += 1
+        captured["payload"] = copy.deepcopy(payload)
+        return "token"
+
+    def fake_decode(token):
+        assert token == "token"
+        return copy.deepcopy(captured["payload"])
+
+    def fake_post(url, documento, meta, **kwargs):
+        calls["post"] += 1
+        captured["meta"] = copy.deepcopy(meta)
+        return {"estado": "Procesado"}
+
+    monkeypatch.setattr("utils.jws.sign_json", fake_sign)
+    monkeypatch.setattr(dte, "_decode_jws_payload", fake_decode)
+    monkeypatch.setattr(dte, "_post_dte", fake_post)
+
+    result = dte._enviar_documento(db, 1, data, "normal")
+
+    assert result["estado"] == "Procesado"
+    assert calls["sign"] == 1
+    assert calls["post"] == 1
+    assert captured["payload"]["identificacion"]["fecEmi"] == controlled_date
+    assert data["identificacion"]["fecEmi"] == controlled_date


### PR DESCRIPTION
## Summary
- limita el ajuste automático de `fecEmi` en `_enviar_documento` a los DTE de notas
- guarda el JSON de notas de remisión con la fecha actual antes de firmar o enviar
- agrega una prueba que asegura que las facturas preservan la fecha de emisión original

## Testing
- pytest tests/test_enviar_documento_fecemi.py
- pytest tests/test_nota_remision.py

------
https://chatgpt.com/codex/tasks/task_e_68db469b658883238e1900f6c3c22ab9