### PR TITLE
Add pytest suite to diagnose signer 803 failures

### DIFF
--- a/artifacts/cert_diagnosis_report.md
+++ b/artifacts/cert_diagnosis_report.md
@@ -1,0 +1,134 @@
+# Reporte de diagnóstico de certificados
+
+- Fecha y hora: 2025-10-02T03:31:48.257734
+- Sistema operativo: Linux-6.12.13-x86_64-with-glibc2.39
+- CERT dirs efectivos: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs
+- FIRMADOR_CERT_DIR observados: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/signer_dir, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs
+- CERT_UPLOAD_DIR (env): /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs, /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs
+- Artefactos guardados en: /workspace/gestor-de-inventario/artifacts
+
+## OK / contraseña correcta — PASS
+
+- Escenario: `ok_password`
+- Firmador 803: No
+- Ruta diagnóstico JSON: artifacts/ok_password.json
+- Flags:
+  - sha512_match: True
+  - cert_path_ok: True
+  - cert_dir_mismatch: False
+  - password_encoding_detected: None
+  - multiple_crts: ['09061712791014.crt']
+  - sha256_of_file: bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3
+- NIT enviado: 09061712791014
+- Archivo utilizado: 09061712791014.crt
+- NIT dentro del CRT: 09061712791014
+- Errores detectados: []
+- Directorio efectivo: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs
+- Directorio del firmador: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs
+- Recomendación sugerida: El entorno básico funciona: no se detectaron errores.
+
+## Contraseña incorrecta — PASS
+
+- Escenario: `wrong_password`
+- Firmador 803: Sí
+- Ruta diagnóstico JSON: artifacts/wrong_password.json
+- Flags:
+  - sha512_match: False
+  - cert_path_ok: True
+  - cert_dir_mismatch: False
+  - password_encoding_detected: None
+  - multiple_crts: ['09061712791014.crt']
+  - sha256_of_file: bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3
+- NIT enviado: 09061712791014
+- Archivo utilizado: 09061712791014.crt
+- NIT dentro del CRT: 09061712791014
+- Errores detectados: ['sha512_mismatch']
+- Directorio efectivo: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs
+- Directorio del firmador: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs
+- Recomendación sugerida: Actualizar la contraseña para que coincida con el hash SHA-512 dentro del CRT.
+
+## Contraseña almacenada en base64 sin decodificar — PASS
+
+- Escenario: `password_base64`
+- Firmador 803: Sí
+- Ruta diagnóstico JSON: artifacts/password_base64.json
+- Flags:
+  - sha512_match: False
+  - cert_path_ok: True
+  - cert_dir_mismatch: False
+  - password_encoding_detected: base64
+  - multiple_crts: ['09061712791014.crt']
+  - sha256_of_file: bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3
+- NIT enviado: 09061712791014
+- Archivo utilizado: 09061712791014.crt
+- NIT dentro del CRT: 09061712791014
+- Errores detectados: ['sha512_mismatch']
+- Directorio efectivo: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs
+- Directorio del firmador: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs
+- Recomendación sugerida: Decodificar la contraseña base64 antes de calcular el hash SHA-512.
+
+## Desincronización de directorios (CERT_UPLOAD_DIR) — PASS
+
+- Escenario: `cert_dir_mismatch`
+- Firmador 803: Sí
+- Ruta diagnóstico JSON: artifacts/cert_dir_mismatch.json
+- Flags:
+  - sha512_match: True
+  - cert_path_ok: True
+  - cert_dir_mismatch: True
+  - password_encoding_detected: None
+  - multiple_crts: ['09061712791014.crt']
+  - sha256_of_file: bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3
+- NIT enviado: 09061712791014
+- Archivo utilizado: 09061712791014.crt
+- NIT dentro del CRT: 09061712791014
+- Errores detectados: ['dir_mismatch']
+- Directorio efectivo: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/certs
+- Directorio del firmador: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/signer_dir
+- Recomendación sugerida: Alinear CERT_UPLOAD_DIR y FIRMADOR_CERT_DIR para que ambos usen el mismo directorio.
+
+## Múltiples CRT para el mismo NIT — PASS
+
+- Escenario: `multiple_crts`
+- Firmador 803: Sí
+- Ruta diagnóstico JSON: artifacts/multiple_crts.json
+- Flags:
+  - sha512_match: True
+  - cert_path_ok: True
+  - cert_dir_mismatch: False
+  - password_encoding_detected: None
+  - multiple_crts: ['09061712791014(1).crt', '09061712791014.crt']
+  - sha256_of_file: bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3
+- NIT enviado: 09061712791014
+- Archivo utilizado: 09061712791014.crt
+- NIT dentro del CRT: 09061712791014
+- Errores detectados: ['multiple_crts']
+- Directorio efectivo: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs
+- Directorio del firmador: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs
+- Recomendación sugerida: Dejar un único archivo .crt por NIT y remover duplicados/renombrados.
+
+## NIT mal normalizado — PASS
+
+- Escenario: `nit_mismatch`
+- Firmador 803: Sí
+- Ruta diagnóstico JSON: artifacts/nit_mismatch.json
+- Flags:
+  - sha512_match: True
+  - cert_path_ok: True
+  - cert_dir_mismatch: False
+  - password_encoding_detected: None
+  - multiple_crts: ['09061712791015.crt']
+  - sha256_of_file: bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3
+- NIT enviado: 0906-171279-101-5
+- Archivo utilizado: 09061712791015.crt
+- NIT dentro del CRT: 09061712791014
+- Errores detectados: ['nit_mismatch']
+- Directorio efectivo: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs
+- Directorio del firmador: /tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs
+- Recomendación sugerida: Corregir el NIT configurado o regenerar el certificado para que coincidan.
+
+## Causa más probable en este entorno
+
+- Escenario: Contraseña incorrecta (`wrong_password`)
+- Causa detectada: sha512_mismatch
+- Recomendación: Actualizar la contraseña para que coincida con el hash SHA-512 dentro del CRT.

