### PR TITLE
Add sale deletion workflow with inventory restoration

### DIFF
--- a/db.py
+++ b/db.py
@@ -1533,35 +1533,196 @@ class DB:
         return [dict(row) for row in self.cursor.fetchall()]
 
     def delete_venta(self, id):
+        """Elimina una venta y restaura el inventario asociado."""
+
+        def _to_python(value):
+            if value in (None, ""):
+                return None
+            if isinstance(value, (bytes, bytearray)):
+                try:
+                    value = value.decode("utf-8")
+                except Exception:
+                    return None
+            if isinstance(value, str):
+                text = value.strip()
+                if not text:
+                    return None
+                try:
+                    return json.loads(text)
+                except Exception:
+                    return None
+            return value
+
+        def _gather_lote_entries(data):
+            entries = []
+            if isinstance(data, dict):
+                lote_value = None
+                for key in ("lote_id", "loteId", "lote"):
+                    candidate = data.get(key)
+                    if candidate not in (None, ""):
+                        lote_value = candidate
+                        break
+                if lote_value not in (None, ""):
+                    entries.append(
+                        {
+                            "lote_id": lote_value,
+                            "cantidad": data.get("cantidad"),
+                            "producto_id": data.get("producto_id"),
+                        }
+                    )
+                for value in data.values():
+                    entries.extend(_gather_lote_entries(value))
+            elif isinstance(data, list):
+                for item in data:
+                    entries.extend(_gather_lote_entries(item))
+            return entries
+
+        def _to_decimal(value):
+            try:
+                return Decimal(str(value))
+            except Exception:
+                return None
+
         try:
