### PR TITLE
Fix pending DTE serialization to preserve Decimal values

### DIFF
--- a/db.py
+++ b/db.py
@@ -17,6 +17,7 @@ from utils.line_totals import compute_line_totals
 from utils.monto import d8
 from utils.snapshot import Snapshot
 from utils.fecha import fecha_ddmmaaaa, normalizar_fecha_iso
+from utils.stable_json import stable_stringify
 from paths import DTES_DIR, get_canonical_dte_dir, user_data_path
 
 logging.basicConfig(level=logging.INFO)
@@ -2134,7 +2135,7 @@ class DB:
         fecha = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.cursor.execute(
             "INSERT INTO dte_pendientes (venta_id, dte_json, modo, fecha_creacion) VALUES (?, ?, ?, ?)",
-            (venta_id, json.dumps(dte_json, ensure_ascii=False), modo, fecha),
+            (venta_id, stable_stringify(dte_json), modo, fecha),
         )
         self.conn.commit()
         return self.cursor.lastrowid
@@ -2145,7 +2146,7 @@ class DB:
         rows = [dict(row) for row in self.cursor.fetchall()]
         for r in rows:
             try:
-                r["dte_json"] = json.loads(r["dte_json"])
+                r["dte_json"] = json.loads(r["dte_json"], parse_float=Decimal)
             except Exception:
                 pass
         return rows

--- a/tests/test_db_dte_pendientes.py
+++ b/tests/test_db_dte_pendientes.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+
+from db import DB
+
+
+def test_add_dte_pendiente_handles_decimal(tmp_path):
+    db_path = tmp_path / "inventario.db"
+    database = DB(db_path)
+
+    database.cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dte_pendientes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            venta_id INTEGER,
+            dte_json TEXT,
+            modo TEXT,
+            fecha_creacion TEXT,
+            transmitido INTEGER DEFAULT 0
+        )
+        """
+    )
+    database.conn.commit()
+
+    payload = {"resumen": {"totalPagar": Decimal("10.50")}}
+
+    row_id = database.add_dte_pendiente(venta_id=1, dte_json=payload, modo="2")
+
+    pendientes = database.get_dte_pendientes()
+
+    match = next(p for p in pendientes if p["id"] == row_id)
+
+    assert match["dte_json"]["resumen"]["totalPagar"] == Decimal("10.50")
+    assert match["modo"] == "2"


### PR DESCRIPTION
## Summary
- use the shared `stable_stringify` helper when storing pending DTE payloads to support `Decimal`
- deserialize pending DTEs with `Decimal` values intact when reading them back
- add a regression test that verifies contingency inserts keep `Decimal` totals

## Testing
- pytest tests/test_db_dte_pendientes.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd5cf8990832398d777175304fb7d