### PR TITLE
Permitir edición de cantidades por lote en inventario actual

### DIFF
--- a/db.py
+++ b/db.py
@@ -2622,6 +2622,56 @@ class DB:
             self.conn.commit()
 
 
+    def update_detalle_compra_cantidad(self, detalle_id: int, nueva_cantidad: int) -> None:
+        """Actualiza la cantidad de un detalle de compra y sincroniza el stock.
+
+        Args:
+            detalle_id: Identificador del registro en ``detalles_compra``.
+            nueva_cantidad: Cantidad que tendrá el lote después de la edición.
+
+        Raises:
+            ValueError: Si el lote no existe o la cantidad es negativa.
+        """
+
+        if detalle_id is None:
+            raise ValueError("El lote seleccionado no existe.")
+
+        if nueva_cantidad is None:
+            raise ValueError("La cantidad no es válida.")
+
+        if nueva_cantidad < 0:
+            raise ValueError("La cantidad no puede ser negativa.")
+
+        with self.lock:
+            row = self.cursor.execute(
+                "SELECT producto_id FROM detalles_compra WHERE id=?",
+                (detalle_id,),
+            ).fetchone()
+
+            if row is None:
+                raise ValueError("El lote seleccionado no existe.")
+
+            producto_id = row["producto_id"]
+
+            self.cursor.execute(
+                "UPDATE detalles_compra SET cantidad=? WHERE id=?",
+                (nueva_cantidad, detalle_id),
+            )
+
+            if producto_id:
+                total_row = self.cursor.execute(
+                    "SELECT COALESCE(SUM(cantidad), 0) AS total FROM detalles_compra WHERE producto_id=?",
+                    (producto_id,),
+                ).fetchone()
+                total = total_row["total"] if total_row else 0
+                self.cursor.execute(
+                    "UPDATE productos SET stock=? WHERE id=?",
+                    (total, producto_id),
+                )
+
+            self.conn.commit()
+
+
     def add_movimiento(
         self,
         fecha,

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -276,6 +276,12 @@ class InventoryManager:
         self.db.aumentar_stock(producto_id, cantidad)
         self.refresh_data()
 
+    def update_detalle_compra_cantidad(self, detalle_id: int, nueva_cantidad: int) -> None:
+        """Actualiza la cantidad de un lote específico y refresca los datos."""
+
+        self.db.update_detalle_compra_cantidad(detalle_id, nueva_cantidad)
+        self.refresh_data()
+
     def exportar_inventario_json(self, filename, tab_order=None):
         datos_negocio = {}
         if os.path.exists(DATOS_NEGOCIO_PATH):

--- a/tests/test_update_compra.py
+++ b/tests/test_update_compra.py
@@ -1,3 +1,5 @@
+import pytest
+
 from db import DB
 
 
@@ -88,3 +90,73 @@ def test_update_compra_detallada_updates_totals_and_stock():
     db.cursor.execute("SELECT stock FROM productos WHERE id=?", (prod_id,))
     stock = db.cursor.fetchone()["stock"]
     assert stock == 5
+
+
+def test_update_detalle_compra_cantidad_updates_stock():
+    db = create_db()
+    db.add_Distribuidor("D1")
+    dist_id = db.cursor.lastrowid
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, dist_id, 0, 0, 0, 0)
+    prod_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "producto_id": None,
+            "cantidad": 0,
+            "precio_unitario": 0,
+            "total": 0,
+            "Distribuidor_id": dist_id,
+            "comision_pct": 0,
+            "comision_monto": 0,
+            "vendedor_id": vend_id,
+        }
+    )
+
+    db.add_detalle_compra(compra_id, prod_id, 10, 5)
+    detalle_id = db.cursor.lastrowid
+
+    db.update_detalle_compra_cantidad(detalle_id, 6)
+
+    detalle = db.get_detalles_compra(compra_id)[0]
+    assert detalle["cantidad"] == 6
+
+    db.cursor.execute("SELECT stock FROM productos WHERE id=?", (prod_id,))
+    stock = db.cursor.fetchone()["stock"]
+    assert stock == 6
+
+
+def test_update_detalle_compra_cantidad_validates_input():
+    db = create_db()
+    db.add_Distribuidor("D1")
+    dist_id = db.cursor.lastrowid
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, dist_id, 0, 0, 0, 0)
+    prod_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "producto_id": None,
+            "cantidad": 0,
+            "precio_unitario": 0,
+            "total": 0,
+            "Distribuidor_id": dist_id,
+            "comision_pct": 0,
+            "comision_monto": 0,
+            "vendedor_id": vend_id,
+        }
+    )
+
+    db.add_detalle_compra(compra_id, prod_id, 10, 5)
+    detalle_id = db.cursor.lastrowid
+
+    with pytest.raises(ValueError):
+        db.update_detalle_compra_cantidad(detalle_id, -1)
+
+    with pytest.raises(ValueError):
+        db.update_detalle_compra_cantidad(None, 1)
+

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -497,6 +497,12 @@ class MainWindow(QMainWindow):
         self.inventario_actual_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         inventario_actual_layout.addWidget(self.inventario_actual_table)
 
