### PR TITLE
Integrate contingency workflow into invoicing UI

### DIFF
--- a/api/facturas.py
+++ b/api/facturas.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, FastAPI, HTTPException, Request
 from facturas_db.facturas_repo import FacturasRepo
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, root_validator, validator
 import logging
 
 logger = logging.getLogger(__name__)
@@ -17,8 +17,49 @@ def get_repo(request: Request) -> FacturasRepo:
 
 
 class ContingenciaIn(BaseModel):
+    modeloFacturacion: int = Field(2, description="Modelo de facturación para contingencia")
+    tipoTransmision: int = Field(2, description="Tipo de transmisión para contingencia")
     tipoContingencia: int
-    motivoContin: str | None = None
+    motivoContingencia: str | None = None
+
+    @root_validator(pre=True)
+    def _compat_motivo(cls, values: dict) -> dict:
+        legacy = values.get("motivoContin")
+        if values.get("motivoContingencia") is None and legacy is not None:
+            values["motivoContingencia"] = legacy
+        return values
+
+    @validator("modeloFacturacion")
+    def _modelo_valido(cls, value: int) -> int:
+        if value != 2:
+            raise ValueError("modeloFacturacion debe ser 2 en modo contingencia")
+        return value
+
+    @validator("tipoTransmision")
+    def _transmision_valida(cls, value: int) -> int:
+        if value != 2:
+            raise ValueError("tipoTransmision debe ser 2 en modo contingencia")
+        return value
+
+    @validator("tipoContingencia")
+    def _tipo_valido(cls, value: int) -> int:
+        if value not in {1, 2, 3, 4, 5}:
+            raise ValueError("Tipo de contingencia inválido")
+        return value
+
+    @validator("motivoContingencia", always=True)
+    def _motivo_validado(cls, value: str | None, values: dict) -> str | None:
+        tipo = values.get("tipoContingencia")
+        if tipo == 5:
+            if not value or not value.strip():
+                raise ValueError(
+                    "Motivo es obligatorio cuando el tipo es 'Otro' (máx. 500)."
+                )
+            trimmed = value.strip()
+            if len(trimmed) > 500:
+                trimmed = trimmed[:500]
+            return trimmed
+        return None
 
 
 @app.post("/api/facturas/{factura_id}/contingencia")
@@ -33,7 +74,7 @@ def guardar_en_contingencia(
     if factura.estado_envio == "Enviado":
         raise HTTPException(status_code=400, detail="Factura ya enviada")
     repo.guardar_en_contingencia(
-        factura_id, data.tipoContingencia, data.motivoContin
+        factura_id, data.tipoContingencia, data.motivoContingencia
     )
     logger.info("accion=forzar_contingencia_por_usuario factura_id=%s", factura_id)
     return {"ok": True, "factura": factura.to_dict()}

--- a/facturas_db/facturas_repo.py
+++ b/facturas_db/facturas_repo.py
@@ -88,7 +88,11 @@ class FacturasRepo:
         factura.modo_transmision = "contingencia"
         factura.estado_envio = "Pendiente"
         factura.tipo_contingencia = tipo_contingencia
-        factura.motivo_contin = motivo_contin
+        if tipo_contingencia == 5 and motivo_contin:
+            motivo_limpio = motivo_contin.strip()
+            factura.motivo_contin = motivo_limpio[:500]
+        else:
+            factura.motivo_contin = None
         self.add(factura)
         return factura
 

--- a/tests/test_contingencia_api.py
+++ b/tests/test_contingencia_api.py
@@ -35,14 +35,18 @@ def test_guardar_en_contingencia_actualiza_estado(client_repo):
     repo.add(Factura(id=1))
     resp = client.post(
         "/api/facturas/1/contingencia",
-        json={"tipoContingencia": 1, "motivoContin": ""},
+        json={
+            "modeloFacturacion": 2,
+            "tipoTransmision": 2,
+            "tipoContingencia": 1,
+        },
     )
     assert resp.status_code == 200
     factura = repo.get(1)
     assert factura.modo_transmision == "contingencia"
     assert factura.estado_envio == "Pendiente"
     assert factura.tipo_contingencia == 1
-    assert factura.motivo_contin == ""
+    assert factura.motivo_contin is None
 
 
 def test_guardar_en_contingencia_idempotente(client_repo):
@@ -57,7 +61,11 @@ def test_guardar_en_contingencia_idempotente(client_repo):
     )
     resp = client.post(
         "/api/facturas/2/contingencia",
-        json={"tipoContingencia": 1, "motivoContin": ""},
+        json={
+            "modeloFacturacion": 2,
+            "tipoTransmision": 2,
+            "tipoContingencia": 1,
+        },
     )
     assert resp.status_code == 200
     factura = repo.get(2)
