### PR TITLE
Normalizar estado_ui y estado_ui_tag con mapeo robusto de Hacienda

### DIFF
--- a/db.py
+++ b/db.py
@@ -2,14 +2,14 @@ import os
 import re
 import shutil
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
 import threading
 import unicodedata
 from pathlib import Path
 from decimal import Decimal
-from typing import Any
+from typing import Any, Mapping
 
 from utils import versioned_dte
 from utils.fiscal_extra import build_fiscal_extra, normalize_tipo_fiscal
@@ -2664,27 +2664,126 @@ class DB:
     ):
         """Guarda un registro del estado de transmisión de un DTE.
 
-        Siempre asegura las columnas ``codigo_generacion`` y ``numero_control`` y
-        almacena ``codigo_generacion`` en mayúsculas cuando se provee.
+        Adicionalmente, preserva un ``estado_ui`` estable calculado en
+        función de la respuesta de Hacienda y del último registro previo
+        del mismo documento.
         """
 
         self.ensure_column("dte_envios", "respuesta", "TEXT")
         self.ensure_column("dte_envios", "codigo_lote", "TEXT")
         self.ensure_column("dte_envios", "codigo_generacion", "TEXT")
         self.ensure_column("dte_envios", "numero_control", "TEXT")
+        self.ensure_column("dte_envios", "estado_ui", "TEXT")
+        self.ensure_column("dte_envios", "estado_ui_tag", "TEXT")
 
-        # Normaliza valores
-        codigo_generacion = (codigo_generacion or "").upper() or None
-        numero_control = numero_control or None
+        try:
+            self.cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_envios_codgen_upper ON dte_envios(UPPER(codigo_generacion))"
+            )
+        except Exception:
+            pass
+        try:
+            self.cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_envios_numctrl_upper ON dte_envios(UPPER(numero_control))"
+            )
+        except Exception:
+            pass
 