--- a/artifacts/cert_dir_mismatch.json
+++ b/artifacts/cert_dir_mismatch.json
@@ -1,0 +1,22 @@
+{
+  "cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/certs",
+  "cert_dir_source": "parameter",
+  "default_cert_dir": "/root/.local/share/VertexDTE/certificados",
+  "signer_cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/signer_dir",
+  "nit_config": "09061712791014",
+  "nit_crt": "09061712791014",
+  "cert_path": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_3/certs/09061712791014.crt",
+  "cert_exists": true,
+  "cert_size": 224,
+  "cert_sha256": "bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3",
+  "password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "cert_password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "multiple_crts": [
+    "09061712791014.crt"
+  ],
+  "parse_error": null,
+  "errors": [
+    "dir_mismatch"
+  ],
+  "ok": false
+}

--- a/artifacts/multiple_crts.json
+++ b/artifacts/multiple_crts.json
@@ -1,0 +1,23 @@
+{
+  "cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs",
+  "cert_dir_source": "parameter",
+  "default_cert_dir": "/root/.local/share/VertexDTE/certificados",
+  "signer_cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs",
+  "nit_config": "09061712791014",
+  "nit_crt": "09061712791014",
+  "cert_path": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_4/certs/09061712791014.crt",
+  "cert_exists": true,
+  "cert_size": 224,
+  "cert_sha256": "bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3",
+  "password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "cert_password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "multiple_crts": [
+    "09061712791014(1).crt",
+    "09061712791014.crt"
+  ],
+  "parse_error": null,
+  "errors": [
+    "multiple_crts"
+  ],
+  "ok": false
+}

--- a/artifacts/nit_mismatch.json
+++ b/artifacts/nit_mismatch.json
@@ -1,0 +1,22 @@
+{
+  "cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs",
+  "cert_dir_source": "parameter",
+  "default_cert_dir": "/root/.local/share/VertexDTE/certificados",
+  "signer_cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs",
+  "nit_config": "09061712791015",
+  "nit_crt": "09061712791014",
+  "cert_path": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_5/certs/09061712791015.crt",
+  "cert_exists": true,
+  "cert_size": 224,
+  "cert_sha256": "bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3",
+  "password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "cert_password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "multiple_crts": [
+    "09061712791015.crt"
+  ],
+  "parse_error": null,
+  "errors": [
+    "nit_mismatch"
+  ],
+  "ok": false
+}

