### PR TITLE
Evitar duplicados por tickets en lista de facturas

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -2608,6 +2608,11 @@ class FacturacionTab(QWidget):
             pdf = paths.get(".pdf")
             js = paths.get(".json")
             tipo = paths.get("tipo")
+            if tipo == "Ticket":
+                # Los PDFs generados en formato ticket corresponden a la misma
+                # factura y no deben mostrarse como documentos independientes
+                # en la lista de facturación.
+                continue
             estado, envio = self._detectar_estado_factura(
                 None,
                 pdf,


### PR DESCRIPTION
## Summary
- evita que los PDF generados en formato ticket aparezcan como facturas independientes en la lista

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3050b6b188323810e1390baca8fdd