### PR TITLE
Add deletion workflows for purchases and inventory lots

### DIFF
--- a/db.py
+++ b/db.py
@@ -2672,6 +2672,139 @@ class DB:
             self.conn.commit()
 
 
+    def delete_detalle_compra(self, detalle_id: int) -> None:
+        """Elimina un lote de compra y ajusta el stock y totales asociados."""
+
+        if detalle_id is None:
+            raise ValueError("El lote seleccionado no existe.")
+
+        with self.lock:
+            detalle = self.cursor.execute(
+                """
+                SELECT compra_id, producto_id, cantidad, precio_unitario, descuento,
+                       iva, iva_tipo, comision_monto, comision_tipo
+                FROM detalles_compra
+                WHERE id=?
+                """,
+                (detalle_id,),
+            ).fetchone()
+
+            if detalle is None:
+                raise ValueError("El lote seleccionado no existe.")
+
+            compra_id = detalle["compra_id"]
+            producto_id = detalle["producto_id"]
+            cantidad = detalle["cantidad"] or 0
+
+            try:
+                if producto_id:
+                    self.cursor.execute(
+                        "UPDATE productos SET stock = stock - ? WHERE id = ?",
+                        (cantidad, producto_id),
+                    )
+
+                self.cursor.execute(
+                    "DELETE FROM detalles_compra WHERE id=?",
+                    (detalle_id,),
+                )
+
+                if compra_id:
+                    self._recalculate_compra_totals(compra_id)
+
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
+    def delete_compra(self, compra_id: int) -> None:
+        """Elimina una compra y revierte sus movimientos de inventario."""
+
+        if compra_id is None:
+            raise ValueError("La compra seleccionada no existe.")
+
+        with self.lock:
+            existe = self.cursor.execute(
+                "SELECT 1 FROM compras WHERE id=?",
+                (compra_id,),
+            ).fetchone()
+            if existe is None:
+                raise ValueError("La compra seleccionada no existe.")
+
+            detalles = [
+                dict(row)
+                for row in self.cursor.execute(
+                    "SELECT producto_id, cantidad FROM detalles_compra WHERE compra_id=?",
+                    (compra_id,),
+                ).fetchall()
+            ]
+
+            try:
+                for detalle in detalles:
+                    producto_id = detalle.get("producto_id")
+                    cantidad = detalle.get("cantidad", 0) or 0
+                    if producto_id:
+                        self.cursor.execute(
+                            "UPDATE productos SET stock = stock - ? WHERE id = ?",
+                            (cantidad, producto_id),
+                        )
+
+                self.cursor.execute(
+                    "DELETE FROM detalles_compra WHERE compra_id=?",
+                    (compra_id,),
+                )
+                self.cursor.execute(
+                    "DELETE FROM compras WHERE id=?",
+                    (compra_id,),
+                )
+
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
+    def _recalculate_compra_totals(self, compra_id: int) -> None:
+        """Recalcula el total y la comisión de una compra a partir de sus lotes."""
+
+        detalles = self.cursor.execute(
+            """
+            SELECT cantidad, precio_unitario, descuento, iva, iva_tipo,
+                   comision_monto, comision_tipo
+            FROM detalles_compra
+            WHERE compra_id=?
+            """,
+            (compra_id,),
+        ).fetchall()
+
+        total = 0.0
+        comision_total = 0.0
+
+        for detalle in detalles:
+            cantidad = detalle["cantidad"] or 0
+            precio = detalle["precio_unitario"] or 0
+            descuento = detalle["descuento"] or 0
+            iva = detalle["iva"] or 0
+            iva_tipo = (detalle["iva_tipo"] or "").strip().lower()
+            comision_monto = detalle["comision_monto"] or 0
+            comision_tipo = (detalle["comision_tipo"] or "").strip().lower()
+
+            subtotal = max((cantidad * precio) - descuento, 0)
+            linea_total = subtotal
+
+            if iva_tipo == "añadido":
+                linea_total += iva or 0
+
+            if comision_tipo == "añadida al total":
+                linea_total += comision_monto or 0
+
+            total += float(linea_total)
+            comision_total += float(comision_monto or 0)
+
+        self.cursor.execute(
+            "UPDATE compras SET total=?, comision_monto=? WHERE id=?",
+            (total, comision_total, compra_id),
+        )
+
+
     def add_movimiento(
         self,
         fecha,

--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -276,6 +276,18 @@ class InventoryManager:
         self.db.aumentar_stock(producto_id, cantidad)
         self.refresh_data()
 
+    def delete_compra(self, compra_id: int) -> None:
+        """Elimina una compra y actualiza las vistas relacionadas."""
+
+        self.db.delete_compra(compra_id)
+        self.refresh_data()
+
+    def delete_detalle_compra(self, detalle_id: int) -> None:
+        """Elimina un lote específico y sincroniza el inventario."""
+
+        self.db.delete_detalle_compra(detalle_id)
+        self.refresh_data()
+
     def update_detalle_compra_cantidad(self, detalle_id: int, nueva_cantidad: int) -> None:
         """Actualiza la cantidad de un lote específico y refresca los datos."""
 

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -124,8 +124,10 @@ class PurchasesTab(QWidget):
         side_layout = QVBoxLayout()
         self.btn_ver = QPushButton("Ver")
         self.btn_editar = QPushButton("Editar")
+        self.btn_eliminar = QPushButton("Eliminar")
         side_layout.addWidget(self.btn_ver)
         side_layout.addWidget(self.btn_editar)
+        side_layout.addWidget(self.btn_eliminar)
         side_layout.addStretch(1)
         content_layout.addLayout(side_layout)
 
@@ -141,6 +143,7 @@ class PurchasesTab(QWidget):
         self.search_bar.textChanged.connect(self.load_purchases)
         self.btn_ver.clicked.connect(self.show_selected_detail)
         self.btn_editar.clicked.connect(self.edit_selected_purchase)
+        self.btn_eliminar.clicked.connect(self.delete_selected_purchase)
 
     def _selected_compra_id(self):
         row = self.table.currentRow()
@@ -169,6 +172,72 @@ class PurchasesTab(QWidget):
         compra_id = self._selected_compra_id()
         if compra_id is not None:
             self.edit_purchase(compra_id)
+
+    def delete_selected_purchase(self):
+        compra_id = self._selected_compra_id()
+        if compra_id is None:
+            QMessageBox.warning(
+                self,
+                "Eliminar compra",
+                "Seleccione una compra para eliminar.",
+            )
+            return
+        self.delete_purchase(compra_id)
+
+    def delete_purchase(self, compra_id: int):
+        compra = self._compras_cache.get(compra_id)
+        if not compra:
+            compra = self.manager.db.get_compra(compra_id)
+        if not compra:
+            QMessageBox.warning(
+                self,
+                "Compra no encontrada",
+                "No fue posible cargar la compra seleccionada. Intente nuevamente.",
+            )
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar compra",
+            f"¿Está seguro de eliminar la compra #{compra_id}? Esta acción deshará el ingreso de sus lotes al inventario.",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            self.manager.delete_compra(compra_id)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Eliminar compra", str(exc))
+            return
+        except Exception as exc:  # pragma: no cover - defensive UI handling
+            logger.exception("Error al eliminar la compra %s", compra_id)
+            QMessageBox.critical(
+                self,
+                "Eliminar compra",
+                "Ocurrió un error al eliminar la compra seleccionada.",
+            )
+            return
+
+        self._compras_cache.pop(compra_id, None)
+        self._detalles_cache.pop(compra_id, None)
+        self.load_purchases()
+
+        parent = self.parent()
+        if parent and hasattr(parent, "_actualizar_inventario_actual"):
+            try:
+                parent._actualizar_inventario_actual()
+            except Exception:  # pragma: no cover - keep UI responsive
+                logger.exception("No se pudo refrescar el inventario actual tras eliminar la compra")
+        if parent and hasattr(parent, "data_changed"):
+            parent.data_changed.emit()
+
+        QMessageBox.information(
+            self,
+            "Eliminar compra",
+            "La compra seleccionada se eliminó correctamente.",
+        )
 
     def _toggle_date_filter(self, checked):
         self.quick_range.setEnabled(checked)

--- a/tests/test_update_compra.py
+++ b/tests/test_update_compra.py
@@ -160,3 +160,108 @@ def test_update_detalle_compra_cantidad_validates_input():
     with pytest.raises(ValueError):
         db.update_detalle_compra_cantidad(None, 1)
 
+
+def test_delete_detalle_compra_updates_totals_and_stock():
+    db = create_db()
+    db.add_Distribuidor("D1")
+    dist_id = db.cursor.lastrowid
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, dist_id, 0, 0, 0, 0)
+    prod_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "producto_id": None,
+            "cantidad": 0,
+            "precio_unitario": 0,
+            "total": 72,
+            "Distribuidor_id": dist_id,
+            "comision_pct": 0,
+            "comision_monto": 2,
+            "vendedor_id": vend_id,
+        }
+    )
+
+    db.add_detalle_compra(
+        compra_id,
+        prod_id,
+        10,
+        5,
+        "",
+        0,
+        "%",
+        0,
+        "ninguno",
+        0,
+        2,
+        "Añadida al total",
+    )
+    detalle_eliminar = db.cursor.lastrowid
+    db.aumentar_stock(prod_id, 10)
+
+    db.add_detalle_compra(
+        compra_id,
+        prod_id,
+        5,
+        4,
+        "",
+        0,
+        "%",
+        0,
+        "ninguno",
+        0,
+        0,
+        "Añadida al total",
+    )
+    db.aumentar_stock(prod_id, 5)
+
+    db.delete_detalle_compra(detalle_eliminar)
+
+    compra = db.get_compra(compra_id)
+    assert compra["total"] == 20
+    assert compra["comision_monto"] == 0
+
+    detalles_restantes = db.get_detalles_compra(compra_id)
+    assert len(detalles_restantes) == 1
+    assert detalles_restantes[0]["cantidad"] == 5
+
+    stock = db.cursor.execute("SELECT stock FROM productos WHERE id=?", (prod_id,)).fetchone()["stock"]
+    assert stock == 5
+
+
+def test_delete_compra_removes_records_and_stock():
+    db = create_db()
+    db.add_Distribuidor("D1")
+    dist_id = db.cursor.lastrowid
+    db.add_vendedor("V1")
+    vend_id = db.cursor.lastrowid
+    db.add_producto("Prod", "P1", None, vend_id, dist_id, 0, 0, 0, 0)
+    prod_id = db.cursor.lastrowid
+
+    compra_id = db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "producto_id": None,
+            "cantidad": 0,
+            "precio_unitario": 0,
+            "total": 50,
+            "Distribuidor_id": dist_id,
+            "comision_pct": 0,
+            "comision_monto": 0,
+            "vendedor_id": vend_id,
+        }
+    )
+
+    db.add_detalle_compra(compra_id, prod_id, 10, 5)
+    db.aumentar_stock(prod_id, 10)
+
+    db.delete_compra(compra_id)
+
+    assert not db.get_detalles_compra(compra_id)
+    assert db.get_compra(compra_id) is None
+
+    stock = db.cursor.execute("SELECT stock FROM productos WHERE id=?", (prod_id,)).fetchone()["stock"]
+    assert stock == 0
+

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -500,7 +500,9 @@ class MainWindow(QMainWindow):
         inventario_actual_buttons = QHBoxLayout()
         inventario_actual_buttons.addStretch()
         self.btn_edit_lote = QPushButton("Editar lote")