@@ -71,7 +79,11 @@ def test_guardar_en_contingencia_rechaza_enviado(client_repo):
     repo.add(Factura(id=3, estado_envio="Enviado"))
     resp = client.post(
         "/api/facturas/3/contingencia",
-        json={"tipoContingencia": 1, "motivoContin": ""},
+        json={
+            "modeloFacturacion": 2,
+            "tipoTransmision": 2,
+            "tipoContingencia": 1,
+        },
     )
     assert resp.status_code == 400
 
@@ -79,9 +91,15 @@ def test_guardar_en_contingencia_rechaza_enviado(client_repo):
 def test_repo_persists_contingencia_between_instances(client_repo):
     client, repo, db_path = client_repo
     repo.add(Factura(id=4))
+    motivo = "F" * 510
     resp = client.post(
         "/api/facturas/4/contingencia",
-        json={"tipoContingencia": 2, "motivoContin": "Fallo"},
+        json={
+            "modeloFacturacion": 2,
+            "tipoTransmision": 2,
+            "tipoContingencia": 5,
+            "motivoContingencia": motivo,
+        },
     )
     assert resp.status_code == 200
 
@@ -90,8 +108,8 @@ def test_repo_persists_contingencia_between_instances(client_repo):
     assert factura is not None
     assert factura.modo_transmision == "contingencia"
     assert factura.estado_envio == "Pendiente"
-    assert factura.tipo_contingencia == 2
-    assert factura.motivo_contin == "Fallo"
+    assert factura.tipo_contingencia == 5
+    assert factura.motivo_contin == motivo.strip()[:500]
 
 
 def test_repo_persists_estado_enviado(client_repo):
@@ -103,3 +121,34 @@ def test_repo_persists_estado_enviado(client_repo):
     assert factura is not None
     assert factura.estado_envio == "Enviado"
     assert factura.modo_transmision == "normal"
