### PR TITLE
Allow receptor activity fields to stay null

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3345,16 +3345,6 @@ def generar_dte_json(
             receptor["ordenNo"] = fiscal.get("orden_no")
 
     if receptor and not extra.get("es_ticket"):
-        if not receptor.get("codActividad"):
-            receptor["codActividad"] = (
-                emisor.get("codActividad") or datos.get("cod_giro") or "00000"
-            )
-        if not receptor.get("descActividad"):
-            receptor["descActividad"] = (
-                emisor.get("descActividad")
-                or datos.get("descActividad")
-                or "SIN GIRO"
-            )
         if not receptor.get("correo"):
             receptor["correo"] = "no-reply@example.com"
 

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -363,14 +363,14 @@ def generar_factura_electronica_pdf(
     )
     text_y -= 12
     direccion_emisor = format_direccion(datos_negocio.get("direccion"))
-    draw_text_with_ellipsis(
+    text_y = draw_wrapped_text(
         c,
         f"Dirección: {direccion_emisor}",
         emisor_x + 5,
         text_y,
         emisor_text_width,
+        line_h,
     )
-    text_y -= line_h
     if telefono:
         draw_text_with_ellipsis(
             c,
@@ -480,14 +480,14 @@ def generar_factura_electronica_pdf(
             "complemento": direccion_cliente,
         }
     direccion = format_direccion(cliente_dir)
-    draw_text_with_ellipsis(
+    text_y = draw_wrapped_text(
         c,
         f"Dirección: {direccion}",
         left_x,
         text_y,
         box_w - 10,
+        line_h,
     )
-    text_y -= line_h
 
     if venta_a_cuenta_text or documento_venta_a_cuenta_text:
         spacing = max(line_h - 4, 4)

--- a/nota_remision.py
+++ b/nota_remision.py
@@ -406,9 +406,16 @@ def normalizar_receptor(receptor: dict) -> dict:
     else:
         raise ValueError("tipoDocumento inválido en receptor")
     # Campos adicionales requeridos para receptores
-    for campo in ("codActividad", "descActividad", "telefono", "correo"):
+    for campo in ("telefono", "correo"):
         if not receptor.get(campo):
             raise ValueError(f"receptor requiere {campo}")
+
+    for campo in ("codActividad", "descActividad"):
+        value = receptor.get(campo)
+        if value is None:
+            receptor[campo] = None
+        else:
+            receptor[campo] = str(value).strip() or None
 
     direccion = receptor.get("direccion") or {}
     if not direccion.get("complemento"):
@@ -602,9 +609,6 @@ def generar_nota_remision(
                 receptor["telefono"] = "00000000"
             if not receptor.get("correo"):
                 receptor["correo"] = "no-reply@example.com"
-            if emisor and isinstance(emisor, dict):
-                receptor.setdefault("codActividad", emisor.get("codActividad"))
-                receptor.setdefault("descActividad", emisor.get("descActividad"))
         detalles = detalles or factura.get("cuerpoDocumento", [])
         if documento_relacionado is None:
             documento_relacionado = _build_documento_relacionado_desde_dte(

--- a/utils/receptor.py
+++ b/utils/receptor.py
@@ -8,12 +8,12 @@ _PLACEHOLDERS_RECEPTOR = {
     "nit": "00000000000000",
     "nrc": "0",
     "nombre": "CLIENTE DESCONOCIDO",
-    "codActividad": "00000",
-    "descActividad": "PENDIENTE",
     "nombreComercial": None,
     "telefono": "00000000",
     "correo": "demo@example.com",
 }
+
+_RECEPTOR_NULLABLE_FIELDS = {"codActividad", "descActividad"}
 
 _PLACEHOLDERS_DIRECCION = {
     "departamento": "01",
@@ -54,10 +54,18 @@ def ensure_receptor_completo(receptor: Dict[str, Any] | None, ambiente: str) -> 
                     missing.append(field)
                 else:
                     rec[field] = placeholder
-        elif field in {"nit", "nrc", "telefono", "codActividad"}:
+        elif field in {"nit", "nrc", "telefono"}:
             value = rec.get(field)
             if value is not None:
                 rec[field] = str(value)
+
+    for field in _RECEPTOR_NULLABLE_FIELDS:
+        value = rec.get(field)
+        if value is None:
+            rec[field] = None
+        else:
+            value_str = str(value).strip()
+            rec[field] = value_str or None
 
     for field, placeholder in _PLACEHOLDERS_DIRECCION.items():
         if _needs_placeholder(direccion, field):
@@ -78,6 +86,8 @@ def ensure_receptor_completo(receptor: Dict[str, Any] | None, ambiente: str) -> 
     # Asegura que las claves existan aunque sean None.
     for field in _PLACEHOLDERS_RECEPTOR:
         rec.setdefault(field, _PLACEHOLDERS_RECEPTOR[field])
+    for field in _RECEPTOR_NULLABLE_FIELDS:
+        rec.setdefault(field, None)
     for field in _PLACEHOLDERS_DIRECCION:
         rec["direccion"].setdefault(field, _PLACEHOLDERS_DIRECCION[field])
 


### PR DESCRIPTION
## Summary
- allow receptor normalization for notas to keep codActividad/descActividad as null instead of forcing the emitter defaults
- relax nota de remisión receptor validation so missing activity codes remain null while still normalizing provided values
- wrap emisor and receptor address lines in PDFs so long addresses render fully after removing the activity code fallback

## Testing
- pytest tests/test_nota_credito.py tests/test_nota_debito_remision.py

------
https://chatgpt.com/codex/tasks/task_e_68df5b1ba298832389b3d27517224b56