### PR TITLE
Fix ambiente detection for contingency events

### DIFF
--- a/evento_contingencia.py
+++ b/evento_contingencia.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
 from pathlib import Path
+import unicodedata
 from typing import Any, Iterable, Mapping, Sequence
 from uuid import uuid4
 
@@ -222,11 +223,49 @@ def _iter_dtes_from_fs() -> Iterable[Mapping[str, Any]]:
     return matches
 
 
+_PROD_KEYWORDS = {"prod", "produccion", "production"}
+_TEST_KEYWORDS = {"pruebas", "test", "sandbox"}
+
+
+def _normalize_ambiente_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, int):
+        return f"{value:02d}"
+
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    normalized = unicodedata.normalize("NFKD", text.lower())
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
 def _get_ambiente() -> str:
     datos = dte._load_datos_negocio()
-    ambiente_raw = str((datos.get("dte_api") or {}).get("ambiente") or "").strip().lower()
-    if ambiente_raw.startswith("produc"):
+    ambiente_value = (datos.get("dte_api") or {}).get("ambiente")
+    normalized = _normalize_ambiente_value(ambiente_value)
+
+    if not normalized:
+        return "00"
+
+    digits_only = "".join(ch for ch in normalized if ch.isdigit())
+    if digits_only:
+        try:
+            number = int(digits_only)
+        except ValueError:
+            number = None
+        if number == 1:
+            return "01"
+        if number == 0:
+            return "00"
+
+    collapsed = "".join(ch for ch in normalized if ch.isalnum())
+    if any(keyword in collapsed for keyword in _PROD_KEYWORDS):
         return "01"
+    if any(keyword in collapsed for keyword in _TEST_KEYWORDS):
+        return "00"
+
     return "00"
 
 

--- a/tests/test_evento_contingencia_gen.py
+++ b/tests/test_evento_contingencia_gen.py
@@ -54,6 +54,74 @@ def test_build_v3_and_ambiente_ok(monkeypatch):
     assert lower_bound <= tx_dt <= upper_bound
 
 
+@pytest.mark.parametrize(
+    "ambiente_value",
+    [
+        "01",
+        1,
+        "produccion",
+        "producción",
+        "prod",
+        "production",
+        "prod-01",
+    ],
+)
+def test_ambiente_produccion_variants(monkeypatch, ambiente_value):
+    monkeypatch.setattr(
+        "evento_contingencia.dte._load_datos_negocio",
+        lambda: {"dte_api": {"ambiente": ambiente_value}},
+    )
+
+    payload = build_evento_contingencia(
+        tipo_contingencia=1,
+        motivo=None,
+        f_inicio=_sample_datetime(8),
+        f_fin=_sample_datetime(9),
+        dtes=[{"codigoGeneracion": "abc", "tipoDoc": "01"}],
+    )
+
+    assert payload["identificacion"]["ambiente"] == "01"
+
+
+@pytest.mark.parametrize(
+    "ambiente_value",
+    ["00", 0, "pruebas", "test", "sandbox"],
+)
+def test_ambiente_pruebas_variants(monkeypatch, ambiente_value):
+    monkeypatch.setattr(
+        "evento_contingencia.dte._load_datos_negocio",
+        lambda: {"dte_api": {"ambiente": ambiente_value}},
+    )
+
+    payload = build_evento_contingencia(
+        tipo_contingencia=1,
+        motivo=None,
+        f_inicio=_sample_datetime(8),
+        f_fin=_sample_datetime(9),
+        dtes=[{"codigoGeneracion": "abc", "tipoDoc": "01"}],
+    )
+
+    assert payload["identificacion"]["ambiente"] == "00"
+
+
+@pytest.mark.parametrize("ambiente_value", [None, "", "staging"])
+def test_ambiente_unknown_defaults_to_pruebas(monkeypatch, ambiente_value):
+    monkeypatch.setattr(
+        "evento_contingencia.dte._load_datos_negocio",
+        lambda: {"dte_api": {"ambiente": ambiente_value}},
+    )
+
+    payload = build_evento_contingencia(
+        tipo_contingencia=1,
+        motivo=None,
+        f_inicio=_sample_datetime(8),
+        f_fin=_sample_datetime(9),
+        dtes=[{"codigoGeneracion": "abc", "tipoDoc": "01"}],
+    )
+
+    assert payload["identificacion"]["ambiente"] == "00"
+
+
 def test_cat005_motivo_rules(monkeypatch):
     uuid_val = "11111111-1111-4111-8111-111111111111"
     monkeypatch.setattr("evento_contingencia.uuid4", lambda: uuid_val)


### PR DESCRIPTION
## Summary
- normalize the ambiente configuration value for contingency events
- map production and test keywords and digits to the expected codes
- add unit tests covering production, test, and fallback ambiente detection variants

## Testing
- pytest tests/test_evento_contingencia_gen.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf7a491cc8323a7a31900793f04af