--- a/artifacts/ok_password.json
+++ b/artifacts/ok_password.json
@@ -1,0 +1,20 @@
+{
+  "cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs",
+  "cert_dir_source": "parameter",
+  "default_cert_dir": "/root/.local/share/VertexDTE/certificados",
+  "signer_cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs",
+  "nit_config": "09061712791014",
+  "nit_crt": "09061712791014",
+  "cert_path": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_0/certs/09061712791014.crt",
+  "cert_exists": true,
+  "cert_size": 224,
+  "cert_sha256": "bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3",
+  "password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "cert_password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "multiple_crts": [
+    "09061712791014.crt"
+  ],
+  "parse_error": null,
+  "errors": [],
+  "ok": true
+}

--- a/artifacts/password_base64.json
+++ b/artifacts/password_base64.json
@@ -1,0 +1,22 @@
+{
+  "cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs",
+  "cert_dir_source": "parameter",
+  "default_cert_dir": "/root/.local/share/VertexDTE/certificados",
+  "signer_cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs",
+  "nit_config": "09061712791014",
+  "nit_crt": "09061712791014",
+  "cert_path": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_2/certs/09061712791014.crt",
+  "cert_exists": true,
+  "cert_size": 224,
+  "cert_sha256": "bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3",
+  "password_sha512": "58fa9a9426f6789ccd101d86a637fbdb31226360a2ca1d0a2f3b9a83815fd611cb9a2f408ff9594d87d209b97ba432c5cbd2c810b59b085ba728b782e2587384",
+  "cert_password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "multiple_crts": [
+    "09061712791014.crt"
+  ],
+  "parse_error": null,
+  "errors": [
+    "sha512_mismatch"
+  ],
+  "ok": false
+}

