### PR TITLE
Automate PyInstaller data bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,47 @@ Se cargará el último inventario si está disponible y podrás comenzar a regis
 
 ## Empaquetado y distribución
 
-El proyecto incluye scripts listos para generar el ejecutable y el instalador
-para Windows. Consulta [BUILD.md](BUILD.md) para pasos detallados sobre cómo:
+### Generar el ejecutable *onefile*
 
-* Ejecutar PyInstaller en modo *onedir* (`build/build.ps1`).
-* Empaquetar el instalador `VertexDTE-Setup.exe` con Inno Setup.
-* Realizar las pruebas manuales recomendadas en una máquina sin dependencias.
+El script `setup.py` genera el binario autocontenido de PyInstaller y recopila
+los recursos necesarios recorriendo el repositorio. De forma automática:
+
+* Utiliza el separador correcto (`;` en Windows, `:` en Linux/macOS) al crear
+  las entradas `--add-data`.
+* Omite directorios y artefactos que no deben distribuirse, incluyendo
+  `.git/`, `node_modules/`, `build/`, `dist/`, `tests/`, `__pycache__/`,
+  entornos virtuales y otros directorios de herramientas.
+* Excluye archivos sensibles o temporales (`*.key`, `*.pem`, `*.pub`, `*.pyc`,
+  `*.log`, etc.).
+* Detecta los módulos dinámicos de `reportlab.graphics.barcode` y los añade
+  como `hidden-imports` para evitar errores en tiempo de ejecución.
+
+Pasos sugeridos:
+
+1. (Opcional) Crea un entorno virtual limpio y ejecuta `pip install -r requirements.txt`.
+2. Lanza la compilación:
+
+   ```bash
+   python setup.py
+   ```
+
+   El ejecutable quedará en `dist/InventarioFarmacia` (en Windows se generará
+   `InventarioFarmacia.exe`).
+
+3. Prueba el resultado en un entorno sin el código fuente. En Linux puedes
+   validar que los recursos estén presentes ejecutando:
+
+   ```bash
+   QT_QPA_PLATFORM=offscreen dist/InventarioFarmacia --help
+   ```
+
+   Si aparece un error de bibliotecas del sistema (por ejemplo `libGL.so.1`),
+   instala los paquetes de OpenGL del sistema (`apt-get install libgl1` en
+   Debian/Ubuntu) antes de volver a ejecutar el binario.
+
+El script sigue siendo compatible con el proceso descrito en
+[BUILD.md](BUILD.md) para generar paquetes de Windows usando PowerShell e Inno
+Setup.
 
 Si la interfaz no aparece al ejecutar el binario, inicia el programa desde una terminal para ver los mensajes de error.
 

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,111 @@
 import os
+import pkgutil
+from pathlib import Path
+from typing import Iterable, List
+
 import PyInstaller.__main__
 
-SEP = ';' if os.name == 'nt' else ':'
 
-add_data = [
-    f'db.py{SEP}.',
-    f'dialogs.py{SEP}.',
-    f'inventory_manager.py{SEP}.',
-    f'factura_sv.py{SEP}.',
-    f'ui_mainwindow.py{SEP}.',
-    f'style.qss{SEP}.',
-    f'logoinventario.jpg{SEP}.',
-    f'inventario.json{SEP}.',
-    f'ultimo_inventario.json{SEP}.',
-    f'avatar.jpg{SEP}.',
-    f'svfe-json-schemas{SEP}svfe-json-schemas',
-    f'schema_patches{SEP}schema_patches',
-    f'VERSION{SEP}.',
-    f'datos_negocio.json{SEP}.',
-    f'config_negocio.json{SEP}.',
-    f'utils/catalogos{SEP}utils/catalogos',
-]
+SEP = ';' if os.name == 'nt' else ':'
+ROOT = Path(__file__).resolve().parent
+
+
+EXCLUDED_DIR_NAMES = {
+    '.git',
+    '.github',
+    '.mypy_cache',
+    '.pytest_cache',
+    '.venv',
+    '.vscode',
+    '__pycache__',
+    'build',
+    'dist',
+    'node_modules',
+    'tests',
+}
+
+EXCLUDED_FILE_NAMES = {
+    '.DS_Store',
+    '.python-version',
+}
+
+EXCLUDED_SUFFIXES = {
+    '.key',
+    '.pem',
+    '.pub',
+    '.pyc',
+    '.pyo',
+    '.log',
+    '.tmp',
+}
+
+
+def _should_exclude(path: Path, *, is_dir: bool) -> bool:
+    if any(part in EXCLUDED_DIR_NAMES for part in path.parts):
+        return True
+
+    if not is_dir:
+        if path.name in EXCLUDED_FILE_NAMES:
+            return True
+        if path.suffix.lower() in EXCLUDED_SUFFIXES:
+            return True
+
+    return False
+
+
+def _destination_for(path: Path) -> str:
+    relative_parent = path.relative_to(ROOT).parent
+    if relative_parent == Path('.'):
+        return '.'
+    return relative_parent.as_posix()
+
+
+def collect_add_data(root: Path) -> Iterable[str]:
+    entries: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        current_dir = Path(dirpath)
+
+        # Modificamos dirnames in-place para evitar descender en directorios excluidos
+        dirnames[:] = [
+            dirname
+            for dirname in dirnames
+            if not _should_exclude(current_dir / dirname, is_dir=True)
+        ]
+
+        for filename in filenames:
+            file_path = current_dir / filename
+            if _should_exclude(file_path, is_dir=False):
+                continue
+
+            destination = _destination_for(file_path)
+            entries.append(f"{file_path}{SEP}{destination}")
+
+    return entries
+
+
+add_data = list(collect_add_data(ROOT))
+
+
+def collect_hidden_imports() -> Iterable[str]:
+    modules: List[str] = []
+    try:
+        import reportlab.graphics.barcode as barcode  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        return modules
+
+    for module_info in pkgutil.iter_modules(barcode.__path__, barcode.__name__ + '.'):
+        modules.append(module_info.name)
+
+    return modules
+
+
+hidden_imports = list(collect_hidden_imports())
 
 PyInstaller.__main__.run([
     'main.py',
     '--name=InventarioFarmacia',
-    '--onefile',                # Un solo ejecutable
-    '--windowed',               # Sin consola (para apps gráficas)
+    '--onefile',
+    '--windowed',
     *[arg for item in add_data for arg in ('--add-data', item)],
+    *[arg for module in hidden_imports for arg in ('--hidden-import', module)],
 ])
-
-# Nota:
-# Si usas imágenes, archivos .ui o recursos, agrega más líneas '--add-data=archivo;carpeta_destino'
-# En Mac/Linux, usa ':' en vez de ';' como separador en --add-data


### PR DESCRIPTION
## Summary
- Replace the static PyInstaller `--add-data` list with an automatic directory crawl that filters sensitive or bulky assets and registers dynamic ReportLab barcode modules as hidden imports.
- Document the packaging workflow in the README, including how to regenerate the executable and which paths are excluded by default.

## Testing
- python setup.py
- QT_QPA_PLATFORM=offscreen dist/InventarioFarmacia --help

------
https://chatgpt.com/codex/tasks/task_e_68dc4eb6715c832397c1713889f7c446