### PR TITLE
Fix persistence of purchase details during inventory import

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -520,6 +520,9 @@ class InventoryManager:
         productos_por_id = {
             p.get("id"): p for p in data.get("productos", []) if isinstance(p, dict)
         }
+        compras_por_id = {
+            c.get("id"): c for c in data.get("compras", []) if isinstance(c, dict)
+        }
         cliente_id_map = {}
         venta_id_map = {}
         compra_id_map = {}
@@ -828,6 +831,88 @@ class InventoryManager:
                 )
                 new_id = self.db.cursor.lastrowid
                 compra_id_map[c["id"]] = new_id
+
+            detalles_por_compra: dict[object, list[dict]] = {}
+            for detalle in data.get("detalles_compra", []):
+                if not isinstance(detalle, dict):
+                    continue
+                compra_key = detalle.get("compra_id")
+                if compra_key is None:
+                    continue
+                detalles_por_compra.setdefault(compra_key, []).append(detalle)
+
+            def _to_decimal(value) -> D:
+                try:
+                    if value is None or value == "":
+                        return D("0")
+                    return D(str(value))
+                except (ArithmeticError, ValueError, TypeError):
+                    return D("0")
+
+            def _maybe_create_missing_purchase(compra_key, detalles_list):
+                if compra_key in compra_id_map:
+                    return
+
+                compra_info = compras_por_id.get(compra_key, {}) if compras_por_id else {}
+                base_total = D("0")
+                total_comision = D("0")
+                for det in detalles_list:
+                    cantidad = _to_decimal(det.get("cantidad"))
+                    precio = _to_decimal(det.get("precio_unitario"))
+                    subtotal = cantidad * precio
+                    descuento = _to_decimal(det.get("descuento"))
+                    subtotal_con_descuento = subtotal - descuento
+                    if subtotal_con_descuento < 0:
+                        subtotal_con_descuento = D("0")
+                    iva = _to_decimal(det.get("iva"))
+                    iva_tipo = str(det.get("iva_tipo") or "").strip().lower()
+                    comision_monto = _to_decimal(det.get("comision_monto"))
+                    comision_tipo = str(det.get("comision_tipo") or "").strip().lower()
+                    total_linea = subtotal_con_descuento
+                    if iva_tipo == "añadido" or iva_tipo == "anadido":
+                        total_linea += iva
+                    if comision_tipo in {"añadida al total", "anadida al total"}:
+                        total_linea += comision_monto
+                    base_total += total_linea
+                    total_comision += comision_monto
+
+                if base_total == 0 and not compra_info:
+                    # Nothing meaningful to persist
+                    return
+
+                mapped_dist = None
+                mapped_vendor = None
+                if compra_info:
+                    dist_id = compra_info.get("Distribuidor_id")
+                    if dist_id is not None:
+                        mapped_dist = Distribuidor_id_map.get(dist_id)
+                    vend_id = compra_info.get("vendedor_id")
+                    if vend_id is not None:
+                        mapped_vendor = vendedor_id_map.get(vend_id)
+
+                comision_pct = compra_info.get("comision_pct", 0) if compra_info else 0
+                comision_monto = compra_info.get("comision_monto")
+                if comision_monto is None:
+                    comision_monto = float(total_comision)
+
+                self.db.cursor.execute(
+                    "INSERT INTO compras (fecha, producto_id, cantidad, precio_unitario, total, Distribuidor_id, comision_pct, comision_monto, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        (compra_info.get("fecha") if compra_info else "") or "",
+                        None,
+                        0,
+                        0,
+                        float(base_total) if base_total else compra_info.get("total", 0),
+                        mapped_dist,
+                        comision_pct,
+                        comision_monto,
+                        mapped_vendor,
+                    ),
+                )
+                compra_id_map[compra_key] = self.db.cursor.lastrowid
+
+            for compra_key, detalles_list in detalles_por_compra.items():
+                _maybe_create_missing_purchase(compra_key, detalles_list)
 
             # Detalles de venta
             for d in data.get("detalles_venta", []):

