### PR TITLE
Force null contingency emitter codes

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -5533,10 +5533,8 @@ def generar_evento_contingencia(
         "telefono": telefono,
         "correo": correo,
     }
-    if datos.get("codEstableMH"):
-        emisor["codEstableMH"] = datos.get("codEstableMH")
-    if datos.get("codPuntoVenta"):
-        emisor["codPuntoVenta"] = datos.get("codPuntoVenta")
+    emisor["codEstableMH"] = None
+    emisor["codPuntoVenta"] = None
 
     if not detalle_dte:
         raise ValueError("detalleDTE requerido")


### PR DESCRIPTION
## Summary
- force the contingency event payload to always include `codEstableMH` and `codPuntoVenta` as null values for the emitter

## Testing
- pytest tests/test_evento_contingencia_gen.py

------
https://chatgpt.com/codex/tasks/task_e_68dd17e94d088323aa4d3b500742b063