### PR TITLE
Harden NR related document validation

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -20,12 +20,18 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+import re
 from typing import Iterable, Optional
 
 import logging
 
 from db import DB
-from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
+from dte import (
+    DTE_VERSIONES,
+    generar_cabecera_dte_data,
+    sanitize_dte_payload,
+    normalize_uuid_v4_upper,
+)
 from utils import catalogos
 from utils.fecha import (
     TZ_EL_SALVADOR,
@@ -40,6 +46,32 @@ import warnings
 from utils.sanitize import limpiar_documentos, solo_digitos
 
 Decimal_0 = Decimal("0")
+
+
+_RE_NUM_CONTROL = re.compile(r"^DTE-(\d{2})-S\d{3}P\d{3}-\d{15}$", re.IGNORECASE)
+
+
+def _tipos_dte_validos() -> set[str]:
+    """Obtiene el conjunto de tipos de DTE válidos desde el catálogo."""
+
+    tipos: set[str] = set()
+    for key in catalogos.DTE_TIPOS.keys():
+        if isinstance(key, int):
+            tipos.add(f"{key:02d}")
+            continue
+        key_str = str(key).strip()
+        if key_str.isdigit():
+            try:
+                tipos.add(f"{int(key_str):02d}")
+            except Exception:
+                tipos.add(key_str)
+        elif key_str:
+            tipos.add(key_str)
+    return tipos
+
+
+_TIPOS_DTE_VALIDOS = _tipos_dte_validos()
+_ESTADOS_REL_PERMITIDOS = {"Enviado", "Aceptado"}
 
 
 logger = logging.getLogger(__name__)
@@ -137,31 +169,169 @@ def normalizar_receptor(receptor: dict) -> dict:
 
 
 def _normalizar_documento_relacionado(doc_rel: list[dict]) -> list[dict]:
-    """Valida y normaliza ``documento_relacionado`` si está presente."""
+    """Valida y normaliza ``documento_relacionado`` respetando el número original."""
 
     if not isinstance(doc_rel, list) or not doc_rel:
         raise ValueError("documento_relacionado debe ser una lista no vacía")
-    doc = doc_rel[0] or {}
-    tipo = doc.get("tipoDocumento")
-    numero = doc.get("numeroDocumento")
-    fecha = doc.get("fechaEmision")
-    if tipo not in {"01", "03", "11"}:
+
+    raw = doc_rel[0] or {}
+    tipo_raw = raw.get("tipoDocumento")
+    if isinstance(tipo_raw, int):
+        tipo = f"{tipo_raw:02d}"
+    elif isinstance(tipo_raw, str):
+        tipo_str = tipo_raw.strip()
+        if tipo_str.isdigit() and len(tipo_str) <= 2:
+            tipo = f"{int(tipo_str):02d}"
+        else:
+            tipo = tipo_str or None
+    else:
+        tipo = None
+
+    if tipo not in _TIPOS_DTE_VALIDOS:
         raise ValueError("tipoDocumento inválido en documento_relacionado")
-    if not numero or not fecha:
+
+    numero = raw.get("numeroDocumento")
+    codigo_generacion = raw.get("codigoGeneracion")
+    if codigo_generacion:
+        codigo_generacion_str = str(codigo_generacion).strip()
+        if not codigo_generacion_str:
+            raise ValueError("codigoGeneracion inválido en documento_relacionado")
+        try:
+            codigo_generacion = normalize_uuid_v4_upper(codigo_generacion_str)
+        except Exception:
+            codigo_generacion = codigo_generacion_str.upper()
+        numero = codigo_generacion
+    if not numero:
         raise ValueError(
             "documento_relacionado requiere numeroDocumento y fechaEmision"
         )
+    numero = str(numero).strip()
+
+    fecha = raw.get("fechaEmision")
     fecha_normalizada = fecha_ddmmaaaa(fecha)
     if not fecha_normalizada:
         raise ValueError("fechaEmision inválida en documento_relacionado")
-    return [
-        {
-            "tipoDocumento": tipo,
-            "tipoGeneracion": 2,
-            "numeroDocumento": numero,
-            "fechaEmision": fecha_iso(fecha_normalizada),
-        }
-    ]
+
+    tipo_generacion = raw.get("tipoGeneracion")
+    if isinstance(tipo_generacion, str) and tipo_generacion.isdigit():
+        tipo_generacion = int(tipo_generacion)
+    if tipo_generacion not in {1, 2}:
+        if codigo_generacion:
+            tipo_generacion = 2
+        elif _RE_NUM_CONTROL.fullmatch(numero):
+            tipo_generacion = 1
+        else:
+            try:
+                numero = normalize_uuid_v4_upper(numero)
+            except Exception:
+                tipo_generacion = 1
+            else:
+                tipo_generacion = 2
+
+    if tipo_generacion == 2:
+        try:
+            numero_documento = normalize_uuid_v4_upper(numero)
+        except Exception:
+            numero_documento = str(numero).strip().upper()
+            if not numero_documento:
+                raise ValueError(
+                    "numeroDocumento inválido para tipoGeneracion=2"
+                )
+    else:
+        if not _RE_NUM_CONTROL.fullmatch(numero):
+            raise ValueError(
+                "numeroDocumento inválido para tipoGeneracion=1"
+            )
+        numero_documento = numero.upper()
+        if tipo_generacion == 1:
+            match = _RE_NUM_CONTROL.fullmatch(numero_documento)
+            if match:
+                tipo_from_num = match.group(1)
+                if tipo_from_num != tipo:
+                    raise ValueError(
+                        "tipoDocumento no coincide con el prefijo de numeroDocumento"
+                    )
+
+    resultado = {
+        "tipoDocumento": tipo,
+        "tipoGeneracion": tipo_generacion,
+        "numeroDocumento": numero_documento,
+        "fechaEmision": fecha_iso(fecha_normalizada),
+    }
+    if codigo_generacion:
+        resultado["codigoGeneracion"] = codigo_generacion
+
+    return [resultado]
+
+
+def _verificar_documento_relacionado_recepcionado(db: DB, doc_rel: list[dict]) -> None:
+    """Valida que el documento relacionado tenga estado recepcionado localmente."""
+
+    if not doc_rel:
+        return
+
+    doc = doc_rel[0]
+    tipo_generacion = doc.get("tipoGeneracion")
+    codigo_generacion = doc.get("codigoGeneracion")
+    numero_documento = doc.get("numeroDocumento")
+
+    codigo_consulta = None
+    numero_consulta = None
+    if tipo_generacion == 2:
+        codigo_consulta = (codigo_generacion or numero_documento or "").strip().upper()
+    elif tipo_generacion == 1:
+        numero_consulta = (numero_documento or "").strip().upper()
+        if codigo_generacion:
+            codigo_consulta = str(codigo_generacion).strip().upper()
+    else:
+        if codigo_generacion:
+            codigo_consulta = str(codigo_generacion).strip().upper()
+        if not codigo_consulta and numero_documento:
+            numero_consulta = str(numero_documento).strip().upper()
+
+    for column, definition in (
+        ("codigo_lote", "TEXT"),
+        ("codigo_generacion", "TEXT"),
+        ("numero_control", "TEXT"),
+        ("estado_ui", "TEXT"),
+        ("estado_ui_tag", "TEXT"),
+    ):
+        db.ensure_column("dte_envios", column, definition)
+
+    row = None
+    if codigo_consulta:
+        row = db.cursor.execute(
+            """
+            SELECT estado_ui FROM dte_envios
+            WHERE codigo_generacion IS NOT NULL AND codigo_generacion = ?
+            ORDER BY id DESC LIMIT 1
+            """,
+            (codigo_consulta,),
+        ).fetchone()
+    if row is None and numero_consulta:
+        row = db.cursor.execute(
+            """
+            SELECT estado_ui FROM dte_envios
+            WHERE numero_control IS NOT NULL AND numero_control = ?
+            ORDER BY id DESC LIMIT 1
+            """,
+            (numero_consulta,),
+        ).fetchone()
+
+    if row is None:
+        raise ValueError(
+            "El documento relacionado aún no ha sido recepcionado por MH (sin registro local)"
+        )
+
+    try:
+        estado_ui = row["estado_ui"]
+    except Exception:
+        estado_ui = row[0] if row else None
+
+    if (estado_ui or "").strip() not in _ESTADOS_REL_PERMITIDOS:
+        raise ValueError(
+            "El documento relacionado aún no ha sido recepcionado por MH"
+        )
 
 
 def generar_nota_remision(
@@ -298,6 +468,7 @@ def generar_nota_remision(
 
     if documento_relacionado:
         documento_relacionado = _normalizar_documento_relacionado(documento_relacionado)
+        _verificar_documento_relacionado_recepcionado(db, documento_relacionado)
     numero_doc = (
         documento_relacionado[0].get("numeroDocumento")
         if documento_relacionado

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -19,6 +19,10 @@ from typing import Iterable, Optional
 
 from db import DB
 from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
+from nota_remision import (
+    _normalizar_documento_relacionado as _normalizar_doc_rel_nr,
+    _verificar_documento_relacionado_recepcionado as _verificar_doc_rel_nr,
+)
 from utils import catalogos
 from utils.fecha import TZ_EL_SALVADOR, fecha_ddmmaaaa, fecha_emision_hoy_str, fecha_iso
 from utils.monto import d2, monto_a_texto_sv
@@ -138,6 +142,9 @@ def _generar_base(
     """Construye la estructura base común de una NR."""
     if not documento_relacionado:
         raise ValueError("documento_relacionado es obligatorio")
+
+    documento_relacionado = _normalizar_doc_rel_nr(documento_relacionado)
+    _verificar_doc_rel_nr(db, documento_relacionado)
 
     limpiar_documentos(emisor)
     emisor.setdefault("tipoEstablecimiento", "01")

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 import pytest
 import warnings
 
 from db import DB
+import nota_remision
 from nota_remision_electronica import (
     generar_nota_remision_desde_factura,
     generar_nota_remision_independiente,
@@ -44,6 +47,48 @@ def _sample_doc_rel():
     ]
 
 
+def _registrar_envio_relacionado(
+    db: DB,
+    *,
+    codigo_generacion: str | None = None,
+    numero_control: str | None = None,
+    estado_ui: str = "Aceptado",
+):
+    for column, definition in (
+        ("codigo_lote", "TEXT"),
+        ("codigo_generacion", "TEXT"),
+        ("numero_control", "TEXT"),
+        ("estado_ui", "TEXT"),
+        ("estado_ui_tag", "TEXT"),
+    ):
+        db.ensure_column("dte_envios", column, definition)
+    codigo_val = (codigo_generacion or "").strip().upper() or None
+    numero_val = (numero_control or "").strip().upper() or None
+    db.cursor.execute(
+        """
+        INSERT INTO dte_envios (
+            venta_id, modo, estado, sello, fecha_hora,
+            respuesta, codigo_lote, codigo_generacion, numero_control, estado_ui, estado_ui_tag
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            None,
+            None,
+            "PROCESADO",
+            "",
+            datetime.utcnow().isoformat(),
+            "",
+            None,
+            codigo_val,
+            numero_val,
+            estado_ui,
+            "" if estado_ui in {"Aceptado", "Enviado"} else "no_recepcion",
+        ),
+    )
+    db.conn.commit()
+
+
 def test_nr_desde_factura_documento_relacionado(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")
@@ -66,6 +111,10 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion="12345678-ABCD-1234-ABCD-1234567890AB",
+    )
     data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     doc_rel = data["documentoRelacionado"][0]
     assert doc_rel["tipoDocumento"] == "03"
@@ -92,6 +141,40 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     assert float(resumen["descuGravada"]) == 0.0
 
 
+def test_nr_documento_relacionado_con_numero_control(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-S001P001-000000000000447",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": _sample_emisor(),
+        "receptor": _sample_receptor(),
+        "cuerpoDocumento": [
+            {"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}
+        ],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    _registrar_envio_relacionado(
+        db,
+        numero_control="DTE-03-S001P001-000000000000447",
+        estado_ui="Enviado",
+    )
+    data = generar_nota_remision_desde_factura(db, factura, extension=extension)
+    doc_rel = data["documentoRelacionado"][0]
+    assert doc_rel["tipoDocumento"] == "03"
+    assert doc_rel["numeroDocumento"] == "DTE-03-S001P001-000000000000447"
+    assert doc_rel["tipoGeneracion"] == 1
+
+
 def test_nr_desde_factura_extension(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")
@@ -112,6 +195,10 @@ def test_nr_desde_factura_extension(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion="12345678-ABCD-1234-ABCD-1234567890AB",
+    )
     data = generar_nota_remision_desde_factura(
         db, factura, extension=extension
     )
@@ -119,6 +206,52 @@ def test_nr_desde_factura_extension(monkeypatch):
     rec = data["receptor"]
     assert "nombreComercial" in rec
     assert rec["nombreComercial"] is None
+
+
+def test_normalizar_documento_relacionado_preserva_prefijo():
+    doc_rel = [
+        {
+            "tipoDocumento": "03",
+            "numeroDocumento": "DTE-03-S001P001-000000000000447",
+            "fechaEmision": "2024-09-30",
+        }
+    ]
+    normalized = nota_remision._normalizar_documento_relacionado(doc_rel)
+    assert normalized[0]["numeroDocumento"] == "DTE-03-S001P001-000000000000447"
+    assert normalized[0]["tipoGeneracion"] == 1
+
+
+def test_normalizar_documento_relacionado_codigo_generacion():
+    doc_rel = [
+        {
+            "tipoDocumento": "03",
+            "codigoGeneracion": "a8748223-7cd8-42a3-84b2-c7d2473504dc",
+            "fechaEmision": "30/09/2025",
+        }
+    ]
+    normalized = nota_remision._normalizar_documento_relacionado(doc_rel)
+    assert normalized[0]["tipoGeneracion"] == 2
+    assert (
+        normalized[0]["numeroDocumento"]
+        == "A8748223-7CD8-42A3-84B2-C7D2473504DC"
+    )
+    assert (
+        normalized[0]["codigoGeneracion"]
+        == "A8748223-7CD8-42A3-84B2-C7D2473504DC"
+    )
+    assert normalized[0]["fechaEmision"] == "2025-09-30"
+
+
+def test_normalizar_documento_relacionado_tipo_incoherente():
+    doc_rel = [
+        {
+            "tipoDocumento": "01",
+            "numeroDocumento": "DTE-03-S001P001-000000000000447",
+            "fechaEmision": "2024-09-30",
+        }
+    ]
+    with pytest.raises(ValueError, match="prefijo de numeroDocumento"):
+        nota_remision._normalizar_documento_relacionado(doc_rel)
 
 
 def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
@@ -155,7 +288,12 @@ def test_nr_desde_factura_extension_actualiza_receptor(monkeypatch):
         "docuRecibe": "0614-140710-001-2",
         "tipoDocRecibe": "36",
         "nrcRecibe": "1234567",
+        "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion="12345678-ABCD-1234-ABCD-1234567890AB",
+    )
     data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     rec = data["receptor"]
     assert rec["tipoDocumento"] == "36"
@@ -181,6 +319,10 @@ def test_nr_independiente_extension(monkeypatch):
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
     doc_rel = _sample_doc_rel()
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=doc_rel[0]["numeroDocumento"],
+    )
     data = generar_nota_remision_independiente(
         db,
         emisor=emisor,
@@ -222,6 +364,10 @@ def test_nr_independiente_extension_sin_observaciones(monkeypatch):
         "docuRecibe": "1234 5678",
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+    )
     with pytest.raises(ValueError):
         generar_nota_remision_independiente(
             db,
@@ -246,6 +392,10 @@ def test_nr_independiente_extension_observaciones_vacia(monkeypatch):
         "observaciones": "   ",
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+    )
     with pytest.raises(ValueError):
         generar_nota_remision_independiente(
             db,
@@ -270,6 +420,10 @@ def test_nr_item_validation(monkeypatch):
             "docuRecibe": "456",
             "observaciones": "Obs",
         }
+        _registrar_envio_relacionado(
+            db,
+            codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+        )
         generar_nota_remision_independiente(
             db,
             emisor=emisor,
@@ -285,6 +439,10 @@ def test_nr_item_validation(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+    )
     data = generar_nota_remision_independiente(
         db,
         emisor=emisor,
@@ -329,6 +487,10 @@ def test_receptor_dui_sin_nrc(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=factura["identificacion"]["codigoGeneracion"],
+    )
     with warnings.catch_warnings(record=True) as w:
         data = generar_nota_remision_desde_factura(db, factura, extension=extension)
     rec = data["receptor"]
@@ -366,6 +528,10 @@ def test_receptor_nit_sin_nrc_error(monkeypatch):
         "observaciones": "Obs",
     }
     detalles = [{"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}]
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+    )
     with pytest.raises(ValueError):
         generar_nota_remision_independiente(
             db,
@@ -392,6 +558,10 @@ def test_receptor_campo_obligatorio_faltante(monkeypatch, campo):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+    )
     with pytest.raises(ValueError, match=f"receptor requiere {campo}"):
         generar_nota_remision_independiente(
             db,
@@ -417,6 +587,10 @@ def test_receptor_direccion_complemento_faltante(monkeypatch):
         "docuRecibe": "456",
         "observaciones": "Obs",
     }
+    _registrar_envio_relacionado(
+        db,
+        codigo_generacion=_sample_doc_rel()[0]["numeroDocumento"],
+    )
     with pytest.raises(ValueError, match="receptor requiere direccion.complemento"):
         generar_nota_remision_independiente(
             db,
@@ -426,3 +600,60 @@ def test_receptor_direccion_complemento_faltante(monkeypatch):
             documento_relacionado=_sample_doc_rel(),
             extension=extension,
         )
+
+
+def test_nr_documento_relacionado_rechazado(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-S001P001-000000000000447",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": _sample_emisor(),
+        "receptor": _sample_receptor(),
+        "cuerpoDocumento": [
+            {"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}
+        ],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    _registrar_envio_relacionado(
+        db,
+        numero_control="DTE-03-S001P001-000000000000447",
+        estado_ui="Rechazado",
+    )
+    with pytest.raises(ValueError, match="aún no ha sido recepcionado por MH"):
+        generar_nota_remision_desde_factura(db, factura, extension=extension)
+
+
+def test_nr_documento_relacionado_inexistente(monkeypatch):
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-S001P001-000000000000999",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": _sample_emisor(),
+        "receptor": _sample_receptor(),
+        "cuerpoDocumento": [
+            {"descripcion": "Prod", "cantidad": 1, "uniMedida": 59}
+        ],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+    with pytest.raises(ValueError, match="sin registro local"):
+        generar_nota_remision_desde_factura(db, factura, extension=extension)


### PR DESCRIPTION
## Summary
- tighten nota de remisión related-document normalization to align control prefixes, preserve provided UUIDs, and validate reception status via dte_envios records
- reuse the shared related-document normalization/verification in the electronic NR generator so both flows respect the same safeguards
- extend nota_remision tests with helpers and cases covering UUID-only references, prefix mismatches, and local reception state errors

## Testing
- pytest tests/test_nota_remision.py

------
https://chatgpt.com/codex/tasks/task_e_68db88ede52c8323a49eb87bd8457f97