+        self.btn_delete_lote = QPushButton("Eliminar lote")
         inventario_actual_buttons.addWidget(self.btn_edit_lote)
+        inventario_actual_buttons.addWidget(self.btn_delete_lote)
         inventario_actual_layout.addLayout(inventario_actual_buttons)
 
         inventario_actual_tab.setLayout(inventario_actual_layout)
@@ -656,6 +658,7 @@ class MainWindow(QMainWindow):
         self.cliente_search.textChanged.connect(self._actualizar_tabla_clientes)
         self.actual_search_bar.textChanged.connect(self._actualizar_inventario_actual)
         self.btn_edit_lote.clicked.connect(self._editar_lote_inventario_actual)
+        self.btn_delete_lote.clicked.connect(self._eliminar_lote_inventario_actual)
         self._actualizar_tabla_clientes()  # <-- SOLO AGREGA ESTA LÍNEA AL FINAL DE _setup_ui
         self._actualizar_inventario_actual()  # <-- AGREGA ESTA LÍNEA AL FINAL DE _setup_ui
 
@@ -1862,6 +1865,74 @@ class MainWindow(QMainWindow):
         )
 
         self._actualizar_inventario_actual()
+        self.filter_products()
+        self.data_changed.emit()
+
+    def _eliminar_lote_inventario_actual(self):
+        row = self.inventario_actual_table.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Eliminar lote", "Seleccione un lote para eliminar.")
+            return
+
+        item_producto = self.inventario_actual_table.item(row, 0)
+        if not item_producto:
+            QMessageBox.warning(
+                self,
+                "Eliminar lote",
+                "No se pudo obtener la información del lote seleccionado.",
+            )
+            return
+
+        data = item_producto.data(Qt.UserRole) or {}
+        detalle_id = data.get("detalle_id")
+        if not detalle_id:
+            QMessageBox.warning(
+                self,
+                "Eliminar lote",
+                "No se encontró el identificador del lote seleccionado.",
+            )
+            return
+
+        producto = data.get("producto", "")
+        codigo = data.get("codigo", "")
+        cantidad = data.get("cantidad", 0)
+
+        confirm = QMessageBox.question(
+            self,
+            "Eliminar lote",
+            f"¿Eliminar el lote de {producto} (código {codigo}) con {cantidad} unidades?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirm != QMessageBox.Yes:
+            return
+
+        try:
+            self.manager.delete_detalle_compra(detalle_id)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Eliminar lote", str(exc))
+            return
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Error al eliminar el lote %s", detalle_id)
+            QMessageBox.critical(
+                self,
+                "Eliminar lote",
+                "Ocurrió un error al eliminar el lote seleccionado.",
+            )
+            return
+
+        QMessageBox.information(
+            self,
+            "Eliminar lote",
+            "El lote se eliminó correctamente del inventario.",
+        )
+
+        self._actualizar_inventario_actual()
+        if hasattr(self, "compras_tab") and hasattr(self.compras_tab, "load_purchases"):
+            try:
+                self.compras_tab.load_purchases()
+            except Exception:  # pragma: no cover - keep UI responsive
+                logger.exception("No se pudo refrescar la pestaña de compras tras eliminar el lote")
         self.filter_products()
         self.data_changed.emit()
 


### PR DESCRIPTION
## Summary
- add delete purchase control to the purchases tab and refresh dependent views after removal
- implement database and manager helpers to delete purchases or individual lots while updating stock and totals
- add a delete lot action to the inventory tab and expand unit tests to cover the new deletion behaviour

## Testing
- pytest tests/test_update_compra.py

------
https://chatgpt.com/codex/tasks/task_e_68e35468445c83238c68998e795e8693