+        inventario_actual_buttons = QHBoxLayout()
+        inventario_actual_buttons.addStretch()
+        self.btn_edit_lote = QPushButton("Editar lote")
+        inventario_actual_buttons.addWidget(self.btn_edit_lote)
+        inventario_actual_layout.addLayout(inventario_actual_buttons)
+
         inventario_actual_tab.setLayout(inventario_actual_layout)
 
         # --- AGREGA LAS CUATRO PESTAÑAS AL QTabWidget ---
@@ -649,6 +655,7 @@ class MainWindow(QMainWindow):
         self.btn_delete_cliente.clicked.connect(self._eliminar_cliente)
         self.cliente_search.textChanged.connect(self._actualizar_tabla_clientes)
         self.actual_search_bar.textChanged.connect(self._actualizar_inventario_actual)
+        self.btn_edit_lote.clicked.connect(self._editar_lote_inventario_actual)
         self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA AL FINAL DE _setup_ui
         self._actualizar_inventario_actual()  # <-- AGREGA ESTA LÍNEA AL FINAL DE _setup_ui
 
@@ -1736,7 +1743,10 @@ class MainWindow(QMainWindow):
                     "precio_compra": d.get("precio_unitario", 0),
                     "fecha_compra": compra.get("fecha", ""),
                     "fecha_vencimiento": fecha_vencimiento,
-                    "Distribuidor": Distribuidores_dict.get(compra.get("Distribuidor_id"), "")
+                    "Distribuidor": Distribuidores_dict.get(compra.get("Distribuidor_id"), ""),
+                    "detalle_id": d.get("id"),
+                    "producto_id": d.get("producto_id"),
+                    "compra_id": compra_id,
                 })
 
         # Filtra solo los lotes con stock > 0
@@ -1752,7 +1762,9 @@ class MainWindow(QMainWindow):
 
         self.inventario_actual_table.setRowCount(len(detalles))
         for row, d in enumerate(detalles):
-            self.inventario_actual_table.setItem(row, 0, QTableWidgetItem(d["producto"]))
+            item_producto = QTableWidgetItem(d["producto"])
+            item_producto.setData(Qt.UserRole, d)
+            self.inventario_actual_table.setItem(row, 0, item_producto)
             self.inventario_actual_table.setItem(row, 1, QTableWidgetItem(d["codigo"]))
             item_cantidad = QTableWidgetItem(str(d["cantidad"]))
             stock = d.get("cantidad", 0)
@@ -1792,6 +1804,66 @@ class MainWindow(QMainWindow):
                     pass
             self.inventario_actual_table.setItem(row, 5, item_venc)
             self.inventario_actual_table.setItem(row, 6, QTableWidgetItem(d["Distribuidor"]))
+
+    def _editar_lote_inventario_actual(self):
+        row = self.inventario_actual_table.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Editar lote", "Seleccione un lote para editar.")
+            return
+
+        item_producto = self.inventario_actual_table.item(row, 0)
+        if not item_producto:
+            QMessageBox.warning(self, "Editar lote", "No se pudo obtener la información del lote seleccionado.")
+            return
+
+        data = item_producto.data(Qt.UserRole) or {}
+        detalle_id = data.get("detalle_id")
+
+        if not detalle_id:
+            QMessageBox.warning(self, "Editar lote", "No se encontró el identificador del lote seleccionado.")
+            return
+
+        cantidad_actual = int(data.get("cantidad", 0) or 0)
+        producto = data.get("producto", "")
+        codigo = data.get("codigo", "")
+
+        nueva_cantidad, ok = QInputDialog.getInt(
+            self,
+            "Editar lote",
+            f"Ingrese la nueva cantidad para el lote de {producto} (código {codigo}):",
+            value=cantidad_actual,
+            min=0,
+        )
+
+        if not ok:
+            return
+
+        if nueva_cantidad == cantidad_actual:
+            return
+
+        try:
+            self.manager.update_detalle_compra_cantidad(detalle_id, nueva_cantidad)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Editar lote", str(exc))
+            return
+        except Exception as exc:  # pragma: no cover - logging unexpected errors
+            logger.exception("Error al actualizar el lote: %s", exc)
+            QMessageBox.critical(
+                self,
+                "Editar lote",
+                "Ocurrió un error al actualizar la cantidad del lote.",
+            )
+            return
+
+        QMessageBox.information(
+            self,
+            "Editar lote",
+            "La cantidad del lote se actualizó correctamente.",
+        )
+
+        self._actualizar_inventario_actual()
+        self.filter_products()
+        self.data_changed.emit()
 
     def _on_table_clicked(self, index):
         self.selected_row = index.row()


### PR DESCRIPTION
## Summary
- add an "Editar lote" action in the Inventario actual tab to request a new lot quantity and refresh related tables
- provide database and manager helpers to update purchase detail quantities while keeping product stock in sync
- cover the new workflow with tests that validate stock updates and input validation

## Testing
- pytest tests/test_update_compra.py

------
https://chatgpt.com/codex/tasks/task_e_68e35215f70883239be0fc621f9ecf74