### PR TITLE
Create DTE pending table and mark contingency invoices

### DIFF
--- a/db.py
+++ b/db.py
@@ -728,7 +728,20 @@ class DB:
                 fecha_creacion TEXT,
                 FOREIGN KEY (venta_id) REFERENCES ventas(id)
             )
-        """
+            """
+        )
+
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS dte_pendientes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venta_id INTEGER,
+                dte_json TEXT,
+                modo TEXT,
+                fecha_creacion TEXT,
+                transmitido INTEGER DEFAULT 0
+            )
+            """
         )
 
         self.cursor.execute(

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1858,6 +1858,30 @@ class FacturacionTab(QWidget):
 
         envio = "Pendiente de envío"
 
+        contingencia_pendiente = False
+        venta_id_lookup = None
+        if venta_id is not None:
+            try:
+                venta_id_lookup = int(venta_id)
+            except (TypeError, ValueError):
+                venta_id_lookup = None
+        if cur is not None and venta_id_lookup is not None:
+            try:
+                cur.execute(
+                    """
+                    SELECT 1
+                    FROM dte_pendientes
+                    WHERE venta_id=? AND transmitido=0
+                    LIMIT 1
+                    """,
+                    (venta_id_lookup,),
+                )
+                contingencia_pendiente = cur.fetchone() is not None
+            except Exception:
+                contingencia_pendiente = False
+        if contingencia_pendiente:
+            estado = "Contingencia"
+
         def _row_get(row, key):
             if row is None:
                 return None

--- a/tests/test_db_dte_pendientes.py
+++ b/tests/test_db_dte_pendientes.py
@@ -7,20 +7,6 @@ def test_add_dte_pendiente_handles_decimal(tmp_path):
     db_path = tmp_path / "inventario.db"
     database = DB(db_path)
 
-    database.cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS dte_pendientes (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            venta_id INTEGER,
-            dte_json TEXT,
-            modo TEXT,
-            fecha_creacion TEXT,
-            transmitido INTEGER DEFAULT 0
-        )
-        """
-    )
-    database.conn.commit()
-
     payload = {"resumen": {"totalPagar": Decimal("10.50")}}
 
     row_id = database.add_dte_pendiente(venta_id=1, dte_json=payload, modo="2")

--- a/tests/test_facturacion_tab_contingencia.py
+++ b/tests/test_facturacion_tab_contingencia.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from facturacion_tab import FacturacionTab
+except ImportError as exc:  # pragma: no cover - skip when Qt is unavailable
+    pytest.skip(f"PyQt5 no disponible: {exc}", allow_module_level=True)
+
+from db import DB
+
+
+def test_detectar_estado_factura_marca_contingencia(tmp_path):
+    db_path = tmp_path / "inventario.db"
+    database = DB(db_path)
+
+    venta_id = database.add_venta("2024-01-01", 10)
+    database.add_dte_pendiente(venta_id=venta_id, dte_json={}, modo="2")
+
+    venta = database.get_venta_by_id(venta_id)
+    estado, envio = FacturacionTab._detectar_estado_factura(
+        venta,
+        None,
+        None,
+        database.cursor,
+        venta_id=venta_id,
+    )
+
+    assert estado == "Contingencia"
+    assert envio == "Pendiente de envío"


### PR DESCRIPTION
## Summary
- create the `dte_pendientes` table during database setup so pending DTEs persist automatically
- show "Contingencia" for invoices that still have pending contingency transmissions
- simplify the pending DTE unit test setup and add a regression test for the contingency status logic

## Testing
- pytest tests/test_db_dte_pendientes.py tests/test_facturacion_tab_contingencia.py


------
https://chatgpt.com/codex/tasks/task_e_68dcd826ba548323b7c2d76d631ae853