### PR TITLE
Auto-fill crédito fiscal remisión number from correlativo

### DIFF
--- a/db.py
+++ b/db.py
@@ -2304,6 +2304,23 @@ class DB:
         logger.debug("Correlativo asignado %s", correlativo)
         return correlativo
 
+    def peek_next_dte_correlativo(self, tipo: str, sucursal: str, punto: str) -> int:
+        """Devuelve el siguiente correlativo sin persistir cambios."""
+
+        with self.lock:
+            self.cursor.execute(
+                "SELECT correlativo FROM dte_correlativos WHERE tipo=? AND sucursal=? AND punto=?",
+                (tipo, sucursal, punto),
+            )
+            row = self.cursor.fetchone()
+        if row is None:
+            return 1
+        try:
+            current = int(row["correlativo"])
+        except (TypeError, ValueError, KeyError):
+            current = int(row[0])
+        return current + 1
+
     def add_dte_pendiente(self, venta_id, dte_json, modo):
         """Registra un DTE pendiente de transmisión a Hacienda."""
         fecha = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -32,6 +32,7 @@ from utils.certificates import copy_certificate_to_signer_dir, resolve_signer_ce
 from utils.catalogos import CONTINGENCIA
 from utils.sanitize import solo_digitos
 from svfe.config import CAT012_DEPARTAMENTOS, CAT013_MUNICIPIOS
+from dte import peek_next_correlativo
 getcontext().prec = 28
 getcontext().rounding = ROUND_HALF_UP
 IVA_RATE = Decimal("0.13")
@@ -2338,6 +2339,7 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
         self._on_descuento_tipo_changed()
         self._update_condicion_pago_fields()
         self.load_payment_data(venta_extra)
+        self._autofill_remision_fields(venta_extra)
 
     def set_productos_data(self, productos_data):
         self.productos_data = productos_data
@@ -2759,6 +2761,37 @@ class RegisterCreditoFiscalDialog(QDialog, ProductDialogBase):
             if referencia:
                 self.referencia_edit.setText(str(referencia))
         self._update_condicion_pago_fields()
+
+    def _autofill_remision_fields(self, venta_extra):
+        data = {}
+        if isinstance(venta_extra, str):
+            try:
+                data = json.loads(venta_extra)
+            except (TypeError, ValueError):
+                data = {}
+        elif isinstance(venta_extra, dict):
+            data = dict(venta_extra)
+
+        existing_remision = str(
+            (data.get("no_remision") or data.get("noRemision") or "")
+        ).strip()
+        existing_orden = str((data.get("orden_no") or data.get("ordenNo") or "")).strip()
+
+        if existing_remision:
+            self.no_remision_edit.setText(existing_remision)
+        if existing_orden:
+            self.orden_no_edit.setText(existing_orden)
+
+        if self.no_remision_edit.text().strip() and self.orden_no_edit.text().strip():
+            return
+
+        _, remision = peek_next_correlativo(self.db, "03")
+        if not remision:
+            return
+        if not self.no_remision_edit.text().strip():
+            self.no_remision_edit.setText(remision)
+        if not self.orden_no_edit.text().strip():
+            self.orden_no_edit.setText(remision)
 
 class DistribuidorDialog(QDialog):
     def __init__(self, parent=None, Distribuidor=None):

