### PR TITLE
Preserve purchase details when exporting and importing inventory

### DIFF
--- a/inventory_manager.py
+++ b/inventory_manager.py
@@ -520,10 +520,24 @@ class InventoryManager:
         productos_por_id = {
             p.get("id"): p for p in data.get("productos", []) if isinstance(p, dict)
         }
+        compras_por_id = {
+            c.get("id"): c for c in data.get("compras", []) if isinstance(c, dict)
+        }
         cliente_id_map = {}
         venta_id_map = {}
-        compra_id_map = {}
+        compra_id_map: dict[object, int] = {}
         trabajador_id_map = {}
+        detalle_compra_id_map: dict[object, int] = {}
+
+        def _coerce_int(value):
+            if value in (None, ""):
+                return None
+            if isinstance(value, int):
+                return value
+            try:
+                return int(str(value))
+            except (TypeError, ValueError):
+                return None
 
         self.db.ensure_column("ventas", "sincronizada", "INTEGER DEFAULT 1")
         self.db.conn.execute("BEGIN")
@@ -812,55 +826,147 @@ class InventoryManager:
                 )
                 comision_pct = c.get("comision_pct", 0)
                 comision_monto = c.get("comision_monto", 0)
+                old_id_raw = c.get("id")
+                specified_id = _coerce_int(old_id_raw)
+                columns = [
+                    "fecha",
+                    "producto_id",
+                    "cantidad",
+                    "precio_unitario",
+                    "total",
+                    "Distribuidor_id",
+                    "comision_pct",
+                    "comision_monto",
+                    "vendedor_id",
+                ]
+                values = [
+                    c.get("fecha", ""),
+                    None,
+                    0,
+                    0,
+                    c.get("total", 0),
+                    Distribuidor_id,
+                    comision_pct,
+                    comision_monto,
+                    vendedor_id,
+                ]
+                if specified_id is not None:
+                    columns.insert(0, "id")
+                    values.insert(0, specified_id)
+                placeholders = ", ".join(["?"] * len(values))
                 self.db.cursor.execute(
-                    "INSERT INTO compras (fecha, producto_id, cantidad, precio_unitario, total, Distribuidor_id, comision_pct, comision_monto, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        c.get("fecha", ""),
-                        None,
-                        0,
-                        0,
-                        c.get("total", 0),
-                        Distribuidor_id,
-                        comision_pct,
-                        comision_monto,
-                        vendedor_id,
-                    ),
+                    f"INSERT INTO compras ({', '.join(columns)}) VALUES ({placeholders})",
+                    tuple(values),
                 )
-                new_id = self.db.cursor.lastrowid
-                compra_id_map[c["id"]] = new_id
+                new_id = specified_id if specified_id is not None else self.db.cursor.lastrowid
+                if old_id_raw is not None:
+                    compra_id_map[old_id_raw] = new_id
+                    compra_id_map[str(old_id_raw)] = new_id
+                if specified_id is not None:
+                    compra_id_map[specified_id] = new_id
 
