### PR TITLE
Capture venta metadata before cleanup to restore ticket correlativos

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -5228,21 +5228,54 @@ class FacturacionTab(QWidget):
         ticket_path=None,
         dte_json_path=None,
         archive_subdir=None,
+        extra_data=None,
     ):
         archive_dir = None
         if archive_subdir:
             archive_dir = self._ensure_archive_directory(archive_subdir)
 
+        if not isinstance(extra_data, dict):
+            extra_data = {}
+            if venta_id:
+                venta = None
+                try:
+                    venta = self.manager.db.get_venta_by_id(venta_id)
+                except Exception:
+                    venta = None
+                if venta:
+                    raw_extra = venta.get("extra")
+                    if isinstance(raw_extra, str) and raw_extra.strip():
+                        try:
+                            extra_data = json.loads(raw_extra)
+                        except Exception:
+                            extra_data = {}
+
         numero_control = None
-        if dte_json_path and os.path.exists(dte_json_path):
+        candidate_paths = []
+        if dte_json_path:
+            candidate_paths.append(dte_json_path)
+        for key in ("dteJsonPath", "jsonPath"):
+            candidate = extra_data.get(key) if isinstance(extra_data, dict) else None
+            if candidate and candidate not in candidate_paths:
+                candidate_paths.append(candidate)
+
+        resolved_json_path = None
+        for candidate in candidate_paths:
+            if not candidate or not os.path.exists(candidate):
+                continue
             try:
-                with open(dte_json_path, "r", encoding="utf-8") as fh:
+                with open(candidate, "r", encoding="utf-8") as fh:
                     jdata = json.load(fh)
                 ident = jdata.get("identificacion") or jdata.get("identificador") or {}
                 numero_control = ident.get("numeroControl")
             except Exception:
                 numero_control = None
+            else:
+                resolved_json_path = candidate
+                break
 
+        if resolved_json_path:
+            dte_json_path = resolved_json_path
             abs_json = os.path.normpath(dte_json_path)
             for root_dir in map(
                 os.path.normpath, (DTES_DIR, DTE_FALLIDOS_DIR, DTES_PENDIENTES_DIR)
@@ -5256,6 +5289,9 @@ class FacturacionTab(QWidget):
                         except OSError:
                             pass
                     break
+
+        if not numero_control and isinstance(extra_data, dict):
+            numero_control = extra_data.get("numeroControl")
 
         if numero_control:
             m = re.match(r"^DTE-(\d{2})-S(\d{3})P(\d{3})-(\d{15})$", numero_control)
@@ -5300,6 +5336,20 @@ class FacturacionTab(QWidget):
             venta_id, factura=factura, entry=entry
         )
 
+        venta = None
+        extra_data = {}
+        try:
+            venta = self.manager.db.get_venta_by_id(venta_id)
+        except Exception:
+            venta = None
+        if venta:
+            raw_extra = venta.get("extra")
+            if isinstance(raw_extra, str) and raw_extra.strip():
+                try:
+                    extra_data = json.loads(raw_extra)
+                except Exception:
+                    extra_data = {}
+
         numero_control = None
         if dte_json_path and os.path.exists(dte_json_path):
             try:
@@ -5328,6 +5378,7 @@ class FacturacionTab(QWidget):
             ticket_path=ticket_path,
             dte_json_path=dte_json_path,
             archive_subdir=archive_label,
+            extra_data=extra_data,
         )
 
         self.load_invoices()
@@ -5388,6 +5439,20 @@ class FacturacionTab(QWidget):
             venta_id, factura=factura, entry=data
         )
 
+        venta = None
+        extra_data = {}
+        try:
+            venta = self.manager.db.get_venta_by_id(venta_id)
+        except Exception:
+            venta = None
+        if venta:
+            raw_extra = venta.get("extra")
+            if isinstance(raw_extra, str) and raw_extra.strip():
+                try:
+                    extra_data = json.loads(raw_extra)
+                except Exception:
+                    extra_data = {}
+
         if not self.manager.db.delete_venta(venta_id):
             QMessageBox.critical(self, "Eliminar", "No se pudo eliminar la venta seleccionada.")
             return
@@ -5398,6 +5463,7 @@ class FacturacionTab(QWidget):
             pdf_path=pdf_path,
             ticket_path=ticket_path,
             dte_json_path=dte_json_path,
+            extra_data=extra_data,
         )
 
         QMessageBox.information(self, "Eliminar", "Factura eliminada")


### PR DESCRIPTION
## Summary
- capture and pass venta.extra metadata before deleting sales so cleanup can locate DTE JSON and numeroControl
- allow cleanup routine to accept pre-parsed metadata, preventing loss of correlativo information when removing tickets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfde8a4580832387332bb40097291f