+
+
+def test_rechaza_motivo_faltante_para_otro(client_repo):
+    client, repo, _ = client_repo
+    repo.add(Factura(id=6))
+    resp = client.post(
+        "/api/facturas/6/contingencia",
+        json={
+            "modeloFacturacion": 2,
+            "tipoTransmision": 2,
+            "tipoContingencia": 5,
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_acepta_campo_legacy_motivo_contin(client_repo):
+    client, repo, _ = client_repo
+    repo.add(Factura(id=7))
+    resp = client.post(
+        "/api/facturas/7/contingencia",
+        json={
+            "modeloFacturacion": 2,
+            "tipoTransmision": 2,
+            "tipoContingencia": 5,
+            "motivoContin": "causa",
+        },
+    )
+    assert resp.status_code == 200
+    factura = repo.get(7)
+    assert factura.motivo_contin == "causa"

--- a/ui/services/facturasApi.ts
+++ b/ui/services/facturasApi.ts
@@ -1,12 +1,18 @@
+export interface ContingenciaPayload {
+  modeloFacturacion: number;
+  tipoTransmision: number;
+  tipoContingencia: number;
+  motivoContingencia?: string;
+}
+
 export async function guardarEnContingencia(
   facturaId: string,
-  tipoContingencia: number,
-  motivoContin = ''
+  payload: ContingenciaPayload
 ) {
   const res = await fetch(`/api/facturas/${facturaId}/contingencia`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ tipoContingencia, motivoContin })
+    body: JSON.stringify(payload)
   });
   if (!res.ok) {
     throw new Error('Error al guardar en contingencia');

--- a/ui/tests/FacturaForm.spec.ts
+++ b/ui/tests/FacturaForm.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import FacturaForm from '../ventas/FacturaForm.vue';
 
 vi.mock('../services/facturasApi', () => ({
@@ -12,56 +12,161 @@ describe('FacturaForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-  it('confirma contingencia cuando está activa', async () => {
-    const wrapper = mount(FacturaForm, {
-      props: { facturaId: '1', config: { modoContingencia: true } }
+
+  function mountForm(configOverrides: Record<string, unknown> = {}, facturaId = '1') {
+    return mount(FacturaForm, {
+      props: {
+        facturaId,
+        config: {
+          modoTransmision: 1,
+          pendientesContingencia: [],
+          ...configOverrides
+        }
+      }
     });
-    await wrapper.find('button').trigger('click');
-    const dialog = wrapper.findComponent({ name: 'ConfirmDialog' });
-    expect(dialog.exists()).toBe(true);
-    await dialog.vm.$emit('confirm');
-    expect(api.guardarEnContingencia).toHaveBeenCalledWith('1', 1, '');
+  }
+
+  it('oculta controles de contingencia cuando el modo es normal', () => {
+    const wrapper = mountForm();
+    expect(wrapper.find('#tipo').exists()).toBe(false);
+    expect(wrapper.find('.guardar').attributes('disabled')).toBeUndefined();
   });
 
-  it('muestra diálogo de error y guarda en contingencia tras fallo', async () => {
-    const wrapper = mount(FacturaForm, {
-      props: { facturaId: '2', config: { modoContingencia: false } }
-    });
-    await wrapper.find('button').trigger('click');
-    const dialogs = wrapper.findAllComponents({ name: 'ConfirmDialog' });
-    const errorDialog = dialogs.find(d => d.props('title') === 'Error al enviar a Hacienda');
-    expect(errorDialog).toBeTruthy();
-    await errorDialog!.vm.$emit('confirm');
-    expect(api.guardarEnContingencia).toHaveBeenCalledWith('2', 1, '');
-  });
-
-  it('no llama API al cancelar', async () => {
-    const wrapper = mount(FacturaForm, {
-      props: { facturaId: '3', config: { modoContingencia: true } }
-    });
-    await wrapper.find('button').trigger('click');
-    const dialog = wrapper.findComponent({ name: 'ConfirmDialog' });
-    await dialog.vm.$emit('cancel');
+  it('requiere tipo de contingencia al guardar en modo contingencia', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 });
+    const saveButton = wrapper.find('.guardar');
+    expect(saveButton.attributes('disabled')).toBeUndefined();
+    await saveButton.trigger('click');
+    await wrapper.vm.$nextTick();
+    const tipoError = wrapper
+      .findAll('.error-message')
+      .map(node => node.text())
+      .find(text => text.includes('Selecciona un tipo de contingencia'));
+    expect(tipoError).toBeTruthy();
     expect(api.guardarEnContingencia).not.toHaveBeenCalled();
   });
 
-  it('muestra controles de contingencia y envía los datos seleccionados', async () => {
-    const wrapper = mount(FacturaForm, {
-      props: { facturaId: '4', config: { modoContingencia: true } }
-    });
-    const select = wrapper.find('select');
-    expect(select.exists()).toBe(true);
+  it('muestra motivo obligatorio cuando el tipo es “Otro” y limita a 500 caracteres', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 });
+    const select = wrapper.find('#tipo');
     await select.setValue('5');
-    const input = wrapper.find('input');
-    expect(input.exists()).toBe(true);
-    await input.setValue('fallo electrico');
-    await wrapper.find('button').trigger('click');
-    const dialog = wrapper.findComponent({ name: 'ConfirmDialog' });
-    await dialog.vm.$emit('confirm');
-    expect(api.guardarEnContingencia).toHaveBeenCalledWith(
-      '4',
-      5,
-      'fallo electrico'
-    );
+    const textarea = wrapper.find('#motivo');
+    expect(textarea.exists()).toBe(true);
+    const longText = 'x'.repeat(600);
+    await textarea.setValue(longText);
+    expect((textarea.element as HTMLTextAreaElement).value.length).toBe(500);
+    expect(wrapper.find('.counter').text()).toBe('500/500');
+
+    await textarea.setValue('   ');
+    await wrapper.find('.guardar').trigger('click');
+    await wrapper.vm.$nextTick();
+    const motivoError = wrapper
+      .findAll('.error-message')
+      .map(node => node.text())
+      .find(text => text.includes('Motivo es obligatorio cuando el tipo es ‘Otro’'));
+    expect(motivoError).toBeTruthy();
+  });
+
+  it('limpia el motivo cuando se cambia el tipo a un valor diferente de “Otro”', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 });
+    const select = wrapper.find('#tipo');
+    await select.setValue('5');
+    const textarea = wrapper.find('#motivo');
+    await textarea.setValue('corte eléctrico');
+    await select.setValue('4');
+    expect(wrapper.find('#motivo').exists()).toBe(false);
+  });
+
+  it('envía los indicadores de contingencia al confirmar el guardado', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 }, '42');
+    await wrapper.find('#tipo').setValue('3');
+    await wrapper.find('.guardar').trigger('click');
+    await wrapper.vm.$nextTick();
+    const confirmDialog = wrapper
+      .findAllComponents({ name: 'ConfirmDialog' })
+      .find(dialog => dialog.props('title') === 'Modo contingencia activado');
+    expect(confirmDialog).toBeTruthy();
+    await confirmDialog!.vm.$emit('confirm');
+    expect(api.guardarEnContingencia).toHaveBeenCalledWith('42', {
+      modeloFacturacion: 2,
+      tipoTransmision: 2,
+      tipoContingencia: 3
+    });
+  });
+
+  it('muestra advertencia antes de descartar datos de contingencia', async () => {
+    const wrapper = mountForm({
+      modoTransmision: 2,
+      tipoContingencia: 5,
+      motivoContingencia: 'Otro motivo'
+    });
+    const modoSelect = wrapper.find('#modo');
+    await modoSelect.setValue('1');
+    await wrapper.vm.$nextTick();
+    const warningDialog = wrapper
+      .findAllComponents({ name: 'ConfirmDialog' })
+      .find(dialog => dialog.props('title') === 'Cambiar a modo normal');
+    expect(warningDialog).toBeTruthy();
+    await warningDialog!.vm.$emit('confirm');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('#tipo').exists()).toBe(false);
+  });
+
+  it('gestiona el flujo de evento de contingencia y valida los campos requeridos', async () => {
+    const wrapper = mountForm({
+      modoTransmision: 2,
+      pendientesContingencia: [
+        { codigoGeneracion: 'A', tipoDocumento: '01' },
+        { codigoGeneracion: 'B', tipoDocumento: '03' }
+      ]
+    });
+    const eventoButton = wrapper.find('button.evento');
+    expect(eventoButton.exists()).toBe(true);
+    await eventoButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const continuar = wrapper.find('.evento-content .primary');
+    await continuar.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('Completa la fecha y hora de inicio.');
+
+    const [inicioFecha, finFecha] = wrapper.findAll('input[type="date"]');
+    const [inicioHora, finHora] = wrapper.findAll('input[type="time"]');
+    await inicioFecha.setValue('2024-01-01');
+    await inicioHora.setValue('08:00');
+    await finFecha.setValue('2024-01-01');
+    await finHora.setValue('09:00');
+    await wrapper.find('#evento-tipo').setValue('5');
+    await wrapper.find('#evento-motivo').setValue('Fallo prolongado');
+    await continuar.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('Paso 2: DTE pendientes');
+    expect(wrapper.find('.json-preview').text()).toContain('"codigoGeneracion": "A"');
+  });
+
+  it('advierte cuando hay más de 1000 DTE y limita la previsualización', async () => {
+    const pendientes = Array.from({ length: 1002 }, (_, index) => ({
+      codigoGeneracion: `DTE-${index}`,
+      tipoDocumento: '01'
+    }));
+    const wrapper = mountForm({ modoTransmision: 2, pendientesContingencia: pendientes });
+    await wrapper.find('button.evento').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const [inicioFecha, finFecha] = wrapper.findAll('input[type="date"]');
+    const [inicioHora, finHora] = wrapper.findAll('input[type="time"]');
+    await inicioFecha.setValue('2024-01-01');
+    await inicioHora.setValue('08:00');
+    await finFecha.setValue('2024-01-02');
+    await finHora.setValue('09:00');
+    await wrapper.find('#evento-tipo').setValue('1');
+    await wrapper.find('.evento-content .primary').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const json = wrapper.find('.json-preview').text();
+    expect(wrapper.text()).toContain('Divide el envío en varios eventos');
+    expect(json).toContain('"codigoGeneracion": "DTE-0"');
+    expect(json).not.toContain('"codigoGeneracion": "DTE-1001"');
   });
 });