-        fecha_hora = datetime.now().isoformat()
+        # Importación tardía para evitar ciclos en tiempo de carga.
+        from dte import (  # type: ignore circular
+            _map_estado_hacienda,
+            _merge_estado_tag,
+            _merge_estado_ui,
+        )
+
+        respuesta_dict: Mapping[str, Any] | None = None
+        respuesta_text: str = ""
+        if isinstance(respuesta_json, Mapping):
+            respuesta_dict = respuesta_json
+            try:
+                respuesta_text = json.dumps(respuesta_json, ensure_ascii=False)
+            except Exception:
+                respuesta_text = json.dumps(respuesta_json)
+        elif isinstance(respuesta_json, str):
+            respuesta_text = respuesta_json
+            if respuesta_json.strip():
+                try:
+                    respuesta_dict = json.loads(respuesta_json)
+                except Exception:
+                    respuesta_dict = None
+        elif respuesta_json is None:
+            respuesta_text = ""
+        else:
+            try:
+                respuesta_text = json.dumps(respuesta_json)
+            except Exception:
+                respuesta_text = str(respuesta_json)
+
+        mapped_estado = _map_estado_hacienda(respuesta_dict)
+        new_ui = mapped_estado["ui"]
+        if new_ui == "Pendiente":
+            estado_base = mapped_estado.get("raw") or str(estado or "").strip().upper()
+            if estado_base == "ACEPTADO":
+                new_ui = "Aceptado"
+            elif estado_base == "RECHAZADO":
+                new_ui = "Rechazado"
+            elif estado_base in {"TRANSMITIDO", "RECIBIDO", "PROCESADO"}:
+                new_ui = "Enviado"
+
+        # Normaliza valores utilizados para consultas
+        codigo_generacion_val = (codigo_generacion or "").strip().upper()
+        codigo_generacion_upper = codigo_generacion_val or None
+        numero_control_val = (numero_control or "").strip().upper()
+        numero_control_upper = numero_control_val or None
+
+        prev_ui = None
+        prev_tag = None
+        row = None
+        if codigo_generacion_upper:
+            row = self.cursor.execute(
+                """
+                SELECT estado_ui, estado_ui_tag FROM dte_envios
+                WHERE codigo_generacion IS NOT NULL AND codigo_generacion = ?
+                ORDER BY id DESC LIMIT 1
+                """,
+                (codigo_generacion_upper,),
+            ).fetchone()
+        if (row is None) and numero_control_upper:
+            row = self.cursor.execute(
+                """
+                SELECT estado_ui, estado_ui_tag FROM dte_envios
+                WHERE numero_control IS NOT NULL AND numero_control = ?
+                ORDER BY id DESC LIMIT 1
+                """,
+                (numero_control_upper,),
+            ).fetchone()
+        if row is not None:
+            try:
+                prev_ui = row["estado_ui"]
+            except Exception:
+                try:
+                    prev_ui = row[0]
+                except Exception:
+                    prev_ui = None
+            try:
+                prev_tag = row["estado_ui_tag"]
+            except Exception:
+                try:
+                    prev_tag = row[1]
+                except Exception:
+                    prev_tag = None
+
+        merged_ui = _merge_estado_ui(prev_ui, new_ui)
+        merged_tag = _merge_estado_tag(prev_tag, mapped_estado.get("tag"), merged_ui)
+
+        fecha_hora = datetime.now(timezone.utc).isoformat()
         self.cursor.execute(
             """
             INSERT INTO dte_envios (
                 venta_id, modo, estado, sello, fecha_hora,
-                respuesta, codigo_lote, codigo_generacion, numero_control
+                respuesta, codigo_lote, codigo_generacion, numero_control, estado_ui, estado_ui_tag
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 venta_id,
@@ -2692,10 +2791,12 @@ class DB:
                 estado,
                 sello,
                 fecha_hora,
-                respuesta_json,
+                respuesta_text,
                 codigo_lote,
-                codigo_generacion,
-                numero_control,
+                codigo_generacion_upper,
+                numero_control_upper,
+                merged_ui,
+                merged_tag,
             ),
         )
         self.conn.commit()

--- a/dte.py
+++ b/dte.py
@@ -10,6 +10,7 @@ import shutil
 import hashlib
 import logging
 import time
+from collections.abc import Mapping as AbcMapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP, getcontext
 from typing import Any, Mapping, Optional
@@ -90,6 +91,201 @@ except Exception:  # pragma: no cover - fallback when VERSION is missing
 
 logger = logging.getLogger(__name__)
 TIMEOUT = int(os.getenv("DTE_HTTP_TIMEOUT", "20"))
+
+SUCCESS_RAW = {"TRANSMITIDO", "RECIBIDO", "PROCESADO"}
+ACCEPT_RAW = {"ACEPTADO"}
+REJECT_RAW = {"RECHAZADO"}
+
+
+def _get_in(mapping: Mapping[str, Any] | None, key: str) -> Any:
+    if not isinstance(mapping, AbcMapping):
+        return None
+
+    visited: set[int] = set()
+
+    def _walk(node: Any) -> Any:
+        if isinstance(node, AbcMapping):
+            marker = id(node)
+            if marker in visited:
+                return None
+            visited.add(marker)
+            if key in node:
+                return node[key]
+            for value in node.values():
+                found = _walk(value)
+                if found is not None:
+                    return found
+        elif isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+            marker = id(node)
+            if marker in visited:
+                return None
+            visited.add(marker)
+            for item in node:
+                found = _walk(item)
+                if found is not None:
+                    return found
+        return None
+
+    try:
+        return _walk(mapping)
+    except RecursionError:
+        return None
+
+
+def _extract_raw_estado(resp: Mapping[str, Any] | None) -> str:
+    if not isinstance(resp, AbcMapping):
+        return ""
+    for key in (
+        "estado",
+        "estadoDte",
+        "estadoEvento",
+        "descripcionEstado",
+        "descripcionEstadoDte",
+    ):
+        value = _get_in(resp, key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().upper()
+    return ""
+
+
+def _extract_meta(resp: Mapping[str, Any] | None) -> dict[str, Any]:
+    descripcion = _get_in(resp, "descripcionMsg")
+    clasifica = _get_in(resp, "clasificaMsg")
+    codigo = _get_in(resp, "codigoMsg")
+    observaciones_raw = _get_in(resp, "observaciones")
+
+    if isinstance(descripcion, str):
+        descripcion_up = descripcion.strip().upper()
+    else:
+        descripcion_up = ""
+
+    if isinstance(clasifica, str):
+        clasifica_up = clasifica.strip().upper()
+    else:
+        clasifica_up = ""
+
+    if isinstance(codigo, str):
+        codigo_up = codigo.strip().upper()
+    elif isinstance(codigo, (int, float)):
+        codigo_up = str(codigo).strip().upper()
+    else:
+        codigo_up = ""
+
+    observaciones_list: list[Any] = []
+    if isinstance(observaciones_raw, (list, tuple, set)):
+        observaciones_list = [obs for obs in observaciones_raw if obs not in (None, "")]
+    elif isinstance(observaciones_raw, str) and observaciones_raw.strip():
+        observaciones_list = [observaciones_raw.strip()]
+
+    return {
+        "descripcion": descripcion_up,
+        "clasifica": clasifica_up,
+        "codigo": codigo_up,
+        "observaciones": observaciones_list,
+    }
+
+
+def _map_estado_hacienda(resp: Mapping[str, Any] | None) -> dict[str, str]:
+    raw = _extract_raw_estado(resp)
+    meta = _extract_meta(resp)
+    descripcion = meta["descripcion"]
+    clasifica = meta["clasifica"]
+    codigo = meta["codigo"]
+    observaciones = meta["observaciones"]
+
+    raw_upper = raw.strip().upper() if isinstance(raw, str) else ""
+
+    text_pool = (raw_upper, descripcion, clasifica)
+
+    ui = "Pendiente"
+    if any("RECHAZ" in value for value in text_pool if value):
+        ui = "Rechazado"
+    elif any("ACEPT" in value for value in text_pool if value):
+        ui = "Aceptado"
+    elif any(value and token in value for value in text_pool for token in ("PROCES", "RECIB", "TRANSMIT")):
+        ui = "Enviado"
+    elif any(
+        value and token in value
+        for value in (descripcion, clasifica)
+        for token in ("RECIBIDO", "PROCESADO")
+    ):
+        ui = "Enviado"
+
+    tag = ""
+    code_int: int | None = None
+    if codigo:
+        try:
+            code_int = int(codigo.lstrip("0") or "0")
+        except Exception:
+            code_int = None
+    if ui == "Enviado":
+        has_observaciones = bool(observaciones) or (
+            descripcion and "OBSERVACION" in descripcion
+        )
+        if has_observaciones:
+            allow_tag = False
+            if not clasifica:
+                allow_tag = True
+            elif clasifica == "10":
+                if (code_int is not None and code_int in (1, 2)) or codigo in {"001", "002"}:
+                    allow_tag = True
+            if allow_tag:
+                tag = "observado"
+    elif ui == "Rechazado":
+        if (code_int == 96) or codigo == "096" or (
+            descripcion and "ESQUEMA JSON" in descripcion
+        ):
+            tag = "schema"
+        elif (code_int == 17) or codigo == "017" or (
+            descripcion and "FECHA NO ES CORRECTA" in descripcion
+        ):
+            tag = "fecha"
+        elif (code_int == 14) or codigo == "014" or (
+            descripcion and "NO EXISTE UN REGISTRO" in descripcion
+        ):
+            tag = "no_registro"
+
+    return {"ui": ui, "tag": tag, "raw": raw_upper, "code": codigo, "desc": descripcion}
+
+
+def _merge_estado_ui(prev_ui: str | None, new_ui: str) -> str:
+    prev = (prev_ui or "").strip().capitalize()
+    new = (new_ui or "").strip().capitalize()
+    if prev == "Aceptado":
+        return "Aceptado"
+    if new == "Aceptado":
+        return "Aceptado"
+    if prev == "Rechazado" and new == "Pendiente":
+        return "Rechazado"
+    if new == "Rechazado":
+        return "Rechazado"
+    if prev == "Rechazado" and new == "Enviado":
+        return "Rechazado"
+    if not prev or prev == "Pendiente":
+        return new
+    if prev == "Enviado" and new == "Enviado":
+        return "Enviado"
+    return prev
+
+
+def _merge_estado_tag(prev_tag: str | None, new_tag: str | None, merged_ui: str) -> str:
+    merged = (merged_ui or "").strip().capitalize()
+    prev = (prev_tag or "").strip().lower()
+    new = (new_tag or "").strip().lower()
+
+    if merged == "Aceptado":
+        return ""
+    if merged == "Rechazado":
+        if new:
+            return new
+        return prev
+    if merged == "Enviado":
+        if new == "observado":
+            return "observado"
+        if prev == "observado":
+            return "observado"
+        return ""
+    return new or prev
 
 # Flags y valores por defecto esperados para diagnósticos HTTP:
 # - DTE_DEBUG_HTTP=0

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1115,16 +1115,14 @@ class FacturacionTab(QWidget):
 
     @staticmethod
     def _map_envio_state(state):
-        est = str(state).lower()
-        if est == "aceptado":
+        est = str(state or "").strip().upper()
+        if est == "ACEPTADO":
             return "Aceptado"
-        if est == "rechazado":
+        if est == "RECHAZADO":
             return "Rechazado"
-        if est == "error":
-            return "Error"
-        if est in {"transmitido", "recibido", "procesado"}:
+        if est in {"TRANSMITIDO", "RECIBIDO", "PROCESADO"}:
             return "Enviado"
-        return "Pendiente"
+        return "Pendiente de envío"
 
     @classmethod
     def _detectar_estado_factura(
@@ -1161,66 +1159,85 @@ class FacturacionTab(QWidget):
                 estado = "Sin venta" if pdf_exists and json_exists else "Incompleta"
 
         envio = "Pendiente de envío"
+
+        def _row_get(row, key):
+            if row is None:
+                return None
+            try:
+                return row[key]
+            except Exception:
+                pass
+            getter = getattr(row, "get", None)
+            if callable(getter):
+                try:
+                    return getter(key)
+                except Exception:
+                    return None
+            try:
+                keys = row.keys()
+            except Exception:
+                return None
+            try:
+                index = list(keys).index(key)
+            except Exception:
+                return None
+            try:
+                return row[index]
+            except Exception:
+                return None
+
+        def _map_row_estado(row):
+            if not row:
+                return "Pendiente de envío"
+            ui_val = _row_get(row, "estado_ui")
+            tag_val = _row_get(row, "estado_ui_tag")
+            if isinstance(ui_val, str) and ui_val.strip():
+                base = ui_val.strip()
+                if base == "Pendiente":
+                    base = "Pendiente de envío"
+                if isinstance(tag_val, str):
+                    tag_norm = tag_val.strip().lower()
+                    if tag_norm and base in {"Enviado", "Rechazado"}:
+                        return f"{base} ({tag_norm})"
+                return base
+            estado_val = _row_get(row, "estado")
+            return cls._map_envio_state(estado_val)
+
         env_row = None
-        success_states = ("TRANSMITIDO", "RECIBIDO", "PROCESADO", "ACEPTADO")
         try:
-            if cur is not None:
-                if venta_id is not None:
-                    success = cur.execute(
+            if cur is not None and (codigo_generacion or numero_control):
+                env_row = cur.execute(
+                    """
+                    SELECT estado_ui, estado_ui_tag, estado FROM dte_envios
+                    WHERE codigo_generacion IS NOT NULL AND UPPER(codigo_generacion)=UPPER(?)
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (codigo_generacion or "",),
+                ).fetchone()
+                if not env_row:
+                    env_row = cur.execute(
                         """
-                        SELECT estado FROM dte_envios
-                        WHERE venta_id=? AND UPPER(estado) IN (?, ?, ?, ?)
+                        SELECT estado_ui, estado_ui_tag, estado FROM dte_envios
+                        WHERE numero_control IS NOT NULL AND UPPER(numero_control)=UPPER(?)
                         ORDER BY id DESC LIMIT 1
                         """,
-                        (venta_id, *success_states),
+                        (numero_control or "",),
                     ).fetchone()