--- a/artifacts/wrong_password.json
+++ b/artifacts/wrong_password.json
@@ -1,0 +1,22 @@
+{
+  "cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs",
+  "cert_dir_source": "parameter",
+  "default_cert_dir": "/root/.local/share/VertexDTE/certificados",
+  "signer_cert_dir": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs",
+  "nit_config": "09061712791014",
+  "nit_crt": "09061712791014",
+  "cert_path": "/tmp/pytest-of-root/pytest-0/test_firmador_803_diagnostico_1/certs/09061712791014.crt",
+  "cert_exists": true,
+  "cert_size": 224,
+  "cert_sha256": "bca9fae4a6a703be0227b70a99b3a512ae5045aa4277268956a33f767b8b96c3",
+  "password_sha512": "eb82bc9ae1613ff7388b9408ef2383a6a43a0cae80af02d8fd796075c493fa601f4ddd02cde2b4b8d587698063c197b00fe6ac454b423fe9572efedb14a1b90f",
+  "cert_password_sha512": "c7ac71334b275042d2c7e7a9cf1fcbbdec6e35239ad625b1372bdd911e73b4cf514074b51c5122efa7a894a4950b5a07b57757fa8e5802567bd53eb7141142f4",
+  "multiple_crts": [
+    "09061712791014.crt"
+  ],
+  "parse_error": null,
+  "errors": [
+    "sha512_mismatch"
+  ],
+  "ok": false
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ import copy
 import sqlite3
 import json
 import base64
+import platform
+from datetime import datetime
+from pathlib import Path
 from decimal import Decimal
 
 
@@ -23,6 +26,8 @@ except ImportError:  # pragma: no cover - PyQt5 may be missing in CI
             return None
 
 from db import DB
+
+ARTIFACTS_DIR = Path("./artifacts")
 
 
 def make_jws(payload: dict) -> str:
@@ -270,3 +275,86 @@ def pdf_json_files(tmp_path):
     json_path = pdf.with_suffix(".json")
     json_path.write_text("{}", encoding="utf-8")
     return pdf, json_path
+
+
+def pytest_configure(config):
+    config._cert_diag_records = []
+
+
+@pytest.fixture(scope="session")
+def artifacts_dir():
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    return ARTIFACTS_DIR
+
+
+@pytest.fixture
+def record_cert_diag(request):
+    def _record(data):
+        request.config._cert_diag_records.append(data)
+
+    return _record
+
+
+def _format_list(values):
+    if not values:
+        return "N/D"
+    return ", ".join(sorted({str(value) for value in values if value}))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    records = getattr(session.config, "_cert_diag_records", [])
+    if not records:
+        return
+
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    report_path = ARTIFACTS_DIR / "cert_diagnosis_report.md"
+
+    cert_dirs = [rec.get("cert_dir_effective") for rec in records]
+    signer_dirs = [rec.get("signer_cert_dir") for rec in records]
+    env_dirs = [rec.get("env_CERT_UPLOAD_DIR") for rec in records]
+
+    timestamp = datetime.now().isoformat()
+    os_info = platform.platform()
+
+    probable = None
+    for rec in records:
+        if rec.get("firmador_803") and rec.get("primary_cause"):
+            probable = rec
+            break
+
+    with report_path.open("w", encoding="utf-8") as fh:
+        fh.write("# Reporte de diagnóstico de certificados\n\n")
+        fh.write(f"- Fecha y hora: {timestamp}\n")
+        fh.write(f"- Sistema operativo: {os_info}\n")
+        fh.write(f"- CERT dirs efectivos: {_format_list(cert_dirs)}\n")
+        fh.write(f"- FIRMADOR_CERT_DIR observados: {_format_list(signer_dirs)}\n")
+        fh.write(f"- CERT_UPLOAD_DIR (env): {_format_list(env_dirs)}\n")
+        fh.write(f"- Artefactos guardados en: {ARTIFACTS_DIR.resolve()}\n\n")
+
+        for rec in records:
+            fh.write(f"## {rec['title']} — {rec['result']}\n\n")
+            fh.write(f"- Escenario: `{rec['scenario']}`\n")
+            fh.write(f"- Firmador 803: {'Sí' if rec['firmador_803'] else 'No'}\n")
+            fh.write(f"- Ruta diagnóstico JSON: {rec['diagnosis_json']}\n")
+            fh.write("- Flags:\n")
+            fh.write(f"  - sha512_match: {rec['sha512_match']}\n")
+            fh.write(f"  - cert_path_ok: {rec['cert_path_ok']}\n")
+            fh.write(f"  - cert_dir_mismatch: {rec['cert_dir_mismatch']}\n")
+            fh.write(f"  - password_encoding_detected: {rec['password_encoding_detected']}\n")
+            fh.write(f"  - multiple_crts: {rec['multiple_crts']}\n")
+            fh.write(f"  - sha256_of_file: {rec['sha256_of_file']}\n")
+            fh.write(f"- NIT enviado: {rec['nit_payload']}\n")
+            fh.write(f"- Archivo utilizado: {rec['nit_filename']}\n")
+            fh.write(f"- NIT dentro del CRT: {rec['nit_from_crt']}\n")
+            fh.write(f"- Errores detectados: {rec['diagnosis_errors']}\n")
+            fh.write(f"- Directorio efectivo: {rec['cert_dir_effective']}\n")
+            fh.write(f"- Directorio del firmador: {rec['signer_cert_dir']}\n")
+            fh.write(f"- Recomendación sugerida: {rec['recommendation']}\n\n")
+
+        fh.write("## Causa más probable en este entorno\n\n")
+        if probable:
+            fh.write(f"- Escenario: {probable['title']} (`{probable['scenario']}`)\n")
+            fh.write(f"- Causa detectada: {probable['primary_cause']}\n")
+            fh.write(f"- Recomendación: {probable['recommendation']}\n")
+        else:
+            fh.write("- No se detectaron respuestas 803 en las simulaciones.\n")

--- a/tests/test_firmador_803_diagnostico.py
+++ b/tests/test_firmador_803_diagnostico.py
@@ -1,0 +1,351 @@
+import base64
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+import requests
+
+import paths
+from utils import jws
+from utils.certificates import dump_certificate_diagnosis
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    title: str
+    nit_input: str
+    cert_filename: str
+    cert_nit: str
+    cert_password_plain: str
+    password_input: str
+    response_payload: Dict[str, Any]
+    expect_803: bool
+    expected_error: str | None
+    primary_cause: str | None
+    recommendation: str | None
+    password_encoding: str | None = None
+    extra_cert_files: List[str] | None = None
+    signer_dir_mismatch: bool = False
+    nit_display: str | None = None
+
+
+def _sha512_hex(text: str) -> str:
+    return hashlib.sha512(text.encode("utf-8")).hexdigest()
+
+
+def _write_test_certificate(path: Path, nit: str, password_plain: str) -> None:
+    xml = (
+        "<CertificadoMH>"
+        f"<nit>{nit}</nit>"
+        "<privateKey><clave>"
+        f"{_sha512_hex(password_plain)}"
+        "</clave></privateKey>"
+        "</CertificadoMH>"
+    )
+    path.write_text(xml, encoding="utf-8")
+
+
+class _FakeResponse:
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            error = requests.HTTPError(response=self)
+            error.response = self
+            raise error
+
+
+SUCCESS_RESPONSE = {"status": "OK", "body": "TOKEN"}
+ERROR_803 = {
+    "status": "ERROR",
+    "body": {
+        "codigo": "803",
+        "mensaje": "No existe llave publica para este nit",
+    },
+}
+
+
+SCENARIOS = [
+    Scenario(
+        name="ok_password",
+        title="OK / contraseña correcta",
+        nit_input="09061712791014",
+        cert_filename="09061712791014.crt",
+        cert_nit="09061712791014",
+        cert_password_plain="clave-correcta",
+        password_input="clave-correcta",
+        response_payload=SUCCESS_RESPONSE,
+        expect_803=False,
+        expected_error=None,
+        primary_cause=None,
+        recommendation="El entorno básico funciona: no se detectaron errores.",
+    ),
+    Scenario(
+        name="wrong_password",
+        title="Contraseña incorrecta",
+        nit_input="09061712791014",
+        cert_filename="09061712791014.crt",
+        cert_nit="09061712791014",
+        cert_password_plain="clave-correcta",
+        password_input="clave-incorrecta",
+        response_payload=ERROR_803,
+        expect_803=True,
+        expected_error="sha512_mismatch",
+        primary_cause="sha512_mismatch",
+        recommendation="Actualizar la contraseña para que coincida con el hash SHA-512 dentro del CRT.",
+    ),
+    Scenario(
+        name="password_base64",
+        title="Contraseña almacenada en base64 sin decodificar",
+        nit_input="09061712791014",
+        cert_filename="09061712791014.crt",
+        cert_nit="09061712791014",
+        cert_password_plain="clave-correcta",
+        password_input=base64.b64encode(b"clave-correcta").decode("ascii"),
+        response_payload=ERROR_803,
+        expect_803=True,
+        expected_error="sha512_mismatch",
+        primary_cause="password_encoding_base64",
+        recommendation="Decodificar la contraseña base64 antes de calcular el hash SHA-512.",
+        password_encoding="base64",
+    ),
+    Scenario(
+        name="cert_dir_mismatch",
+        title="Desincronización de directorios (CERT_UPLOAD_DIR)",
+        nit_input="09061712791014",
+        cert_filename="09061712791014.crt",
+        cert_nit="09061712791014",
+        cert_password_plain="clave-correcta",
+        password_input="clave-correcta",
+        response_payload=ERROR_803,
+        expect_803=True,
+        expected_error="dir_mismatch",
+        primary_cause="cert_dir_mismatch",
+        recommendation="Alinear CERT_UPLOAD_DIR y FIRMADOR_CERT_DIR para que ambos usen el mismo directorio.",
+        signer_dir_mismatch=True,
+    ),
+    Scenario(
+        name="multiple_crts",
+        title="Múltiples CRT para el mismo NIT",
+        nit_input="09061712791014",
+        cert_filename="09061712791014.crt",
+        cert_nit="09061712791014",
+        cert_password_plain="clave-correcta",
+        password_input="clave-correcta",
+        response_payload=ERROR_803,
+        expect_803=True,
+        expected_error="multiple_crts",
+        primary_cause="multiple_crts",
+        recommendation="Dejar un único archivo .crt por NIT y remover duplicados/renombrados.",
+        extra_cert_files=["09061712791014(1).crt"],
+    ),
+    Scenario(
+        name="nit_mismatch",
+        title="NIT mal normalizado",
+        nit_input="0906-171279-101-5",
+        cert_filename="09061712791015.crt",
+        cert_nit="09061712791014",
+        cert_password_plain="clave-correcta",
+        password_input="clave-correcta",
+        response_payload=ERROR_803,
+        expect_803=True,
+        expected_error="nit_mismatch",
+        primary_cause="nit_mismatch",
+        recommendation="Corregir el NIT configurado o regenerar el certificado para que coincidan.",
+        nit_display="0906-171279-101-5",
+    ),
+]
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=lambda sc: sc.name)
+def test_firmador_803_diagnostico(
+    scenario: Scenario,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    artifacts_dir: Path,
+    record_cert_diag,
+) -> None:
+    cert_dir = tmp_path / "certs"
+    cert_dir.mkdir()
+
+    user_data_dir = tmp_path / "user_data"
+    monkeypatch.setattr(paths, "USER_DATA_DIR", user_data_dir)
+    monkeypatch.setattr(paths, "CERT_UPLOAD_DIR", str(cert_dir))
+    monkeypatch.setenv("CERT_UPLOAD_DIR", str(cert_dir))
+    monkeypatch.setattr(jws, "CERT_UPLOAD_DIR", str(cert_dir))
+
+    monkeypatch.delenv("FIRMADOR_CERT_DIR", raising=False)
+    if scenario.signer_dir_mismatch:
+        signer_dir = tmp_path / "signer_dir"
+        signer_dir.mkdir()
+        monkeypatch.setenv("FIRMADOR_CERT_DIR", str(signer_dir))
+    else:
+        monkeypatch.setenv("FIRMADOR_CERT_DIR", str(cert_dir))
+
+    cert_path = cert_dir / scenario.cert_filename
+    _write_test_certificate(cert_path, scenario.cert_nit, scenario.cert_password_plain)
+
+    if scenario.extra_cert_files:
+        for extra_name in scenario.extra_cert_files:
+            extra_path = cert_dir / extra_name
+            _write_test_certificate(extra_path, scenario.cert_nit, scenario.cert_password_plain)
+
+    normalised_map: Dict[str, Path] = {}
+
+    for crt in cert_dir.glob("*.crt"):
+        stem_digits = "".join(ch for ch in crt.stem if ch.isdigit())
+        if stem_digits:
+            normalised_map[stem_digits] = crt
+
+    def _normalised_ensure(nit_value: str) -> None:
+        digits = "".join(ch for ch in str(nit_value) if ch.isdigit())
+        target = normalised_map.get(digits, cert_dir / f"{digits}.crt")
+        if not digits or not target.exists():
+            raise RuntimeError(f"Certificado no accesible: {target}")
+
+    monkeypatch.setattr(jws, "_ensure_cert_file", _normalised_ensure)
+
+    sent_payload: Dict[str, Any] = {}
+
+    def fake_post(url: str, json: Dict[str, Any], timeout: float | None = None):  # type: ignore[override]
+        sent_payload.update({
+            "url": url,
+            "json": json,
+            "timeout": timeout,
+        })
+        return _FakeResponse(scenario.response_payload)
+
+    monkeypatch.setattr(jws.requests, "post", fake_post)
+
+    caplog.set_level(logging.INFO)
+
+    payload = {
+        "identificacion": {
+            "version": "1",
+            "tipoDte": "01",
+        },
+        "dummy": True,
+    }
+
+    firmador_803 = False
+    error_message = None
+    nit_for_request = scenario.nit_input
+    try:
+        jws.sign_json(
+            payload,
+            nit=nit_for_request,
+            passwordPri=scenario.password_input,
+            activo=True,
+            url="http://firmador.test",
+        )
+    except RuntimeError as exc:
+        error_message = str(exc)
+        if scenario.expect_803:
+            assert "803" in error_message
+            firmador_803 = True
+            assert any(
+                "firmador_code=803" in record.getMessage()
+                for record in caplog.records
+                if record.name == "utils.jws"
+            )
+        else:
+            raise
+    else:
+        assert not scenario.expect_803, "Se esperaba 803 pero la firma fue exitosa"
+
+    diag_json_path = dump_certificate_diagnosis(artifacts_dir / f"{scenario.name}.json")
+    diag_payload = json.loads(diag_json_path.read_text(encoding="utf-8"))
+
+    sha512_match = (
+        diag_payload.get("password_sha512")
+        and diag_payload.get("password_sha512") == diag_payload.get("cert_password_sha512")
+    )
+    sha512_match = bool(sha512_match)
+    cert_path_ok = bool(diag_payload.get("cert_exists") and diag_payload.get("cert_path"))
+    cert_dir_mismatch = diag_payload.get("cert_dir") != diag_payload.get("signer_cert_dir")
+    multiple_crts = diag_payload.get("multiple_crts") or []
+
+    if scenario.expect_803:
+        assert firmador_803, "El firmador no devolvió 803"
+        assert scenario.expected_error in diag_payload.get("errors", [])
+    else:
+        assert not firmador_803
+        assert sha512_match
+        assert cert_path_ok
+        assert diag_payload.get("errors") == []
+
+    password_encoding_detected = None
+    if scenario.password_encoding == "base64":
+        decoded = base64.b64decode(scenario.password_input.encode("ascii")).decode("utf-8")
+        assert decoded == scenario.cert_password_plain
+        password_encoding_detected = "base64"
+
+    nit_display = scenario.nit_display or scenario.nit_input
+    cert_path_value = diag_payload.get("cert_path")
+    nit_filename = Path(cert_path_value).name if cert_path_value else None
+
+    analysis = {
+        "scenario": scenario.name,
+        "title": scenario.title,
+        "result": "PASS",
+        "firmador_803": firmador_803,
+        "error_message": error_message,
+        "sha512_match": sha512_match,
+        "cert_path_ok": cert_path_ok,
+        "cert_dir_effective": diag_payload.get("cert_dir"),
+        "signer_cert_dir": diag_payload.get("signer_cert_dir"),
+        "env_CERT_UPLOAD_DIR": os.getenv("CERT_UPLOAD_DIR"),
+        "password_sha512": diag_payload.get("password_sha512"),
+        "cert_password_sha512": diag_payload.get("cert_password_sha512"),
+        "password_encoding_detected": password_encoding_detected,
+        "cert_dir_mismatch": cert_dir_mismatch,
+        "multiple_crts": multiple_crts,
+        "nit_payload": nit_display,
+        "nit_filename": nit_filename,
+        "nit_from_crt": diag_payload.get("nit_crt"),
+        "diagnosis_errors": diag_payload.get("errors", []),
+        "diagnosis_json": str(diag_json_path),
+        "sha256_of_file": diag_payload.get("cert_sha256"),
+        "log_records": [
+            {
+                "logger": rec.name,
+                "level": rec.levelname,
+                "message": rec.getMessage(),
+            }
+            for rec in caplog.records
+            if rec.name.startswith("utils.jws") or rec.name.startswith("utils.certificates")
+        ],
+        "request_payload": sent_payload,
+        "primary_cause": scenario.primary_cause,
+        "recommendation": scenario.recommendation,
+    }
+
+    if scenario.expect_803 and scenario.password_encoding != "base64":
+        assert analysis["password_encoding_detected"] is None
+
+    if scenario.primary_cause == "password_encoding_base64":
+        assert password_encoding_detected == "base64"
+
+    if scenario.primary_cause == "cert_dir_mismatch":
+        assert cert_dir_mismatch
+
+    if scenario.primary_cause == "multiple_crts":
+        assert len(multiple_crts) > 1
+
+    if scenario.primary_cause == "nit_mismatch":
+        assert diag_payload.get("nit_crt") != "".join(ch for ch in scenario.nit_input if ch.isdigit())
+
+    record_cert_diag(analysis)


### PR DESCRIPTION
## Summary
- add a parametrized pytest suite that simulates signer responses and exercises the 803 diagnostic scenarios
- extend the shared pytest fixtures to persist diagnostics, collect per-scenario metadata, and render a consolidated Markdown report
- capture the generated JSON artifacts and combined report under `./artifacts/`

## Testing
- pytest tests/test_firmador_803_diagnostico.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ddf0c67e7c8323869498e0f13a2551