-            # Detalles de venta
-            for d in data.get("detalles_venta", []):
-                venta_id = venta_id_map.get(d.get("venta_id"))
-                producto_id = producto_id_map.get(d.get("producto_id"))
-                vendedor_id = None
-                old_vend_id = d.get("vendedor_id")
-                if old_vend_id is not None:
-                    vendedor_id = trabajador_id_map.get(old_vend_id)
-                    if vendedor_id is None:
-                        logger.warning(
-                            "detalle_venta vendedor_id %s not found in mapping, defaulting to None",
-                            old_vend_id,
-                        )
-                if venta_id and producto_id:
-                    self.db.cursor.execute(
-                        "INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                        (
-                            venta_id,
-                            producto_id,
-                            d.get("cantidad", 0),
-                            d.get("precio_unitario", 0),
-                            d.get("descuento", 0),
-                            d.get("descuento_tipo", ""),
-                            d.get("iva", 0),
-                            d.get("comision", 0),
-                            d.get("iva_tipo", ""),
-                            d.get("tipo_fiscal", "Gravada"),
-                            d.get("extra", None),
-                            d.get("precio_con_iva", 0),
-                            vendedor_id,
-                        ),
-                    )
+            detalles_por_compra: dict[object, list[dict]] = {}
+            for detalle in data.get("detalles_compra", []):
+                if not isinstance(detalle, dict):
+                    continue
+                compra_key = detalle.get("compra_id")
+                if compra_key is None:
+                    continue
+                detalles_por_compra.setdefault(compra_key, []).append(detalle)
+
+            def _to_decimal(value) -> D:
+                try:
+                    if value is None or value == "":
+                        return D("0")
+                    return D(str(value))
+                except (ArithmeticError, ValueError, TypeError):
+                    return D("0")
+
+            def _maybe_create_missing_purchase(compra_key, detalles_list):
+                if compra_key in compra_id_map:
+                    return
+
+                compra_info = compras_por_id.get(compra_key, {}) if compras_por_id else {}
+                base_total = D("0")
+                total_comision = D("0")
+                for det in detalles_list:
+                    cantidad = _to_decimal(det.get("cantidad"))
+                    precio = _to_decimal(det.get("precio_unitario"))
+                    subtotal = cantidad * precio
+                    descuento = _to_decimal(det.get("descuento"))
+                    subtotal_con_descuento = subtotal - descuento
+                    if subtotal_con_descuento < 0:
+                        subtotal_con_descuento = D("0")
+                    iva = _to_decimal(det.get("iva"))
+                    iva_tipo = str(det.get("iva_tipo") or "").strip().lower()
+                    comision_monto = _to_decimal(det.get("comision_monto"))
+                    comision_tipo = str(det.get("comision_tipo") or "").strip().lower()
+                    total_linea = subtotal_con_descuento
+                    if iva_tipo == "añadido" or iva_tipo == "anadido":
+                        total_linea += iva
+                    if comision_tipo in {"añadida al total", "anadida al total"}:
+                        total_linea += comision_monto
+                    base_total += total_linea
+                    total_comision += comision_monto
+
+                if base_total == 0 and not compra_info:
+                    # Nothing meaningful to persist
+                    return
+
+                mapped_dist = None
+                mapped_vendor = None
+                if compra_info:
+                    dist_id = compra_info.get("Distribuidor_id")
+                    if dist_id is not None:
+                        mapped_dist = Distribuidor_id_map.get(dist_id)
+                    vend_id = compra_info.get("vendedor_id")
+                    if vend_id is not None:
+                        mapped_vendor = vendedor_id_map.get(vend_id)
+
+                comision_pct = compra_info.get("comision_pct", 0) if compra_info else 0
+                comision_monto = compra_info.get("comision_monto")
+                if comision_monto is None:
+                    comision_monto = float(total_comision)
+
+                old_id = _coerce_int(compra_key)
+                columns = [
+                    "fecha",
+                    "producto_id",
+                    "cantidad",
+                    "precio_unitario",
+                    "total",
+                    "Distribuidor_id",
+                    "comision_pct",
+                    "comision_monto",
+                    "vendedor_id",
+                ]
+                values = [
+                    (compra_info.get("fecha") if compra_info else "") or "",
+                    None,
+                    0,
+                    0,
+                    float(base_total) if base_total else compra_info.get("total", 0),
+                    mapped_dist,
+                    comision_pct,
+                    comision_monto,
+                    mapped_vendor,
+                ]
+                if old_id is not None:
+                    columns.insert(0, "id")
+                    values.insert(0, old_id)
+                placeholders = ", ".join(["?"] * len(values))
+                self.db.cursor.execute(
+                    f"INSERT INTO compras ({', '.join(columns)}) VALUES ({placeholders})",
+                    tuple(values),
+                )
+                new_id = old_id if old_id is not None else self.db.cursor.lastrowid
+                compra_id_map[compra_key] = new_id
+                compra_id_map[str(compra_key)] = new_id
+                if old_id is not None:
+                    compra_id_map[old_id] = new_id
+
+            for compra_key, detalles_list in detalles_por_compra.items():
+                _maybe_create_missing_purchase(compra_key, detalles_list)
 
             # Detalles de compra
             for d in data.get("detalles_compra", []):
@@ -916,7 +1022,23 @@ class InventoryManager:
                             )
                             producto_id = None
                 if compra_id and producto_id:
-                    self.db.add_detalle_compra(
+                    old_detalle_id = d.get("id")
+                    specified_detalle_id = _coerce_int(old_detalle_id)
+                    columns = [
+                        "compra_id",
+                        "producto_id",
+                        "cantidad",
+                        "precio_unitario",
+                        "fecha_vencimiento",
+                        "descuento",
+                        "descuento_tipo",
+                        "iva",
+                        "iva_tipo",
+                        "comision_pct",
+                        "comision_monto",
+                        "comision_tipo",
+                    ]
+                    values = [
                         compra_id,
                         producto_id,
                         d.get("cantidad", 0),
@@ -929,7 +1051,115 @@ class InventoryManager:
                         d.get("comision_pct", 0),
                         d.get("comision_monto", 0),
                         d.get("comision_tipo", ""),
-                        commit=False,
+                    ]
+                    if specified_detalle_id is not None:
+                        columns.insert(0, "id")
+                        values.insert(0, specified_detalle_id)
+                    placeholders = ", ".join(["?"] * len(values))
+                    self.db.cursor.execute(
+                        f"INSERT INTO detalles_compra ({', '.join(columns)}) VALUES ({placeholders})",
+                        tuple(values),
+                    )
+                    new_detalle_id = (
+                        specified_detalle_id
+                        if specified_detalle_id is not None
+                        else self.db.cursor.lastrowid
+                    )
+                    if old_detalle_id is not None:
+                        detalle_compra_id_map[old_detalle_id] = new_detalle_id
+                        detalle_compra_id_map[str(old_detalle_id)] = new_detalle_id
+                    if specified_detalle_id is not None:
+                        detalle_compra_id_map[specified_detalle_id] = new_detalle_id
+
+            # Ajustar secuencias de AUTOINCREMENT para compras y detalles de compra
+            max_compra_id = (
+                self.db.cursor.execute("SELECT MAX(id) FROM compras").fetchone()[0] or 0
+            )
+            self.db.cursor.execute(
+                "UPDATE sqlite_sequence SET seq=? WHERE name='compras'",
+                (max_compra_id,),
+            )
+            max_detalle_compra_id = (
+                self.db.cursor.execute("SELECT MAX(id) FROM detalles_compra").fetchone()[0]
+                or 0
+            )
+            self.db.cursor.execute(
+                "UPDATE sqlite_sequence SET seq=? WHERE name='detalles_compra'",
+                (max_detalle_compra_id,),
+            )
+
+            def _remap_lote_references(value):
+                if isinstance(value, dict):
+                    updated = {}
+                    for key, item in value.items():
+                        if key in {"lote_id", "loteId", "lote"}:
+                            replacement = detalle_compra_id_map.get(item, item)
+                            if replacement is item:
+                                replacement = detalle_compra_id_map.get(str(item), item)
+                            updated[key] = replacement
+                        else:
+                            updated[key] = _remap_lote_references(item)
+                    return updated
+                if isinstance(value, list):
+                    return [_remap_lote_references(item) for item in value]
+                return detalle_compra_id_map.get(value, value)
+
+            # Detalles de venta
+            for d in data.get("detalles_venta", []):
+                venta_id = venta_id_map.get(d.get("venta_id"))
+                producto_id = producto_id_map.get(d.get("producto_id"))
+                vendedor_id = None
+                old_vend_id = d.get("vendedor_id")
+                if old_vend_id is not None:
+                    vendedor_id = trabajador_id_map.get(old_vend_id)
+                    if vendedor_id is None:
+                        logger.warning(
+                            "detalle_venta vendedor_id %s not found in mapping, defaulting to None",
+                            old_vend_id,
+                        )
+                if venta_id and producto_id:
+                    extra = d.get("extra", None)
+                    extra_was_string = isinstance(extra, str)
+                    if extra_was_string:
+                        text = extra.strip()
+                        if text:
+                            try:
+                                extra = json.loads(text)
+                            except Exception:
+                                extra = text
+                    remapped_extra = _remap_lote_references(extra)
+                    if remapped_extra is None:
+                        extra_value = None
+                    elif isinstance(remapped_extra, (dict, list)):
+                        try:
+                            extra_value = json.dumps(remapped_extra)
+                        except Exception:
+                            extra_value = json.dumps(remapped_extra, default=str)
+                    elif isinstance(remapped_extra, str):
+                        extra_value = remapped_extra
+                    else:
+                        if extra_was_string:
+                            extra_value = json.dumps(remapped_extra)
+                        else:
+                            extra_value = remapped_extra
+
+                    self.db.cursor.execute(
+                        "INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            venta_id,
+                            producto_id,
+                            d.get("cantidad", 0),
+                            d.get("precio_unitario", 0),
+                            d.get("descuento", 0),
+                            d.get("descuento_tipo", ""),
+                            d.get("iva", 0),
+                            d.get("comision", 0),
+                            d.get("iva_tipo", ""),
+                            d.get("tipo_fiscal", "Gravada"),
+                            extra_value,
+                            d.get("precio_con_iva", 0),
+                            vendedor_id,
+                        ),
                     )
 
             # Movimientos (opcional, si tienes movimientos)