-                    if success:
-                        env_row = success
-                    else:
+                if not env_row:
+                    like_val = codigo_generacion or numero_control
+                    if like_val:
                         env_row = cur.execute(
-                            "SELECT estado FROM dte_envios WHERE venta_id=? ORDER BY id DESC LIMIT 1",
-                            (venta_id,),
+                            """
+                            SELECT estado FROM dte_envios
+                            WHERE respuesta LIKE ?
+                            ORDER BY id DESC LIMIT 1
+                            """,
+                            (f"%{like_val}%",),
                         ).fetchone()
-                elif codigo_generacion or numero_control:
-                    query_success = (
-                        "SELECT estado FROM dte_envios "
-                        "WHERE venta_id IS NULL AND respuesta LIKE ? "
-                        "AND UPPER(estado) IN (?, ?, ?, ?) "
-                        "ORDER BY id DESC LIMIT 1"
-                    )
-                    query_latest = (
-                        "SELECT estado FROM dte_envios WHERE venta_id IS NULL AND respuesta LIKE ? ORDER BY id DESC LIMIT 1"
-                    )
-                    if codigo_generacion:
-                        env_row = cur.execute(
-                            query_success,
-                            (
-                                f"%{codigo_generacion}%",
-                                *success_states,
-                            ),
-                        ).fetchone()
-                        if not env_row:
-                            env_row = cur.execute(
-                                query_latest,
-                                (f"%{codigo_generacion}%",),
-                            ).fetchone()
-                    if not env_row and numero_control:
-                        env_row = cur.execute(
-                            query_success,
-                            (
-                                f"%{numero_control}%",
-                                *success_states,
-                            ),
-                        ).fetchone()
-                        if not env_row:
-                            env_row = cur.execute(
-                                query_latest,
-                                (f"%{numero_control}%",),
-                            ).fetchone()
         except Exception:
             env_row = None
