### PR TITLE
Refactor PDF ellipsis helper and apply to invoice table

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -7,7 +7,7 @@ from reportlab.graphics.barcode import qr
 from reportlab.graphics.shapes import Drawing
 from reportlab.lib.units import mm
 
-from utils.pdf_utils import draw_wrapped_text, draw_text_with_ellipsis
+from utils.pdf_utils import draw_wrapped_text, draw_text_with_ellipsis, ellipsize_text
 import utils.catalogos as catalogos
 from decimal import Decimal, InvalidOperation
 from urllib.parse import urlencode
@@ -516,6 +516,10 @@ def generar_factura_electronica_pdf(
     tipo_norm = (tipo_documento or "").strip().lower()
     is_consumidor_final = tipo_norm.startswith("consumidor final")
 
+    table_padding = 6
+    body_fontname = "Helvetica"
+    body_fontsize = 8
+
     if is_consumidor_final:
         tabla_columnas = [
             "Cantidad",
@@ -525,6 +529,7 @@ def generar_factura_electronica_pdf(
             "Exentas",
             "Gravadas",
         ]
+        col_widths = [44, 170, 90, 60, 60, 90]
     else:
         tabla_columnas = [
             "Cantidad",
@@ -535,6 +540,10 @@ def generar_factura_electronica_pdf(
             "Exentas",
             "Gravadas",
         ]
+        col_widths = [44, 150, 90, 50, 60, 60, 70]
+
+    descripcion_col_idx = tabla_columnas.index("Descripción")
+    descripcion_col_width = max(col_widths[descripcion_col_idx] - 2 * table_padding, 0)
 
     tabla_data = [tabla_columnas]
     for d in detalles:
@@ -545,9 +554,16 @@ def generar_factura_electronica_pdf(
             descuento = (cantidad * precio_unitario * descuento) / Decimal("100")
         gravada_total = cantidad * precio_unitario - descuento
 
+        descripcion = ellipsize_text(
+            d.get("descripcion", ""),
+            body_fontname,
+            body_fontsize,
+            descripcion_col_width,
+        )
+
         fila = [
             str(d.get("cantidad", "")),
-            d.get("descripcion", ""),
+            descripcion,
             f"{float(precio_unitario):.4f}",
         ]
 
@@ -568,10 +584,6 @@ def generar_factura_electronica_pdf(
 
         tabla_data.append(fila)
 
-    col_widths = [44, 150, 90, 50, 60, 60, 70]
-    if is_consumidor_final:
-        col_widths = [44, 170, 90, 60, 60, 90]
-
     tabla = Table(
         tabla_data,
         colWidths=col_widths,
@@ -584,9 +596,11 @@ def generar_factura_electronica_pdf(
         ('ALIGN', (2,0), (-1,-1), 'RIGHT'),  # Números a la derecha
         ('ALIGN', (1,0), (1,-1), 'LEFT'),    # Descripción a la izquierda
         ('VALIGN', (0,0), (-1,-1), 'MIDDLE'),
-        ('FONTSIZE', (0,0), (-1,-1), 8),
+        ('FONTSIZE', (0,0), (-1,-1), body_fontsize),
         ('FONTNAME', (0,0), (-1,0), 'Helvetica-Bold'),
-        ('FONTNAME', (0,1), (-1,-1), 'Helvetica'),
+        ('FONTNAME', (0,1), (-1,-1), body_fontname),
+        ('LEFTPADDING', (0,0), (-1,-1), table_padding),
+        ('RIGHTPADDING', (0,0), (-1,-1), table_padding),
     ]))
 
     # Dibuja la tabla

--- a/tests/test_pdf_utils_draw.py
+++ b/tests/test_pdf_utils_draw.py
@@ -39,3 +39,17 @@ def test_draw_text_with_ellipsis_short_text(tmp_path):
     drawn = pdf_utils.draw_text_with_ellipsis(c, text, 10, 700, 200)
     c.save()
     assert drawn == text
+
+
+def test_ellipsize_text_returns_original_when_fits():
+    text = "Texto breve"
+    result = pdf_utils.ellipsize_text(text, "Helvetica", 10, 200)
+    assert result == text
+
+
+def test_ellipsize_text_truncates_and_fits_width():
+    text = "Descripcion muy larga que necesita truncamiento"
+    max_width = 100
+    result = pdf_utils.ellipsize_text(text, "Helvetica", 10, max_width)
+    assert result.endswith("...")
+    assert pdf_utils.pdfmetrics.stringWidth(result, "Helvetica", 10) <= max_width

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -50,30 +50,24 @@ def draw_wrapped_text(c, text, x, y, max_width, line_height):
     return y
 
 
-def draw_text_with_ellipsis(c, text, x, y, max_width):
-    """Draw ``text`` ensuring it fits within ``max_width`` using an ellipsis."""
+def ellipsize_text(text, fontname, fontsize, max_width):
+    """Return ``text`` truncated with an ellipsis so it fits ``max_width``."""
 
     text = "" if text is None else str(text)
 
     if max_width is None:
-        c.drawString(x, y, text)
         return text
 
     if max_width <= 0:
-        c.drawString(x, y, "")
         return ""
 
-    fontname = c._fontname
-    fontsize = c._fontsize
     text_width = pdfmetrics.stringWidth(text, fontname, fontsize)
     if text_width <= max_width:
-        c.drawString(x, y, text)
         return text
 
     ellipsis = "..."
     ellipsis_width = pdfmetrics.stringWidth(ellipsis, fontname, fontsize)
     if ellipsis_width > max_width:
-        c.drawString(x, y, "")
         return ""
 
     # Binary search the longest prefix that fits with ellipsis appended
@@ -90,5 +84,14 @@ def draw_text_with_ellipsis(c, text, x, y, max_width):
         else:
             high = mid - 1
 
-    c.drawString(x, y, best)
     return best
+
+
+def draw_text_with_ellipsis(c, text, x, y, max_width):
+    """Draw ``text`` ensuring it fits within ``max_width`` using an ellipsis."""
+
+    fontname = c._fontname
+    fontsize = c._fontsize
+    truncated = ellipsize_text(text, fontname, fontsize, max_width)
+    c.drawString(x, y, truncated)
+    return truncated


### PR DESCRIPTION
## Summary
- extract the ellipsis truncation logic into a reusable helper for PDF rendering
- compute invoice table description widths with padding and ellipsize the cell contents accordingly
- cover the new helper with targeted unit tests

## Testing
- pytest tests/test_pdf_utils_draw.py

------
https://chatgpt.com/codex/tasks/task_e_68df090998648323b6a58e4c987e3f5e