--- a/tests/test_import_compras_missing_purchase.py
+++ b/tests/test_import_compras_missing_purchase.py
@@ -1,0 +1,117 @@
+import json
+import sys
+import types
+import importlib.machinery
+
+
+def _install_qt_stubs():
+    if "PyQt5" in sys.modules:
+        sys.modules.pop("PyQt5", None)
+        sys.modules.pop("PyQt5.QtCore", None)
+        sys.modules.pop("PyQt5.QtGui", None)
+
+    qt = types.ModuleType("PyQt5")
+    qtcore = types.ModuleType("PyQt5.QtCore")
+    qtgui = types.ModuleType("PyQt5.QtGui")
+    qt.__path__ = []
+    qt.__spec__ = importlib.machinery.ModuleSpec("PyQt5", loader=None, is_package=True)
+    qtcore.__spec__ = importlib.machinery.ModuleSpec("PyQt5.QtCore", loader=None)
+    qtgui.__spec__ = importlib.machinery.ModuleSpec("PyQt5.QtGui", loader=None)
+
+    class _DummyModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def beginResetModel(self):
+            pass
+
+        def endResetModel(self):
+            pass
+
+    class _QtNamespace:
+        DisplayRole = 0
+        BackgroundRole = 1
+        Horizontal = 1
+
+    class _DummyColor:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    qtcore.QAbstractTableModel = _DummyModel
+    qtcore.Qt = _QtNamespace
+    qtgui.QColor = _DummyColor
+    qt.QtCore = qtcore
+    qt.QtGui = qtgui
+
+    sys.modules["PyQt5"] = qt
+    sys.modules["PyQt5.QtCore"] = qtcore
+    sys.modules["PyQt5.QtGui"] = qtgui
+
+
+def test_import_recreates_missing_purchase(tmp_path):
+    _install_qt_stubs()
+
+    from inventory_manager import InventoryManager
+    from db import DB
+
+    data = {
+        "schemaVersion": 1,
+        "productos": [
+            {
+                "id": 1,
+                "nombre": "Producto",
+                "codigo": "P1",
+                "precio_compra": 5,
+                "precio_venta_minorista": 5,
+                "precio_venta_mayorista": 5,
+                "stock": 2,
+            }
+        ],
+        "vendedores": [],
+        "distribuidores": [],
+        "clientes": [],
+        "ventas": [],
+        "detalles_venta": [],
+        "compras": [],
+        "movimientos": [],
+        "detalles_compra": [
+            {
+                "id": 1,
+                "compra_id": 99,
+                "producto_id": 1,
+                "cantidad": 2,
+                "precio_unitario": 5,
+                "descuento": 1,
+                "iva": 0.6,
+                "iva_tipo": "añadido",
+                "comision_monto": 0.4,
+                "comision_tipo": "Añadida al total",
+            }
+        ],
+        "dte_envios": [],
+        "notas": [],
+        "facturas_pdf": [],
+        "tickets_pdf": [],
+        "trabajadores": [],
+        "datos_negocio": {},
+        "ventas_credito_fiscal": [],
+    }
+
+    inv_file = tmp_path / "inventory.json"
+    inv_file.write_text(json.dumps(data))
+
+    manager = InventoryManager(DB(":memory:"))
+    manager.importar_inventario_json(str(inv_file))
+
+    compras = manager.db.get_compras()
+    assert len(compras) == 1
+    compra = compras[0]
+    assert compra["total"] == 10.0
+    assert compra["comision_monto"] == 0.4
+
+    detalles = manager.db.get_detalles_compra(compra["id"])
+    assert len(detalles) == 1
+    detalle = detalles[0]
+    assert detalle["producto_id"] is not None
+    assert detalle["cantidad"] == 2

