### PR TITLE
Ensure certificate uploads refresh canonical copy

### DIFF
--- a/tests/test_copy_certificate_to_signer_dir.py
+++ b/tests/test_copy_certificate_to_signer_dir.py
@@ -18,10 +18,11 @@ def test_copy_certificate_from_signer_dir(monkeypatch, tmp_path):
     dest = copy_certificate_to_signer_dir(selected, "0614")
 
     signer_dir = resolve_signer_cert_dir()
+    canonical = signer_dir / "0614.crt"
     assert dest == signer_dir / "seleccionado.crt"
     assert dest.read_bytes() == b"nuevo"
     assert canonical.read_bytes() == b"nuevo"
     assert selected.exists(), "El archivo seleccionado no debe eliminarse durante la copia"
     assert not extra.exists(), "Otros certificados deben limpiarse"
-    assert list(sorted(p.name for p in cert_dir.glob("*.crt"))) == ["seleccionado.crt"]
+    assert list(sorted(p.name for p in cert_dir.glob("*.crt"))) == ["0614.crt", "seleccionado.crt"]
 

--- a/utils/certificates.py
+++ b/utils/certificates.py
@@ -240,6 +240,7 @@ def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     dest_path = dest_dir / source_path.name
+    canonical_path = dest_dir / f"{nit}{_CERT_EXT}"
 
     temp_path: Path | None = None
     copy_source = source_path
@@ -253,7 +254,7 @@ def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
     for existing in dest_dir.iterdir():
         if existing.suffix.lower() != ".crt":
             continue
-        if existing.name == dest_path.name:
+        if existing.name in {dest_path.name, canonical_path.name}:
             continue
         try:
             existing_resolved = existing.resolve()
@@ -267,6 +268,9 @@ def copy_certificate_to_signer_dir(source: Path | str, nit: str) -> Path:
             logger.warning("CERT.ERROR: no se pudo eliminar %s: %s", existing, exc)
 
     shutil.copy2(copy_source, dest_path)
+
+    if canonical_path != dest_path:
+        shutil.copy2(dest_path, canonical_path)
 
     if temp_path is not None:
         try:


### PR DESCRIPTION
## Summary
- define the canonical certificate path when copying uploads and keep it in sync with the selected filename
- prevent removal of the canonical file during cleanup and ensure permissions are updated
- extend the certificate copy test to assert the canonical NIT-named file exists with the new contents

## Testing
- pytest tests/test_copy_certificate_to_signer_dir.py

------
https://chatgpt.com/codex/tasks/task_e_68df3f264064832393479b2429674938