### PR TITLE
Allow configuring accepted ambientes during prevalidation

### DIFF
--- a/svfe/prevalidate.py
+++ b/svfe/prevalidate.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 
 # Keys that may be present in a document returned by MH after processing but
@@ -52,14 +52,18 @@ def _decode_jws(jws: str) -> Dict[str, Any]:
 
 
 def prevalidate_envelope(
-    sobre: Dict[str, Any], jws: str, schema_path: str | None = None
+    sobre: Dict[str, Any],
+    jws: str,
+    schema_path: str | None = None,
+    allowed_ambientes: Iterable[str] | None = None,
 ) -> None:
     """Pre-validate an envelope ``sobre`` and its signed payload ``jws``.
 
     The function verifies basic envelope consistency (``tipoDte``,
     ``codigoGeneracion`` and ``ambiente``) but no longer validates the payload
     against a JSON schema.  ``schema_path`` is accepted for backwards
-    compatibility and ignored.
+    compatibility and ignored.  ``allowed_ambientes`` can be used to specify the
+    accepted values for ``identificacion.ambiente`` (``"00"`` por defecto).
     """
 
     payload = _decode_jws(jws)
@@ -76,7 +80,12 @@ def prevalidate_envelope(
     assert (
         sobre["codigoGeneracion"] == ident.get("codigoGeneracion")
     ), "codigoGeneracion no coincide"
-    assert ident.get("ambiente") == "00", "ambiente debe ser '00' en pruebas"
+
+    ambientes = tuple(allowed_ambientes or ("00",))
+    ambiente = ident.get("ambiente")
+    assert ambiente in ambientes, (
+        f"ambiente debe ser uno de {', '.join(sorted(ambientes))}"
+    )
 
 
 # Backwards compatibility -----------------------------------------------------

--- a/tests/test_envio_hacienda.py
+++ b/tests/test_envio_hacienda.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 import auth
 import dte
+from svfe.prevalidate import prevalidate_envelope
 
 from db import DB
 from dte import transmitir_dte
@@ -20,6 +21,29 @@ def create_sale(db):
     venta_id = db.add_venta("2024-01-01", 10)
     db.add_detalle_venta(venta_id, pid, 1, 10, vendedor_id=vid)
     return venta_id
+
+
+def _make_envelope(ambiente: str):
+    codigo = "00000000-0000-4000-8000-000000000999"
+    sobre = {"tipoDte": "01", "codigoGeneracion": codigo}
+    payload = {
+        "identificacion": {
+            "tipoDte": "01",
+            "codigoGeneracion": codigo,
+            "ambiente": ambiente,
+        }
+    }
+    return sobre, make_jws(payload)
+
+
+def test_prevalidate_envelope_accepts_pruebas():
+    sobre, jws = _make_envelope("00")
+    prevalidate_envelope(sobre, jws)
+
+
+def test_prevalidate_envelope_accepts_produccion():
+    sobre, jws = _make_envelope("01")
+    prevalidate_envelope(sobre, jws, allowed_ambientes=("00", "01"))
 
 
 def test_transmision_exitosa(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- allow specifying the accepted identificacion.ambiente values when prevalidating envelopes
- add focused tests that cover both pruebas and produccion environments without assertion failures

## Testing
- pytest tests/test_envio_hacienda.py -k prevalidate

------
https://chatgpt.com/codex/tasks/task_e_68e1d252e67c832393f9858f3213e295