-        if env_row:
-            envio = cls._map_envio_state(env_row["estado"])
+
+        envio = _map_row_estado(env_row)
 
         return estado, envio
 

--- a/tests/test_dte_resend_block.py
+++ b/tests/test_dte_resend_block.py
@@ -118,13 +118,99 @@ def test_detectar_estado_factura_prioriza_exitosos(monkeypatch):
 
     db = DB(":memory:")
     venta = create_sale(db)
-    db.registrar_envio_dte(venta, "normal", "PROCESADO", "S")
-    db.registrar_envio_dte(venta, "normal", "Rechazado", "")
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "PROCESADO",
+        "S",
+        {"estado": "Procesado"},
+        codigo_generacion="ABC",
+        numero_control="NC1",
+    )
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "Rechazado",
+        "",
+        {"estado": "Rechazado"},
+        codigo_generacion="ABC",
+        numero_control="NC1",
+    )
 
     _, envio = FacturacionTab._detectar_estado_factura(
-        {}, cur=db.cursor, venta_id=venta
+        {},
+        cur=db.cursor,
+        venta_id=venta,
+        codigo_generacion="ABC",
+        numero_control="NC1",
     )
-    assert envio == "Enviado"
+    assert envio == "Rechazado"
+
+
+def test_detectar_estado_factura_muestra_observado(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    facturacion_tab = pytest.importorskip(
+        "facturacion_tab", reason="PyQt5 no disponible", exc_type=ImportError
+    )
+    FacturacionTab = facturacion_tab.FacturacionTab
+
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "PROCESADO",
+        "S",
+        {
+            "estado": "Procesado",
+            "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+            "observaciones": ["detalle"],
+        },
+        codigo_generacion="ABC-OBS",
+    )
+
+    _, envio = FacturacionTab._detectar_estado_factura(
+        {},
+        cur=db.cursor,
+        venta_id=venta,
+        codigo_generacion="ABC-OBS",
+        numero_control=None,
+    )
+
+    assert envio == "Enviado (observado)"
+
+
+def test_detectar_estado_factura_muestra_tag_rechazado(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    facturacion_tab = pytest.importorskip(
+        "facturacion_tab", reason="PyQt5 no disponible", exc_type=ImportError
+    )
+    FacturacionTab = facturacion_tab.FacturacionTab
+
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "RECHAZADO",
+        "S",
+        {
+            "estado": "Rechazado",
+            "codigoMsg": "096",
+            "descripcionMsg": "DOCUMENTO NO CUMPLE ESQUEMA JSON",
+        },
+        codigo_generacion="ABC-RECH",
+    )
+
+    _, envio = FacturacionTab._detectar_estado_factura(
+        {},
+        cur=db.cursor,
+        venta_id=venta,
+        codigo_generacion="ABC-RECH",
+        numero_control=None,
+    )
+
+    assert envio == "Rechazado (schema)"
 
 
 def test_detectar_estado_factura_nota_remision(tmp_path):