--- a/ui/ventas/FacturaForm.vue
+++ b/ui/ventas/FacturaForm.vue
@@ -1,12 +1,81 @@
 <template>
-  <div>
-    <div v-if="props.config?.modoContingencia">
-      <select v-model.number="tipoContingencia">
-        <option v-for="n in 5" :key="n" :value="n">{{ n }}</option>
+  <div class="factura-form">
+    <section class="modo-transmision">
+      <label for="modo">Modo de transmisión</label>
+      <select id="modo" v-model.number="modoTransmision">
+        <option :value="1">1 — Normal</option>
+        <option :value="2">2 — Contingencia</option>
       </select>
-      <input v-if="tipoContingencia === 5" v-model="motivoContin" />
+    </section>
+
+    <section v-if="isContingencia" class="contingencia-panel">
+      <p class="helper">Si eliges “Otro”, el motivo es obligatorio.</p>
+      <div :class="['field', { error: showTipoError }]">
+        <label for="tipo">Tipo de Contingencia (CAT-005)</label>
+        <select
+          id="tipo"
+          ref="tipoSelect"
+          v-model.number="tipoContingencia"
+        >
+          <option disabled value="">Selecciona una opción</option>
+          <option
+            v-for="option in CONTINGENCIA_OPTIONS"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+        <p v-if="showTipoError" class="error-message">
+          {{ tipoErrorMessage }}
+        </p>
+      </div>
+
+      <div
+        v-if="requiresMotivo"
+        :class="['field', { error: showMotivoError }]"
+      >
+        <label for="motivo">Motivo</label>
+        <textarea
+          id="motivo"
+          ref="motivoInput"
+          v-model="motivoContingencia"
+          @input="enforceMotivoLimit"
+          rows="3"
+        ></textarea>
+        <div class="field-footer">
+          <span class="counter">{{ motivoLength }}/500</span>
+        </div>
+        <p v-if="showMotivoError" class="error-message">
+          {{ motivoErrorMessage }}
+        </p>
+      </div>
+    </section>
+
+    <section v-if="statusMessage" class="status success">
+      {{ statusMessage }}
+    </section>
+    <section v-if="saveErrorMessage" class="status error">
+      {{ saveErrorMessage }}
+    </section>
+
+    <div class="actions">
+      <button
+        class="guardar"
+        :disabled="isSaveDisabled"
+        @click="onSave"
+      >
+        Guardar y Enviar
+      </button>
+      <button
+        v-if="hasPendingContingencia"
+        class="evento"
+        @click="openEventoDialog"
+      >
+        Crear Evento de Contingencia
+      </button>
     </div>
