### PR TITLE
Add warning prompt before editing or deleting purchases and lots

### DIFF
--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -25,6 +25,20 @@ class PurchasesTab(QWidget):
         self._setup_ui()
         self.load_purchases()
 
+    def _confirm_inventory_conflict(self, target: str) -> bool:
+        message = (
+            f"Editar o eliminar {target} puede causar conflictos en el inventario, "
+            "proceda solo si está seguro de que no causará conflictos con sus cambios."
+        )
+        result = QMessageBox.warning(
+            self,
+            "Advertencia",
+            message,
+            QMessageBox.Ok | QMessageBox.Cancel,
+            QMessageBox.Cancel,
+        )
+        return result == QMessageBox.Ok
+
     def refresh_filters(self):
         """Refresh distributor and vendor filter combos with current data."""
         self.distribuidor_combo.blockSignals(True)
@@ -194,6 +208,9 @@ class PurchasesTab(QWidget):
                 "Compra no encontrada",
                 "No fue posible cargar la compra seleccionada. Intente nuevamente.",
             )
+            return
+
+        if not self._confirm_inventory_conflict("esta compra"):
             return
 
         confirm = QMessageBox.question(
@@ -450,6 +467,9 @@ class PurchasesTab(QWidget):
         productos = [dict(p) for p in self.manager.db.get_productos()]
         Distribuidores = [dict(d) for d in self.manager.db.get_Distribuidores()]
         proveedores = [dict(v) for v in self.manager.db.get_vendedores_distribuidores()]
+
+        if not self._confirm_inventory_conflict("esta compra"):
+            return
 
         dlg = RegisterPurchaseDialog(
             productos,

--- a/ui_mainwindow.py
+++ b/ui_mainwindow.py
@@ -1808,6 +1808,20 @@ class MainWindow(QMainWindow):
             self.inventario_actual_table.setItem(row, 5, item_venc)
             self.inventario_actual_table.setItem(row, 6, QTableWidgetItem(d["Distribuidor"]))
 
+    def _confirm_inventory_conflict(self, target: str) -> bool:
+        message = (
+            f"Editar o eliminar {target} puede causar conflictos en el inventario, "
+            "proceda solo si está seguro de que no causará conflictos con sus cambios."
+        )
+        result = QMessageBox.warning(
+            self,
+            "Advertencia",
+            message,
+            QMessageBox.Ok | QMessageBox.Cancel,
+            QMessageBox.Cancel,
+        )
+        return result == QMessageBox.Ok
+
     def _editar_lote_inventario_actual(self):
         row = self.inventario_actual_table.currentRow()
         if row < 0:
@@ -1829,6 +1843,9 @@ class MainWindow(QMainWindow):
         cantidad_actual = int(data.get("cantidad", 0) or 0)
         producto = data.get("producto", "")
         codigo = data.get("codigo", "")
+
+        if not self._confirm_inventory_conflict("este lote"):
+            return
 
         nueva_cantidad, ok = QInputDialog.getInt(
             self,
@@ -1896,6 +1913,9 @@ class MainWindow(QMainWindow):
         producto = data.get("producto", "")
         codigo = data.get("codigo", "")
         cantidad = data.get("cantidad", 0)
+
+        if not self._confirm_inventory_conflict("este lote"):
+            return
 
         confirm = QMessageBox.question(
             self,


### PR DESCRIPTION
## Summary
- add a shared confirmation warning before editing or deleting lot entries from the inventory tab
- prompt users with the same warning before editing or deleting purchases in the purchases tab

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e35fe167f883239502fc91da2cdc44