### PR TITLE
Adjust header spacing on letter-sized invoices

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -38,7 +38,10 @@ def generar_cabecera_dte(
     c.setFont("Helvetica-Bold", 12)
     c.drawCentredString(width / 2, top, tipo_documento.upper())
 
-    row_y = top - 40
+    # Reduce the vertical gap between the title block and the header boxes so
+    # the left-side information sits a little higher on the page without
+    # colliding with the titles.
+    row_y = top - 25
     c.setFont("Helvetica", 10)
 
     col_margin = 15

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -125,7 +125,9 @@ def generar_factura_electronica_pdf(
     c.drawCentredString(width / 2, top, titulo)
 
 
-    row_y = top - 40
+    # Elevar ligeramente la cabecera para aprovechar mejor el espacio sin
+    # acercarla demasiado al título principal.
+    row_y = top - 25
     c.setFont("Helvetica", 10)
 
     # --- Configuración de columnas para las cajas y el QR ---


### PR DESCRIPTION
## Summary
- raise the header info blocks on letter-sized DTE header PDFs
- adjust the invoice PDF layout so generation details sit higher without touching the title

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3170386b083238c2c655e4d061ad5