### PR TITLE
Remove remision fields from receptor payload

### DIFF
--- a/dte.py
+++ b/dte.py
@@ -3376,12 +3376,6 @@ def generar_dte_json(
         raise ValueError("Correo de receptor inválido")
     if receptor and receptor.get("telefono") and not PHONE_RE.fullmatch(receptor["telefono"]):
         raise ValueError("Teléfono de receptor inválido")
-    if fiscal and receptor:
-        if fiscal.get("no_remision"):
-            receptor["noRemision"] = fiscal.get("no_remision")
-        if fiscal.get("orden_no"):
-            receptor["ordenNo"] = fiscal.get("orden_no")
-
     if receptor and not extra.get("es_ticket"):
         if not receptor.get("correo"):
             receptor["correo"] = "no-reply@example.com"
@@ -3414,9 +3408,7 @@ def generar_dte_json(
                     "correo",
                     "direccion",
                 ]
-                fields_to_remove = ["numDocumento", "tipoDocumento"]
-                if tipo_dte != "03":
-                    fields_to_remove.extend(["noRemision", "ordenNo"])
+                fields_to_remove = ["numDocumento", "tipoDocumento", "noRemision", "ordenNo"]
                 for f in fields_to_remove:
                     receptor.pop(f, None)
 
@@ -4585,19 +4577,9 @@ def validate_dte_json(
                 "correo",
                 "direccion",
             ]
-            if tipo_dte == "03":
-                base_remision = correlativo if correlativo is not None else numero_control
-                derived_remision = _derive_remision_from_correlativo(base_remision)
-                if derived_remision:
-                    if not receptor.get("noRemision"):
-                        receptor["noRemision"] = derived_remision
-                    if not receptor.get("ordenNo"):
-                        receptor["ordenNo"] = derived_remision
             for f in required_rec_fields:
                 receptor.setdefault(f, None)
-            fields_to_remove = ["numDocumento", "tipoDocumento"]
-            if tipo_dte != "03":
-                fields_to_remove.extend(["noRemision", "ordenNo"])
+            fields_to_remove = ["numDocumento", "tipoDocumento", "noRemision", "ordenNo"]
             for f in fields_to_remove:
                 receptor.pop(f, None)
         payload["receptor"] = receptor

--- a/tests/test_generar_dte_json.py
+++ b/tests/test_generar_dte_json.py
@@ -2603,7 +2603,7 @@ def test_generar_dte_json_sets_venta_tercero_credito_fiscal(monkeypatch):
     }
 
 
-def test_generar_dte_json_credito_fiscal_autofills_remision(monkeypatch):
+def test_generar_dte_json_credito_fiscal_no_injects_remision(monkeypatch):
     import dte as dte_module
     import svfe.config as svfe_config
 
@@ -2671,13 +2671,10 @@ def test_generar_dte_json_credito_fiscal_autofills_remision(monkeypatch):
     )
 
     data = dte_module.generar_dte_json(db, venta_id, tipo_dte="03")
-    numero_control = data["identificacion"]["numeroControl"]
-    correlativo_segment = numero_control.rsplit("-", 1)[-1]
-    expected = correlativo_segment[-4:]
 
     receptor = data["receptor"]
-    assert receptor["noRemision"] == expected
-    assert receptor["ordenNo"] == expected
+    assert "noRemision" not in receptor
+    assert "ordenNo" not in receptor
 
 
 def test_generar_dte_json_ignores_invalid_venta_tercero_doc(monkeypatch):


### PR DESCRIPTION
## Summary
- stop adding the noRemision and ordenNo fields to the receptor block when generating DTE payloads
- strip those fields during validation for every DTE type to keep payloads schema-compliant
- adjust the crédito fiscal regression test to ensure the receptor stays free of remisión metadata

## Testing
- pytest tests/test_generar_dte_json.py -k remision

------
https://chatgpt.com/codex/tasks/task_e_68e2e60707b083238058ff310ceba615