### PR TITLE
Normaliza ambiente de producción en notas desde dte

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -5103,6 +5103,7 @@ def generar_nde_desde_dte(
 ) -> dict:
     """Genera la estructura JSON de una Nota de Débito a partir de un DTE."""
 
+    ambiente = resolve_ambiente(ambiente)
     cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
     identificacion = {
@@ -5360,6 +5361,7 @@ def generar_nota_remision_json(
     cantidades = cantidades or {}
     ident_factura = factura.get("identificacion", {})
 
+    ambiente = resolve_ambiente(ambiente)
     cabecera = generar_cabecera_dte_data(1, 1, "04", db, ambiente=ambiente)
     now = datetime.now(TZ_EL_SALVADOR)
     identificacion = {
@@ -5670,6 +5672,55 @@ def _load_dte_api_config():
     print("CFG: AMB=", ambiente, "URL=", url)
     print("CFG: HAS_MANUAL_TOKEN=", bool(token_configured))
     return {"ambiente": ambiente, "url": url}
+
+
+def _normalize_ambiente_value(raw: str | None) -> str | None:
+    """Normaliza representaciones diversas de ambiente a ``"00"`` o ``"01"``."""
+
+    if raw is None:
+        return None
+
+    text = str(raw).strip()
+    if not text:
+        return None
+
+    if text in {"00", "01"}:
+        return text
+
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if digits.startswith("01"):
+        return "01"
+    if digits.startswith("00"):
+        return "00"
+
+    lowered = text.lower()
+    if lowered.startswith("pro"):
+        return "01"
+    if lowered.startswith("pru"):
+        return "00"
+
+    if text == "1":
+        return "01"
+    if text == "0":
+        return "00"
+
+    return None
+
+
+def resolve_ambiente(ambiente: str | None) -> str:
+    """Resuelve el ambiente efectivo tomando en cuenta la configuración local."""
+
+    try:
+        config = _load_dte_api_config() or {}
+    except Exception:
+        config = {}
+
+    config_ambiente = _normalize_ambiente_value(config.get("ambiente"))
+    if config_ambiente == "01":
+        return "01"
+
+    normalized = _normalize_ambiente_value(ambiente)
+    return normalized or "00"
 
 
 def _assert_no_ejemplo(path: str) -> None:

--- a/nota_credito_electronica.py
+++ b/nota_credito_electronica.py
@@ -24,6 +24,7 @@ from dte import (
     DTE_VERSIONES,
     generar_cabecera_dte_data,
     generar_dte_json,
+    resolve_ambiente,
     sanitize_dte_payload,
 )
 from utils import catalogos
@@ -111,6 +112,7 @@ def generar_nce_desde_nota(
         Código de ambiente (``00`` pruebas, ``01`` producción).
     """
 
+    ambiente = resolve_ambiente(ambiente)
     strict = STRICT_SNAPSHOT_DEFAULT if strict_snapshot is None else bool(strict_snapshot)
     start = time.perf_counter()
     row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
@@ -252,6 +254,7 @@ def generar_nce_desde_dte(
     fecha_origen: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una NCE."""
+    ambiente = resolve_ambiente(ambiente)
     if detalles is None:
         if ratio is None or ratio <= Decimal_0:
             raise ValueError("El porcentaje a acreditar debe ser mayor que cero")

--- a/nota_debito_electronica.py
+++ b/nota_debito_electronica.py
@@ -21,6 +21,7 @@ from dte import (
     DTE_VERSIONES,
     generar_cabecera_dte_data,
     generar_dte_json,
+    resolve_ambiente,
     sanitize_dte_payload,
     d4,
 )
@@ -89,6 +90,7 @@ def generar_nde_desde_nota(
 ) -> dict:
     """Genera una NDE basada en la nota registrada en ``notas``."""
 
+    ambiente = resolve_ambiente(ambiente)
     strict = STRICT_SNAPSHOT_DEFAULT if strict_snapshot is None else bool(strict_snapshot)
     start = time.perf_counter()
     row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
@@ -204,6 +206,7 @@ def generar_nde_desde_dte(
     fecha_origen: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una NDE."""
+    ambiente = resolve_ambiente(ambiente)
     origen_ident = dte_origen.get("identificacion", {})
 
     cabecera = generar_cabecera_dte_data(1, 1, "06", db, ambiente=ambiente)

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -32,6 +32,7 @@ from dte import (
     generar_cabecera_dte_data,
     sanitize_dte_payload,
     normalize_uuid_v4_upper,
+    resolve_ambiente,
     _map_estado_hacienda,
 )
 from utils import catalogos
@@ -571,6 +572,7 @@ def generar_nota_remision(
     fecha_documento_relacionado: Optional[str] = None,
 ) -> dict:
     """Genera la estructura JSON de una Nota de Remisión."""
+    ambiente = resolve_ambiente(ambiente)
     allowed_ext_keys = {
         "nombEntrega",
         "docuEntrega",
@@ -751,6 +753,7 @@ def generar_nota_remision_desde_db(
     Obtiene los datos de la nota y la venta asociada para construir la
     estructura base y delega la construcción final a :func:`generar_nota_remision`.
     """
+    ambiente = resolve_ambiente(ambiente)
     row = db.cursor.execute("SELECT * FROM notas WHERE id=?", (nota_id,)).fetchone()
     if not row:
         raise ValueError("Nota no encontrada")

--- a/nota_remision_electronica.py
+++ b/nota_remision_electronica.py
@@ -18,7 +18,12 @@ from decimal import Decimal
 from typing import Iterable, Optional
 
 from db import DB
-from dte import DTE_VERSIONES, generar_cabecera_dte_data, sanitize_dte_payload
+from dte import (
+    DTE_VERSIONES,
+    generar_cabecera_dte_data,
+    resolve_ambiente,
+    sanitize_dte_payload,
+)
 from nota_remision import (
     _build_documento_relacionado_desde_dte as _doc_rel_from_dte,
     _normalizar_documento_relacionado as _normalizar_doc_rel_nr,
@@ -140,6 +145,7 @@ def _generar_base(
     ambiente: str = "00",
 ) -> dict:
     """Construye la estructura base común de una NR."""
+    ambiente = resolve_ambiente(ambiente)
     if not documento_relacionado:
         raise ValueError("documento_relacionado es obligatorio")
 

--- a/tests/test_dte_note_wrappers.py
+++ b/tests/test_dte_note_wrappers.py
@@ -1,0 +1,58 @@
+from db import DB
+from dte import generar_nde_desde_dte
+
+
+def create_db():
+    return DB(":memory:")
+
+
+def test_generar_nde_desde_dte_wrapper_config_produccion(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        "dte_api": {"prefijo_control": "DTE-01-S001P001"},
+    }
+
+    monkeypatch.setattr("dte._load_dte_api_config", lambda: {"ambiente": "produccion"})
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "numeroControl": "DTE-03-S001P001-000000001",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {"nit": "06141407100012", "nrc": "1234567"},
+        "receptor": {
+            "nombre": "Cliente",
+            "tipoDocumento": "36",
+            "numDocumento": "06141407100012",
+            "nrc": "1234567",
+        },
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "montoTotalOperacion": 1.0,
+            "totalPagar": 1.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "totalLetras": "UNO",
+        },
+    }
+
+    nde = generar_nde_desde_dte(db, dte_origen, None, 1.0, "Ajuste", ambiente="00")
+
+    assert nde["identificacion"]["ambiente"] == "01"

--- a/tests/test_generar_nota_remision_json.py
+++ b/tests/test_generar_nota_remision_json.py
@@ -74,3 +74,73 @@ def test_generar_nota_remision_json_from_dte(db_conn):
     assert resumen["descuNoSuj"] == Decimal("0.00")
     assert resumen["descuExenta"] == Decimal("0.00")
     assert resumen["descuGravada"] == Decimal("0.00")
+
+
+def test_generar_nota_remision_json_config_produccion_impone_ambiente(
+    monkeypatch, db_conn
+):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        "dte_api": {"prefijo_control": "DTE-01-S001P001"},
+    }
+
+    monkeypatch.setattr("dte._load_dte_api_config", lambda: {"ambiente": "produccion"})
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+
+    factura = {
+        "identificacion": {
+            "tipoDte": "03",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {"nit": "06141407100012", "nrc": "1234567"},
+        "receptor": {
+            "numDocumento": "0614-123456-102-3",
+            "tipoDocumento": "36",
+            "nrc": "1234567",
+            "nombre": "Cliente",
+            "codActividad": "6201",
+            "descActividad": "Servicios de software",
+            "telefono": "70000001",
+            "correo": "cliente@example.com",
+            "direccion": {
+                "departamento": "06",
+                "municipio": "23",
+                "complemento": "San Salvador",
+            },
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "descripcion": "Prod",
+                "cantidad": 1,
+                "uniMedida": 59,
+            }
+        ],
+    }
+
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "123",
+        "nombRecibe": "Ana",
+        "docuRecibe": "456",
+        "observaciones": "Obs",
+    }
+
+    nr = generar_nota_remision_json(
+        db_conn,
+        factura,
+        extension=extension,
+        ambiente="00",
+    )
+
+    assert nr["identificacion"]["ambiente"] == "01"

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -601,6 +601,82 @@ def test_generar_nce_receptor_incompleto_en_produccion(monkeypatch):
 
     assert "nit" in str(exc.value)
     assert "nrc" in str(exc.value)
+
+
+def test_generar_nce_config_produccion_impone_ambiente(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        "dte_api": {"prefijo_control": "DTE-01-S001P001"},
+    }
+
+    monkeypatch.setattr("dte._load_dte_api_config", lambda: {"ambiente": "produccion"})
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+
+    ambientes_recibidos: list[str] = []
+
+    def _fake_ensure_receptor(base, ambiente):
+        ambientes_recibidos.append(ambiente)
+        receptor = dict(base)
+        receptor.setdefault("nombre", "Cliente")
+        receptor.setdefault("nit", "06141407100012")
+        receptor.setdefault("nrc", "1234567")
+        receptor.setdefault("tipoDocumento", "36")
+        receptor.setdefault("numDocumento", "06141407100012")
+        receptor.setdefault(
+            "direccion",
+            {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        )
+        return receptor
+
+    monkeypatch.setattr(
+        "nota_credito_electronica.ensure_receptor_completo", _fake_ensure_receptor
+    )
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "numeroControl": "DTE-01-S001P001-000000001",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {"nit": "06141407100012", "nrc": "1234567"},
+        "receptor": {"nombre": "Cliente"},
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    nce = generar_nce_desde_dte(db, dte_origen, Decimal("1"), ambiente="00")
+
+    assert nce["identificacion"]["ambiente"] == "01"
+    assert ambientes_recibidos == ["01"]
+
+
 def test_nota_credito_total_nueve(monkeypatch):
     monkeypatch.setattr(
         "svfe.config.load_datos_negocio",

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -651,6 +651,80 @@ def test_generar_nde_receptor_incompleto_en_produccion(monkeypatch):
     assert "nrc" in str(exc.value)
 
 
+def test_generar_nde_config_produccion_impone_ambiente(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        "dte_api": {"prefijo_control": "DTE-01-S001P001"},
+    }
+
+    monkeypatch.setattr("dte._load_dte_api_config", lambda: {"ambiente": "produccion"})
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+
+    ambientes_recibidos: list[str] = []
+
+    def _fake_ensure_receptor(base, ambiente):
+        ambientes_recibidos.append(ambiente)
+        receptor = dict(base)
+        receptor.setdefault("nombre", "Cliente")
+        receptor.setdefault("nit", "06141407100012")
+        receptor.setdefault("nrc", "1234567")
+        receptor.setdefault("tipoDocumento", "36")
+        receptor.setdefault("numDocumento", "06141407100012")
+        receptor.setdefault(
+            "direccion",
+            {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        )
+        return receptor
+
+    monkeypatch.setattr(
+        "nota_debito_electronica.ensure_receptor_completo", _fake_ensure_receptor
+    )
+
+    db = create_db()
+    dte_origen = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "numeroControl": "DTE-01-S001P001-000000001",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {"nit": "06141407100012", "nrc": "1234567"},
+        "receptor": {"nombre": "Cliente"},
+        "resumen": {
+            "totalNoSuj": 0.0,
+            "totalExenta": 0.0,
+            "totalGravada": 1.0,
+            "subTotal": 1.0,
+            "subTotalVentas": 1.0,
+            "descuNoSuj": 0.0,
+            "descuExenta": 0.0,
+            "descuGravada": 0.0,
+            "totalDescu": 0.0,
+            "ivaPerci1": 0.0,
+            "ivaRete1": 0.0,
+            "reteRenta": 0.0,
+            "condicionOperacion": 1,
+            "tributos": [],
+            "montoTotalOperacion": 1.0,
+            "totalLetras": "UNO",
+        },
+    }
+
+    nde = generar_nde_desde_dte(db, dte_origen, None, 1.0, "Ajuste", ambiente="00")
+
+    assert nde["identificacion"]["ambiente"] == "01"
+    assert ambientes_recibidos == ["01"]
+
+
 def test_generar_nde_ticket_minimo(monkeypatch):
     datos = {
         "nit": "0614-140710-001-2",

--- a/tests/test_nota_remision.py
+++ b/tests/test_nota_remision.py
@@ -186,6 +186,87 @@ def test_nr_desde_factura_documento_relacionado(monkeypatch):
     assert float(resumen["descuGravada"]) == 0.0
 
 
+def test_generar_nota_remision_config_produccion_impone_ambiente(monkeypatch):
+    datos = {
+        "nit": "0614-140710-001-2",
+        "nrc": "1234567",
+        "nombre": "Emisor",
+        "nombreComercial": "Emisor",
+        "codActividad": "111111",
+        "descActividad": "Giro",
+        "telefono": "22223456",
+        "correo": "test@example.com",
+        "direccion": {"departamento": "05", "municipio": "24", "complemento": "Dir"},
+        "dte_api": {"prefijo_control": "DTE-01-S001P001"},
+    }
+
+    monkeypatch.setattr("dte._load_dte_api_config", lambda: {"ambiente": "produccion"})
+    monkeypatch.setattr("dte._load_datos_negocio", lambda: datos)
+    monkeypatch.setattr("svfe.config.load_datos_negocio", lambda: datos)
+
+    db = DB(":memory:")
+    factura = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": "12345678-1234-1234-1234-1234567890AB",
+            "numeroControl": "DTE-01-S001P001-000000001",
+            "fecEmi": "2024-01-01",
+        },
+        "emisor": {
+            "nit": "06141407100012",
+            "nrc": "1234567",
+            "codActividad": "111111",
+            "descActividad": "Giro",
+        },
+        "receptor": {
+            "nombre": "Cliente",
+            "tipoDocumento": "36",
+            "numDocumento": "06141407100012",
+            "nrc": "1234567",
+            "telefono": "22223333",
+            "correo": "cliente@example.com",
+            "codActividad": "6201",
+            "descActividad": "Servicios",
+            "direccion": {
+                "departamento": "05",
+                "municipio": "24",
+                "complemento": "Dir",
+            },
+        },
+        "cuerpoDocumento": [
+            {
+                "numItem": 1,
+                "descripcion": "Servicio",
+                "cantidad": 1,
+                "uniMedida": 59,
+                "precioUni": 10,
+                "montoDescu": 0,
+                "ventaGravada": 10,
+                "ventaExenta": 0,
+                "ventaNoSuj": 0,
+                "tributos": [],
+            }
+        ],
+    }
+    extension = {
+        "nombEntrega": "Juan",
+        "docuEntrega": "061414071",
+        "nombRecibe": "Ana",
+        "docuRecibe": "061414071",
+        "observaciones": "Entrega",
+    }
+
+    nota = nota_remision.generar_nota_remision(
+        db,
+        factura,
+        ambiente="00",
+        extension=extension,
+        verificar_documento_relacionado=False,
+    )
+
+    assert nota["identificacion"]["ambiente"] == "01"
+
+
 def test_nr_documento_relacionado_con_numero_control(monkeypatch):
     monkeypatch.setattr("dte._load_datos_negocio", lambda: {"dte_api": {}})
     db = DB(":memory:")


### PR DESCRIPTION
## Summary
- actualiza los generadores de nota de débito y remisión expuestos desde `dte` para que resuelvan el ambiente efectivo usando la configuración
- agrega pruebas que confirman que ambos generadores fuerzan el ambiente `01` cuando la configuración indica producción

## Testing
- pytest tests/test_dte_note_wrappers.py tests/test_generar_nota_remision_json.py

------
https://chatgpt.com/codex/tasks/task_e_68dd035a30ec83239679c26937fbc74a