### PR TITLE
Add warning prompt when signer service is offline

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -107,6 +107,11 @@ SNAPSHOT_MISSING_MESSAGE = (
     "Seleccione el documento original o regenere el snapshot antes de enviar."
 )
 GENERIC_SEND_ERROR = "No se pudo enviar el documento. Revise los registros y reintente."
+SIGNER_DOWN_WARNING = (
+    "El firmador no está corriendo, si desea proceder enviando el DTE hay altas "
+    "probabilidades de ser rechazado, se recomienda iniciar el firmador en "
+    "configuración y luego enviar el DTE"
+)
 
 # Directory where debit notes will be stored
 # Paths are provided by ``paths`` to keep user data outside the installation
@@ -3121,6 +3126,37 @@ class FacturacionTab(QWidget):
         )
         return any(keyword in text for keyword in keywords)
 
+    @staticmethod
+    def _is_signer_connection_error(exc: Exception) -> bool:
+        text = str(exc or "").strip().lower()
+        if not text or "error al firmar" not in text:
+            return False
+        connection_keywords = (
+            "failed to establish a new connection",
+            "connection refused",
+            "no se puede establecer una conexión",
+            "max retries exceeded",
+        )
+        if any(keyword in text for keyword in connection_keywords):
+            return True
+        cause = getattr(exc, "__cause__", None)
+        while cause is not None:
+            if isinstance(cause, ConnectionRefusedError):
+                return True
+            cause = getattr(cause, "__cause__", None)
+        return False
+
+    def _confirm_send_without_signer(self) -> bool:
+        msg = QMessageBox(self)
+        msg.setIcon(QMessageBox.Warning)
+        msg.setWindowTitle("Enviar a Hacienda")
+        msg.setText(SIGNER_DOWN_WARNING)
+        send_button = msg.addButton("Enviar sin el firmador", QMessageBox.AcceptRole)
+        cancel_button = msg.addButton("Cancelar", QMessageBox.RejectRole)
+        msg.setDefaultButton(cancel_button)
+        msg.exec_()
+        return msg.clickedButton() == send_button
+
     def _report_snapshot_missing(self, exc: SnapshotNotFoundError) -> None:
         venta_id = getattr(exc, "venta_id", None)
         nota_id = getattr(exc, "nota_id", None)
@@ -3431,12 +3467,20 @@ class FacturacionTab(QWidget):
                     if self._is_auth_runtime_error(exc):
                         QMessageBox.warning(self, "Enviar a Hacienda", token_msg)
                     else:
-                        logger.exception("Error al enviar documento", exc_info=exc)
-                        QMessageBox.critical(
-                            self,
-                            "Enviar a Hacienda",
-                            GENERIC_SEND_ERROR,
-                        )
+                        if self._is_signer_connection_error(exc):
+                            logger.warning(
+                                "Firmador no disponible al enviar documento",
+                                exc_info=exc,
+                            )
+                            if not self._confirm_send_without_signer():
+                                return
+                        else:
+                            logger.exception("Error al enviar documento", exc_info=exc)
+                            QMessageBox.critical(
+                                self,
+                                "Enviar a Hacienda",
+                                GENERIC_SEND_ERROR,
+                            )
                 except Exception as exc:
                     print("UI: EXC_CAUGHT", type(exc).__name__, str(exc)[:200])
                     logger.exception("Error inesperado al enviar documento", exc_info=exc)

--- a/tests/test_dtejson_object.py
+++ b/tests/test_dtejson_object.py
@@ -22,6 +22,19 @@ def test_sign_json_sends_dtejson_as_object(monkeypatch):
                 return {"status": "OK", "body": "<JWS>"}
         return R()
 
+    def fake_get(url, timeout=None):
+        captured["health"] = {"url": url, "timeout": timeout}
+
+        class R:
+            status_code = 200
+            text = "OK"
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr(jws.requests, "get", fake_get)
     monkeypatch.setattr(jws.requests, "post", fake_post)
 
     payload = '{"identificacion":{"version":"1","tipoDte":"01"}}'
@@ -49,6 +62,19 @@ def test_sign_json_converts_decimal_values(monkeypatch):
                 return {"status": "OK", "body": "<JWS>"}
         return R()
 
+    def fake_get(url, timeout=None):
+        captured["health"] = {"url": url, "timeout": timeout}
+
+        class R:
+            status_code = 200
+            text = "OK"
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr(jws.requests, "get", fake_get)
     monkeypatch.setattr(jws.requests, "post", fake_post)
 
     payload = {"identificacion": {"version": "1", "tipoDte": "01"}, "monto": Decimal("1.50")}
@@ -56,3 +82,41 @@ def test_sign_json_converts_decimal_values(monkeypatch):
 
     assert isinstance(captured["json"]["dteJson"], dict)
     assert isinstance(captured["json"]["dteJson"]["monto"], float)