--- a/tests/test_envio_registra_campos.py
+++ b/tests/test_envio_registra_campos.py
@@ -9,14 +9,184 @@ def test_registrar_envio_dte_guarda_campos():
         "normal",
         "Procesado",
         "0" * 40,
+        {"estado": "Procesado"},
         codigo_generacion="abc",
         numero_control="DTE-01-S001P001-000000000000001",
     )
     row = db.cursor.execute(
-        "SELECT codigo_generacion, numero_control, estado, sello FROM dte_envios WHERE venta_id=?",
+        """
+        SELECT codigo_generacion, numero_control, estado, sello, estado_ui, estado_ui_tag
+        FROM dte_envios WHERE venta_id=?
+        """,
         (venta_id,),
     ).fetchone()
     assert row["codigo_generacion"] == "ABC"
     assert row["numero_control"] == "DTE-01-S001P001-000000000000001"
     assert row["estado"] == "Procesado"
     assert row["sello"] == "0" * 40
+    assert row["estado_ui"] == "Enviado"
+    assert row["estado_ui_tag"] == ""
+
+
+def test_registrar_envio_dte_estado_ui_monotonic():
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-01", 10)
+    codigo = "abc-123"
+
+    etapas = [
+        ({"estado": "Transmitido"}, "TRANSMITIDO", "Enviado", ""),
+        ({"estado": "Procesado"}, "PROCESADO", "Enviado", ""),
+        (
+            {
+                "estado": "Rechazado",
+                "codigoMsg": "096",
+                "descripcionMsg": "DOCUMENTO NO CUMPLE ESQUEMA JSON",
+            },
+            "RECHAZADO",
+            "Rechazado",
+            "schema",
+        ),
+        ({"estado": "Aceptado"}, "ACEPTADO", "Aceptado", ""),
+        ({"estado": "Procesado"}, "PROCESADO", "Aceptado", ""),
+    ]
+
+    for payload, estado, esperado, tag_esperado in etapas:
+        db.registrar_envio_dte(
+            venta_id,
+            "normal",
+            estado,
+            "S",
+            payload,
+            codigo_generacion=codigo,
+        )
+        row = db.cursor.execute(
+            """
+            SELECT estado, estado_ui, estado_ui_tag FROM dte_envios
+            WHERE codigo_generacion=?
+            ORDER BY id DESC LIMIT 1
+            """,
+            (codigo.upper(),),
+        ).fetchone()
+        assert row["estado_ui"] == esperado
+        assert row["estado_ui_tag"] == tag_esperado
+
+
+def test_registrar_envio_dte_estado_ui_por_numero_control():
+    db = DB(":memory:")
+    numero = "DTE-01-S001P001-000000000000009"
+
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "TRANSMITIDO",
+        "S",
+        {"estado": "Transmitido"},
+        numero_control=numero,
+    )
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "ACEPTADO",
+        "S",
+        {"estado": "Aceptado"},
+        numero_control=numero,
+    )
+
+    row = db.cursor.execute(
+        """
+        SELECT estado_ui, estado_ui_tag, numero_control FROM dte_envios
+        WHERE numero_control=?
+        ORDER BY id DESC LIMIT 1
+        """,
+        (numero.upper(),),
+    ).fetchone()
+
+    assert row["numero_control"] == numero.upper()
+    assert row["estado_ui"] == "Aceptado"
+    assert row["estado_ui_tag"] == ""
+
+
+def test_registrar_envio_dte_prioriza_codigo_generacion_sobre_numero_control():
+    db = DB(":memory:")
+
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "RECHAZADO",
+        "S",
+        {
+            "estado": "Rechazado",
+            "codigoMsg": "096",
+            "descripcionMsg": "DOCUMENTO NO CUMPLE ESQUEMA JSON",
+        },
+        codigo_generacion="abc",
+        numero_control="NC-ORIG",
+    )
+
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "PROCESADO",
+        "S",
+        {"estado": "Procesado"},
+        numero_control="nc-dup",
+    )
+
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "PROCESADO",
+        "S",
+        {"estado": "Procesado"},
+        codigo_generacion="ABC",
+        numero_control="nc-dup",
+    )
+
+    row = db.cursor.execute(
+        """
+        SELECT estado_ui, estado_ui_tag FROM dte_envios
+        ORDER BY id DESC LIMIT 1
+        """
+    ).fetchone()
+
+    assert row["estado_ui"] == "Rechazado"
+    assert row["estado_ui_tag"] == "schema"
+
+
+def test_registrar_envio_dte_fusion_por_numero_control():
+    db = DB(":memory:")
+    numero = "dte-01-s001p001-000000000000099"
+
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "RECHAZADO",
+        "S",
+        {
+            "estado": "Rechazado",
+            "codigoMsg": "014",
+            "descripcionMsg": "NO EXISTE UN REGISTRO CON ESTE DATO",
+        },
+        numero_control=numero,
+    )
+
+    db.registrar_envio_dte(
+        None,
+        "normal",
+        "PROCESADO",
+        "S",
+        {"estado": "Procesado"},
+        numero_control=numero,
+    )
+
+    row = db.cursor.execute(
+        """
+        SELECT estado_ui, estado_ui_tag FROM dte_envios
+        WHERE numero_control=?
+        ORDER BY id DESC LIMIT 1
+        """,
+        (numero.upper(),),
+    ).fetchone()
+
+    assert row["estado_ui"] == "Rechazado"
+    assert row["estado_ui_tag"] == "no_registro"