--- a/tests/test_import_compras_missing_purchase.py
+++ b/tests/test_import_compras_missing_purchase.py
@@ -1,0 +1,117 @@
+import json
+import sys
+import types
+import importlib.machinery
+
+
+def _install_qt_stubs():
+    if "PyQt5" in sys.modules:
+        sys.modules.pop("PyQt5", None)
+        sys.modules.pop("PyQt5.QtCore", None)
+        sys.modules.pop("PyQt5.QtGui", None)
+
+    qt = types.ModuleType("PyQt5")
+    qtcore = types.ModuleType("PyQt5.QtCore")
+    qtgui = types.ModuleType("PyQt5.QtGui")
+    qt.__path__ = []
+    qt.__spec__ = importlib.machinery.ModuleSpec("PyQt5", loader=None, is_package=True)
+    qtcore.__spec__ = importlib.machinery.ModuleSpec("PyQt5.QtCore", loader=None)
+    qtgui.__spec__ = importlib.machinery.ModuleSpec("PyQt5.QtGui", loader=None)
+
+    class _DummyModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def beginResetModel(self):
+            pass
+
+        def endResetModel(self):
+            pass
+
+    class _QtNamespace:
+        DisplayRole = 0
+        BackgroundRole = 1
+        Horizontal = 1
+
+    class _DummyColor:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    qtcore.QAbstractTableModel = _DummyModel
+    qtcore.Qt = _QtNamespace
+    qtgui.QColor = _DummyColor
+    qt.QtCore = qtcore
+    qt.QtGui = qtgui
+
+    sys.modules["PyQt5"] = qt
+    sys.modules["PyQt5.QtCore"] = qtcore
+    sys.modules["PyQt5.QtGui"] = qtgui
+
+
+def test_import_recreates_missing_purchase(tmp_path):
+    _install_qt_stubs()
+
+    from inventory_manager import InventoryManager
+    from db import DB
+
+    data = {
+        "schemaVersion": 1,
+        "productos": [
+            {
+                "id": 1,
+                "nombre": "Producto",
+                "codigo": "P1",
+                "precio_compra": 5,
+                "precio_venta_minorista": 5,
+                "precio_venta_mayorista": 5,
+                "stock": 2,
+            }
+        ],
+        "vendedores": [],
+        "distribuidores": [],
+        "clientes": [],
+        "ventas": [],
+        "detalles_venta": [],
+        "compras": [],
+        "movimientos": [],
+        "detalles_compra": [
+            {
+                "id": 1,
+                "compra_id": 99,
+                "producto_id": 1,
+                "cantidad": 2,
+                "precio_unitario": 5,
+                "descuento": 1,
+                "iva": 0.6,
+                "iva_tipo": "añadido",
+                "comision_monto": 0.4,
+                "comision_tipo": "Añadida al total",
+            }
+        ],
+        "dte_envios": [],
+        "notas": [],
+        "facturas_pdf": [],
+        "tickets_pdf": [],
+        "trabajadores": [],
+        "datos_negocio": {},
+        "ventas_credito_fiscal": [],
+    }
+
+    inv_file = tmp_path / "inventory.json"
+    inv_file.write_text(json.dumps(data))
+
+    manager = InventoryManager(DB(":memory:"))
+    manager.importar_inventario_json(str(inv_file))
+
+    compras = manager.db.get_compras()
+    assert len(compras) == 1
+    compra = compras[0]
+    assert compra["total"] == 10.0
+    assert compra["comision_monto"] == 0.4
+
+    detalles = manager.db.get_detalles_compra(compra["id"])
+    assert len(detalles) == 1
+    detalle = detalles[0]
+    assert detalle["producto_id"] is not None
+    assert detalle["cantidad"] == 2


### PR DESCRIPTION
## Summary
- ensure inventory imports recreate missing purchase records so detail lines remain associated
- add regression coverage that simulates the import without PyQt by installing lightweight stubs

## Testing
- pytest tests/test_import_compras_missing_purchase.py

------
https://chatgpt.com/codex/tasks/task_e_68e3519eebb08323b1041ca6ff96332b