### PR TITLE
Actualizar inventario tras eliminar ventas

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -5321,6 +5321,14 @@ class FacturacionTab(QWidget):
             QMessageBox.critical(self, "Eliminar", "No se pudo eliminar la venta seleccionada.")
             return
         self.manager.refresh_data()
+        main_window = self.window()
+        if main_window and hasattr(main_window, "_actualizar_inventario_actual"):
+            try:
+                main_window._actualizar_inventario_actual()
+            except Exception:
+                logger.exception(
+                    "Error al actualizar inventario actual tras eliminar factura"
+                )
 
         self._cleanup_invoice_artifacts(
             venta_id,

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -368,6 +368,12 @@ class SalesTab(QWidget):
             )
             return
         self.manager.refresh_data()
+        main_window = self.window()
+        if main_window and hasattr(main_window, "_actualizar_inventario_actual"):
+            try:
+                main_window._actualizar_inventario_actual()
+            except Exception:
+                logger.exception("Error al actualizar inventario actual tras eliminar venta")
         self.load_sales()
         QMessageBox.information(
             self,


### PR DESCRIPTION
## Summary
- invocar la actualización de la pestaña de Inventario actual tras eliminar una venta desde la pestaña de Ventas
- replicar la actualización automática de inventario al borrar una factura desde la pestaña de Facturación

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe02a53c083239a964e0a82f0e6db