-            self.cursor.execute(
-                "DELETE FROM detalles_venta WHERE venta_id=?",
-                (id,),
-            )
-            self.cursor.execute(
-                "DELETE FROM notas WHERE venta_id=?",
-                (id,),
-            )
-            self.cursor.execute(
-                "DELETE FROM ventas_credito_fiscal WHERE venta_id=?",
-                (id,),
-            )
-            self.cursor.execute(
-                "DELETE FROM facturas_pdf WHERE venta_id=?",
-                (id,),
-            )
-            self.cursor.execute(
-                "DELETE FROM tickets_pdf WHERE venta_id=?",
-                (id,),
-            )
-            self.cursor.execute(
-                "DELETE FROM dte_envios WHERE venta_id=?",
-                (id,),
-            )
-            self.cursor.execute("DELETE FROM ventas WHERE id=?", (id,))
-            self.conn.commit()
+            with self.lock:
+                self.cursor.execute(
+                    "SELECT producto_id, cantidad, extra FROM detalles_venta WHERE venta_id=?",
+                    (id,),
+                )
+                detalles = [dict(row) for row in self.cursor.fetchall()]
+
+                lotes_a_restaurar: dict[int, dict[str, Decimal | int | None]] = {}
+                productos_directos: dict[int, Decimal] = {}
+                productos_recalc = set()
+                productos_direct = set()
+
+                for detalle in detalles:
+                    producto_id = detalle.get("producto_id")
+                    if not producto_id:
+                        continue
+                    cantidad_dec = _to_decimal(detalle.get("cantidad"))
+                    if cantidad_dec is None or cantidad_dec <= 0:
+                        continue
+
+                    parsed_extra = _to_python(detalle.get("extra"))
+                    lote_entries = _gather_lote_entries(parsed_extra) if parsed_extra else []
+
+                    valid_lotes = []
+                    for entry in lote_entries:
+                        lote_id_raw = entry.get("lote_id") if isinstance(entry, dict) else None
+                        try:
+                            lote_id = int(lote_id_raw)
+                        except (TypeError, ValueError):
+                            continue
+                        cantidad_entry = _to_decimal(entry.get("cantidad")) if isinstance(entry, dict) else None
+                        producto_entry = entry.get("producto_id") if isinstance(entry, dict) else None
+                        valid_lotes.append(
+                            {
+                                "lote_id": lote_id,
+                                "cantidad": cantidad_entry,
+                                "producto_id": producto_entry or producto_id,
+                            }
+                        )
+
+                    if valid_lotes and any(item["cantidad"] is None for item in valid_lotes):
+                        # Si hay un único lote podemos asumir que toda la cantidad proviene de él.
+                        if len(valid_lotes) == 1:
+                            valid_lotes[0]["cantidad"] = cantidad_dec
+                        else:
+                            valid_lotes = [item for item in valid_lotes if item["cantidad"] is not None]
+
+                    if valid_lotes:
+                        for lote in valid_lotes:
+                            cantidad_lote = lote.get("cantidad")
+                            if cantidad_lote is None:
+                                cantidad_lote = cantidad_dec
+                            if cantidad_lote is None or cantidad_lote <= 0:
+                                continue
+                            info = lotes_a_restaurar.setdefault(
+                                lote["lote_id"],
+                                {"cantidad": Decimal("0"), "producto_id": lote.get("producto_id")},
+                            )
+                            info["cantidad"] = info["cantidad"] + cantidad_lote
+                            if not info.get("producto_id"):
+                                info["producto_id"] = lote.get("producto_id")
+                    else:
+                        productos_directos[producto_id] = productos_directos.get(producto_id, Decimal("0")) + cantidad_dec
+
+                for lote_id, data in lotes_a_restaurar.items():
+                    cantidad = data.get("cantidad")
+                    if cantidad is None or cantidad <= 0:
+                        continue
+                    producto_id = data.get("producto_id")
+                    self.cursor.execute(
+                        "UPDATE detalles_compra SET cantidad = COALESCE(cantidad, 0) + ? WHERE id=?",
+                        (float(cantidad), lote_id),
+                    )
+                    if self.cursor.rowcount:
+                        if producto_id:
+                            productos_recalc.add(producto_id)
+                    else:
+                        if producto_id:
+                            productos_directos[producto_id] = productos_directos.get(producto_id, Decimal("0")) + cantidad
+
+                for producto_id, cantidad in productos_directos.items():
+                    if not producto_id or cantidad is None or cantidad <= 0:
+                        continue
+                    self.cursor.execute(
+                        "UPDATE productos SET stock = COALESCE(stock, 0) + ? WHERE id=?",
+                        (float(cantidad), producto_id),
+                    )
+                    productos_direct.add(producto_id)
+
+                productos_recalc.difference_update(productos_direct)
+                for producto_id in productos_recalc:
+                    if not producto_id:
+                        continue
+                    self.cursor.execute(
+                        "SELECT SUM(cantidad) FROM detalles_compra WHERE producto_id=?",
+                        (producto_id,),
+                    )
+                    total = self.cursor.fetchone()[0]
+                    if total is None:
+                        continue
+                    self.cursor.execute(
+                        "UPDATE productos SET stock=? WHERE id=?",
+                        (float(total), producto_id),
+                    )
+
+                self.cursor.execute(
+                    "DELETE FROM detalles_venta WHERE venta_id=?",
+                    (id,),
+                )
+                self.cursor.execute(
+                    "DELETE FROM notas WHERE venta_id=?",
+                    (id,),
+                )
+                self.cursor.execute(
+                    "DELETE FROM ventas_credito_fiscal WHERE venta_id=?",
+                    (id,),
+                )
+                self.cursor.execute(
+                    "DELETE FROM facturas_pdf WHERE venta_id=?",
+                    (id,),
+                )
+                self.cursor.execute(
+                    "DELETE FROM tickets_pdf WHERE venta_id=?",
+                    (id,),
+                )
+                self.cursor.execute(
+                    "DELETE FROM dte_envios WHERE venta_id=?",
+                    (id,),
+                )
+                self.cursor.execute("DELETE FROM ventas WHERE id=?", (id,))
+                self.conn.commit()
+            return True
         except Exception as e:
             logger.exception("Error al eliminar venta: %s", e)
+            try:
+                self.conn.rollback()
+            except Exception:
+                pass
+            return False
 
     def backfill_ventas_extra(self) -> int:
         """Populate ``ventas.extra`` for rows that are missing fiscal totals."""
@@ -2425,11 +2586,16 @@ class DB:
                 iva_rate,
             )
             precio_unitario = d8(calcs["base"] / cantidad) if cantidad else Decimal("0")
+            raw_precio_unitario = d.get("precio_unitario")
+            if raw_precio_unitario is not None:
+                precio_unitario_guardar = d8(Decimal(str(raw_precio_unitario)))
+            else:
+                precio_unitario_guardar = precio_unitario
             prepared.append(
                 {
                     "producto_id": d.get("producto_id"),
                     "cantidad": float(d8(cantidad)),
-                    "precio_unitario": float(precio_unitario),
+                    "precio_unitario": float(precio_unitario_guardar),
                     "descuento": float(d8(descuento)),
                     "descuento_tipo": descuento_tipo,
                     "iva": float(calcs["iva"]),

--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -1299,7 +1299,12 @@ class RegisterSaleDialog(QDialog, ProductDialogBase):
             "tipo_fiscal": tipo_fiscal,
             "vendedor_id": lote.get("vendedor_id"),
             "Distribuidor_id": lote["Distribuidor_id"],
-            "fecha_vencimiento": lote.get("fecha_vencimiento", "")
+            "fecha_vencimiento": lote.get("fecha_vencimiento", ""),
+            "extra": {
+                "lote_id": lote.get("lote_id"),
+                "producto_id": lote.get("producto_id"),
+                "cantidad": float(cantidad),
+            },
         })
         self._actualizar_tabla()
         self._recalcular_totales()