--- a/tests/test_inventory_import_preserves_purchase_details.py
+++ b/tests/test_inventory_import_preserves_purchase_details.py
@@ -1,0 +1,147 @@
+import json
+import sys
+import types
+import importlib.machinery
+
+
+def _install_qt_stubs():
+    for name in list(sys.modules):
+        if name.startswith("PyQt5"):
+            sys.modules.pop(name, None)
+
+    qt = types.ModuleType("PyQt5")
+    qt.__path__ = []
+    qt.__spec__ = importlib.machinery.ModuleSpec("PyQt5", loader=None, is_package=True)
+
+    qtcore = types.ModuleType("PyQt5.QtCore")
+    qtcore.__spec__ = importlib.machinery.ModuleSpec("PyQt5.QtCore", loader=None)
+    qtgui = types.ModuleType("PyQt5.QtGui")
+    qtgui.__spec__ = importlib.machinery.ModuleSpec("PyQt5.QtGui", loader=None)
+
+    class _DummyModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def beginResetModel(self):
+            pass
+
+        def endResetModel(self):
+            pass
+
+    class _QtNamespace:
+        DisplayRole = 0
+        BackgroundRole = 1
+        Horizontal = 1
+
+    class _DummyColor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    qtcore.QAbstractTableModel = _DummyModel
+    qtcore.Qt = _QtNamespace
+    qtgui.QColor = _DummyColor
+    qt.QtCore = qtcore
+    qt.QtGui = qtgui
+
+    sys.modules["PyQt5"] = qt
+    sys.modules["PyQt5.QtCore"] = qtcore
+    sys.modules["PyQt5.QtGui"] = qtgui
+
+
+def test_export_and_import_preserve_purchase_details(tmp_path):
+    _install_qt_stubs()
+
+    from inventory_manager import InventoryManager
+    from db import DB
+
+    manager = InventoryManager(DB(":memory:"))
+    manager.db.add_Distribuidor("Distribuidor")
+    dist_id = manager.db.cursor.lastrowid
+    manager.db.add_vendedor("Proveedor")
+    vendor_id = manager.db.cursor.lastrowid
+    manager.db.add_producto(
+        "Producto",
+        "P-001",
+        None,
+        vendor_id,
+        dist_id,
+        5,
+        7,
+        9,
+        10,
+    )
+    product_id = manager.db.cursor.lastrowid
+
+    compra_id = manager.db.add_compra_detallada(
+        {
+            "fecha": "2024-01-01",
+            "total": 50,
+            "Distribuidor_id": dist_id,
+            "comision_pct": 0,
+            "comision_monto": 0,
+            "vendedor_id": vendor_id,
+        }
+    )
+    manager.db.add_detalle_compra(
+        compra_id,
+        product_id,
+        5,
+        10,
+        "2024-12-31",
+        0,
+        "%",
+        0,
+        "ninguno",
+        0,
+        0,
+        "",
+    )
+    detalle_id = manager.db.cursor.lastrowid
+
+    manager.db.cursor.execute(
+        "INSERT INTO ventas (id, fecha, total, cliente_id, Distribuidor_id, vendedor_id, extra, estado, sincronizada) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (1, "2024-01-02", 20, None, dist_id, None, None, "Pagada", 1),
+    )
+    manager.db.cursor.execute(
+        "INSERT INTO detalles_venta (venta_id, producto_id, cantidad, precio_unitario, descuento, descuento_tipo, iva, comision, iva_tipo, tipo_fiscal, extra, precio_con_iva, vendedor_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            1,
+            product_id,
+            2,
+            10,
+            0,
+            "%",
+            0,
+            0,
+            "ninguno",
+            "Gravada",
+            json.dumps({"lote_id": detalle_id, "producto_id": product_id, "cantidad": 2}),
+            10,
+            None,
+        ),
+    )
+    manager.db.conn.commit()
+
+    export_path = tmp_path / "inventory.json"
+    manager.exportar_inventario_json(str(export_path), {})
+
+    imported = InventoryManager(DB(":memory:"))
+    imported.importar_inventario_json(str(export_path), strict=False)
+
+    compras = imported.db.get_compras()
+    assert len(compras) == 1
+    compra = compras[0]
+    assert compra["id"] == compra_id
+
+    detalles = imported.db.get_detalles_compra(compra["id"])
+    assert len(detalles) == 1
+    detalle = detalles[0]
+    assert detalle["id"] == detalle_id
+    assert detalle["producto_id"] == product_id
+    assert detalle["cantidad"] == 5
+
+    imported.db.cursor.execute("SELECT extra FROM detalles_venta")
+    extra_raw = imported.db.cursor.fetchone()[0]
+    parsed = json.loads(extra_raw)
+    assert parsed["lote_id"] == detalle_id
+


### PR DESCRIPTION
## Summary
- keep original purchase and detail identifiers when importing inventories to maintain lot references and vendor mappings
- remap any remaining lot references in sale extras and ensure sequences stay in sync
- add regression test covering export/import of purchases with associated sale lot references

## Testing
- pytest tests/test_import_compras_missing_purchase.py tests/test_inventory_import_preserves_purchase_details.py

------
https://chatgpt.com/codex/tasks/task_e_68e3519eebb08323b1041ca6ff96332b