### PR TITLE
Mostrar nombre del cliente al seleccionar en ventas

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -616,7 +616,7 @@ class ProductDialogBase:
         if selector.exec_():
             cli = selector.get_selected_cliente()
             if cli:
-                nombre = get_field(cli, "codigo", "") or get_field(cli, "nombre", "")
+                nombre = get_field(cli, "nombre", "") or get_field(cli, "codigo", "")
                 nit = get_field(cli, "nit", "")
                 self.selected_cliente = cli
                 self.cliente_label.setText(f"{nombre} | NIT: {nit}")


### PR DESCRIPTION
## Summary
- prioriza el nombre del cliente al actualizar la etiqueta en los diálogos de registro de venta

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df0fb7e41c832394d70e27669e43a5