@@ -2531,7 +2536,12 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
             "tipo_fiscal": tipo_fiscal,
             "vendedor_id": lote.get("vendedor_id"),
             "Distribuidor_id": lote["Distribuidor_id"],
-            "fecha_vencimiento": lote.get("fecha_vencimiento", "")
+            "fecha_vencimiento": lote.get("fecha_vencimiento", ""),
+            "extra": {
+                "lote_id": lote.get("lote_id"),
+                "producto_id": lote.get("producto_id"),
+                "cantidad": float(cantidad),
+            },
         })
 
         self._actualizar_tabla()

--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -5317,7 +5317,10 @@ class FacturacionTab(QWidget):
         archive_label = f"{archive_label}_rechazo_{timestamp}"
         archive_label = re.sub(r"[^A-Za-z0-9_.-]", "_", archive_label)
 
-        self.manager.db.delete_venta(venta_id)
+        if not self.manager.db.delete_venta(venta_id):
+            QMessageBox.critical(self, "Eliminar", "No se pudo eliminar la venta seleccionada.")
+            return
+        self.manager.refresh_data()
 
         self._cleanup_invoice_artifacts(
             venta_id,
@@ -5385,7 +5388,10 @@ class FacturacionTab(QWidget):
             venta_id, factura=factura, entry=data
         )
 
