### PR TITLE
Fix purchase editing vendor persistence and import details

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -2406,6 +2406,11 @@ class RegisterPurchaseDialog(QDialog):
             else None
         )
 
+        if vendedor_id is None and self.edit_mode:
+            vendedor_id = self._compra_data.get("vendedor_id")
+        if Distribuidor_id is None and self.edit_mode:
+            Distribuidor_id = self._compra_data.get("Distribuidor_id")
+
         if vendedor_id is None or Distribuidor_id is None:
             respuesta = QMessageBox.question(
                 self,
@@ -3838,8 +3843,48 @@ class CompraDetalleDialog(QDialog):
         Distribuidores_dict = {d["id"]: d["nombre"] for d in Distribuidores}
         productos_dict = {p["id"]: p["nombre"] for p in productos}
 
-        vendedor_nombre = vendedores_dict.get(compra.get("vendedor_id"), "Desconocido")
-        Distribuidor_nombre = Distribuidores_dict.get(compra.get("Distribuidor_id"), "Desconocido")
+        db = None
+        if parent and hasattr(parent, "manager"):
+            db = getattr(parent.manager, "db", None)
+
+        vendedor_id = compra.get("vendedor_id")
+        Distribuidor_id = compra.get("Distribuidor_id")
+
+        vendedor_nombre = vendedores_dict.get(vendedor_id)
+        Distribuidor_nombre = Distribuidores_dict.get(Distribuidor_id)
+
+        if vendedor_nombre is None and db and vendedor_id is not None:
+            try:
+                db.cursor.execute("SELECT nombre FROM vendedores WHERE id=?", (vendedor_id,))
+                row = db.cursor.fetchone()
+            except Exception:
+                row = None
+                logger.exception(
+                    "No fue posible obtener el nombre del vendedor %s", vendedor_id
+                )
+            if row:
+                vendedor_nombre = row[0]
+                vendedores_dict[vendedor_id] = vendedor_nombre
+
+        if Distribuidor_nombre is None and db and Distribuidor_id is not None:
+            try:
+                db.cursor.execute(
+                    "SELECT nombre FROM Distribuidores WHERE id=?",
+                    (Distribuidor_id,),
+                )
+                row = db.cursor.fetchone()
+            except Exception:
+                row = None
+                logger.exception(
+                    "No fue posible obtener el nombre del Distribuidor %s",
+                    Distribuidor_id,
+                )
+            if row:
+                Distribuidor_nombre = row[0]
+                Distribuidores_dict[Distribuidor_id] = Distribuidor_nombre
+
+        vendedor_nombre = vendedor_nombre or "Desconocido"
+        Distribuidor_nombre = Distribuidor_nombre or "Desconocido"
 
         layout.addWidget(QLabel(f"Fecha: {compra.get('fecha', '')}"))
         layout.addWidget(QLabel(f"Vendedor: {vendedor_nombre}"))

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -517,6 +517,9 @@ class InventoryManager:
         vendedor_id_map = {}
         Distribuidor_id_map = {}
         producto_id_map = {}
+        productos_por_id = {
+            p.get("id"): p for p in data.get("productos", []) if isinstance(p, dict)
+        }
         cliente_id_map = {}
         venta_id_map = {}
         compra_id_map = {}
@@ -862,7 +865,56 @@ class InventoryManager:
             # Detalles de compra
             for d in data.get("detalles_compra", []):
                 compra_id = compra_id_map.get(d.get("compra_id"))
-                producto_id = producto_id_map.get(d.get("producto_id"))
+                if not compra_id:
+                    continue
+                old_producto_id = d.get("producto_id")
+                producto_id = producto_id_map.get(old_producto_id)
+                if producto_id is None and old_producto_id is not None:
+                    producto_info = productos_por_id.get(old_producto_id)
+                    if producto_info:
+                        vend = vendedor_id_map.get(producto_info.get("vendedor_id"))
+                        dist = Distribuidor_id_map.get(producto_info.get("Distribuidor_id"))
+                        stock = producto_info.get("stock", 0)
+                        try:
+                            stock = float(stock) if stock is not None else 0
+                        except (TypeError, ValueError):
+                            stock = 0
+                        self.db.add_producto(
+                            producto_info.get("nombre", f"Producto {old_producto_id}"),
+                            producto_info.get("codigo", ""),
+                            producto_info.get("sku"),
+                            vend,
+                            dist,
+                            producto_info.get("precio_compra", 0),
+                            producto_info.get("precio_venta_minorista", 0),
+                            producto_info.get("precio_venta_mayorista", 0),
+                            stock,
+                            commit=False,
+                        )
+                        producto_id = self.db.cursor.lastrowid
+                        producto_id_map[old_producto_id] = producto_id
+                    else:
+                        try:
+                            self.db.add_producto(
+                                f"Producto {old_producto_id}",
+                                "",
+                                None,
+                                None,
+                                None,
+                                d.get("precio_unitario", 0),
+                                d.get("precio_unitario", 0),
+                                d.get("precio_unitario", 0),
+                                d.get("cantidad", 0),
+                                commit=False,
+                            )
+                            producto_id = self.db.cursor.lastrowid
+                            producto_id_map[old_producto_id] = producto_id
+                        except Exception:
+                            logger.exception(
+                                "No fue posible recrear el producto %s para el detalle de compra",
+                                old_producto_id,
+                            )
+                            producto_id = None
                 if compra_id and producto_id:
                     self.db.add_detalle_compra(
                         compra_id,


### PR DESCRIPTION
## Summary
- preserve the selected vendor and distributor when editing a purchase even if the combos temporarily lose their data
- ensure purchase detail dialogs fetch missing vendor/distributor names directly from the database
- keep purchase line items when re-importing an inventory by recreating missing products on the fly during import

## Testing
- pytest tests/test_update_compra.py

------
https://chatgpt.com/codex/tasks/task_e_68e34e5cb238832390428cca4b6b4175