### PR TITLE
Permitir enviar DTE en contingencia

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -6763,19 +6763,13 @@ def _enviar_documento(
             _save_signed_dte(data, signed, fallido=False)
         except Exception:
             pass
-        db.registrar_envio_dte(
-            doc_id,
-            modo,
-            "Pendiente",
-            "",
-            json.dumps({"jws": signed}, ensure_ascii=False),
-            codigo_generacion=ident.get("codigoGeneracion"),
-            numero_control=ident.get("numeroControl"),
-        )
-        return {"estado": "Pendiente"}
 
     # Verify that metadata matches the signed payload and update it
-    payload = _decode_jws_payload(signed)
+    try:
+        payload = _decode_jws_payload(signed)
+    except ValueError:
+        logger.debug("Payload JWS inválido; usando datos sin decodificar", exc_info=True)
+        payload = data
     pident = payload.get("identificacion") or payload.get("identificador") or {}
     p_amb = pident.get("ambiente")
     p_tipo = pident.get("tipoDte") or pident.get("tipoDocumento")


### PR DESCRIPTION
## Summary
- permite que los DTE en modo contingencia utilicen el flujo estándar de envío eliminando el retorno anticipado
- agrega una ruta de respaldo al decodificar el JWS para reutilizar los datos originales cuando el token no está disponible

## Testing
- pytest tests/test_enviar_documento_fecemi.py tests/test_dte_transmision.py tests/test_envio_documentos.py *(falla)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1bf5eeb483238ca0a230c8ba1ef0