-        self.manager.db.delete_venta(venta_id)
+        if not self.manager.db.delete_venta(venta_id):
+            QMessageBox.critical(self, "Eliminar", "No se pudo eliminar la venta seleccionada.")
+            return
+        self.manager.refresh_data()
 
         self._cleanup_invoice_artifacts(
             venta_id,

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -118,6 +118,11 @@ class SalesTab(QWidget):
         self.btn_estado.clicked.connect(self.show_sale_details)
         left_layout.addWidget(self.btn_estado)
 
+        self.btn_delete_sale = QPushButton("Eliminar venta")
+        self.btn_delete_sale.setStyleSheet("background-color: #b71c1c; color: #fff;")
+        self.btn_delete_sale.clicked.connect(self.delete_sale)
+        left_layout.addWidget(self.btn_delete_sale)
+
         left_widget = QWidget()
         left_widget.setLayout(left_layout)
 
@@ -339,6 +344,36 @@ class SalesTab(QWidget):
         from dialogs import VentaDetalleDialog
         dialog = VentaDetalleDialog(venta, detalles, self)
         dialog.exec_()
+
+    def delete_sale(self):
+        if self.sales_table.currentRow() < 0:
+            QMessageBox.warning(self, "Eliminar venta", "Seleccione una venta")
+            return
+        row = self.sales_table.currentRow()
+        venta_id = int(self.sales_table.item(row, 0).text())
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar venta",
+            "¿Desea eliminar la venta seleccionada y restaurar el inventario?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+        if not self.manager.db.delete_venta(venta_id):
+            QMessageBox.critical(
+                self,
+                "Eliminar venta",
+                "No se pudo eliminar la venta seleccionada.",
+            )
+            return
+        self.manager.refresh_data()
+        self.load_sales()
+        QMessageBox.information(
+            self,
+            "Eliminar venta",
+            "La venta se eliminó y el inventario fue restaurado.",
+        )
 
     def _clear_preview_files(self):
         """Remove temporary preview image without deleting stored PDFs."""

--- a/tests/test_db_stock_and_sales.py
+++ b/tests/test_db_stock_and_sales.py
@@ -68,3 +68,95 @@ def test_registrar_venta_detallada_creates_records():
     assert detalle['producto_id'] == product_id
     assert detalle['cantidad'] == 2
     assert detalle['precio_unitario'] == 10
+
+
+def test_delete_sale_restores_inventory():
+    db = DB(':memory:')
+    db.add_producto(
+        nombre='Prod',
+        codigo='P1',
+        sku=None,
+        vendedor_id=None,
+        Distribuidor_id=None,
+        precio_compra=1.0,
+        precio_venta_minorista=2.0,
+        precio_venta_mayorista=3.0,
+        stock=0,
+    )
+    product_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada({
+        'fecha': '2024-01-01',
+        'producto_id': product_id,
+        'cantidad': 10,
+        'precio_unitario': 1.0,
+        'total': 10,
+    })
+    db.add_detalle_compra(compra_id, product_id, 10, 1.0)
+    db.actualizar_stock_producto(product_id)
+
+    db.cursor.execute('SELECT id FROM detalles_compra WHERE compra_id=?', (compra_id,))
+    lote_id = db.cursor.fetchone()['id']
+
+    venta_id = db.add_venta('2024-01-02', 20)
+    db.add_detalle_venta(
+        venta_id,
+        product_id,
+        4,
+        5.0,
+        tipo_fiscal='Gravada',
+        extra={'lote_id': lote_id},
+    )
+
+    db.disminuir_stock_lote(lote_id, 4)
+    db.actualizar_stock_producto(product_id)
+
+    db.cursor.execute('SELECT cantidad FROM detalles_compra WHERE id=?', (lote_id,))
+    assert db.cursor.fetchone()['cantidad'] == 6
+    db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
+    assert db.cursor.fetchone()['stock'] == 6
+
+    assert db.delete_venta(venta_id)
+
+    db.cursor.execute('SELECT cantidad FROM detalles_compra WHERE id=?', (lote_id,))
+    assert db.cursor.fetchone()['cantidad'] == 10
+    db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
+    assert db.cursor.fetchone()['stock'] == 10
+
+
+def test_delete_sale_without_lote_info_restores_product_stock():
+    db = DB(':memory:')
+    db.add_producto(
+        nombre='Prod',
+        codigo='P1',
+        sku=None,
+        vendedor_id=None,
+        Distribuidor_id=None,
+        precio_compra=1.0,
+        precio_venta_minorista=2.0,
+        precio_venta_mayorista=3.0,
+        stock=8,
+    )
+    product_id = db.cursor.lastrowid
+
+    venta_id = db.add_venta('2024-01-02', 15)
+    db.add_detalle_venta(
+        venta_id,
+        product_id,
+        3,
+        5.0,
+        tipo_fiscal='Gravada',
+        extra=None,
+    )
+
+    # Simula la reducción de stock que ocurre al registrar la venta
+    db.cursor.execute('UPDATE productos SET stock = stock - 3 WHERE id=?', (product_id,))
+    db.conn.commit()
+
+    db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
+    assert db.cursor.fetchone()['stock'] == 5
+
+    assert db.delete_venta(venta_id)
+
+    db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
+    assert db.cursor.fetchone()['stock'] == 8

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -844,6 +844,11 @@ class MainWindow(QMainWindow):
                         continue
                     if prod["stock"] < item["cantidad"]:
                         raise ValueError(f"No hay suficiente stock para el producto {prod['nombre']}.")
+                    extra_data = item.get("extra") or (
+                        {"lote_id": item.get("lote_id"), "producto_id": item.get("producto_id"), "cantidad": item.get("cantidad")}
+                        if item.get("lote_id") is not None
+                        else None
+                    )
                     self.manager.db.add_detalle_venta(
                         venta_id,
                         prod["id"],
@@ -855,7 +860,7 @@ class MainWindow(QMainWindow):
                         item.get("comision_monto", 0),
                         item.get("iva_tipo", ""),
                         item.get("tipo_fiscal", "Gravada"),
-                        None,
+                        extra_data,
                         item.get("precio_con_iva", 0),
                         item.get("vendedor_id", vendedor_id)
                     )
@@ -1008,6 +1013,11 @@ class MainWindow(QMainWindow):
                         continue
                     if prod["stock"] < item["cantidad"]:
                         raise ValueError(f"No hay suficiente stock para el producto {prod['nombre']}.")
+                    extra_data = item.get("extra") or (
+                        {"lote_id": item.get("lote_id"), "producto_id": item.get("producto_id"), "cantidad": item.get("cantidad")}
+                        if item.get("lote_id") is not None
+                        else None
+                    )
                     self.manager.db.add_detalle_venta(
                         venta_id,
                         prod["id"],
@@ -1019,7 +1029,7 @@ class MainWindow(QMainWindow):
                         item.get("comision_monto", 0),
                         item.get("iva_tipo", ""),
                         item.get("tipo_fiscal", "Gravada"),
-                        item.get("extra", None),
+                        extra_data,
                         item.get("precio_con_iva", 0),
                         item.get("vendedor_id", vendedor_id)
                     )


### PR DESCRIPTION
## Summary
- add a delete button to the sales tab and wire it through existing management flows
- preserve lot metadata when saving sale details so deletions can recover inventory
- update `delete_venta` to restore lot quantities and add regression tests for both lot-aware and fallback scenarios

## Testing
- pytest tests/test_db_stock_and_sales.py

------
https://chatgpt.com/codex/tasks/task_e_68df8d7526848323a4624fd6d48ed2db