### PR TITLE
Add purchase and lot deletion controls

### DIFF
--- a/db.py
+++ b/db.py
@@ -1418,6 +1418,134 @@ class DB:
         self.cursor.execute("SELECT * FROM detalles_compra WHERE compra_id=?", (compra_id,))
         return [dict(row) for row in self.cursor.fetchall()]
 
+    def _calculate_compra_totals(self, compra_id):
+        self.cursor.execute(
+            """
+            SELECT cantidad, precio_unitario, descuento, iva, iva_tipo,
+                   comision_monto, comision_tipo
+            FROM detalles_compra WHERE compra_id=?
+            """,
+            (compra_id,),
+        )
+        detalles = [dict(row) for row in self.cursor.fetchall()]
+        total = Decimal("0")
+        comision_total = Decimal("0")
+
+        def _to_decimal(value):
+            try:
+                return Decimal(str(value))
+            except Exception:
+                return Decimal("0")
+
+        for detalle in detalles:
+            cantidad = _to_decimal(detalle.get("cantidad"))
+            precio_unitario = _to_decimal(detalle.get("precio_unitario"))
+            subtotal = cantidad * precio_unitario
+            descuento = _to_decimal(detalle.get("descuento"))
+            subtotal_con_descuento = subtotal - descuento
+            if subtotal_con_descuento < 0:
+                subtotal_con_descuento = Decimal("0")
+            iva = _to_decimal(detalle.get("iva"))
+            iva_tipo = (detalle.get("iva_tipo") or "").strip().lower()
+            comision_monto = _to_decimal(detalle.get("comision_monto"))
+            comision_tipo = (detalle.get("comision_tipo") or "").strip().lower()
+
+            linea_total = subtotal_con_descuento
+            if iva_tipo in {"añadido", "anadido"}:
+                linea_total += iva
+            # Cuando el IVA es desglosado o ninguno, el total permanece igual.
+            if comision_tipo == "añadida al total":
+                linea_total += comision_monto
+
+            total += linea_total
+            comision_total += comision_monto
+
+        return total, comision_total
+
+    def delete_lote(self, detalle_id):
+        with self.lock:
+            self.cursor.execute(
+                """
+                SELECT id, compra_id, producto_id, cantidad
+                FROM detalles_compra WHERE id=?
+                """,
+                (detalle_id,),
+            )
+            row = self.cursor.fetchone()
+            if row is None:
+                return False
+            detalle = dict(row)
+            compra_id = detalle.get("compra_id")
+            producto_id = detalle.get("producto_id")
+            cantidad = detalle.get("cantidad") or 0
+
+            try:
+                cantidad_val = Decimal(str(cantidad))
+            except Exception:
+                cantidad_val = Decimal("0")
+            cantidad_int = int(cantidad_val)
+
+            self.cursor.execute(
+                "DELETE FROM detalles_compra WHERE id=?",
+                (detalle_id,),
+            )
+
+            if producto_id is not None:
+                self.cursor.execute(
+                    "UPDATE productos SET stock = stock - ? WHERE id=?",
+                    (cantidad_int, producto_id),
+                )
+
+            if compra_id is not None:
+                total, comision_total = self._calculate_compra_totals(compra_id)
+                self.cursor.execute(
+                    "UPDATE compras SET total=?, comision_monto=? WHERE id=?",
+                    (float(total), float(comision_total), compra_id),
+                )
+
+            self.conn.commit()
+            return True
+
+    def delete_compra(self, compra_id):
+        with self.lock:
+            self.cursor.execute(
+                "SELECT id FROM compras WHERE id=?",
+                (compra_id,),
+            )
+            if self.cursor.fetchone() is None:
+                return False
+
+            self.cursor.execute(
+                "SELECT producto_id, cantidad FROM detalles_compra WHERE compra_id=?",
+                (compra_id,),
+            )
+            detalles = [dict(row) for row in self.cursor.fetchall()]
+
+            for detalle in detalles:
+                producto_id = detalle.get("producto_id")
+                cantidad = detalle.get("cantidad") or 0
+                try:
+                    cantidad_val = Decimal(str(cantidad))
+                except Exception:
+                    cantidad_val = Decimal("0")
+                cantidad_int = int(cantidad_val)
+                if producto_id is not None:
+                    self.cursor.execute(
+                        "UPDATE productos SET stock = stock - ? WHERE id=?",
+                        (cantidad_int, producto_id),
+                    )
+
+            self.cursor.execute(
+                "DELETE FROM detalles_compra WHERE compra_id=?",
+                (compra_id,),
+            )
+            self.cursor.execute(
+                "DELETE FROM compras WHERE id=?",
+                (compra_id,),
+            )
+            self.conn.commit()
+            return True
+
 
     def get_estado_cuenta(self, persona_id, tipo="cliente", fecha_inicio=None, fecha_fin=None):
         """Obtiene las facturas de un cliente o vendedor en un rango de fechas.

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -124,8 +124,10 @@ class PurchasesTab(QWidget):
         side_layout = QVBoxLayout()
         self.btn_ver = QPushButton("Ver")
         self.btn_editar = QPushButton("Editar")
+        self.btn_eliminar = QPushButton("Eliminar")
         side_layout.addWidget(self.btn_ver)
         side_layout.addWidget(self.btn_editar)
+        side_layout.addWidget(self.btn_eliminar)
         side_layout.addStretch(1)
         content_layout.addLayout(side_layout)
 
@@ -141,6 +143,7 @@ class PurchasesTab(QWidget):
         self.search_bar.textChanged.connect(self.load_purchases)
         self.btn_ver.clicked.connect(self.show_selected_detail)
         self.btn_editar.clicked.connect(self.edit_selected_purchase)
+        self.btn_eliminar.clicked.connect(self.delete_selected_purchase)
 
     def _selected_compra_id(self):
         row = self.table.currentRow()
@@ -169,6 +172,64 @@ class PurchasesTab(QWidget):
         compra_id = self._selected_compra_id()
         if compra_id is not None:
             self.edit_purchase(compra_id)
+
+    def delete_selected_purchase(self):
+        compra_id = self._selected_compra_id()
+        if compra_id is None:
+            QMessageBox.warning(
+                self,
+                "Eliminar compra",
+                "Seleccione una compra para eliminar.",
+            )
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar compra",
+            f"¿Está seguro de eliminar la compra #{compra_id}?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            deleted = self.manager.db.delete_compra(compra_id)
+        except Exception as exc:
+            logger.exception("No fue posible eliminar la compra %s", compra_id)
+            QMessageBox.critical(
+                self,
+                "Eliminar compra",
+                f"Ocurrió un error al eliminar la compra: {exc}",
+            )
+            return
+
+        if not deleted:
+            QMessageBox.warning(
+                self,
+                "Eliminar compra",
+                "La compra seleccionada no existe o ya fue eliminada.",
+            )
+            return
+
+        self.manager.refresh_data()
+        self.refresh_filters()
+        self.load_purchases()
+
+        parent = self.parent()
+        if parent is not None:
+            if hasattr(parent, "filter_products"):
+                parent.filter_products()
+            if hasattr(parent, "_actualizar_inventario_actual"):
+                parent._actualizar_inventario_actual()
+            if hasattr(parent, "data_changed"):
+                parent.data_changed.emit()
+
+        QMessageBox.information(
+            self,
+            "Eliminar compra",
+            "La compra fue eliminada correctamente.",
+        )
 
     def _toggle_date_filter(self, checked):
         self.quick_range.setEnabled(checked)

--- a/tests/test_db_stock_and_sales.py
+++ b/tests/test_db_stock_and_sales.py
@@ -160,3 +160,102 @@ def test_delete_sale_without_lote_info_restores_product_stock():
 
     db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
     assert db.cursor.fetchone()['stock'] == 8
+
+
+def test_delete_compra_removes_stock_and_records():
+    db = DB(':memory:')
+    db.add_producto(
+        nombre='Prod',
+        codigo='P1',
+        sku=None,
+        vendedor_id=None,
+        Distribuidor_id=None,
+        precio_compra=1.0,
+        precio_venta_minorista=2.0,
+        precio_venta_mayorista=3.0,
+        stock=0,
+    )
+    product_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada({
+        'fecha': '2024-01-01',
+        'producto_id': None,
+        'cantidad': 0,
+        'precio_unitario': 0,
+        'total': 10,
+        'Distribuidor_id': None,
+        'comision_pct': 0,
+        'comision_monto': 0,
+        'vendedor_id': None,
+    })
+    db.add_detalle_compra(compra_id, product_id, 10, 1.0)
+    db.aumentar_stock(product_id, 10)
+
+    assert db.delete_compra(compra_id)
+
+    assert db.get_compra(compra_id) is None
+    assert db.get_detalles_compra(compra_id) == []
+    db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
+    assert db.cursor.fetchone()['stock'] == 0
+
+
+def test_delete_lote_updates_totals_and_stock():
+    db = DB(':memory:')
+    db.add_producto(
+        nombre='Prod',
+        codigo='P1',
+        sku=None,
+        vendedor_id=None,
+        Distribuidor_id=None,
+        precio_compra=1.0,
+        precio_venta_minorista=2.0,
+        precio_venta_mayorista=3.0,
+        stock=0,
+    )
+    product_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada({
+        'fecha': '2024-01-01',
+        'producto_id': None,
+        'cantidad': 0,
+        'precio_unitario': 0,
+        'total': 22,
+        'Distribuidor_id': None,
+        'comision_pct': 0,
+        'comision_monto': 2,
+        'vendedor_id': None,
+    })
+
+    db.add_detalle_compra(
+        compra_id,
+        product_id,
+        5,
+        2.0,
+        comision_monto=1,
+        comision_tipo='Añadida al total',
+    )
+    db.aumentar_stock(product_id, 5)
+    db.add_detalle_compra(
+        compra_id,
+        product_id,
+        5,
+        2.0,
+        comision_monto=1,
+        comision_tipo='Añadida al total',
+    )
+    db.aumentar_stock(product_id, 5)
+
+    detalles = db.get_detalles_compra(compra_id)
+    assert len(detalles) == 2
+    lote_id = detalles[0]['id']
+
+    assert db.delete_lote(lote_id)
+
+    compra = db.get_compra(compra_id)
+    assert pytest.approx(compra['total'], rel=1e-6) == 11
+    assert pytest.approx(compra['comision_monto'], rel=1e-6) == 1
+
+    remaining = db.get_detalles_compra(compra_id)
+    assert len(remaining) == 1
+    db.cursor.execute('SELECT stock FROM productos WHERE id=?', (product_id,))
+    assert db.cursor.fetchone()['stock'] == 5

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -497,6 +497,12 @@ class MainWindow(QMainWindow):
         self.inventario_actual_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         inventario_actual_layout.addWidget(self.inventario_actual_table)
 
+        inventario_actual_buttons = QHBoxLayout()
+        inventario_actual_buttons.addStretch(1)
+        self.btn_delete_lote = QPushButton("Eliminar lote")
+        inventario_actual_buttons.addWidget(self.btn_delete_lote)
+        inventario_actual_layout.addLayout(inventario_actual_buttons)
+
         inventario_actual_tab.setLayout(inventario_actual_layout)
 
         # --- AGREGA LAS CUATRO PESTAÑAS AL QTabWidget ---
@@ -649,6 +655,7 @@ class MainWindow(QMainWindow):
         self.btn_delete_cliente.clicked.connect(self._eliminar_cliente)
         self.cliente_search.textChanged.connect(self._actualizar_tabla_clientes)
         self.actual_search_bar.textChanged.connect(self._actualizar_inventario_actual)
+        self.btn_delete_lote.clicked.connect(self._eliminar_lote_inventario)
         self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA AL FINAL DE _setup_ui
         self._actualizar_inventario_actual()  # <-- AGREGA ESTA LÍNEA AL FINAL DE _setup_ui
 
@@ -1730,13 +1737,15 @@ class MainWindow(QMainWindow):
                 # Busca la fecha de vencimiento en el detalle si la tienes (ajusta si la guardas en la tabla)
                 fecha_vencimiento = d.get("fecha_vencimiento", "")
                 detalles.append({
+                    "detalle_id": d.get("id"),
                     "producto": prod.get("nombre", ""),
                     "codigo": prod.get("codigo", ""),
                     "cantidad": d.get("cantidad", 0),
                     "precio_compra": d.get("precio_unitario", 0),
                     "fecha_compra": compra.get("fecha", ""),
                     "fecha_vencimiento": fecha_vencimiento,
-                    "Distribuidor": Distribuidores_dict.get(compra.get("Distribuidor_id"), "")
+                    "Distribuidor": Distribuidores_dict.get(compra.get("Distribuidor_id"), ""),
+                    "producto_id": d.get("producto_id"),
                 })
 
         # Filtra solo los lotes con stock > 0
@@ -1752,7 +1761,10 @@ class MainWindow(QMainWindow):
 
         self.inventario_actual_table.setRowCount(len(detalles))
         for row, d in enumerate(detalles):
-            self.inventario_actual_table.setItem(row, 0, QTableWidgetItem(d["producto"]))
+            item_producto = QTableWidgetItem(d["producto"])
+            item_producto.setData(Qt.UserRole, d.get("detalle_id"))
+            item_producto.setData(Qt.UserRole + 1, d.get("producto_id"))
+            self.inventario_actual_table.setItem(row, 0, item_producto)
             self.inventario_actual_table.setItem(row, 1, QTableWidgetItem(d["codigo"]))
             item_cantidad = QTableWidgetItem(str(d["cantidad"]))
             stock = d.get("cantidad", 0)
@@ -1792,6 +1804,69 @@ class MainWindow(QMainWindow):
                     pass
             self.inventario_actual_table.setItem(row, 5, item_venc)
             self.inventario_actual_table.setItem(row, 6, QTableWidgetItem(d["Distribuidor"]))
+
+    def _get_selected_lote(self):
+        row = self.inventario_actual_table.currentRow()
+        if row < 0:
+            return None, None, None
+        item = self.inventario_actual_table.item(row, 0)
+        if not item:
+            return None, None, None
+        detalle_id = item.data(Qt.UserRole)
+        producto_id = item.data(Qt.UserRole + 1)
+        nombre = item.text()
+        return detalle_id, producto_id, nombre
+
+    def _eliminar_lote_inventario(self):
+        detalle_id, _, nombre = self._get_selected_lote()
+        if not detalle_id:
+            QMessageBox.warning(
+                self,
+                "Eliminar lote",
+                "Seleccione un lote para eliminar.",
+            )
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar lote",
+            f"¿Desea eliminar el lote de '{nombre}' del inventario?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            eliminado = self.manager.db.delete_lote(detalle_id)
+        except Exception as exc:
+            QMessageBox.critical(
+                self,
+                "Eliminar lote",
+                f"No fue posible eliminar el lote: {exc}",
+            )
+            return
+
+        if not eliminado:
+            QMessageBox.warning(
+                self,
+                "Eliminar lote",
+                "El lote seleccionado no existe o ya fue eliminado.",
+            )
+            return
+
+        self.manager.refresh_data()
+        self.filter_products()
+        self.compras_tab.refresh_filters()
+        self.compras_tab.load_purchases()
+        self._actualizar_inventario_actual()
+        self.data_changed.emit()
+
+        QMessageBox.information(
+            self,
+            "Eliminar lote",
+            "El lote fue eliminado correctamente.",
+        )
 
     def _on_table_clicked(self, index):
         self.selected_row = index.row()


### PR DESCRIPTION
## Summary
- add a delete purchase control in the purchases tab and refresh related views after removal
- surface a delete lot action in the inventory tab with selection metadata for each lot row
- extend the database API and tests to support removing purchases and individual lots while keeping totals and stock in sync

## Testing
- pytest tests/test_db_stock_and_sales.py tests/test_update_compra.py

------
https://chatgpt.com/codex/tasks/task_e_68e351ce0b4083238409cf816a00c5c1