### PR TITLE
Improve contingency accessibility and event preview fidelity

### DIFF
--- a/ui/components/ContingenciaConfigDialog.vue
+++ b/ui/components/ContingenciaConfigDialog.vue
@@ -1,0 +1,387 @@
+<template>
+  <div v-if="visible" class="contingencia-dialog-overlay">
+    <div class="contingencia-dialog" role="dialog" aria-modal="true">
+      <header class="dialog-header">
+        <h2>Configurar contingencia</h2>
+        <button
+          type="button"
+          class="close"
+          @click="requestClose"
+          aria-label="Cerrar"
+        >
+          ×
+        </button>
+      </header>
+      <section class="dialog-body">
+        <p class="helper">
+          Tipo de Contingencia (CAT-005) — obligatorio. Si seleccionas “Otro”,
+          el motivo es obligatorio.
+        </p>
+        <div :class="['field', { error: showTipoError }]">
+          <label for="contingencia-tipo">Tipo de Contingencia (CAT-005)</label>
+          <select
+            id="contingencia-tipo"
+            ref="tipoSelect"
+            v-model.number="form.tipo"
+            :aria-invalid="showTipoError ? 'true' : 'false'"
+            :aria-describedby="
+              showTipoError ? 'contingencia-tipo-error' : undefined
+            "
+          >
+            <option disabled value="">Selecciona una opción</option>
+            <option
+              v-for="option in CONTINGENCIA_OPTIONS"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+          <p
+            v-if="showTipoError"
+            id="contingencia-tipo-error"
+            class="error-message"
+          >
+            Selecciona un tipo de contingencia (CAT-005).
+          </p>
+        </div>
+
+        <div v-if="requiresMotivo" :class="['field', { error: showMotivoError }]">
+          <label for="contingencia-motivo">Motivo</label>
+            <textarea
+              id="contingencia-motivo"
+              ref="motivoInput"
+              v-model="form.motivo"
+              rows="3"
+              @input="enforceMotivoLimit"
+              :aria-invalid="showMotivoError ? 'true' : 'false'"
+              :aria-describedby="
+                showMotivoError ? 'contingencia-motivo-error' : undefined
+              "
+            ></textarea>
+          <div class="field-footer">
+            <span class="counter">{{ motivoLength }}/500</span>
+          </div>
+          <p
+            v-if="showMotivoError"
+            id="contingencia-motivo-error"
+            class="error-message"
+          >
+            Motivo es obligatorio cuando el tipo es ‘Otro’ (máx. 500).
+          </p>
+        </div>
+
+        <section class="evento-informativo">
+          <h3>Evento de contingencia (informativo)</h3>
+          <p class="helper">Zona horaria: America/El_Salvador (UTC-6)</p>
+          <div class="field-group">
+            <label>Fecha y hora de inicio</label>
+            <input type="datetime-local" disabled />
+          </div>
+          <div class="field-group">
+            <label>Fecha y hora de fin</label>
+            <input type="datetime-local" disabled />
+          </div>
+        </section>
+      </section>
+      <footer class="dialog-footer">
+        <button type="button" @click="requestClose">Cancelar</button>
+        <button
+          type="button"
+          class="primary"
+          :disabled="confirmDisabled"
+          @click="handleConfirm"
+        >
+          Confirmar
+        </button>
+      </footer>
+    </div>
+
+    <ConfirmDialog
+      v-model="discardDialogVisible"
+      title="Descartar cambios"
+      message="Tienes cambios sin guardar. ¿Deseas descartarlos?"
+      confirm-text="Descartar"
+      cancel-text="Seguir editando"
+      @confirm="confirmDiscard"
+      @cancel="cancelDiscard"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, reactive, ref, watch } from 'vue';
+import ConfirmDialog from './ConfirmDialog.vue';
+
+const CONTINGENCIA_OPTIONS = [
+  { value: 1, label: '1 — No disponibilidad del sistema del MH' },
+  { value: 2, label: '2 — No disponibilidad del sistema del emisor' },
+  { value: 3, label: '3 — Falla en servicio de Internet del emisor' },
+  { value: 4, label: '4 — Falla en energía eléctrica del emisor' },
+  { value: 5, label: '5 — Otro' }
+] as const;
+
+type ContingenciaOptionValue = (typeof CONTINGENCIA_OPTIONS)[number]['value'];
+
+type ContingenciaFormState = {
+  tipo: ContingenciaOptionValue | null;
+  motivo: string;
+};
+
+const props = defineProps<{
+  visible: boolean;
+  initialConfig: ContingenciaFormState;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:visible', value: boolean): void;
+  (e: 'confirm', payload: { tipo: ContingenciaOptionValue; motivo?: string }): void;
+  (e: 'cancel'): void;
+}>();
+
+const form = reactive<ContingenciaFormState>({ tipo: null, motivo: '' });
+const tipoSelect = ref<HTMLSelectElement>();
+const motivoInput = ref<HTMLTextAreaElement>();
+const discardDialogVisible = ref(false);
+const pristineSnapshot = ref<ContingenciaFormState>({ tipo: null, motivo: '' });
+
+watch(
+  () => props.visible,
+  async (visible) => {
+    if (visible) {
+      const rawTipo = props.initialConfig?.tipo ?? null;
+      const tipo =
+        rawTipo !== null &&
+        CONTINGENCIA_OPTIONS.some(option => option.value === rawTipo)
+          ? rawTipo
+          : null;
+      const motivo = props.initialConfig?.motivo?.slice(0, 500) ?? '';
+      pristineSnapshot.value = { tipo, motivo };
+      form.tipo = tipo;
+      form.motivo = motivo;
+      await nextTick();
+      if (tipoSelect.value) {
+        tipoSelect.value.focus();
+      }
+    } else {
+      discardDialogVisible.value = false;
+    }
+  }
+);
+
+const visible = computed({
+  get: () => props.visible,
+  set: (value: boolean) => emit('update:visible', value)
+});
+
+const requiresMotivo = computed(() => form.tipo === 5);
+const motivoLength = computed(() => form.motivo.length);
+
+const tipoError = computed(
+  () =>
+    form.tipo === null ||
+    !CONTINGENCIA_OPTIONS.some(option => option.value === form.tipo)
+);
+const motivoError = computed(() => {
+  if (!requiresMotivo.value) {
+    return false;
+  }
+  return form.motivo.trim().length === 0;
+});
+
+const showTipoError = computed(() => tipoError.value);
+const showMotivoError = computed(() => motivoError.value);
+
+const confirmDisabled = computed(
+  () => tipoError.value || (requiresMotivo.value && motivoError.value)
+);
+
+const isDirty = computed(() => {
+  if (form.tipo !== pristineSnapshot.value.tipo) {
+    return true;
+  }
+  return form.motivo !== pristineSnapshot.value.motivo;
+});
+
+watch(
+  () => form.tipo,
+  (value) => {
+    if (
+      value !== null &&
+      !CONTINGENCIA_OPTIONS.some(option => option.value === value)
+    ) {
+      form.tipo = null;
+    }
+  }
+);
+
+function enforceMotivoLimit() {
+  if (form.motivo.length > 500) {
+    form.motivo = form.motivo.slice(0, 500);
+  }
+}
+
+function handleConfirm() {
+  if (tipoError.value) {
+    if (tipoSelect.value) {
+      tipoSelect.value.focus();
+    }
+    return;
+  }
+  if (requiresMotivo.value && motivoError.value) {
+    if (motivoInput.value) {
+      motivoInput.value.focus();
+    }
+    return;
+  }
+  emit('confirm', {
+    tipo: form.tipo as ContingenciaOptionValue,
+    ...(requiresMotivo.value ? { motivo: form.motivo.trim() } : {})
+  });
+  emit('update:visible', false);
+}
+
+function requestClose() {
+  if (isDirty.value) {
+    discardDialogVisible.value = true;
+    return;
+  }
+  emit('update:visible', false);
+  emit('cancel');
+}
+
+function confirmDiscard() {
+  discardDialogVisible.value = false;
+  emit('update:visible', false);
+  emit('cancel');
+}
+
+function cancelDiscard() {
+  discardDialogVisible.value = false;
+}
+</script>
+
+<style scoped>
+.contingencia-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.contingencia-dialog {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+  max-width: 480px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.dialog-body {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.field,
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field select,
+.field textarea,
+.field-group input {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.field.error select,
+.field.error textarea {
+  border-color: #c0392b;
+}
+
+.error-message {
+  color: #c0392b;
+  font-size: 0.875rem;
+}
+
+.helper {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.field-footer {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.counter {
+  font-variant-numeric: tabular-nums;
+}
+
+.dialog-footer .primary {
+  background-color: #2c3e50;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.dialog-footer button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.evento-informativo {
+  padding: 1rem;
+  border: 1px dashed #ccc;
+  border-radius: 6px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.evento-informativo input {
+  background: #f0f0f0;
+  color: #666;
+}
+</style>

--- a/ui/tests/FacturaForm.spec.ts
+++ b/ui/tests/FacturaForm.spec.ts
@@ -28,58 +28,128 @@ describe('FacturaForm', () => {
 
   it('oculta controles de contingencia cuando el modo es normal', () => {
     const wrapper = mountForm();
-    expect(wrapper.find('#tipo').exists()).toBe(false);
+    expect(wrapper.find('.contingencia-panel').exists()).toBe(false);
     expect(wrapper.find('.guardar').attributes('disabled')).toBeUndefined();
   });
 
-  it('requiere tipo de contingencia al guardar en modo contingencia', async () => {
-    const wrapper = mountForm({ modoTransmision: 2 });
-    const saveButton = wrapper.find('.guardar');
-    expect(saveButton.attributes('disabled')).toBeUndefined();
-    await saveButton.trigger('click');
+  it('muestra el botón de contingencia al activar el modo', async () => {
+    const wrapper = mountForm();
+    const modoSelect = wrapper.find('#modo');
+    await modoSelect.setValue('2');
     await wrapper.vm.$nextTick();
-    const tipoError = wrapper
-      .findAll('.error-message')
-      .map(node => node.text())
-      .find(text => text.includes('Selecciona un tipo de contingencia'));
-    expect(tipoError).toBeTruthy();
+    expect(wrapper.find('.configurar-contingencia').exists()).toBe(true);
+  });
+
+  it('resume los datos existentes al iniciar en modo contingencia', () => {
+    const wrapper = mountForm({ modoTransmision: 2, tipoContingencia: 3 });
+    expect(wrapper.find('.configurar-contingencia').exists()).toBe(true);
+    expect(wrapper.find('.chip').text()).toContain('Tipo 3');
+  });
+
+  it('exige completar la configuración de contingencia antes de guardar', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 });
+    await wrapper.find('.guardar').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain(
+      'Completa la configuración de contingencia antes de guardar.'
+    );
     expect(api.guardarEnContingencia).not.toHaveBeenCalled();
   });
 
-  it('muestra motivo obligatorio cuando el tipo es “Otro” y limita a 500 caracteres', async () => {
+  it('valida tipo y motivo dentro del diálogo de contingencia', async () => {
     const wrapper = mountForm({ modoTransmision: 2 });
-    const select = wrapper.find('#tipo');
-    await select.setValue('5');
-    const textarea = wrapper.find('#motivo');
-    expect(textarea.exists()).toBe(true);
-    const longText = 'x'.repeat(600);
-    await textarea.setValue(longText);
-    expect((textarea.element as HTMLTextAreaElement).value.length).toBe(500);
-    expect(wrapper.find('.counter').text()).toBe('500/500');
-
-    await textarea.setValue('   ');
-    await wrapper.find('.guardar').trigger('click');
+    await wrapper.find('.configurar-contingencia').trigger('click');
     await wrapper.vm.$nextTick();
-    const motivoError = wrapper
-      .findAll('.error-message')
-      .map(node => node.text())
-      .find(text => text.includes('Motivo es obligatorio cuando el tipo es ‘Otro’'));
-    expect(motivoError).toBeTruthy();
+
+    const modal = wrapper.find('.contingencia-dialog');
+    expect(modal.exists()).toBe(true);
+
+    const confirmButton = modal.find('.primary');
+    expect(confirmButton.attributes('disabled')).toBeDefined();
+
+    const tipoSelect = modal.find('#contingencia-tipo');
+    expect(modal.text()).toContain('Selecciona un tipo de contingencia (CAT-005).');
+
+    await tipoSelect.setValue('5');
+    await wrapper.vm.$nextTick();
+    const motivo = modal.find('#contingencia-motivo');
+    expect(motivo.exists()).toBe(true);
+
+    const longText = 'x'.repeat(600);
+    await motivo.setValue(longText);
+    expect((motivo.element as HTMLTextAreaElement).value.length).toBe(500);
+    expect(modal.find('.counter').text()).toBe('500/500');
+
+    await motivo.setValue('motivo válido');
+    await wrapper.vm.$nextTick();
+    expect(modal.find('.primary').attributes('disabled')).toBeUndefined();
+
+    await motivo.setValue('   ');
+    await wrapper.vm.$nextTick();
+    expect(modal.text()).toContain(
+      'Motivo es obligatorio cuando el tipo es ‘Otro’ (máx. 500).'
+    );
+    expect(modal.find('.primary').attributes('disabled')).toBeDefined();
   });
 
-  it('limpia el motivo cuando se cambia el tipo a un valor diferente de “Otro”', async () => {
+  it('actualiza el resumen al confirmar la configuración', async () => {
     const wrapper = mountForm({ modoTransmision: 2 });
-    const select = wrapper.find('#tipo');
-    await select.setValue('5');
-    const textarea = wrapper.find('#motivo');
-    await textarea.setValue('corte eléctrico');
-    await select.setValue('4');
-    expect(wrapper.find('#motivo').exists()).toBe(false);
+    await wrapper.find('.configurar-contingencia').trigger('click');
+    await wrapper.vm.$nextTick();
+    const modal = wrapper.find('.contingencia-dialog');
+    await modal.find('#contingencia-tipo').setValue('3');
+    await wrapper.vm.$nextTick();
+    await modal.find('.primary').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.chip').text()).toContain('Tipo 3');
+  });
+
+  it('marca motivo capturado cuando el tipo es “Otro”', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 });
+    await wrapper.find('.configurar-contingencia').trigger('click');
+    await wrapper.vm.$nextTick();
+    const modal = wrapper.find('.contingencia-dialog');
+    await modal.find('#contingencia-tipo').setValue('5');
+    await wrapper.vm.$nextTick();
+    const motivo = modal.find('#contingencia-motivo');
+    await motivo.setValue('Falla eléctrica prolongada');
+    await wrapper.vm.$nextTick();
+    await modal.find('.primary').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.chip').text()).toContain('Motivo capturado');
+  });
+
+  it('advierte al cerrar el diálogo con cambios sin confirmar', async () => {
+    const wrapper = mountForm({ modoTransmision: 2 });
+    await wrapper.find('.configurar-contingencia').trigger('click');
+    await wrapper.vm.$nextTick();
+    const modal = wrapper.find('.contingencia-dialog');
+    await modal.find('#contingencia-tipo').setValue('1');
+    await wrapper.vm.$nextTick();
+    await modal.find('.close').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const discardDialog = wrapper
+      .findAllComponents({ name: 'ConfirmDialog' })
+      .find(dialog =>
+        dialog.props('message') === 'Tienes cambios sin guardar. ¿Deseas descartarlos?'
+      );
+    expect(discardDialog).toBeTruthy();
+    await discardDialog!.vm.$emit('confirm');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.contingencia-dialog').exists()).toBe(false);
   });
 
   it('envía los indicadores de contingencia al confirmar el guardado', async () => {
     const wrapper = mountForm({ modoTransmision: 2 }, '42');
-    await wrapper.find('#tipo').setValue('3');
+    await wrapper.find('.configurar-contingencia').trigger('click');
+    await wrapper.vm.$nextTick();
+    const modal = wrapper.find('.contingencia-dialog');
+    await modal.find('#contingencia-tipo').setValue('3');
+    await wrapper.vm.$nextTick();
+    await modal.find('.primary').trigger('click');
+    await wrapper.vm.$nextTick();
+
     await wrapper.find('.guardar').trigger('click');
     await wrapper.vm.$nextTick();
     const confirmDialog = wrapper
@@ -105,11 +175,13 @@ describe('FacturaForm', () => {
     await wrapper.vm.$nextTick();
     const warningDialog = wrapper
       .findAllComponents({ name: 'ConfirmDialog' })
-      .find(dialog => dialog.props('title') === 'Cambiar a modo normal');
+      .find(dialog =>
+        dialog.props('message') === 'Perderás la configuración de contingencia. ¿Continuar?'
+      );
     expect(warningDialog).toBeTruthy();
     await warningDialog!.vm.$emit('confirm');
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#tipo').exists()).toBe(false);
+    expect(wrapper.find('.configurar-contingencia').exists()).toBe(false);
   });
 
   it('gestiona el flujo de evento de contingencia y valida los campos requeridos', async () => {
@@ -142,7 +214,13 @@ describe('FacturaForm', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.text()).toContain('Paso 2: DTE pendientes');
-    expect(wrapper.find('.json-preview').text()).toContain('"codigoGeneracion": "A"');
+    const preview = wrapper.find('.json-preview').text();
+    expect(preview).toContain('"version": 3');
+    expect(preview).toContain('"noItem": 1');
+    expect(preview).toContain('"codigoGeneracion": "A"');
+    expect(preview).toContain('"tipoDoc": "01"');
+    expect(wrapper.text()).toContain('Mostrando 2 de 2 (máx. 1000)');
+    expect(wrapper.find('.copy-codes').exists()).toBe(true);
   });
 
   it('advierte cuando hay más de 1000 DTE y limita la previsualización', async () => {
@@ -168,5 +246,48 @@ describe('FacturaForm', () => {
     expect(wrapper.text()).toContain('Divide el envío en varios eventos');
     expect(json).toContain('"codigoGeneracion": "DTE-0"');
     expect(json).not.toContain('"codigoGeneracion": "DTE-1001"');
+    expect(wrapper.text()).toContain('Mostrando 1000 de 1002 (máx. 1000)');
+  });
+
+  it('normaliza valores inválidos del modo de transmisión a normal', () => {
+    const wrapper = mountForm({ modoTransmision: 5 as unknown as number });
+    const modo = wrapper.find('#modo');
+    expect((modo.element as HTMLSelectElement).value).toBe('1');
+  });
+
+  it('permite copiar los códigos de los DTE en la previsualización del evento', async () => {
+    const pendientes = [
+      { codigoGeneracion: 'abc123', tipoDocumento: '01' },
+      { codigoGeneracion: 'def456', tipoDocumento: '03' }
+    ];
+    const wrapper = mountForm({ modoTransmision: 2, pendientesContingencia: pendientes });
+    await wrapper.find('button.evento').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const [inicioFecha, finFecha] = wrapper.findAll('input[type="date"]');
+    const [inicioHora, finHora] = wrapper.findAll('input[type="time"]');
+    await inicioFecha.setValue('2024-01-01');
+    await inicioHora.setValue('08:00');
+    await finFecha.setValue('2024-01-01');
+    await finHora.setValue('09:30');
+    await wrapper.find('#evento-tipo').setValue('1');
+    await wrapper.find('.evento-content .primary').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true
+    });
+
+    await wrapper.find('.copy-codes').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(writeText).toHaveBeenCalledWith('ABC123\nDEF456');
+    expect(wrapper.text()).toContain('Códigos copiados al portapapeles.');
+
+    // clean up clipboard mock
+    // @ts-expect-error
+    delete window.navigator.clipboard;
   });
 });

--- a/ui/ventas/FacturaForm.vue
+++ b/ui/ventas/FacturaForm.vue
@@ -2,60 +2,47 @@
   <div class="factura-form">
     <section class="modo-transmision">
       <label for="modo">Modo de transmisión</label>
-      <select id="modo" v-model.number="modoTransmision">
+      <select
+        id="modo"
+        ref="modoSelect"
+        v-model.number="modoTransmision"
+        aria-label="Selecciona el modo de transmisión"
+      >
         <option :value="1">1 — Normal</option>
         <option :value="2">2 — Contingencia</option>
       </select>
     </section>
 
     <section v-if="isContingencia" class="contingencia-panel">
-      <p class="helper">Si eliges “Otro”, el motivo es obligatorio.</p>
-      <div :class="['field', { error: showTipoError }]">
-        <label for="tipo">Tipo de Contingencia (CAT-005)</label>
-        <select
-          id="tipo"
-          ref="tipoSelect"
-          v-model.number="tipoContingencia"
-        >
-          <option disabled value="">Selecciona una opción</option>
-          <option
-            v-for="option in CONTINGENCIA_OPTIONS"
-            :key="option.value"
-            :value="option.value"
-          >
-            {{ option.label }}
-          </option>
-        </select>
-        <p v-if="showTipoError" class="error-message">
-          {{ tipoErrorMessage }}
-        </p>
-      </div>
-
-      <div
-        v-if="requiresMotivo"
-        :class="['field', { error: showMotivoError }]"
+      <button
+        type="button"
+        class="configurar-contingencia"
+        ref="contingenciaButton"
+        @click="openContingenciaDialog"
       >
-        <label for="motivo">Motivo</label>
-        <textarea
-          id="motivo"
-          ref="motivoInput"
-          v-model="motivoContingencia"
-          @input="enforceMotivoLimit"
-          rows="3"
-        ></textarea>
-        <div class="field-footer">
-          <span class="counter">{{ motivoLength }}/500</span>
-        </div>
-        <p v-if="showMotivoError" class="error-message">
-          {{ motivoErrorMessage }}
-        </p>
+        Configurar contingencia…
+      </button>
+      <div class="contingencia-resumen" aria-live="polite">
+        <span v-if="contingenciaSummary" class="chip">
+          {{ contingenciaSummary }}
+        </span>
       </div>
     </section>
 
-    <section v-if="statusMessage" class="status success">
+    <section
+      v-if="statusMessage"
+      class="status success"
+      role="status"
+      aria-live="polite"
+    >
       {{ statusMessage }}
     </section>
-    <section v-if="saveErrorMessage" class="status error">
+    <section
+      v-if="saveErrorMessage"
+      class="status error"
+      role="alert"
+      aria-live="assertive"
+    >
       {{ saveErrorMessage }}
     </section>
 
@@ -95,11 +82,17 @@
     <ConfirmDialog
       v-model="lossConfirmVisible"
       title="Cambiar a modo normal"
-      message="Perderás los datos de contingencia de esta factura. ¿Continuar?"
+      message="Perderás la configuración de contingencia. ¿Continuar?"
       confirm-text="Continuar"
       cancel-text="Cancelar"
       @confirm="confirmClearContingencia"
       @cancel="cancelClearContingencia"
+    />
+
+    <ContingenciaConfigDialog
+      v-model:visible="contingenciaDialogVisible"
+      :initial-config="contingenciaDialogInitial"
+      @confirm="handleContingenciaConfirm"
     />
 
     <div v-if="eventoVisible" class="evento-dialog">
@@ -118,24 +111,56 @@
                 type="date"
                 ref="eventoInicioFecha"
                 v-model="eventoForm.inicioFecha"
+                :aria-invalid="eventoErrors.inicio ? 'true' : 'false'"
+                :aria-describedby="
+                  eventoErrors.inicio ? 'evento-inicio-error' : undefined
+                "
               />
               <input
                 type="time"
                 ref="eventoInicioHora"
                 v-model="eventoForm.inicioHora"
+                :aria-invalid="eventoErrors.inicio ? 'true' : 'false'"
+                :aria-describedby="
+                  eventoErrors.inicio ? 'evento-inicio-error' : undefined
+                "
               />
             </div>
-            <p v-if="eventoErrors.inicio" class="error-message">
+            <p
+              v-if="eventoErrors.inicio"
+              id="evento-inicio-error"
+              class="error-message"
+            >
               {{ eventoErrors.inicio }}
             </p>
           </div>
           <div :class="['field-group', { error: eventoErrors.fin }]">
             <label>Fecha y hora de fin</label>
             <div class="inputs">
-              <input type="date" ref="eventoFinFecha" v-model="eventoForm.finFecha" />
-              <input type="time" ref="eventoFinHora" v-model="eventoForm.finHora" />
+              <input
+                type="date"
+                ref="eventoFinFecha"
+                v-model="eventoForm.finFecha"
+                :aria-invalid="eventoErrors.fin ? 'true' : 'false'"
+                :aria-describedby="
+                  eventoErrors.fin ? 'evento-fin-error' : undefined
+                "
+              />
+              <input
+                type="time"
+                ref="eventoFinHora"
+                v-model="eventoForm.finHora"
+                :aria-invalid="eventoErrors.fin ? 'true' : 'false'"
+                :aria-describedby="
+                  eventoErrors.fin ? 'evento-fin-error' : undefined
+                "
+              />
             </div>
-            <p v-if="eventoErrors.fin" class="error-message">
+            <p
+              v-if="eventoErrors.fin"
+              id="evento-fin-error"
+              class="error-message"
+            >
               {{ eventoErrors.fin }}
             </p>
           </div>
@@ -145,6 +170,10 @@
               id="evento-tipo"
               ref="eventoTipo"
               v-model.number="eventoForm.tipo"
+              :aria-invalid="eventoErrors.tipo ? 'true' : 'false'"
+              :aria-describedby="
+                eventoErrors.tipo ? 'evento-tipo-error' : undefined
+              "
             >
               <option disabled value="">Selecciona una opción</option>
               <option
@@ -155,7 +184,11 @@
                 {{ option.label }}
               </option>
             </select>
-            <p v-if="eventoErrors.tipo" class="error-message">
+            <p
+              v-if="eventoErrors.tipo"
+              id="evento-tipo-error"
+              class="error-message"
+            >
               {{ eventoErrors.tipo }}
             </p>
           </div>
@@ -170,11 +203,19 @@
               v-model="eventoForm.motivo"
               @input="enforceEventoMotivoLimit"
               rows="3"
+              :aria-invalid="eventoErrors.motivo ? 'true' : 'false'"
+              :aria-describedby="
+                eventoErrors.motivo ? 'evento-motivo-error' : undefined
+              "
             ></textarea>
             <div class="field-footer">
               <span class="counter">{{ eventoMotivoLength }}/500</span>
             </div>
-            <p v-if="eventoErrors.motivo" class="error-message">
+            <p
+              v-if="eventoErrors.motivo"
+              id="evento-motivo-error"
+              class="error-message"
+            >
               {{ eventoErrors.motivo }}
             </p>
           </div>
@@ -190,6 +231,22 @@
           <p>Total de DTE: {{ pendingDtes.length }}</p>
           <p v-if="pendingDtes.length > 1000" class="info">
             Se generarán hasta 1000 DTE por evento. Divide el envío en varios eventos si es necesario.
+          </p>
+          <p class="counter">Mostrando {{ eventoDetalleLimit.length }} de {{ pendingDtes.length }} (máx. 1000)</p>
+          <button
+            type="button"
+            class="copy-codes"
+            @click="copyEventoCodigos"
+          >
+            Copiar códigos
+          </button>
+          <p
+            v-if="eventoCopyMessage"
+            class="copy-status"
+            role="status"
+            aria-live="polite"
+          >
+            {{ eventoCopyMessage }}
           </p>
           <ul class="dte-list">
             <li v-for="dte in eventoDetalleLimit" :key="dte.codigoGeneracion">
@@ -213,6 +270,7 @@
 <script setup lang="ts">
 import { computed, nextTick, reactive, ref, watch } from 'vue';
 import ConfirmDialog from '../components/ConfirmDialog.vue';
+import ContingenciaConfigDialog from '../components/ContingenciaConfigDialog.vue';
 import { guardarEnContingencia } from '../services/facturasApi';
 
 const CONTINGENCIA_OPTIONS = [
@@ -224,6 +282,7 @@ const CONTINGENCIA_OPTIONS = [
 ] as const;
 
 type ContingenciaOptionValue = (typeof CONTINGENCIA_OPTIONS)[number]['value'];
+type ModoTransmision = 1 | 2;
 
 type PendingDte = {
   codigoGeneracion: string;
@@ -231,10 +290,15 @@ type PendingDte = {
 };
 
 interface FacturaConfig {
-  modoTransmision: ContingenciaOptionValue | 1 | 2;
+  modoTransmision: ModoTransmision;
   tipoContingencia?: ContingenciaOptionValue | null;
   motivoContingencia?: string | null;
   pendientesContingencia?: PendingDte[];
+}
+
+interface ContingenciaConfigState {
+  tipo: ContingenciaOptionValue | null;
+  motivo: string;
 }
 
 const props = defineProps<{ facturaId: string; config: FacturaConfig }>();
@@ -244,75 +308,56 @@ const errorVisible = ref(false);
 const lossConfirmVisible = ref(false);
 const statusMessage = ref('');
 const saveErrorMessage = ref('');
-const hasAttemptedSubmit = ref(false);
 
-const modoTransmision = ref<number>(props.config?.modoTransmision ?? 1);
-const tipoContingencia = ref<number | ''>(
-  props.config?.modoTransmision === 2
-    ? props.config?.tipoContingencia ?? ''
-    : ''
+const modoSelect = ref<HTMLSelectElement>();
+const contingenciaButton = ref<HTMLButtonElement>();
+
+function sanitizeModo(value: unknown): ModoTransmision {
+  return value === 2 ? 2 : 1;
+}
+
+const modoTransmision = ref<ModoTransmision>(
+  sanitizeModo(props.config?.modoTransmision)
 );
-const motivoContingencia = ref(props.config?.motivoContingencia ?? '');
+const contingenciaConfig = reactive<ContingenciaConfigState>({
+  tipo:
+    props.config?.modoTransmision === 2
+      ? props.config?.tipoContingencia ?? null
+      : null,
+  motivo:
+    props.config?.modoTransmision === 2
+      ? props.config?.motivoContingencia?.trim() ?? ''
+      : ''
+});
+const contingenciaConfigured = ref(
+  props.config?.modoTransmision === 2 &&
+    contingenciaConfig.tipo !== null &&
+    (contingenciaConfig.tipo !== 5 || contingenciaConfig.motivo.trim().length > 0)
+);
 
-const tipoSelect = ref<HTMLSelectElement>();
-const motivoInput = ref<HTMLTextAreaElement>();
+const contingenciaDialogVisible = ref(false);
+const contingenciaDialogInitial = ref<ContingenciaConfigState>({
+  tipo: contingenciaConfig.tipo,
+  motivo: contingenciaConfig.motivo
+});
 
 const pendingDtes = computed(() => props.config?.pendientesContingencia ?? []);
 const hasPendingContingencia = computed(() => pendingDtes.value.length > 0);
 
 const isContingencia = computed(() => modoTransmision.value === 2);
-const requiresMotivo = computed(
-  () => isContingencia.value && tipoContingencia.value === 5
-);
-
-const motivoLength = computed(() => motivoContingencia.value.length);
-
-const tipoErrorMessage = computed(() => {
-  if (!isContingencia.value) {
+const contingenciaSummary = computed(() => {
+  if (!contingenciaConfigured.value || contingenciaConfig.tipo === null) {
     return '';
   }
-  const value = tipoContingencia.value;
-  if (value === '' || value === null) {
-    return 'Selecciona un tipo de contingencia (CAT-005).';
+  const base = `En contingencia: Tipo ${contingenciaConfig.tipo}`;
+  if (contingenciaConfig.tipo === 5 && contingenciaConfig.motivo.trim()) {
+    return `${base} — Motivo capturado`;
   }
-  if (![1, 2, 3, 4, 5].includes(Number(value))) {
-    return 'Selecciona un tipo de contingencia (CAT-005).';
-  }
-  return '';
+  return base;
 });
 
-const showTipoError = computed(
-  () => hasAttemptedSubmit.value && tipoErrorMessage.value !== ''
-);
-
-const motivoErrorMessage = computed(() => {
-  if (!requiresMotivo.value) {
-    return '';
-  }
-  const trimmed = motivoContingencia.value.trim();
-  if (!trimmed) {
-    return "Motivo es obligatorio cuando el tipo es ‘Otro’ (máx. 500).";
-  }
-  if (trimmed.length > 500) {
-    return 'Motivo no puede exceder 500 caracteres.';
-  }
-  return '';
-});
-
-const showMotivoError = computed(
-  () => hasAttemptedSubmit.value && motivoErrorMessage.value !== ''
-);
-
-const isFormValid = computed(() => {
-  if (!isContingencia.value) {
-    return true;
-  }
-  return tipoErrorMessage.value === '' && motivoErrorMessage.value === '';
-});
-
-const isSaveDisabled = computed(
-  () => isContingencia.value && hasAttemptedSubmit.value && !isFormValid.value
-);
+const isSaveDisabled = computed(() => false);
+const eventoCopyMessage = ref('');
 
 watch(modoTransmision, async (newValue, oldValue) => {
   if (oldValue === 2 && newValue === 1 && hasContingenciaData()) {
@@ -322,44 +367,32 @@ watch(modoTransmision, async (newValue, oldValue) => {
     return;
   }
   if (newValue !== 2) {
-    tipoContingencia.value = '';
-    motivoContingencia.value = '';
-    hasAttemptedSubmit.value = false;
-  }
-});
-
-watch(tipoContingencia, (newValue) => {
-  if (newValue !== 5) {
-    motivoContingencia.value = '';
-  }
-});
-
-watch(motivoContingencia, (value) => {
-  if (value.length > 500) {
-    motivoContingencia.value = value.slice(0, 500);
+    contingenciaConfig.tipo = null;
+    contingenciaConfig.motivo = '';
+    contingenciaConfigured.value = false;
+    statusMessage.value = '';
+    saveErrorMessage.value = '';
   }
 });
 
 function hasContingenciaData(): boolean {
-  const tipo = tipoContingencia.value;
-  const motivo = motivoContingencia.value.trim();
-  return tipo !== '' || motivo.length > 0;
-}
-
-function enforceMotivoLimit(): void {
-  if (motivoContingencia.value.length > 500) {
-    motivoContingencia.value = motivoContingencia.value.slice(0, 500);
+  if (contingenciaConfigured.value) {
+    return true;
   }
+  return (
+    contingenciaConfig.tipo !== null || contingenciaConfig.motivo.trim().length > 0
+  );
 }
 
 async function onSave() {
-  hasAttemptedSubmit.value = true;
   statusMessage.value = '';
   saveErrorMessage.value = '';
   if (isContingencia.value) {
-    if (!isFormValid.value) {
+    if (!contingenciaConfigured.value) {
+      saveErrorMessage.value =
+        'Completa la configuración de contingencia antes de guardar.';
       await nextTick();
-      focusFirstInvalid();
+      focusMainContingenciaTrigger();
       return;
     }
     confirmVisible.value = true;
@@ -374,13 +407,17 @@ async function onSave() {
 
 async function saveContingencia() {
   try {
-    const motivo = requiresMotivo.value
-      ? motivoContingencia.value.trim()
-      : undefined;
+    if (contingenciaConfig.tipo === null) {
+      throw new Error('Configuración de contingencia incompleta.');
+    }
+    const motivo =
+      contingenciaConfig.tipo === 5
+        ? contingenciaConfig.motivo.trim()
+        : undefined;
     await guardarEnContingencia(props.facturaId, {
       modeloFacturacion: 2,
       tipoTransmision: 2,
-      tipoContingencia: Number(tipoContingencia.value),
+      tipoContingencia: Number(contingenciaConfig.tipo),
       ...(motivo ? { motivoContingencia: motivo } : {})
     });
     statusMessage.value = 'Contingencia guardada en la factura.';
@@ -390,26 +427,40 @@ async function saveContingencia() {
   }
 }
 
-function focusFirstInvalid() {
-  if (tipoErrorMessage.value && tipoSelect.value) {
-    tipoSelect.value.focus();
-    return;
-  }
-  if (motivoErrorMessage.value && motivoInput.value) {
-    motivoInput.value.focus();
-  }
-}
-
 function confirmClearContingencia() {
   lossConfirmVisible.value = false;
   modoTransmision.value = 1;
-  tipoContingencia.value = '';
-  motivoContingencia.value = '';
-  hasAttemptedSubmit.value = false;
+  contingenciaConfig.tipo = null;
+  contingenciaConfig.motivo = '';
+  contingenciaConfigured.value = false;
+  statusMessage.value = '';
+  saveErrorMessage.value = '';
 }
 
 function cancelClearContingencia() {
   lossConfirmVisible.value = false;
+}
+
+function openContingenciaDialog() {
+  contingenciaDialogInitial.value = {
+    tipo: contingenciaConfig.tipo,
+    motivo: contingenciaConfig.motivo
+  };
+  contingenciaDialogVisible.value = true;
+}
+
+function handleContingenciaConfirm({
+  tipo,
+  motivo
+}: {
+  tipo: ContingenciaOptionValue;
+  motivo?: string;
+}) {
+  contingenciaConfig.tipo = tipo;
+  contingenciaConfig.motivo = motivo?.trim() ?? '';
+  contingenciaConfigured.value = true;
+  contingenciaDialogVisible.value = false;
+  saveErrorMessage.value = '';
 }
 
 function openEventoDialog() {
@@ -420,10 +471,12 @@ function openEventoDialog() {
 
 function closeEventoDialog() {
   eventoVisible.value = false;
+  eventoCopyMessage.value = '';
 }
 
 function volverEvento() {
   eventoStep.value = 1;
+  eventoCopyMessage.value = '';
 }
 
 const eventoVisible = ref(false);
@@ -488,6 +541,7 @@ function resetEvento() {
   eventoErrors.fin = '';
   eventoErrors.tipo = '';
   eventoErrors.motivo = '';
+  eventoCopyMessage.value = '';
 }
 
 function continuarEvento() {
@@ -574,27 +628,32 @@ const eventoPreview = computed(() => {
   if (eventoStep.value !== 2) {
     return '';
   }
-  const detalle = eventoDetalleLimit.value.map((dte) => ({
-    codigoGeneracion: dte.codigoGeneracion,
-    tipoDocumento: dte.tipoDocumento
+  const detalle = eventoDetalleLimit.value.map((dte, index) => ({
+    noItem: index + 1,
+    codigoGeneracion: dte.codigoGeneracion.toUpperCase(),
+    tipoDoc: dte.tipoDocumento
   }));
-  const motivo = eventoRequiresMotivo.value
+  const descripcionMotivo = eventoRequiresMotivo.value
     ? eventoForm.motivo.trim()
     : CONTINGENCIA_OPTIONS.find((o) => o.value === eventoForm.tipo)?.label ?? '';
   const payload = {
     identificacion: {
+      version: 3,
+      ambiente: '00',
       tipoEvento: 'CONTINGENCIA',
-      tipoContingencia: eventoForm.tipo,
-      periodo: {
-        inicio: `${eventoForm.inicioFecha}T${eventoForm.inicioHora}`,
-        fin: `${eventoForm.finFecha}T${eventoForm.finHora}`
-      }
+      tipoContingencia: eventoForm.tipo || null,
+      codigoGeneracion: '00000000-0000-0000-0000-000000000000',
+      fTransmision: eventoForm.inicioFecha || '----',
+      hTransmision: eventoForm.inicioHora || '--:--'
     },
-    emisor: {
-      nit: '000000-0',
-      nombre: 'Ejemplo S.A. de C.V.'
+    motivo: {
+      tipoContingencia: eventoForm.tipo || null,
+      descripcion: descripcionMotivo,
+      fInicio: eventoForm.inicioFecha || '----',
+      hInicio: eventoForm.inicioHora || '--:--',
+      fFin: eventoForm.finFecha || '----',
+      hFin: eventoForm.finHora || '--:--'
     },
-    motivo,
     detalleDTE: detalle
   };
   return JSON.stringify(payload, null, 2);
@@ -603,6 +662,44 @@ const eventoPreview = computed(() => {
 function enviarAHacienda(): Promise<void> {
   return Promise.reject(new Error('fallo'));
 }
+
+function focusMainContingenciaTrigger() {
+  if (contingenciaButton.value) {
+    contingenciaButton.value.focus();
+    return;
+  }
+  if (modoSelect.value) {
+    modoSelect.value.focus();
+  }
+}
+
+async function copyEventoCodigos() {
+  const codes = eventoDetalleLimit.value
+    .map((dte) => dte.codigoGeneracion.toUpperCase())
+    .join('\n');
+  if (!codes) {
+    eventoCopyMessage.value = 'No hay códigos para copiar.';
+    return;
+  }
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(codes);
+    } else {
+      const textarea = document.createElement('textarea');
+      textarea.value = codes;
+      textarea.setAttribute('readonly', 'true');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+    eventoCopyMessage.value = 'Códigos copiados al portapapeles.';
+  } catch (error) {
+    eventoCopyMessage.value = 'No se pudieron copiar los códigos.';
+  }
+}
 </script>
 
 <style scoped>
@@ -610,6 +707,41 @@ function enviarAHacienda(): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.contingencia-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.configurar-contingencia {
+  background-color: #2c3e50;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.configurar-contingencia:hover {
+  background-color: #1f2e3a;
+}
+
+.contingencia-resumen {
+  min-height: 1.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #e3f2fd;
+  color: #0d47a1;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
 }
 
 .field,
@@ -747,5 +879,24 @@ button:disabled {
   color: #8c6d1f;
   padding: 0.5rem;
   border-radius: 4px;
+}
+
+.copy-codes {
+  align-self: flex-start;
+  background: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.copy-codes:hover {
+  background: #125a9c;
+}
+
+.copy-status {
+  font-size: 0.875rem;
+  color: #2e7d32;
 }
 </style>


### PR DESCRIPTION
## Summary
- sanitize the transmission mode, clear feedback when leaving contingency, and ensure focus returns to the contingency trigger when validation fails
- add accessibility attributes, contingency preview details, a copy-codes helper, and counts to the event workflow while tightening the contingency dialog validation
- expand FacturaForm tests to cover the refined preview payload, mode normalization, and clipboard helper flow

## Testing
- npm test -- FacturaForm

------
https://chatgpt.com/codex/tasks/task_e_68dc9d6ef3b88323a4d397f654b853da