--- a/dte.py
+++ b/dte.py
@@ -2898,6 +2898,42 @@ def _format_numero_control(tipo: str, sucursal: str, punto: str, correlativo: in
     return f"DTE-{tipo}-S{sucursal}P{punto}-{secuencia}"
 
 
+def _derive_remision_from_correlativo(value: int | str | None) -> str | None:
+    """Deriva el número de remisión a partir de un correlativo numérico."""
+
+    if value is None:
+        return None
+    digits = "".join(ch for ch in str(value) if ch.isdigit())
+    if not digits:
+        return None
+    return digits[-4:].zfill(4)
+
+
+def peek_next_correlativo(db: DB | None, tipo_dte: str) -> tuple[int | None, str | None]:
+    """Obtiene el correlativo siguiente y su remisión derivada sin consumirlo."""
+
+    if db is None:
+        return None, None
+    preview_getter = getattr(db, "peek_next_dte_correlativo", None)
+    if not callable(preview_getter):
+        return None, None
+    datos = _load_datos_negocio()
+    prefijo = str(datos.get("dte_api", {}).get("prefijo_control", ""))
+    sucursal = "001"
+    punto = "001"
+    match = re.search(r"S(\d{3})P(\d{3})", prefijo)
+    if match:
+        sucursal, punto = match.groups()
+    sucursal = _norm3(sucursal)
+    punto = _norm3(punto)
+    try:
+        correlativo = preview_getter(tipo_dte, sucursal, punto)
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Fallo al previsualizar correlativo para tipo %s", tipo_dte)
+        return None, None
+    return correlativo, _derive_remision_from_correlativo(correlativo)
+
+
 def generar_numero_control(
     db: DB, tipo: str, sucursal: str, punto: str
 ) -> tuple[str, int]:
@@ -3378,7 +3414,9 @@ def generar_dte_json(
                     "correo",
                     "direccion",
                 ]
-                fields_to_remove = ["noRemision", "ordenNo", "numDocumento", "tipoDocumento"]
+                fields_to_remove = ["numDocumento", "tipoDocumento"]
+                if tipo_dte != "03":
+                    fields_to_remove.extend(["noRemision", "ordenNo"])
                 for f in fields_to_remove:
                     receptor.pop(f, None)
 
@@ -4547,9 +4585,19 @@ def validate_dte_json(
                 "correo",
                 "direccion",
             ]
+            if tipo_dte == "03":
+                base_remision = correlativo if correlativo is not None else numero_control
+                derived_remision = _derive_remision_from_correlativo(base_remision)
+                if derived_remision:
+                    if not receptor.get("noRemision"):
+                        receptor["noRemision"] = derived_remision
+                    if not receptor.get("ordenNo"):
+                        receptor["ordenNo"] = derived_remision
             for f in required_rec_fields:
                 receptor.setdefault(f, None)
-            fields_to_remove = ["noRemision", "ordenNo", "numDocumento", "tipoDocumento"]
+            fields_to_remove = ["numDocumento", "tipoDocumento"]
+            if tipo_dte != "03":
+                fields_to_remove.extend(["noRemision", "ordenNo"])
             for f in fields_to_remove:
                 receptor.pop(f, None)
         payload["receptor"] = receptor

--- a/tests/test_credito_fiscal_dialog_iva.py
+++ b/tests/test_credito_fiscal_dialog_iva.py
@@ -178,3 +178,41 @@ def test_get_data_credito_fiscal_discount_total(qt_app):
     assert data["total"] == pytest.approx(13.5)
     assert f"{data['total']:.2f}" == "13.50"
     assert data["descuentos"] == pytest.approx(1.32743363)
+
+
+def test_dialog_autofills_remision_from_correlativo(monkeypatch, qt_app):
+    import dte as dte_module
+
+    monkeypatch.setattr(
+        dte_module,
+        "_load_datos_negocio",
+        lambda: {"dte_api": {"prefijo_control": "DTE-03-S987P654"}},
+    )
+
+    class DummyDB:
+        def __init__(self):
+            self.calls = []
+
+        def peek_next_dte_correlativo(self, tipo, sucursal, punto):
+            self.calls.append((tipo, sucursal, punto))
+            return 12
+
+    productos = [
+        {
+            "lote_id": 1,
+            "producto_id": 1,
+            "nombre": "Producto X",
+            "precio_venta_minorista": 1,
+            "precio_venta_mayorista": 1,
+            "Distribuidor_id": 1,
+        }
+    ]
+    Distribuidores = [{"nombre": "Dist"}]
+
+    dialog = RegisterCreditoFiscalDialog(productos, Distribuidores, [], db=DummyDB())
+
+    assert dialog.no_remision_edit.text() == "0012"
+    assert dialog.orden_no_edit.text() == "0012"
+    assert dialog.db.calls == [("03", "987", "654")]
+
+    dialog.close()

--- a/tests/test_dte_correlativo.py
+++ b/tests/test_dte_correlativo.py
@@ -173,3 +173,12 @@ def test_generate_invoice_pdf_correlativo_increment(tmp_path, monkeypatch):
 
     assert corr1 == 1
     assert corr2 == 2
+
+
+def test_peek_next_dte_correlativo_preview(tmp_path):
+    _setup_datos_negocio(tmp_path)
+    db, _ = _setup_db()
+
+    assert db.peek_next_dte_correlativo("03", "123", "456") == 1
+    assert db.next_dte_correlativo("03", "123", "456") == 1
+    assert db.peek_next_dte_correlativo("03", "123", "456") == 2

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -2603,6 +2603,83 @@ def test_generar_dte_json_sets_venta_tercero_credito_fiscal(monkeypatch):
     }
 
 
