### PR TITLE
Add update build mode excluding sensitive artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Pasos sugeridos:
    El ejecutable quedará en `dist/InventarioFarmacia` (en Windows se generará
    `InventarioFarmacia.exe`).
 
+   Para distribuir una **actualización limpia** sin el firmador ni archivos
+   con datos reales recopilados durante el desarrollo, utiliza el modo
+   `update`:
+
+   ```bash
+   python setup.py --mode update
+   ```
+
+   Esta variante conserva la lógica del ejecutable pero excluye directorios y
+   archivos sensibles como `svfe-api-firmador/`, bases de datos SQLite, DTE
+   firmados, respaldos y configuraciones reales (`datos_negocio.json`,
+   `config_negocio.json`, `ultimo_inventario.json`, etc.).
+
 3. Prueba el resultado en un entorno sin el código fuente. En Linux puedes
    validar que los recursos estén presentes ejecutando:
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
+import argparse
+import fnmatch
 import os
 import pkgutil
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional, Sequence, Set
 
 import PyInstaller.__main__
 
@@ -10,7 +13,7 @@ SEP = ';' if os.name == 'nt' else ':'
 ROOT = Path(__file__).resolve().parent
 
 
-EXCLUDED_DIR_NAMES = {
+DEFAULT_EXCLUDED_DIR_NAMES = {
     '.git',
     '.github',
     '.mypy_cache',
@@ -24,12 +27,12 @@ EXCLUDED_DIR_NAMES = {
     'tests',
 }
 
-EXCLUDED_FILE_NAMES = {
+DEFAULT_EXCLUDED_FILE_NAMES = {
     '.DS_Store',
     '.python-version',
 }
 
-EXCLUDED_SUFFIXES = {
+DEFAULT_EXCLUDED_SUFFIXES = {
     '.key',
     '.pem',
     '.pub',
@@ -39,15 +42,91 @@ EXCLUDED_SUFFIXES = {
     '.tmp',
 }
 
+DEFAULT_EXCLUDED_PREFIXES: Set[str] = set()
 
-def _should_exclude(path: Path, *, is_dir: bool) -> bool:
-    if any(part in EXCLUDED_DIR_NAMES for part in path.parts):
+
+@dataclass(frozen=True)
+class BuildConfig:
+    name: str
+    excluded_dir_names: Set[str]
+    excluded_file_names: Set[str]
+    excluded_suffixes: Set[str]
+    excluded_prefixes: Set[str]
+    excluded_globs: Set[str]
+
+    @classmethod
+    def full(cls) -> "BuildConfig":
+        return cls(
+            name="full",
+            excluded_dir_names=set(DEFAULT_EXCLUDED_DIR_NAMES),
+            excluded_file_names=set(DEFAULT_EXCLUDED_FILE_NAMES),
+            excluded_suffixes=set(DEFAULT_EXCLUDED_SUFFIXES),
+            excluded_prefixes=set(DEFAULT_EXCLUDED_PREFIXES),
+            excluded_globs=set(),
+        )
+
+    @classmethod
+    def update(cls) -> "BuildConfig":
+        sensitive_dirs = {
+            'artifacts',
+            'dte_fallidos',
+            'dte_firmados',
+            'dtes',
+            'dtes_pendientes',
+            'logs',
+            'tickets',
+            'svfe-api-firmador',
+        }
+
+        sensitive_files = {
+            'config_negocio.json',
+            'datos_negocio.json',
+            'inventario.db',
+            'ultimo_inventario.json',
+        }
+
+        sensitive_suffixes = {
+            '.bak',
+            '.crt',
+            '.db',
+            '.sqlite',
+            '.sqlite3',
+        }
+
+        sensitive_prefixes = {
+            'dte_firmado',
+            'facturas_',
+        }
+
+        config = cls.full()
+        return cls(
+            name="update",
+            excluded_dir_names=config.excluded_dir_names | sensitive_dirs,
+            excluded_file_names=config.excluded_file_names | sensitive_files,
+            excluded_suffixes=config.excluded_suffixes | sensitive_suffixes,
+            excluded_prefixes=config.excluded_prefixes | sensitive_prefixes,
+            excluded_globs=config.excluded_globs
+            | {
+                '*.sqlite',
+                '*.sqlite3',
+                '*.db',
+                '*.bak',
+            },
+        )
+
+
+def _should_exclude(path: Path, *, is_dir: bool, config: BuildConfig) -> bool:
+    if any(part in config.excluded_dir_names for part in path.parts):
         return True
 
     if not is_dir:
-        if path.name in EXCLUDED_FILE_NAMES:
+        if path.name in config.excluded_file_names:
             return True
-        if path.suffix.lower() in EXCLUDED_SUFFIXES:
+        if any(path.name.startswith(prefix) for prefix in config.excluded_prefixes):
+            return True
+        if path.suffix.lower() in config.excluded_suffixes:
+            return True
+        if any(fnmatch.fnmatch(path.name, pattern) for pattern in config.excluded_globs):
             return True
 
     return False
@@ -60,7 +139,7 @@ def _destination_for(path: Path) -> str:
     return relative_parent.as_posix()
 
 
-def collect_add_data(root: Path) -> Iterable[str]:
+def collect_add_data(root: Path, *, config: BuildConfig) -> Iterable[str]:
     entries: List[str] = []
     for dirpath, dirnames, filenames in os.walk(root):
         current_dir = Path(dirpath)
@@ -69,12 +148,12 @@ def collect_add_data(root: Path) -> Iterable[str]:
         dirnames[:] = [
             dirname
             for dirname in dirnames
-            if not _should_exclude(current_dir / dirname, is_dir=True)
+            if not _should_exclude(current_dir / dirname, is_dir=True, config=config)
         ]
 
         for filename in filenames:
             file_path = current_dir / filename
-            if _should_exclude(file_path, is_dir=False):
+            if _should_exclude(file_path, is_dir=False, config=config):
                 continue
 
             destination = _destination_for(file_path)
@@ -83,7 +162,23 @@ def collect_add_data(root: Path) -> Iterable[str]:
     return entries
 
 
-add_data = list(collect_add_data(ROOT))
+def build(config: BuildConfig, additional_args: Optional[Sequence[str]] = None) -> None:
+    add_data = list(collect_add_data(ROOT, config=config))
+    hidden_imports = list(collect_hidden_imports())
+
+    args = [
+        'main.py',
+        '--name=InventarioFarmacia',
+        '--onefile',
+        '--windowed',
+        *[arg for item in add_data for arg in ('--add-data', item)],
+        *[arg for module in hidden_imports for arg in ('--hidden-import', module)],
+    ]
+
+    if additional_args:
+        args.extend(additional_args)
+
+    PyInstaller.__main__.run(args)
 
 
 def collect_hidden_imports() -> Iterable[str]:
@@ -99,13 +194,30 @@ def collect_hidden_imports() -> Iterable[str]:
     return modules
 
 
-hidden_imports = list(collect_hidden_imports())
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Empaquetador de InventarioFarmacia')
+    parser.add_argument(
+        '--mode',
+        choices=('full', 'update'),
+        default='full',
+        help=(
+            'Selecciona el tipo de build. "full" replica el instalador original. '
+            '"update" excluye el firmador y archivos con datos sensibles para '
+            'distribuir actualizaciones a clientes.'
+        ),
+    )
+    return parser.parse_args()
 
-PyInstaller.__main__.run([
-    'main.py',
-    '--name=InventarioFarmacia',
-    '--onefile',
-    '--windowed',
-    *[arg for item in add_data for arg in ('--add-data', item)],
-    *[arg for module in hidden_imports for arg in ('--hidden-import', module)],
-])
+
+def main() -> None:
+    args = parse_args()
+    if args.mode == 'update':
+        config = BuildConfig.update()
+    else:
+        config = BuildConfig.full()
+
+    build(config)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add argument parsing to setup.py to support a sanitized update build that skips the firmador and sensitive artefacts
- document the new `--mode update` build workflow in the README

## Testing
- python -m compileall setup.py

------
https://chatgpt.com/codex/tasks/task_e_68df8e27c5e08323bee789b2f6071c17