### PR TITLE
Ensure certificate uploads target signer directory

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -28,6 +28,7 @@ import re
 from db import DB
 
 from utils import jws
+from utils.certificates import resolve_signer_cert_dir
 from utils.catalogos import CONTINGENCIA
 from utils.sanitize import solo_digitos
 from svfe.config import CAT012_DEPARTAMENTOS, CAT013_MUNICIPIOS
@@ -3855,9 +3856,11 @@ class DTEConfigDialog(QDialog):
         self.incluir_sello_pdf.setChecked(dte_api.get("incluir_sello_pdf", False))
         self.guardar_respuesta_bd.setChecked(dte_api.get("guardar_respuesta", False))
         nit = fe_config.get("nit", "")
-        cert = os.path.join(jws.CERT_UPLOAD_DIR, f"{nit}.crt") if nit else ""
-        if cert and os.path.isfile(cert):
-            self.cert_path.setText(cert)
+        if nit:
+            cert_dir = resolve_signer_cert_dir()
+            cert = cert_dir / f"{nit}.crt"
+            if cert.is_file():
+                self.cert_path.setText(str(cert))
 
     def _restore_defaults(self):
         """Restaurar valores por defecto de URLs y token."""
@@ -3953,23 +3956,24 @@ class DTEConfigDialog(QDialog):
         if not file_path:
             return
         try:
-            dest_dir = os.path.abspath(jws.CERT_UPLOAD_DIR)
-            os.makedirs(dest_dir, exist_ok=True)
-            # Remove any existing files so only the new certificate remains
-            for name in os.listdir(dest_dir):
-                existing = os.path.join(dest_dir, name)
+            dest_dir = resolve_signer_cert_dir()
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            # Remove existing certificates so only the new file remains
+            for existing in dest_dir.iterdir():
+                if existing.suffix.lower() != ".crt":
+                    continue
                 try:
-                    if os.path.isfile(existing) or os.path.islink(existing):
-                        os.remove(existing)
-                    elif os.path.isdir(existing):
-                        shutil.rmtree(existing)
+                    existing.unlink()
                 except Exception as cleanup_exc:
                     logger.warning("No se pudo eliminar %s: %s", existing, cleanup_exc)
-            dest = os.path.join(dest_dir, f"{nit}.crt")
-            shutil.copy(file_path, dest)
-            os.chmod(dest, 0o644)
-            jws.set_cert_upload_dir(dest_dir)
-            self.cert_path.setText(dest)
+            dest = dest_dir / f"{nit}.crt"
+            shutil.copy(file_path, str(dest))
+            try:
+                dest.chmod(0o644)
+            except Exception:
+                pass
+            jws.set_cert_upload_dir(str(dest_dir))
+            self.cert_path.setText(str(dest))
             QMessageBox.information(self, "Éxito", "Certificado copiado correctamente.")
         except Exception as exc:
             QMessageBox.critical(self, "Error", f"No se pudo copiar el certificado: {exc}")

--- a/paths.py
+++ b/paths.py
@@ -106,7 +106,32 @@ DATOS_NEGOCIO_PATH = str(user_data_path("datos_negocio.json"))
 CONFIG_NEGOCIO_PATH = str(user_data_path("config_negocio.json"))
 LAST_INVENTORY_PATH = str(user_data_path("ultimo_inventario.json"))
 
-CERT_UPLOAD_DIR = str(ensure_user_dir("certificados"))
+
+def _default_cert_upload_dir() -> Path:
+    """Return the preferred certificate directory for the signer service.
+
+    When the bundled ``svfe-api-firmador`` directory is available and
+    writeable we store certificates inside its ``uploads`` folder so the
+    Java signer can pick them up immediately. If that location is not
+    accessible (for example in frozen builds without a writeable bundle
+    directory) we fall back to the per-user data directory.
+    """
+
+    firmador_uploads = resource_path("svfe-api-firmador", "uploads")
+    try:
+        firmador_uploads.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    else:
+        try:
+            if firmador_uploads.is_dir() and os.access(str(firmador_uploads), os.W_OK):
+                return firmador_uploads.resolve()
+        except OSError:
+            pass
+    return ensure_user_dir("certificados").resolve()
+
+
+CERT_UPLOAD_DIR = str(_default_cert_upload_dir())
 LOG_DIR = str(ensure_user_dir("logs"))
 
 FACTURAS_CONSUMIDOR_FINAL_DIR = str(get_canonical_dte_dir("ConsumidorFinal"))


### PR DESCRIPTION
## Summary
- update the default certificate upload directory to prefer the signer `uploads` folder when writable
- copy selected certificates to the signer directory, cleaning out previous `.crt` files and updating the UI path

## Testing
- pytest tests/test_signer_doctor.py::test_sign_json_attaches_diagnosis_on_803

------
https://chatgpt.com/codex/tasks/task_e_68df22fcf0688323a8ec4e49969e82b2