-    <button @click="onSave">Guardar y Enviar</button>
+
     <ConfirmDialog
       v-model="confirmVisible"
       title="Modo contingencia activado"
@@ -23,42 +92,660 @@
       cancel-text="No"
       @confirm="saveContingencia"
     />
+    <ConfirmDialog
+      v-model="lossConfirmVisible"
+      title="Cambiar a modo normal"
+      message="Perderás los datos de contingencia de esta factura. ¿Continuar?"
+      confirm-text="Continuar"
+      cancel-text="Cancelar"
+      @confirm="confirmClearContingencia"
+      @cancel="cancelClearContingencia"
+    />
+
+    <div v-if="eventoVisible" class="evento-dialog">
+      <div class="evento-content">
+        <header>
+          <h2>Evento de Contingencia</h2>
+          <button class="cerrar" type="button" @click="closeEventoDialog">×</button>
+        </header>
+        <section v-if="eventoStep === 1" class="evento-step">
+          <h3>Paso 1: Datos del evento</h3>
+          <p class="helper">Zona horaria: America/El_Salvador (UTC-6)</p>
+          <div :class="['field-group', { error: eventoErrors.inicio }]">
+            <label>Fecha y hora de inicio</label>
+            <div class="inputs">
+              <input
+                type="date"
+                ref="eventoInicioFecha"
+                v-model="eventoForm.inicioFecha"
+              />
+              <input
+                type="time"
+                ref="eventoInicioHora"
+                v-model="eventoForm.inicioHora"
+              />
+            </div>
+            <p v-if="eventoErrors.inicio" class="error-message">
+              {{ eventoErrors.inicio }}
+            </p>
+          </div>
+          <div :class="['field-group', { error: eventoErrors.fin }]">
+            <label>Fecha y hora de fin</label>
+            <div class="inputs">
+              <input type="date" ref="eventoFinFecha" v-model="eventoForm.finFecha" />
+              <input type="time" ref="eventoFinHora" v-model="eventoForm.finHora" />
+            </div>
+            <p v-if="eventoErrors.fin" class="error-message">
+              {{ eventoErrors.fin }}
+            </p>
+          </div>
+          <div :class="['field-group', { error: eventoErrors.tipo }]">
+            <label for="evento-tipo">Tipo (CAT-005)</label>
+            <select
+              id="evento-tipo"
+              ref="eventoTipo"
+              v-model.number="eventoForm.tipo"
+            >
+              <option disabled value="">Selecciona una opción</option>
+              <option
+                v-for="option in CONTINGENCIA_OPTIONS"
+                :key="`evento-${option.value}`"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+            <p v-if="eventoErrors.tipo" class="error-message">
+              {{ eventoErrors.tipo }}
+            </p>
+          </div>
+          <div
+            v-if="eventoRequiresMotivo"
+            :class="['field-group', { error: eventoErrors.motivo }]"
+          >
+            <label for="evento-motivo">Motivo</label>
+            <textarea
+              id="evento-motivo"
+              ref="eventoMotivo"
+              v-model="eventoForm.motivo"
+              @input="enforceEventoMotivoLimit"
+              rows="3"
+            ></textarea>
+            <div class="field-footer">
+              <span class="counter">{{ eventoMotivoLength }}/500</span>
+            </div>
+            <p v-if="eventoErrors.motivo" class="error-message">
+              {{ eventoErrors.motivo }}
+            </p>
+          </div>
+          <footer class="dialog-actions">
+            <button type="button" @click="closeEventoDialog">Cancelar</button>
+            <button type="button" class="primary" @click="continuarEvento">
+              Continuar
+            </button>
+          </footer>
+        </section>
+        <section v-else class="evento-step">
+          <h3>Paso 2: DTE pendientes</h3>
+          <p>Total de DTE: {{ pendingDtes.length }}</p>
+          <p v-if="pendingDtes.length > 1000" class="info">
+            Se generarán hasta 1000 DTE por evento. Divide el envío en varios eventos si es necesario.
+          </p>
+          <ul class="dte-list">
+            <li v-for="dte in eventoDetalleLimit" :key="dte.codigoGeneracion">
+              {{ dte.codigoGeneracion }} — {{ dte.tipoDocumento }}
+            </li>
+          </ul>
+          <h4>Previsualización del evento (JSON)</h4>
+          <pre class="json-preview">{{ eventoPreview }}</pre>
+          <footer class="dialog-actions">
+            <button type="button" @click="volverEvento">Volver</button>
+            <button type="button" class="primary" @click="closeEventoDialog">
+              Cerrar
+            </button>
+          </footer>
+        </section>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, nextTick, reactive, ref, watch } from 'vue';
 import ConfirmDialog from '../components/ConfirmDialog.vue';
 import { guardarEnContingencia } from '../services/facturasApi';
 
