### PR TITLE
Add venta_id fallback for DTE envio lookup

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -1944,7 +1944,7 @@ class FacturacionTab(QWidget):
                         ORDER BY id DESC LIMIT 1
                         """,
                         (numero_control or "",),
-                    ).fetchone()
+                        ).fetchone()
                 if not env_row:
                     like_val = codigo_generacion or numero_control
                     if like_val:
@@ -1956,6 +1956,15 @@ class FacturacionTab(QWidget):
                             """,
                             (f"%{like_val}%",),
                         ).fetchone()
+            if env_row is None and cur is not None and venta_id_lookup is not None:
+                env_row = cur.execute(
+                    """
+                    SELECT estado_ui, estado_ui_tag, estado FROM dte_envios
+                    WHERE venta_id = ?
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (venta_id_lookup,),
+                ).fetchone()
         except Exception:
             env_row = None
 

--- a/tests/test_dte_resend_block.py
+++ b/tests/test_dte_resend_block.py
@@ -213,6 +213,36 @@ def test_detectar_estado_factura_muestra_tag_rechazado(monkeypatch):
     assert envio == "Rechazado (schema)"
 
 
+def test_detectar_estado_factura_usa_venta_id(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    facturacion_tab = pytest.importorskip(
+        "facturacion_tab", reason="PyQt5 no disponible", exc_type=ImportError
+    )
+    FacturacionTab = facturacion_tab.FacturacionTab
+
+    db = DB(":memory:")
+    venta = create_sale(db)
+    db.registrar_envio_dte(
+        venta,
+        "normal",
+        "PROCESADO",
+        "S",
+        {"estado": "Procesado"},
+        codigo_generacion=None,
+        numero_control=None,
+    )
+
+    _, envio = FacturacionTab._detectar_estado_factura(
+        {},
+        cur=db.cursor,
+        venta_id=venta,
+        codigo_generacion=None,
+        numero_control=None,
+    )
+
+    assert envio == "Enviado"
+
+
 def test_detectar_estado_factura_nota_remision(tmp_path):
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     facturacion_tab = pytest.importorskip(


### PR DESCRIPTION
## Summary
- add a fallback query by `venta_id` when detecting DTE envio state
- reuse the existing row-to-state mapping for the new lookup result
- add a regression test that validates the venta-based lookup returns "Enviado"

## Testing
- pytest tests/test_dte_resend_block.py

------
https://chatgpt.com/codex/tasks/task_e_68dced3e94d48323b9b7a1381229cf35