--- a/tests/test_estado_ui_mapping.py
+++ b/tests/test_estado_ui_mapping.py
@@ -1,0 +1,160 @@
+import pytest
+
+from dte import _map_estado_hacienda, _merge_estado_tag, _merge_estado_ui
+
+
+@pytest.mark.parametrize(
+    "payload, esperado_ui, esperado_tag",
+    [
+        (
+            {"estado": "Procesado", "descripcionMsg": "RECIBIDO", "observaciones": []},
+            "Enviado",
+            "",
+        ),
+        (
+            {
+                "estado": "Procesado",
+                "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+                "observaciones": ["detalle"],
+            },
+            "Enviado",
+            "observado",
+        ),
+        (
+            {
+                "estado": "Procesado",
+                "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+                "observaciones": ["detalle"],
+                "clasificaMsg": "10",
+                "codigoMsg": "001",
+            },
+            "Enviado",
+            "observado",
+        ),
+        (
+            {
+                "estado": "Procesado",
+                "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+                "observaciones": ["detalle"],
+                "clasificaMsg": "10",
+                "codigoMsg": "002",
+            },
+            "Enviado",
+            "observado",
+        ),
+        (
+            {
+                "estado": "Procesado",
+                "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+                "observaciones": ["detalle"],
+                "clasificaMsg": "10",
+                "codigoMsg": "2",
+            },
+            "Enviado",
+            "observado",
+        ),
+        (
+            {
+                "estado": "Procesado",
+                "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+                "observaciones": ["detalle"],
+                "clasificaMsg": "20",
+                "codigoMsg": "801",
+            },
+            "Enviado",
+            "",
+        ),
+        (
+            {
+                "estado": "Rechazado",
+                "codigoMsg": "096",
+                "descripcionMsg": "DOCUMENTO NO CUMPLE ESQUEMA JSON",
+            },
+            "Rechazado",
+            "schema",
+        ),
+        (
+            {
+                "estado": "Rechazado",
+                "codigoMsg": "96",
+                "descripcionMsg": "DOCUMENTO NO CUMPLE ESQUEMA JSON",
+            },
+            "Rechazado",
+            "schema",
+        ),
+        (
+            {"estado": "Rechazado", "codigoMsg": "017", "descripcionMsg": "FECHA NO ES CORRECTA"},
+            "Rechazado",
+            "fecha",
+        ),
+        (
+            {
+                "estado": "Rechazado",
+                "codigoMsg": "014",
+                "descripcionMsg": "NO EXISTE UN REGISTRO CON ESTE DATO",
+            },
+            "Rechazado",
+            "no_registro",
+        ),
+        (
+            {"estado": "Aceptado", "descripcionMsg": "ACEPTADO"},
+            "Aceptado",
+            "",
+        ),
+    ],
+)
+def test_map_estado_hacienda(payload, esperado_ui, esperado_tag):
+    mapped = _map_estado_hacienda(payload)
+    assert mapped["ui"] == esperado_ui
+    assert mapped["tag"] == esperado_tag
+
+
+def test_merge_estado_ui_tag_sequence():
+    secuencia = [
+        None,
+        {"estado": "Procesado"},
+        {
+            "estado": "Procesado",
+            "descripcionMsg": "RECIBIDO CON OBSERVACIONES",
+            "observaciones": ["detalle"],
+        },
+        {
+            "estado": "Rechazado",
+            "codigoMsg": "096",
+            "descripcionMsg": "DOCUMENTO NO CUMPLE ESQUEMA JSON",
+        },
+        {"estado": "Aceptado"},
+    ]
+
+    prev_ui = None
+    prev_tag = None
+    for payload in secuencia:
+        mapped = _map_estado_hacienda(payload)
+        merged_ui = _merge_estado_ui(prev_ui, mapped["ui"])
+        merged_tag = _merge_estado_tag(prev_tag, mapped["tag"], merged_ui)
+        prev_ui, prev_tag = merged_ui, merged_tag
+
+    assert prev_ui == "Aceptado"
+    assert prev_tag == ""
+
+
+def test_merge_estado_no_degrada_rechazado_con_tag():
+    prev_ui = None
+    prev_tag = None
+
+    mapped_rechazo = _map_estado_hacienda(
+        {
+            "estado": "Rechazado",
+            "codigoMsg": "014",
+            "descripcionMsg": "NO EXISTE UN REGISTRO CON ESTE DATO",
+        }
+    )
+    prev_ui = _merge_estado_ui(prev_ui, mapped_rechazo["ui"])
+    prev_tag = _merge_estado_tag(prev_tag, mapped_rechazo["tag"], prev_ui)
+
+    mapped_enviado = _map_estado_hacienda({"estado": "Procesado"})
+    prev_ui = _merge_estado_ui(prev_ui, mapped_enviado["ui"])
+    prev_tag = _merge_estado_tag(prev_tag, mapped_enviado["tag"], prev_ui)
+
+    assert prev_ui == "Rechazado"
+    assert prev_tag == "no_registro"


### PR DESCRIPTION
## Summary
- normaliza la lectura de respuestas de Hacienda para obtener un estado base y un tag diagnóstico estable, con fusiones monotónicas de ui y tag
- persiste estado_ui y estado_ui_tag normalizados en dte_envios y consulta por código de generación o número de control sin degradar estados previos
- muestra tags en la pestaña de facturación y agrega pruebas unitarias que cubren el mapeo, la fusión y la persistencia
- limita el tag "observado" a respuestas exitosas de Hacienda para evitar diagnósticos ruidosos y permite acuses 002/2 normalizando los códigos de rechazo

## Testing
- pytest tests/test_estado_ui_mapping.py -q


------
https://chatgpt.com/codex/tasks/task_e_68db71c6e7708323b5746fd6921520d3