### PR TITLE
Handle certificates selected from signer directory safely

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -1,4 +1,5 @@
 from decimal import Decimal, getcontext, ROUND_HALF_UP
+from pathlib import Path
 import json
 import logging
 import base64
@@ -22,13 +23,12 @@ from PyQt5.QtGui import (
 )
 
 import os
-import shutil
 import re
 
 from db import DB
 
 from utils import jws
-from utils.certificates import resolve_signer_cert_dir
+from utils.certificates import copy_certificate_to_signer_dir, resolve_signer_cert_dir
 from utils.catalogos import CONTINGENCIA
 from utils.sanitize import solo_digitos
 from svfe.config import CAT012_DEPARTAMENTOS, CAT013_MUNICIPIOS
@@ -3955,24 +3955,17 @@ class DTEConfigDialog(QDialog):
         )
         if not file_path:
             return
+        source_path = Path(file_path).expanduser().resolve()
         try:
-            dest_dir = resolve_signer_cert_dir()
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            # Remove existing certificates so only the new file remains
-            for existing in dest_dir.iterdir():
-                if existing.suffix.lower() != ".crt":
-                    continue
-                try:
-                    existing.unlink()
-                except Exception as cleanup_exc:
-                    logger.warning("No se pudo eliminar %s: %s", existing, cleanup_exc)
-            dest = dest_dir / f"{nit}.crt"
-            shutil.copy(file_path, str(dest))
-            try:
-                dest.chmod(0o644)
-            except Exception:
-                pass
-            jws.set_cert_upload_dir(str(dest_dir))
+            dest = copy_certificate_to_signer_dir(source_path, nit)
+            if not dest.exists():
+                QMessageBox.critical(
+                    self,
+                    "Error",
+                    "No se pudo copiar el certificado al directorio configurado.",
+                )
+                return
+            jws.set_cert_upload_dir(str(dest.parent))
             self.cert_path.setText(str(dest))
             QMessageBox.information(self, "Éxito", "Certificado copiado correctamente.")
         except Exception as exc:

--- a/tests/test_copy_certificate_to_signer_dir.py
+++ b/tests/test_copy_certificate_to_signer_dir.py
@@ -1,0 +1,25 @@
+from utils.certificates import copy_certificate_to_signer_dir, resolve_signer_cert_dir
+
+
+def test_copy_certificate_from_signer_dir(monkeypatch, tmp_path):
+    cert_dir = tmp_path / "certs"
+    monkeypatch.setenv("FIRMADOR_CERT_DIR", str(cert_dir))
+    cert_dir.mkdir()
+
+    existing = cert_dir / "0614.crt"
+    existing.write_bytes(b"contenido-anterior")
+
+    extra = cert_dir / "otro.crt"
+    extra.write_bytes(b"viejo")
+
+    selected = cert_dir / "seleccionado.crt"
+    selected.write_bytes(b"nuevo")
+
+    dest = copy_certificate_to_signer_dir(selected, "0614")
+
+    signer_dir = resolve_signer_cert_dir()
+    assert dest == signer_dir / "0614.crt"
+    assert dest.read_bytes() == b"nuevo"
+    assert selected.exists(), "El archivo seleccionado no debe eliminarse durante la copia"
+    assert not extra.exists(), "Otros certificados deben limpiarse"
+

--- a/utils/certificates.py
+++ b/utils/certificates.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import textwrap
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -210,6 +211,67 @@ def resolve_signer_cert_dir() -> Path:
     if env_value:
         return Path(env_value.strip()).expanduser().resolve()
     return Path(os.getenv("CERT_UPLOAD_DIR", _DEFAULT_CERT_DIR).strip()).expanduser().resolve()
+
+
+def _path_is_relative_to(path: Path, other: Path) -> bool:
+    try:
+        path.relative_to(other)
+        return True
+    except ValueError:
+        return False
+
+
+def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
+    """Copy ``source`` into the signer directory using the provided ``nit`` name."""
+
+    if not nit:
+        raise ValueError("NIT vacío para copiar certificado")
+
+    source_path = Path(source).expanduser().resolve()
+    if not source_path.is_file():
+        raise FileNotFoundError(f"Certificado origen no encontrado: {source_path}")
+    dest_dir = resolve_signer_cert_dir()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = dest_dir / f"{nit}.crt"
+
+    temp_path: Path | None = None
+    copy_source = source_path
+    if _path_is_relative_to(source_path, dest_dir):
+        temp_path = dest_dir / f".tmp_{nit}"
+        shutil.copy2(source_path, temp_path)
+        copy_source = temp_path
+
+    skip_resolved = {source_path, source_path.resolve()}
+    for existing in dest_dir.iterdir():
+        if existing.suffix.lower() != ".crt":
+            continue
+        try:
+            existing_resolved = existing.resolve()
+        except OSError:
+            existing_resolved = existing
+        if existing_resolved in skip_resolved:
+            continue
+        try:
+            existing.unlink()
+        except OSError as exc:
+            logger.warning("CERT.ERROR: no se pudo eliminar %s: %s", existing, exc)
+
+    shutil.copy2(copy_source, dest_path)
+    if temp_path is not None:
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
+
+    try:
+        dest_path.chmod(0o644)
+    except OSError:
+        pass
+
+    if not dest_path.is_file():
+        raise FileNotFoundError(f"No se pudo copiar certificado a {dest_path}")
+
+    return dest_path
 
 
 def verify_certificate_setup(
@@ -789,6 +851,7 @@ __all__ = [
     "CertificateDiagnosis",
     "CertificateFileInfo",
     "DoctorReport",
+    "copy_certificate_to_signer_dir",
     "dump_certificate_diagnosis",
     "fetch_signer_debug",
     "get_effective_cert_dir",


### PR DESCRIPTION
## Summary
- update the certificate selection dialog to resolve the chosen file, reuse the shared helper, and verify the destination exists
- add a `copy_certificate_to_signer_dir` helper that preserves the selected file while cleaning up other certificates
- cover the regression with a pytest exercising the scenario where the source file already lives in the signer directory

## Testing
- pytest tests/test_copy_certificate_to_signer_dir.py

------
https://chatgpt.com/codex/tasks/task_e_68df2a313c788323b8817554b8ad8124