+
+
+def test_sign_json_health_check_allows_missing_endpoint(monkeypatch):
+    monkeypatch.setattr(jws, "_ensure_cert_file", lambda nit: None)
+
+    def fake_get(url, timeout=None):
+
+        class R:
+            status_code = 404
+            text = "Not Found"
+
+            def raise_for_status(self):
+                raise AssertionError("raise_for_status should not be called")
+
+        return R()
+
+    def fake_post(url, json=None, timeout=None):
+
+        class R:
+            status_code = 200
+            text = "OK"
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": "OK", "body": "<JWS>"}
+
+        return R()
+
+    monkeypatch.setattr(jws.requests, "get", fake_get)
+    monkeypatch.setattr(jws.requests, "post", fake_post)
+
+    payload = {"identificacion": {"version": "1", "tipoDte": "01"}}
+
+    token = jws.sign_json(payload, nit="X", passwordPri="Y")
+
+    assert token == "<JWS>"

--- a/tests/test_signer_doctor.py
+++ b/tests/test_signer_doctor.py
@@ -86,6 +86,9 @@ class _SignerHandler(BaseHTTPRequestHandler):
         if parsed.path == "/firma/debug/env":
             self._json_response({"env": self.server.env})
             return
+        if parsed.path == "/firma/firmardocumento/status":
+            self._json_response({"status": "OK"})
+            return
         self.send_error(404)
 
     def do_POST(self) -> None:  # noqa: N802

--- a/utils/jws.py
+++ b/utils/jws.py
@@ -4,6 +4,7 @@ import base64
 import requests
 import logging
 from pathlib import Path
+from urllib.parse import urljoin
 
 from utils.stable_json import (
     stable_stringify,
@@ -26,6 +27,7 @@ from utils.certificates import (
 )
 DEFAULT_SIGN_URL = "http://127.0.0.1:8080/firma/firmardocumento/"
 SIGN_TIMEOUT = float(os.getenv("SIGN_TIMEOUT", "10"))
+SIGN_HEALTH_TIMEOUT = float(os.getenv("SIGN_HEALTH_TIMEOUT", "3"))
 
 SEND_DTEJSON_AS_OBJECT = os.getenv("SEND_DTEJSON_AS_OBJECT", "1") == "1"
 
@@ -56,6 +58,60 @@ def _get_sign_url(path: str = CONFIG_NEGOCIO_PATH) -> str:
         except Exception:
             pass
     return url or DEFAULT_SIGN_URL
+
+
+def _build_signer_status_url(sign_url: str | None) -> str | None:
+    """Return health-check URL for ``sign_url`` if possible."""
+
+    if not sign_url:
+        return None
+    if not sign_url.endswith("/"):
+        sign_url = f"{sign_url}/"
+    return urljoin(sign_url, "status")
+
+
+def _check_signer_available(sign_url: str | None) -> None:
+    """Perform a lightweight health check before signing."""
+
+    status_url = _build_signer_status_url(sign_url)
+    if not status_url:
+        return
+
+    try:
+        logger.debug("SIGN.HEALTH.CHECK: url=%s", status_url)
+        response = requests.get(status_url, timeout=SIGN_HEALTH_TIMEOUT)
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        print("SIGN: HEALTH_ERROR", type(exc).__name__, str(exc)[:200])
+        raise RuntimeError(f"Error al firmar: {exc}") from exc
+
+    if response.status_code in {404, 405}:
+        # Older firmador builds do not expose a status endpoint; assume ready.
+        logger.debug(
+            "SIGN.HEALTH.SKIP: endpoint unavailable status=%s", response.status_code
+        )
+        return
+
+    if response.status_code >= 500:
+        print(
+            "SIGN: HEALTH_ERROR",
+            f"HTTP {response.status_code}",
+            str(getattr(response, "text", ""))[:200],
+        )
+        raise RuntimeError(
+            f"Error al firmar: verificación del firmador devolvió HTTP {response.status_code}"
+        )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        print("SIGN: HEALTH_ERROR", type(exc).__name__, str(exc)[:200])
+        raise RuntimeError(f"Error al firmar: {exc}") from exc
+
+    logger.debug(
+        "SIGN.HEALTH.OK: status=%s body=%s",
+        response.status_code,
+        (response.text or "").strip(),
+    )
 
 
 def _load_config(path: str = CONFIG_NEGOCIO_PATH):
@@ -138,6 +194,8 @@ def sign_json(
         "REMOTE_SIGNER?",
         url is not None,
     )
+
+    _check_signer_available(url)
 
     if passwordPri:
         logger.info(


### PR DESCRIPTION
## Summary
- add a dedicated warning message when the signer service connection fails
- prompt the user to cancel or continue without the signer instead of showing the generic error
- verify signer availability with a status ping before attempting to sign and update supporting tests

## Testing
- pytest tests/test_dtejson_object.py tests/test_signer_doctor.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ab1c9ac483239abedc25b98e9b8f