### PR TITLE
Raise left header block on letter PDFs

### DIFF
--- a/dte_header_pdf.py
+++ b/dte_header_pdf.py
@@ -38,7 +38,10 @@ def generar_cabecera_dte(
     c.setFont("Helvetica-Bold", 12)
     c.drawCentredString(width / 2, top, tipo_documento.upper())
 
-    row_y = top - 40
+    # Reduce the vertical gap between the title block and the header boxes so
+    # the left-side information sits a little higher on the page without
+    # colliding with the titles.
+    row_y = top - 25
     c.setFont("Helvetica", 10)
 
     col_margin = 15
@@ -48,13 +51,14 @@ def generar_cabecera_dte(
     box_h = 30
 
     box_y = row_y - box_h
+    left_box_y = box_y + 6
 
     # --- Caja izquierda ---
     c.setLineWidth(0.7)
     c.setStrokeColor(colors.white)
-    c.roundRect(40, box_y, box_w, box_h, 6, stroke=1, fill=0)
+    c.roundRect(40, left_box_y, box_w, box_h, 6, stroke=1, fill=0)
     c.setStrokeColor(colors.black)
-    text_y = box_y + box_h - 10
+    text_y = left_box_y + box_h - 10
     max_w = box_w - 10
     text_y = draw_wrapped_text(
         c,

--- a/factura_sv.py
+++ b/factura_sv.py
@@ -125,7 +125,9 @@ def generar_factura_electronica_pdf(
     c.drawCentredString(width / 2, top, titulo)
 
 
-    row_y = top - 40
+    # Elevar ligeramente la cabecera para aprovechar mejor el espacio sin
+    # acercarla demasiado al título principal.
+    row_y = top - 25
     c.setFont("Helvetica", 10)
 
     # --- Configuración de columnas para las cajas y el QR ---
@@ -138,13 +140,14 @@ def generar_factura_electronica_pdf(
 
     # Posición inferior de las cajas de cabecera
     box_y = row_y - box_h
+    left_box_y = box_y + 6
 
     # --- Caja izquierda con datos de generación ---
     c.setLineWidth(0.7)
     c.setStrokeColor(colors.white)
-    c.roundRect(x_margin, box_y, box_w, box_h, 6, stroke=1, fill=0)
+    c.roundRect(x_margin, left_box_y, box_w, box_h, 6, stroke=1, fill=0)
     c.setStrokeColor(colors.black)
-    text_y = box_y + box_h - 12
+    text_y = left_box_y + box_h - 12
     max_w = box_w - 10
     text_y = draw_wrapped_text(
         c,


### PR DESCRIPTION
## Summary
- nudge the generation info block higher on the invoice header without moving the QR or sales table
- lift the same block in the standalone DTE header PDF to match the new placement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3170386b083238c2c655e4d061ad5