-const props = defineProps<{ facturaId: string; config: { modoContingencia: boolean } }>();
+const CONTINGENCIA_OPTIONS = [
+  { value: 1, label: '1 — No disponibilidad del sistema del MH' },
+  { value: 2, label: '2 — No disponibilidad del sistema del emisor' },
+  { value: 3, label: '3 — Falla en servicio de Internet del emisor' },
+  { value: 4, label: '4 — Falla en energía eléctrica del emisor' },
+  { value: 5, label: '5 — Otro' }
+] as const;
+
+type ContingenciaOptionValue = (typeof CONTINGENCIA_OPTIONS)[number]['value'];
+
+type PendingDte = {
+  codigoGeneracion: string;
+  tipoDocumento: string;
+};
+
+interface FacturaConfig {
+  modoTransmision: ContingenciaOptionValue | 1 | 2;
+  tipoContingencia?: ContingenciaOptionValue | null;
+  motivoContingencia?: string | null;
+  pendientesContingencia?: PendingDte[];
+}
+
+const props = defineProps<{ facturaId: string; config: FacturaConfig }>();
 
 const confirmVisible = ref(false);
 const errorVisible = ref(false);
-const tipoContingencia = ref(1);
-const motivoContin = ref('');
+const lossConfirmVisible = ref(false);
+const statusMessage = ref('');
+const saveErrorMessage = ref('');
+const hasAttemptedSubmit = ref(false);
+
+const modoTransmision = ref<number>(props.config?.modoTransmision ?? 1);
+const tipoContingencia = ref<number | ''>(
+  props.config?.modoTransmision === 2
+    ? props.config?.tipoContingencia ?? ''
+    : ''
+);
+const motivoContingencia = ref(props.config?.motivoContingencia ?? '');
+
+const tipoSelect = ref<HTMLSelectElement>();
+const motivoInput = ref<HTMLTextAreaElement>();
+
+const pendingDtes = computed(() => props.config?.pendientesContingencia ?? []);
+const hasPendingContingencia = computed(() => pendingDtes.value.length > 0);
+
+const isContingencia = computed(() => modoTransmision.value === 2);
+const requiresMotivo = computed(
+  () => isContingencia.value && tipoContingencia.value === 5
+);
+
+const motivoLength = computed(() => motivoContingencia.value.length);
+
+const tipoErrorMessage = computed(() => {
+  if (!isContingencia.value) {
+    return '';
+  }
+  const value = tipoContingencia.value;
+  if (value === '' || value === null) {
+    return 'Selecciona un tipo de contingencia (CAT-005).';
+  }
+  if (![1, 2, 3, 4, 5].includes(Number(value))) {
+    return 'Selecciona un tipo de contingencia (CAT-005).';
+  }
+  return '';
+});
+
+const showTipoError = computed(
+  () => hasAttemptedSubmit.value && tipoErrorMessage.value !== ''
+);
+
+const motivoErrorMessage = computed(() => {
+  if (!requiresMotivo.value) {
+    return '';
+  }
+  const trimmed = motivoContingencia.value.trim();
+  if (!trimmed) {
+    return "Motivo es obligatorio cuando el tipo es ‘Otro’ (máx. 500).";
+  }
+  if (trimmed.length > 500) {
+    return 'Motivo no puede exceder 500 caracteres.';
+  }
+  return '';
+});
+
+const showMotivoError = computed(
+  () => hasAttemptedSubmit.value && motivoErrorMessage.value !== ''
+);
+
+const isFormValid = computed(() => {
+  if (!isContingencia.value) {
+    return true;
+  }
+  return tipoErrorMessage.value === '' && motivoErrorMessage.value === '';
+});
+
+const isSaveDisabled = computed(
+  () => isContingencia.value && hasAttemptedSubmit.value && !isFormValid.value
+);
+
+watch(modoTransmision, async (newValue, oldValue) => {
+  if (oldValue === 2 && newValue === 1 && hasContingenciaData()) {
+    lossConfirmVisible.value = true;
+    await nextTick();
+    modoTransmision.value = 2;
+    return;
+  }
+  if (newValue !== 2) {
+    tipoContingencia.value = '';
+    motivoContingencia.value = '';
+    hasAttemptedSubmit.value = false;
+  }
+});
+
+watch(tipoContingencia, (newValue) => {
+  if (newValue !== 5) {
+    motivoContingencia.value = '';
+  }
+});
+
+watch(motivoContingencia, (value) => {
+  if (value.length > 500) {
+    motivoContingencia.value = value.slice(0, 500);
+  }
+});
+
+function hasContingenciaData(): boolean {
+  const tipo = tipoContingencia.value;
+  const motivo = motivoContingencia.value.trim();
+  return tipo !== '' || motivo.length > 0;
+}
+
+function enforceMotivoLimit(): void {
+  if (motivoContingencia.value.length > 500) {
+    motivoContingencia.value = motivoContingencia.value.slice(0, 500);
+  }
+}
 
 async function onSave() {
-  if (props.config?.modoContingencia) {
-    confirmVisible.value = true;
-  } else {
-    try {
-      await enviarAHacienda();
-    } catch (e) {
-      errorVisible.value = true;
+  hasAttemptedSubmit.value = true;
+  statusMessage.value = '';
+  saveErrorMessage.value = '';
+  if (isContingencia.value) {
+    if (!isFormValid.value) {
+      await nextTick();
+      focusFirstInvalid();
+      return;
     }
+    confirmVisible.value = true;
+    return;
+  }
+  try {
+    await enviarAHacienda();
+  } catch (e) {
+    errorVisible.value = true;
   }
 }
 
 async function saveContingencia() {
-  await guardarEnContingencia(
-    props.facturaId,
-    tipoContingencia.value,
-    motivoContin.value
-  );
+  try {
+    const motivo = requiresMotivo.value
+      ? motivoContingencia.value.trim()
+      : undefined;
+    await guardarEnContingencia(props.facturaId, {
+      modeloFacturacion: 2,
+      tipoTransmision: 2,
+      tipoContingencia: Number(tipoContingencia.value),
+      ...(motivo ? { motivoContingencia: motivo } : {})
+    });
+    statusMessage.value = 'Contingencia guardada en la factura.';
+  } catch (error) {
+    saveErrorMessage.value =
+      error instanceof Error ? error.message : 'Ocurrió un error al guardar.';
+  }
 }
 
-function enviarAHacienda() {
-  throw new Error('fallo');
+function focusFirstInvalid() {
+  if (tipoErrorMessage.value && tipoSelect.value) {
+    tipoSelect.value.focus();
+    return;
+  }
+  if (motivoErrorMessage.value && motivoInput.value) {
+    motivoInput.value.focus();
+  }
+}
+
+function confirmClearContingencia() {
+  lossConfirmVisible.value = false;
+  modoTransmision.value = 1;
+  tipoContingencia.value = '';
+  motivoContingencia.value = '';
+  hasAttemptedSubmit.value = false;
+}
+
+function cancelClearContingencia() {
+  lossConfirmVisible.value = false;
+}
+
+function openEventoDialog() {
+  eventoVisible.value = true;
+  eventoStep.value = 1;
+  resetEvento();
+}
+
+function closeEventoDialog() {
+  eventoVisible.value = false;
+}
+
+function volverEvento() {
+  eventoStep.value = 1;
+}
+
+const eventoVisible = ref(false);
+const eventoStep = ref<1 | 2>(1);
+const eventoForm = reactive({
+  inicioFecha: '',
+  inicioHora: '',
+  finFecha: '',
+  finHora: '',
+  tipo: '' as number | '',
+  motivo: ''
+});
+const eventoErrors = reactive({
+  inicio: '',
+  fin: '',
+  tipo: '',
+  motivo: ''
+});
+
+const eventoInicioFecha = ref<HTMLInputElement>();
+const eventoInicioHora = ref<HTMLInputElement>();
+const eventoFinFecha = ref<HTMLInputElement>();
+const eventoFinHora = ref<HTMLInputElement>();
+const eventoTipo = ref<HTMLSelectElement>();
+const eventoMotivo = ref<HTMLTextAreaElement>();
+
+const eventoRequiresMotivo = computed(() => eventoForm.tipo === 5);
+const eventoMotivoLength = computed(() => eventoForm.motivo.length);
+
+watch(
+  () => eventoForm.tipo,
+  (newValue) => {
+    if (newValue !== 5) {
+      eventoForm.motivo = '';
+    }
+  }
+);
+
+watch(
+  () => eventoForm.motivo,
+  (value) => {
+    if (value.length > 500) {
+      eventoForm.motivo = value.slice(0, 500);
+    }
+  }
+);
+
+function enforceEventoMotivoLimit() {
+  if (eventoForm.motivo.length > 500) {
+    eventoForm.motivo = eventoForm.motivo.slice(0, 500);
+  }
+}
+
+function resetEvento() {
+  eventoForm.inicioFecha = '';
+  eventoForm.inicioHora = '';
+  eventoForm.finFecha = '';
+  eventoForm.finHora = '';
+  eventoForm.tipo = '';
+  eventoForm.motivo = '';
+  eventoErrors.inicio = '';
+  eventoErrors.fin = '';
+  eventoErrors.tipo = '';
+  eventoErrors.motivo = '';
+}
+
+function continuarEvento() {
+  eventoErrors.inicio = '';
+  eventoErrors.fin = '';
+  eventoErrors.tipo = '';
+  eventoErrors.motivo = '';
+
+  const inicioCompleto =
+    eventoForm.inicioFecha && eventoForm.inicioHora
+      ? new Date(`${eventoForm.inicioFecha}T${eventoForm.inicioHora}`)
+      : null;
+  const finCompleto =
+    eventoForm.finFecha && eventoForm.finHora
+      ? new Date(`${eventoForm.finFecha}T${eventoForm.finHora}`)
+      : null;
+
+  if (!eventoForm.inicioFecha || !eventoForm.inicioHora) {
+    eventoErrors.inicio = 'Completa la fecha y hora de inicio.';
+  }
+  if (!eventoForm.finFecha || !eventoForm.finHora) {
+    eventoErrors.fin = 'Completa la fecha y hora de fin.';
+  }
+  if (inicioCompleto && finCompleto && finCompleto <= inicioCompleto) {
+    eventoErrors.fin = 'La fecha/hora final debe ser mayor que la inicial.';
+  }
+  if (eventoForm.tipo === '' || eventoForm.tipo === null) {
+    eventoErrors.tipo = 'Selecciona un tipo de contingencia (CAT-005).';
+  }
+  if (eventoRequiresMotivo.value) {
+    const trimmed = eventoForm.motivo.trim();
+    if (!trimmed) {
+      eventoErrors.motivo =
+        "Motivo es obligatorio cuando el tipo es ‘Otro’ (máx. 500).";
+    }
+  }
+
+  if (
+    eventoErrors.inicio ||
+    eventoErrors.fin ||
+    eventoErrors.tipo ||
+    eventoErrors.motivo
+  ) {
+    focusEventoFirstInvalid();
+    return;
+  }
+
+  eventoStep.value = 2;
+}
+
+function focusEventoFirstInvalid() {
+  if (eventoErrors.inicio) {
+    if (!eventoForm.inicioFecha && eventoInicioFecha.value) {
+      eventoInicioFecha.value.focus();
+      return;
+    }
+    if (!eventoForm.inicioHora && eventoInicioHora.value) {
+      eventoInicioHora.value.focus();
+      return;
+    }
+  }
+  if (eventoErrors.fin) {
+    if (!eventoForm.finFecha && eventoFinFecha.value) {
+      eventoFinFecha.value.focus();
+      return;
+    }
+    if (!eventoForm.finHora && eventoFinHora.value) {
+      eventoFinHora.value.focus();
+      return;
+    }
+  }
+  if (eventoErrors.tipo && eventoTipo.value) {
+    eventoTipo.value.focus();
+    return;
+  }
+  if (eventoErrors.motivo && eventoMotivo.value) {
+    eventoMotivo.value.focus();
+  }
+}
+
+const eventoDetalleLimit = computed(() => pendingDtes.value.slice(0, 1000));
+
+const eventoPreview = computed(() => {
+  if (eventoStep.value !== 2) {
+    return '';
+  }
+  const detalle = eventoDetalleLimit.value.map((dte) => ({
+    codigoGeneracion: dte.codigoGeneracion,
+    tipoDocumento: dte.tipoDocumento
+  }));
+  const motivo = eventoRequiresMotivo.value
+    ? eventoForm.motivo.trim()
+    : CONTINGENCIA_OPTIONS.find((o) => o.value === eventoForm.tipo)?.label ?? '';
+  const payload = {
+    identificacion: {
+      tipoEvento: 'CONTINGENCIA',
+      tipoContingencia: eventoForm.tipo,
+      periodo: {
+        inicio: `${eventoForm.inicioFecha}T${eventoForm.inicioHora}`,
+        fin: `${eventoForm.finFecha}T${eventoForm.finHora}`
+      }
+    },
+    emisor: {
+      nit: '000000-0',
+      nombre: 'Ejemplo S.A. de C.V.'
+    },
+    motivo,
+    detalleDTE: detalle
+  };
+  return JSON.stringify(payload, null, 2);
+});
+
+function enviarAHacienda(): Promise<void> {
+  return Promise.reject(new Error('fallo'));
 }
 </script>
+
+<style scoped>
+.factura-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field,
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field.error select,
+.field.error textarea,
+.field-group.error input,
+.field-group.error select,
+.field-group.error textarea {
+  border: 1px solid #c0392b;
+}
+
+.error-message {
+  color: #c0392b;
+  font-size: 0.875rem;
+}
+
+.helper {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.field-footer {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.status {
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
+.status.success {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status.error {
+  background: #fdecea;
+  color: #c62828;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.evento-dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.evento-content {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.evento-content header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.evento-content .cerrar {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.inputs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.dialog-actions .primary {
+  background: #1976d2;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.dte-list {
+  max-height: 200px;
+  overflow-y: auto;
+  padding-left: 1rem;
+}
+
+.dte-list li {
+  list-style: disc;
+}
+
+.json-preview {
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow: auto;
+}
+
+.info {
+  background: #fff7e6;
+  color: #8c6d1f;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add full contingency mode controls with validation, messaging, and event flow UI
- adjust API and persistence to capture contingency metadata and enforce new rules
- expand automated tests for UI and backend to cover contingency cases

## Testing
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc95bd3b2483239f6d78b6943b413a