### PR TITLE
Load tickets from DB and align deletion flow

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2286,24 +2286,46 @@ class FacturacionTab(QWidget):
         """
 
         cur = self.manager.db.cursor
-        cur.execute(
-            "SELECT id, venta_id, tipo, ruta, fecha_creacion FROM facturas_pdf"
-        )
-        records = cur.fetchall()
+        factura_records: list[dict[str, Any]] = []
+        ticket_records: list[dict[str, Any]] = []
+
+        try:
+            cur.execute(
+                "SELECT id, venta_id, tipo, ruta, fecha_creacion FROM facturas_pdf"
+            )
+            for row in cur.fetchall():
+                rec = dict(row)
+                rec["_source"] = "factura"
+                factura_records.append(rec)
+        except Exception:
+            factura_records = []
+
+        try:
+            cur.execute(
+                "SELECT id, venta_id, ruta, fecha_creacion FROM tickets_pdf"
+            )
+            for row in cur.fetchall():
+                rec = dict(row)
+                rec["_source"] = "ticket"
+                rec.setdefault("tipo", "Ticket")
+                ticket_records.append(rec)
+        except Exception:
+            ticket_records = []
+
+        records = factura_records + ticket_records
         rows = []
         for rec in records:
-            try:
-                doc_tipo = rec["tipo"]
-            except (KeyError, IndexError):
-                doc_tipo = None
+            source = rec.pop("_source", "factura")
+            doc_tipo = rec.get("tipo")
             tipo_lower = str(doc_tipo or "").strip().lower()
             venta = None
-            if rec["venta_id"] is not None and not tipo_lower.startswith("nota"):
-                venta = self.manager.db.get_venta_by_id(rec["venta_id"])
-            ruta = rec["ruta"]
+            venta_id = rec.get("venta_id")
+            if venta_id is not None and not tipo_lower.startswith("nota"):
+                venta = self.manager.db.get_venta_by_id(venta_id)
+            ruta = rec.get("ruta")
             json_path = os.path.splitext(ruta)[0] + ".json" if ruta else None
 
-            fecha_creacion = rec["fecha_creacion"] or ""
+            fecha_creacion = rec.get("fecha_creacion") or ""
             fdate = None
             if fecha_creacion:
                 try:
@@ -2342,9 +2364,12 @@ class FacturacionTab(QWidget):
                 cliente_id = venta.get("cliente_id")
                 vendedor_id = venta.get("vendedor_id")
                 total = venta.get("total")
-                row_type = "ticket" if self._is_ticket_sale(venta) else "venta"
+                if source == "ticket":
+                    row_type = "ticket"
+                else:
+                    row_type = "ticket" if self._is_ticket_sale(venta) else "venta"
             else:
-                row_type = "orphan"
+                row_type = "ticket" if source == "ticket" else "orphan"
                 if ident_data:
                     numero_control = ident_data.get("numeroControl")
                     codigo_generacion = ident_data.get("codigoGeneracion")
@@ -2389,8 +2414,8 @@ class FacturacionTab(QWidget):
                 base_name = numero_control or ""
             row = {
                 "row_type": row_type,
-                "id": rec["id"],
-                "venta_id": rec["venta_id"],
+                "id": rec.get("id"),
+                "venta_id": venta_id,
                 "name": base_name,
                 "fecha": fecha_str,
                 "_parsed_fecha": fdate,

--- a/tests/test_facturacion_tab_loading.py
+++ b/tests/test_facturacion_tab_loading.py
@@ -2,6 +2,9 @@ import os
 import json
 import pytest
 from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QDate
 
@@ -55,6 +58,50 @@ def test_filters_documents(qt_app, tmp_path, monkeypatch):
     tab.search_bar.setText("")
     tab.load_invoices()
     assert tab.table.rowCount() == 1
+
+
+def test_ticket_rows_loaded_from_db(qt_app, tmp_path, monkeypatch):
+    ticket_dir = tmp_path / "tickets"
+    ticket_dir.mkdir()
+    pdf_path = ticket_dir / "20240103_Test_1_Ticket.pdf"
+    pdf_path.write_text("pdf")
+    json_data = {
+        "identificacion": {
+            "numeroControl": "DTE-01-S001P001-000000000000123",
+            "tipoDte": "01",
+        }
+    }
+    (ticket_dir / "20240103_Test_1_Ticket.json").write_text(json.dumps(json_data))
+
+    db = DB(":memory:")
+    venta_id = db.add_venta("2024-01-03", 5)
+    db.add_ticket_pdf(venta_id, str(pdf_path))
+
+    manager = SimpleNamespace(db=db, _clientes=[], _Distribuidores=[])
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(tmp_path / "cf"))
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(tmp_path / "cfiscal"))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(ticket_dir))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_DEBITO_DIR", str(tmp_path / "nd"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_CREDITO_DIR", str(tmp_path / "nc"))
+    monkeypatch.setattr(facturacion_tab, "NOTAS_REMISION_DIR", str(tmp_path / "nr"))
+    monkeypatch.setattr(facturacion_tab, "ADDITIONAL_DIRS", [])
+
+    tab = facturacion_tab.FacturacionTab(manager)
+    rows = tab._get_invoices_from_db()
+    ticket_rows = [r for r in rows if r.get("venta_id") == venta_id]
+    assert ticket_rows, "expected ticket entry from database"
+    ticket_entry = ticket_rows[0]
+    assert ticket_entry["row_type"] == "ticket"
+    assert ticket_entry["tipo"] == "Ticket"
+
+    docs = tab._scan_documents()
+    names = [r.get("name") for r in docs if r.get("venta_id") == venta_id]
+    assert ticket_entry["name"] in names
+    assert not any(
+        r.get("row_type") == "orphan" and r.get("name") == ticket_entry["name"]
+        for r in docs
+    )
 
 
 def test_orders_by_datetime(qt_app, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- load ticket documents from the tickets_pdf table so they are treated as ticket rows with their venta_id
- ensure ticket deletions reuse the existing invoice cleanup path that restores inventory and reverts correlativos
- add a regression test covering ticket retrieval from the database and prevent orphan duplicates

## Testing
- pytest tests/test_facturacion_tab_loading.py::test_ticket_rows_loaded_from_db


------
https://chatgpt.com/codex/tasks/task_e_68dfee5156a483239ae03458009c5563