+def test_generar_dte_json_credito_fiscal_autofills_remision(monkeypatch):
+    import dte as dte_module
+    import svfe.config as svfe_config
+
+    datos = {
+        "nit": "06141990011019",
+        "nrc": "12345678",
+        "nombre": "Mi Negocio",
+        "nombreComercial": "Mi Negocio",
+        "cod_giro": "123456",
+        "descActividad": "Comercio",
+        "telefono": "22222222",
+        "correo": "test@example.com",
+        "direccion": {
+            "departamento": "06",
+            "municipio": "10",
+            "complemento": "Calle 1",
+        },
+    }
+
+    monkeypatch.setattr(dte_module, "_load_datos_negocio", lambda: datos)
+    monkeypatch.setattr(svfe_config, "load_datos_negocio", lambda: datos)
+
+    db = create_db()
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, None, 0, 0, 0, 10)
+    prod_id = db.cursor.lastrowid
+
+    db.add_cliente(
+        "Cliente FC",
+        "1234567",
+        "06141990011019",
+        "",
+        "Comercio",
+        "22223333",
+        "cli@example.com",
+        "San Salvador",
+        "06",
+        "23",
+    )
+    cliente_id = db.cursor.lastrowid
+
+    venta_id = db.add_venta_credito_fiscal(
+        cliente_id=cliente_id,
+        fecha="2024-06-02",
+        total=11.3,
+        nrc="1234567",
+        nit="06141990011019",
+        giro="Comercio",
+        sumas=10.0,
+        descuentos=0.0,
+        iva=1.3,
+        subtotal=11.3,
+        ventas_exentas=0.0,
+        ventas_no_sujetas=0.0,
+    )
+
+    db.add_detalle_venta(
+        venta_id,
+        prod_id,
+        1,
+        10,
+        tipo_fiscal="venta gravada",
+        vendedor_id=vend_id,
+    )
+
+    data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
+    numero_control = data["identificacion"]["numeroControl"]
+    correlativo_segment = numero_control.rsplit("-", 1)[-1]
+    expected = correlativo_segment[-4:]
+
+    receptor = data["receptor"]
+    assert receptor["noRemision"] == expected
+    assert receptor["ordenNo"] == expected
+
+
 def test_generar_dte_json_ignores_invalid_venta_tercero_doc(monkeypatch):
     import dte as dte_module
     import svfe.config as svfe_config


### PR DESCRIPTION
## Summary
- derive the receptor remisión and order numbers for credit-fiscal DTEs from the generated correlativo
- auto-fill the crédito fiscal dialog remisión/orden inputs from the upcoming correlativo so the UI matches the DTE payload
- add coverage that verifies the remisión/orden fields are auto-filled for type 03 invoices and that the dialog uses the peeked correlativo

## Testing
- pytest tests/test_generar_dte_json.py::test_generar_dte_json_credito_fiscal_autofills_remision
- pytest tests/test_dte_correlativo.py::test_peek_next_dte_correlativo_preview


------
https://chatgpt.com/codex/tasks/task_e_68e2ccc01cac8323a14ce3b3e032bb1a