### PR TITLE
Preserve QR data when reusing ticket PDFs

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -3806,6 +3806,19 @@ class FacturacionTab(QWidget):
         if not entry:
             return None
 
+        derived_path = None
+        if base_pdf_path:
+            derived_path = self._derive_ticket_path(base_pdf_path)
+            if derived_path and os.path.exists(derived_path):
+                return derived_path
+
+        if not derived_path and entry:
+            entry_pdf = entry.get("pdf")
+            if entry_pdf:
+                fallback_path = self._derive_ticket_path(entry_pdf)
+                if fallback_path and os.path.exists(fallback_path):
+                    return fallback_path
+
         venta_id = entry.get("venta_id")
         if venta_id:
             try:
@@ -3984,6 +3997,29 @@ class FacturacionTab(QWidget):
         tipo_desc = str(entry.get("tipo") or "").strip().lower()
         return tipo_desc in {"consumidor final", "crédito fiscal", "credito fiscal"}
 
+    def _derive_ticket_path(self, base_pdf_path: str | None) -> str | None:
+        if not base_pdf_path:
+            return None
+
+        try:
+            output_dir = os.path.dirname(base_pdf_path)
+            base_name = os.path.splitext(os.path.basename(base_pdf_path))[0]
+        except Exception:
+            return None
+
+        if not base_name:
+            return None
+
+        lower_name = base_name.lower()
+        for suffix in ("_consumidorfinal", "_creditofiscal", "_ticket"):
+            if lower_name.endswith(suffix):
+                base_name = base_name[: -len(suffix)] + "_Ticket"
+                break
+        else:
+            base_name = f"{base_name}_Ticket"
+
+        return os.path.join(output_dir, f"{base_name}.pdf")
+
     def _build_ticket_format_pdf(
         self,
         entry: dict,
@@ -4094,25 +4130,72 @@ class FacturacionTab(QWidget):
         except Exception:
             datos_negocio = {}
 
-        payload = dte_to_legacy_ticket_payload(
+        payload_raw = dte_to_legacy_ticket_payload(
             dte_payload,
             venta or {},
             detalles_venta,
             datos_negocio,
         )
-        dte_data = payload.get("dte_data") or {}
+        if isinstance(payload_raw, Mapping):
+            payload: dict[str, Any] = dict(payload_raw)
+        else:
+            payload = {}
+
+        dte_payload_data = payload.get("dte_data") if payload else None
+        if isinstance(dte_payload_data, Mapping):
+            dte_data = dict(dte_payload_data)
+        else:
+            dte_data = {}
+
         if sello:
             dte_data.setdefault("selloRecibido", sello)
         if firma:
             dte_data.setdefault("firmaElectronica", firma)
-        payload["dte_data"] = dte_data
+
+        if payload is not None:
+            payload["dte_data"] = dte_data
+
+        venta_payload = payload.get("venta") if payload else None
+        if not venta_payload:
+            venta_payload = venta or {}
+        elif isinstance(venta_payload, Mapping) and not isinstance(venta_payload, dict):
+            venta_payload = dict(venta_payload)
+
+        detalles_payload = payload.get("detalles") if payload else None
+        if not detalles_payload:
+            detalles_payload = detalles_venta or []
+
+        datos_negocio_payload = payload.get("datos_negocio") if payload else None
+        if not isinstance(datos_negocio_payload, Mapping):
+            datos_negocio_payload = datos_negocio or {}
+        else:
+            datos_negocio_payload = dict(datos_negocio_payload)
+
+        if isinstance(detalles_payload, list):
+            detalles_for_render = detalles_payload
+        elif isinstance(detalles_payload, tuple):
+            detalles_for_render = list(detalles_payload)
+        else:
+            detalles_for_render = detalles_payload or []
 
         venta_id = entry.get("venta_id")
+        output_path = None
         output_dir = None
         ticket_base = None
         if base_pdf_path:
-            output_dir = os.path.dirname(base_pdf_path)
-            ticket_base = os.path.splitext(os.path.basename(base_pdf_path))[0]
+            output_path = self._derive_ticket_path(base_pdf_path)
+            if output_path:
+                output_dir = os.path.dirname(output_path)
+                ticket_base = os.path.splitext(os.path.basename(output_path))[0]
+
+        if not output_path and entry:
+            entry_pdf = entry.get("pdf")
+            if entry_pdf:
+                candidate = self._derive_ticket_path(entry_pdf)
+                if candidate:
+                    output_path = candidate
+                    output_dir = os.path.dirname(candidate)
+                    ticket_base = os.path.splitext(os.path.basename(candidate))[0]
         if not output_dir:
             tipo_entry = str(entry.get("tipo") or "").strip().lower()
             if tipo_entry == "consumidor final":
@@ -4127,27 +4210,44 @@ class FacturacionTab(QWidget):
         except OSError:
             pass
 
-        if ticket_base:
-            lower_name = ticket_base.lower()
-            for suffix in ("_consumidorfinal", "_creditofiscal", "_ticket"):
-                if lower_name.endswith(suffix):
-                    ticket_base = ticket_base[: -len(suffix)] + "_Ticket"
-                    break
-            else:
-                ticket_base = f"{ticket_base}_Ticket"
-        else:
-            ticket_base = f"ticket_print_{uuid.uuid4().hex}"
+        if not output_path:
+            ident = {}
+            if isinstance(dte_payload, dict):
+                ident = dte_payload.get("identificacion") or {}
 
-        output_path = os.path.join(output_dir, f"{ticket_base}.pdf")
+            def _sanitize_ticket_name(value: str | None) -> str | None:
+                if not value:
+                    return None
+                cleaned = re.sub(r"[^A-Za-z0-9_-]+", "_", value).strip("_")
+                if not cleaned:
+                    return None
+                if cleaned.lower().endswith("_ticket"):
+                    cleaned = cleaned[: -7] + "_Ticket"
+                else:
+                    cleaned = f"{cleaned}_Ticket"
+                return cleaned
+
+            ticket_base = None
+            numero_control = ident.get("numeroControl")
+            if isinstance(numero_control, str) and numero_control.strip():
+                ticket_base = _sanitize_ticket_name(numero_control.strip())
+            if not ticket_base:
+                codigo_generacion = ident.get("codigoGeneracion")
+                if isinstance(codigo_generacion, str) and codigo_generacion.strip():
+                    ticket_base = _sanitize_ticket_name(codigo_generacion.strip())
+            if not ticket_base:
+                ticket_base = f"ticket_print_{uuid.uuid4().hex}"
+
+            output_path = os.path.join(output_dir, f"{ticket_base}.pdf")
 
         def _render_ticket(tmp_path):
             try:
                 generar_ticket_personalizado(
-                    payload.get("venta", {}),
-                    payload.get("detalles", []),
+                    venta_payload,
+                    detalles_for_render,
                     archivo=str(tmp_path),
-                    datos_negocio=payload.get("datos_negocio"),
-                    dte_data=payload.get("dte_data"),
+                    datos_negocio=datos_negocio_payload,
+                    dte_data=dte_data,
                 )
             except Exception as exc:  # pragma: no cover - defensive
                 raise RuntimeError(str(exc)) from exc
@@ -4168,12 +4268,6 @@ class FacturacionTab(QWidget):
                 f"No se pudo escribir el ticket: {exc}",
             )
             return None
-
-        if venta_id and output_dir != TICKETS_DIR:
-            try:
-                self.manager.db.add_ticket_pdf(venta_id, output_path)
-            except Exception:
-                pass
 
         return output_path
 

--- a/tests/test_facturacion_tab_actions.py
+++ b/tests/test_facturacion_tab_actions.py
@@ -311,7 +311,9 @@ def test_build_ticket_format_pdf_saves_alongside_invoice(monkeypatch, qt_app, tm
     assert out_path.parent == cf_dir
     assert out_path.stat().st_size > 0
     stored = db.get_ticket_pdf(venta_id)
-    assert stored == str(out_path)
+    assert stored is None
+    resolved = tab._resolve_ticket_pdf(entry, str(pdf_path))
+    assert resolved == str(out_path)
     tab._safe_remove(output)
     assert not out_path.exists()
 
@@ -362,6 +364,47 @@ def test_resolve_ticket_pdf_builds_when_missing(monkeypatch, qt_app, tmp_path):
 
     assert resolved == str(generated)
     assert flags.get("called") is True
+
+
+def test_resolve_ticket_pdf_generates_once(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    cf_dir = tmp_path / "cf"
+    cf_dir.mkdir()
+    carta_path = cf_dir / "20240101_Test.pdf"
+    carta_path.write_text("pdf")
+    db.add_factura_pdf(venta_id, "Consumidor Final", str(carta_path))
+
+    tab = _make_tab(db, cid)
+    entry = {"row_type": "venta", "venta_id": venta_id, "tipo": "Consumidor Final"}
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(cf_dir))
+
+    def fake_ticket(venta, detalles, archivo, datos_negocio=None, dte_data=None):
+        Path(archivo).write_text("ticket")
+
+    monkeypatch.setattr(facturacion_tab, "generar_ticket_personalizado", fake_ticket)
+
+    calls = {"count": 0}
+
+    def fake_write(dest, render):
+        calls["count"] += 1
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        render(dest_path)
+        return dest_path
+
+    monkeypatch.setattr(facturacion_tab, "write_pdf_atomically", fake_write)
+
+    first = tab._resolve_ticket_pdf(entry, str(carta_path))
+    expected = cf_dir / "20240101_Test_Ticket.pdf"
+    assert first == str(expected)
+    assert calls["count"] == 1
+    assert expected.exists()
+
+    second = tab._resolve_ticket_pdf(entry, str(carta_path))
+    assert second == str(expected)
+    assert calls["count"] == 1
 
 
 def test_print_invoice_ticket_entry_allows_format_selection(
@@ -491,6 +534,141 @@ def test_print_invoice_ticket_entry_allows_format_selection(
     assert preview_paths[-1] == str(ticket_pdf)
     assert opened_paths[-1] == str(ticket_pdf)
     assert FakeMessageBox.warnings == []
+
+
+def test_build_ticket_format_pdf_without_base_uses_control(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db, credito=True)
+    credito_dir = tmp_path / "credito"
+    credito_dir.mkdir()
+    json_payload = {
+        "identificacion": {
+            "tipoDte": "03",
+            "numeroControl": "DTE-03-0001",
+            "codigoGeneracion": "12345678-1234-1234-1234-123456789012",
+        },
+        "cuerpoDocumento": [{"cantidad": 1, "descripcion": "Item", "precioUni": 10, "montoTotal": 10}],
+        "resumen": {"totalGravada": 10, "montoTotalOperacion": 10},
+    }
+    json_path = credito_dir / "20240101_credito.json"
+    json_path.write_text(json.dumps(json_payload))
+    entry = {
+        "row_type": "venta",
+        "venta_id": venta_id,
+        "tipo": "Crédito Fiscal",
+        "json": str(json_path),
+    }
+
+    tab = _make_tab(db, cid)
+
+    monkeypatch.setattr(facturacion_tab, "CREDITO_DIR", str(credito_dir))
+    monkeypatch.setattr(facturacion_tab, "TICKETS_DIR", str(tmp_path / "tickets"))
+
+    def fake_ticket(venta, detalles, archivo, datos_negocio=None, dte_data=None):
+        Path(archivo).write_text("ticket")
+
+    monkeypatch.setattr(facturacion_tab, "generar_ticket_personalizado", fake_ticket)
+
+    def fake_write(dest, render):
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        render(dest_path)
+        return dest_path
+
+    monkeypatch.setattr(facturacion_tab, "write_pdf_atomically", fake_write)
+
+    output = tab._build_ticket_format_pdf(entry, None)
+    expected = credito_dir / "DTE-03-0001_Ticket.pdf"
+    assert output == str(expected)
+    assert expected.exists()
+
+    again = tab._build_ticket_format_pdf(entry, None)
+    assert again == str(expected)
+    ticket_files = list(credito_dir.glob("*_Ticket.pdf"))
+    assert ticket_files == [expected]
+
+
+def test_ticket_generation_preserves_qr_payload(monkeypatch, qt_app, tmp_path):
+    db = DB(":memory:")
+    venta_id, cid = _create_sale(db)
+    cf_dir = tmp_path / "cf"
+    cf_dir.mkdir()
+    pdf_path = cf_dir / "20240101_Test.pdf"
+    pdf_path.write_text("pdf")
+    dte_payload = {
+        "identificacion": {
+            "tipoDte": "01",
+            "numeroControl": "DTE-01-0001",
+            "codigoGeneracion": "12345678-1234-1234-1234-123456789012",
+        },
+        "cuerpoDocumento": [{"cantidad": 1, "descripcion": "Item", "precioUni": 10, "montoTotal": 10}],
+        "resumen": {"totalGravada": 10, "montoTotalOperacion": 10},
+        "qrCode": "QR-DATA",
+        "selloRecibido": "SELLO-DOC",
+        "firmaElectronica": "FIRMA-DOC",
+    }
+    json_path = pdf_path.with_suffix(".json")
+    json_path.write_text(json.dumps(dte_payload))
+
+    entry = {
+        "row_type": "venta",
+        "venta_id": venta_id,
+        "tipo": "Consumidor Final",
+        "json": str(json_path),
+        "pdf": str(pdf_path),
+    }
+
+    tab = _make_tab(db, cid)
+
+    monkeypatch.setattr(facturacion_tab, "CF_DIR", str(cf_dir))
+    monkeypatch.setattr(facturacion_tab.dte, "_load_datos_negocio", lambda: {})
+
+    payload_template = {
+        "venta": {"id": venta_id},
+        "detalles": ("detalle",),
+        "datos_negocio": {"nombre": "Negocio"},
+        "dte_data": {
+            "qrCode": "QR-DATA",
+            "selloRecibido": "SELLO-DOC",
+            "firmaElectronica": "FIRMA-DOC",
+        },
+    }
+
+    monkeypatch.setattr(
+        facturacion_tab,
+        "dte_to_legacy_ticket_payload",
+        lambda *a, **k: payload_template,
+    )
+
+    captured = {}
+
+    def fake_write(dest, render):
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        render(dest_path)
+        return dest_path
+
+    monkeypatch.setattr(facturacion_tab, "write_pdf_atomically", fake_write)
+
+    def fake_ticket(venta, detalles, archivo, datos_negocio=None, dte_data=None):
+        captured["venta"] = venta
+        captured["detalles"] = detalles
+        captured["datos_negocio"] = datos_negocio
+        captured["dte_data"] = dte_data
+        Path(archivo).write_text("ticket")
+
+    monkeypatch.setattr(facturacion_tab, "generar_ticket_personalizado", fake_ticket)
+
+    output = tab._build_ticket_format_pdf(entry, str(pdf_path))
+    assert output is not None
+    assert Path(output).exists()
+    assert captured["dte_data"] == payload_template["dte_data"]
+    assert captured["dte_data"] is not payload_template["dte_data"]
+    assert captured["dte_data"]["qrCode"] == "QR-DATA"
+    assert payload_template["dte_data"]["qrCode"] == "QR-DATA"
+    assert isinstance(captured["detalles"], list)
+    assert captured["detalles"] == ["detalle"]
+    assert captured["datos_negocio"] == {"nombre": "Negocio"}
 
 
 def test_print_invoice_notes_skip_format_selection(monkeypatch, qt_app, tmp_path):


### PR DESCRIPTION
## Summary
- copy and normalize ticket payload data before enriching metadata so reusing ticket PDFs does not mutate QR information
- reuse structured venta, detalle y datos_negocio payloads when invoking the ticket renderer to avoid duplicating files while keeping carta PDFs intact
- add a regression test that verifies the ticket generator preserves the QR payload and normalizes the detail list

## Testing
- pytest tests/test_facturacion_tab_actions.py -k "ticket" --no-cov -q

------
https://chatgpt.com/codex/tasks/task_e_68e2f7f511488323aa59b8cc5340ed6d