### PR TITLE
Ajusta el renderizado de direcciones en factura_sv

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -363,14 +363,14 @@ def generar_factura_electronica_pdf(
     )
     text_y -= 12
     direccion_emisor = format_direccion(datos_negocio.get("direccion"))
-    text_y = draw_wrapped_text(
+    draw_text_with_ellipsis(
         c,
         f"Dirección: {direccion_emisor}",
         emisor_x + 5,
         text_y,
         emisor_text_width,
-        line_h,
     )
+    text_y -= line_h
     if telefono:
         draw_text_with_ellipsis(
             c,
@@ -480,14 +480,14 @@ def generar_factura_electronica_pdf(
             "complemento": direccion_cliente,
         }
     direccion = format_direccion(cliente_dir)
-    text_y = draw_wrapped_text(
+    draw_text_with_ellipsis(
         c,
         f"Dirección: {direccion}",
         left_x,
         text_y,
         box_w - 10,
-        line_h,
     )
+    text_y -= line_h
 
     if venta_a_cuenta_text or documento_venta_a_cuenta_text:
         spacing = max(line_h - 4, 4)


### PR DESCRIPTION
## Summary
- reemplaza draw_wrapped_text por draw_text_with_ellipsis en las direcciones del emisor y receptor dentro del PDF
- mantiene el ajuste manual de la coordenada vertical para conservar el conteo de líneas del receptor

## Testing
- pytest tests/test_pdf_utils_draw.py

------
https://chatgpt.com/codex/tasks/task_e_68df0ea7e40883238f523ba6b4c1b7bd