### PR TITLE
Preserve formatted receptor document numbers in notas de remisión

### DIFF
--- a/nota_remision.py
+++ b/nota_remision.py
@@ -127,7 +127,6 @@ def normalizar_receptor(receptor: dict) -> dict:
     num = solo_digitos(receptor.get("numDocumento"))
     if not num:
         raise ValueError("receptor requiere numDocumento")
-    receptor["numDocumento"] = num
 
     nrc_raw = receptor.get("nrc")
     if nrc_raw is not None:

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -88,7 +88,6 @@ def normalizar_receptor(receptor: dict) -> dict:
     num = solo_digitos(receptor.get("numDocumento"))
     if not num:
         raise ValueError("receptor requiere numDocumento")
-    receptor["numDocumento"] = num
 
     nrc_raw = receptor.get("nrc")
     if nrc_raw is not None:


### PR DESCRIPTION
## Summary
- stop overwriting the receptor numDocumento in both NR builders so the UI-provided mask is kept

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db9a5fa95c8323b68b93772de32f28