### PR TITLE
Preserve original certificate file name

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -3684,6 +3684,7 @@ class DTEConfigDialog(QDialog):
         self.cert_path = QLineEdit()
         self.cert_path.setReadOnly(True)
         self.cert_btn = QPushButton("Seleccionar")
+        self._cert_file_name: str | None = None
         self.api_user = QLineEdit()
         self.api_pwd = QLineEdit()
         self.api_pwd.setEchoMode(QLineEdit.Password)
@@ -3858,12 +3859,23 @@ class DTEConfigDialog(QDialog):
         nit = fe_config.get("nit", "")
         self.cert_path.clear()
         self.cert_path.setToolTip("")
-        if nit:
-            cert_dir = resolve_signer_cert_dir()
-            cert = cert_dir / f"{nit}.crt"
-            if cert.is_file():
-                self.cert_path.setText(cert.name)
-                self.cert_path.setToolTip(str(cert))
+        cert_dir = resolve_signer_cert_dir()
+        stored_name = fe_config.get("cert_file")
+        self._cert_file_name = stored_name if stored_name else None
+        candidate: Path | None = None
+        if stored_name:
+            candidate = cert_dir / stored_name
+            if not candidate.is_file():
+                candidate = None
+        if candidate is None and nit:
+            canonical = cert_dir / f"{nit}.crt"
+            if canonical.is_file():
+                candidate = canonical
+                if not self._cert_file_name:
+                    self._cert_file_name = canonical.name
+        if candidate is not None:
+            self.cert_path.setText(candidate.name)
+            self.cert_path.setToolTip(str(candidate))
 
     def _restore_defaults(self):
         """Restaurar valores por defecto de URLs y token."""
@@ -3973,6 +3985,7 @@ class DTEConfigDialog(QDialog):
             self.cert_path.clear()
             self.cert_path.setText(display_name)
             self.cert_path.setToolTip(str(dest))
+            self._cert_file_name = dest.name
             QMessageBox.information(
                 self,
                 "Éxito",
@@ -4007,6 +4020,8 @@ class DTEConfigDialog(QDialog):
             "passwordPri": base64.b64encode(self.dte_pass.text().encode()).decode() if self.dte_pass.text() else "",
             "activo": self.dte_activo.isChecked(),
         }
+        if self._cert_file_name:
+            fe_config["cert_file"] = self._cert_file_name
         urls = {
             "auth_url": self.auth_url.text().strip(),
             "auth": {

--- a/tests/test_copy_certificate_to_signer_dir.py
+++ b/tests/test_copy_certificate_to_signer_dir.py
@@ -18,8 +18,10 @@ def test_copy_certificate_from_signer_dir(monkeypatch, tmp_path):
     dest = copy_certificate_to_signer_dir(selected, "0614")
 
     signer_dir = resolve_signer_cert_dir()
-    assert dest == signer_dir / "0614.crt"
+    canonical = signer_dir / "0614.crt"
+    assert dest == signer_dir / "seleccionado.crt"
     assert dest.read_bytes() == b"nuevo"
+    assert canonical.read_bytes() == b"nuevo"
     assert selected.exists(), "El archivo seleccionado no debe eliminarse durante la copia"
     assert not extra.exists(), "Otros certificados deben limpiarse"
 

--- a/utils/certificates.py
+++ b/utils/certificates.py
@@ -222,7 +222,12 @@ def _path_is_relative_to(path: Path, other: Path) -> bool:
 
 
 def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
-    """Copy ``source`` into the signer directory using the provided ``nit`` name."""
+    """Copy ``source`` into the signer directory preserving its original name.
+
+    For backwards compatibility with the signing service, a canonical copy
+    named ``<nit>.crt`` is also created (or updated) alongside the original
+    filename.
+    """
 
     if not nit:
         raise ValueError("NIT vacío para copiar certificado")
@@ -232,7 +237,9 @@ def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
         raise FileNotFoundError(f"Certificado origen no encontrado: {source_path}")
     dest_dir = resolve_signer_cert_dir()
     dest_dir.mkdir(parents=True, exist_ok=True)
-    dest_path = dest_dir / f"{nit}.crt"
+
+    dest_path = dest_dir / source_path.name
+    canonical_path = dest_dir / f"{nit}.crt"
 
     temp_path: Path | None = None
     copy_source = source_path
@@ -242,8 +249,12 @@ def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
         copy_source = temp_path
 
     skip_resolved = {source_path, source_path.resolve()}
+    desired_names = {dest_path.name, canonical_path.name}
+
     for existing in dest_dir.iterdir():
         if existing.suffix.lower() != ".crt":
+            continue
+        if existing.name in desired_names:
             continue
         try:
             existing_resolved = existing.resolve()
@@ -257,16 +268,20 @@ def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
             logger.warning("CERT.ERROR: no se pudo eliminar %s: %s", existing, exc)
 
     shutil.copy2(copy_source, dest_path)
+    if canonical_path != dest_path:
+        shutil.copy2(dest_path, canonical_path)
+
     if temp_path is not None:
         try:
             temp_path.unlink()
         except OSError:
             pass
 
-    try:
-        dest_path.chmod(0o644)
-    except OSError:
-        pass
+    for target in {dest_path, canonical_path}:
+        try:
+            target.chmod(0o644)
+        except OSError:
+            pass
 
     if not dest_path.is_file():
         raise FileNotFoundError(f"No se pudo copiar certificado a {dest_path}")


### PR DESCRIPTION
## Summary
- keep the uploaded certificate's original filename alongside the NIT-based copy expected by the signer
- remember and show the stored certificate name inside the facturación electrónica configuration dialog
- adjust the certificate copy unit test to cover the duplicated canonical file

## Testing
- pytest tests/test_copy_certificate_to_signer_dir.py

------
https://chatgpt.com/codex/tasks/task_e_68df3588f2488323887c632e6ea7b686