### PR TITLE
Add loading dialogs for DTE operations

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -62,6 +62,7 @@ from utils.jws import sign_and_save
 from utils.sanitize import limpiar_doc, solo_digitos
 from utils.printing import open_pdf as open_pdf_file
 from utils import catalogos
+from utils.loading import create_loading_dialog, loading_dialog
 from paths import (
     DATOS_NEGOCIO_PATH,
     FACTURAS_CONSUMIDOR_FINAL_DIR,
@@ -1896,6 +1897,7 @@ class FacturacionTab(QWidget):
         super().__init__(parent)
         self.manager = manager
         self.email_thread = None
+        self._email_loading_dialog = None
         self._setup_ui()
         # Clean up any stale invoice references before loading
         # documents into the table. This prevents entries tied to
@@ -3405,13 +3407,16 @@ class FacturacionTab(QWidget):
                 json_path = factura.get("json")
                 try:
                     print("UI: CALL_ENVIAR_DOCUMENTO")
-                    note_kind = self._resolve_orphan_note_kind(entry)
-                    if note_kind == "credito":
-                        resp = self._reenviar_nota_credito(entry, factura)
-                    elif note_kind == "debito":
-                        resp = self._reenviar_nota_debito(entry, factura)
-                    else:
-                        resp = dte.transmitir_dte_orphan(self.manager.db, json_path)
+                    with loading_dialog(self, "Enviando a Hacienda…"):
+                        note_kind = self._resolve_orphan_note_kind(entry)
+                        if note_kind == "credito":
+                            resp = self._reenviar_nota_credito(entry, factura)
+                        elif note_kind == "debito":
+                            resp = self._reenviar_nota_debito(entry, factura)
+                        else:
+                            resp = dte.transmitir_dte_orphan(
+                                self.manager.db, json_path
+                            )
                     if resp.get("http_status") in {401, 403}:
                         message = self._auth_error_message(resp, token_msg)
                         QMessageBox.warning(self, "Enviar a Hacienda", message)
@@ -3519,11 +3524,12 @@ class FacturacionTab(QWidget):
                 tipo_dte = self._determine_tipo_dte(entry)
                 try:
                     print("UI: CALL_ENVIAR_DOCUMENTO")
-                    resp = transmitir_dte(
-                        self.manager.db,
-                        entry.get("venta_id"),
-                        tipo_dte=tipo_dte,
-                    )  # tickets también se transmiten con tipo "01"
+                    with loading_dialog(self, "Enviando a Hacienda…"):
+                        resp = transmitir_dte(
+                            self.manager.db,
+                            entry.get("venta_id"),
+                            tipo_dte=tipo_dte,
+                        )  # tickets también se transmiten con tipo "01"
                     if resp.get("http_status") in {401, 403}:
                         message = self._auth_error_message(resp, token_msg)
                         QMessageBox.warning(self, "Enviar a Hacienda", message)
@@ -4537,6 +4543,16 @@ class FacturacionTab(QWidget):
             sello=sello or None,
         )
 
+    def _show_email_loading(self, message: str = "Enviando correo…") -> None:
+        if self._email_loading_dialog:
+            self._email_loading_dialog.finish()
+        self._email_loading_dialog = create_loading_dialog(self, message)
+
+    def _hide_email_loading(self) -> None:
+        if self._email_loading_dialog:
+            self._email_loading_dialog.finish()
+            self._email_loading_dialog = None
+
     def _send_invoice_email(
         self,
         venta_id,
@@ -4748,6 +4764,7 @@ class FacturacionTab(QWidget):
             [pdf_path, json_path],
         )
         self.email_thread.finished.connect(self._on_email_sent)
+        self._show_email_loading()
         self.email_thread.start()
 
     def _ensure_invoice_json_metadata(
@@ -4888,10 +4905,12 @@ class FacturacionTab(QWidget):
             attachments,
         )
         self.email_thread.finished.connect(self._on_email_sent)
+        self._show_email_loading()
         self.email_thread.start()
 
     def _on_email_sent(self, success, message):
         self.btn_enviar.setEnabled(True)
+        self._hide_email_loading()
         if success:
             QMessageBox.information(self, "Enviar por correo", message)
         else:
@@ -5307,7 +5326,25 @@ class FacturacionTab(QWidget):
                 fecha_generacion=fec_emision,
             )
 
-        pdf_path = write_pdf_atomically(pdf_path, _render_note_pdf)
+        resp = None
+        try:
+            with loading_dialog(self, "Creando DTE…"):
+                pdf_path = write_pdf_atomically(pdf_path, _render_note_pdf)
+                _, token = sign_and_save(
+                    nota_json, str(json_path), return_token=True
+                )
+                modo_eff = self._resolve_modo_transmision()
+                resp = dte._enviar_documento(
+                    self.manager.db, nota_id, nota_json, modo=modo_eff, jws_token=token
+                )
+        except dte.DTEValidationError as exc:
+            self._show_validation_errors(exc.errors, exc.json_path)
+            self.load_invoices()
+            return
+        except Exception as exc:
+            QMessageBox.critical(self, "Nota", str(exc))
+            self.load_invoices()
+            return
 
         # Mostrar previsualización del PDF generado
         try:
@@ -5315,26 +5352,13 @@ class FacturacionTab(QWidget):
         except Exception:
             pass
 
-        # Firmar y transmitir automáticamente reutilizando el mismo JSON
-        _, token = sign_and_save(nota_json, str(json_path), return_token=True)
-
-        modo_eff = self._resolve_modo_transmision()
-
-        try:
-            resp = dte._enviar_documento(
-                self.manager.db, nota_id, nota_json, modo=modo_eff, jws_token=token
-            )
-            estado = str(resp.get("estado", "") if resp else "").lower()
-            if estado == "error":
+        estado = str(resp.get("estado", "") if resp else "").lower()
+        if estado == "error":
+            self._mostrar_respuesta_hacienda(resp, title="Nota")
+        else:
+            QMessageBox.information(self, "Nota", "Nota registrada y transmitida")
+            if resp:
                 self._mostrar_respuesta_hacienda(resp, title="Nota")
-            else:
-                QMessageBox.information(self, "Nota", "Nota registrada y transmitida")
-                if resp:
-                    self._mostrar_respuesta_hacienda(resp, title="Nota")
-        except dte.DTEValidationError as exc:
-            self._show_validation_errors(exc.errors, exc.json_path)
-        except Exception as exc:
-            QMessageBox.critical(self, "Nota", str(exc))
         self.load_invoices()
 
     def _get_invoice_paths(self, venta_id, factura=None, entry=None):
@@ -6036,5 +6060,6 @@ class FacturacionTab(QWidget):
             [pdf_path, json_path],
         )
         self.email_thread.finished.connect(self._on_email_sent)
+        self._show_email_loading()
         self.email_thread.start()
 

--- a/sales_tab.py
+++ b/sales_tab.py
@@ -29,6 +29,7 @@ from utils.email_sender import EmailSender
 from utils.email_builder import build_email
 from utils.doc_generation import generate_invoice_pdf, generate_ticket_pdf
 from utils.printing import open_pdf as open_pdf_file
+from utils.loading import create_loading_dialog, loading_dialog
 import tempfile
 import subprocess
 import shutil
@@ -63,6 +64,7 @@ class SalesTab(QWidget):
         self.email_subject = ""
         self.email_body = ""
         self.email_thread = None
+        self._email_loading_dialog = None
         self._setup_ui()
         self._load_email_config()
         if check_smtp:
@@ -617,7 +619,8 @@ class SalesTab(QWidget):
     def _safe_generate(self, generator, venta_id, title, failure_message):
         """Run a document generator and handle unexpected errors gracefully."""
         try:
-            result = generator(venta_id)
+            with loading_dialog(self, "Creando DTE…"):
+                result = generator(venta_id)
         except ValueError as exc:
             QMessageBox.warning(self, title, str(exc))
             return None
@@ -633,6 +636,16 @@ class SalesTab(QWidget):
             QMessageBox.warning(self, title, failure_message)
             return None
         return result
+
+    def _show_email_loading(self, message: str = "Enviando correo…") -> None:
+        if self._email_loading_dialog:
+            self._email_loading_dialog.finish()
+        self._email_loading_dialog = create_loading_dialog(self, message)
+
+    def _hide_email_loading(self) -> None:
+        if self._email_loading_dialog:
+            self._email_loading_dialog.finish()
+            self._email_loading_dialog = None
 
     def save_invoice(self):
         """Generate and store the document for the selected sale."""
@@ -887,9 +900,11 @@ class SalesTab(QWidget):
             email_data["attachments"],
         )
         self.email_thread.finished.connect(self._on_email_sent)
+        self._show_email_loading()
         self.email_thread.start()
 
     def _on_email_sent(self, success, message):
+        self._hide_email_loading()
         if success:
             self.status_label.setText("Estado actual: Enviado")
             self.sent_label.setText("Último envío: " + datetime.now().strftime("%Y-%m-%d %H:%M"))

--- a/utils/loading.py
+++ b/utils/loading.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+"""Utility widgets to display a lightweight loading indicator."""
+
+from contextlib import contextmanager
+
+from PyQt5.QtCore import QPointF, QTimer, Qt, QSize
+from PyQt5.QtGui import QColor, QPainter, QPen
+from PyQt5.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QSizePolicy, QWidget
+
+
+class _SpinnerWidget(QWidget):
+    """Simple circular spinner drawn with a ``QPainter``."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._line_count = 12
+        self._line_length = 12
+        self._line_width = 4
+        self._inner_radius = 10
+        self._counter = 0
+
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._rotate)
+        self._timer.start(80)
+
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+    def sizeHint(self):  # noqa: D401 - Qt API compatibility
+        diameter = (self._inner_radius + self._line_length + self._line_width) * 2
+        return QSize(diameter, diameter)
+
+    def minimumSizeHint(self):  # noqa: D401 - Qt API compatibility
+        return self.sizeHint()
+
+    def _rotate(self) -> None:
+        self._counter = (self._counter + 1) % self._line_count
+        self.update()
+
+    def stop(self) -> None:
+        self._timer.stop()
+
+    def paintEvent(self, event):  # noqa: D401 - Qt API compatibility
+        super().paintEvent(event)
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        painter.translate(self.rect().center())
+
+        color = QColor(33, 150, 243)
+        for i in range(self._line_count):
+            painter.save()
+            rotate_angle = 360 * (i + self._counter) / self._line_count
+            painter.rotate(rotate_angle)
+            painter.translate(self._inner_radius, 0)
+            alpha = int(255 * (i + 1) / self._line_count)
+            color.setAlpha(alpha)
+            pen = QPen(color, self._line_width, Qt.SolidLine, Qt.RoundCap)
+            painter.setPen(pen)
+            painter.drawLine(QPointF(0, 0), QPointF(self._line_length, 0))
+            painter.restore()
+
+        painter.end()
+
+
+class LoadingDialog(QDialog):
+    """Small frameless dialog with a spinner and status message."""
+
+    def __init__(self, message: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent, Qt.Dialog | Qt.FramelessWindowHint)
+        self.setModal(True)
+        self.setWindowModality(Qt.ApplicationModal)
+        self.setAttribute(Qt.WA_TranslucentBackground, True)
+        self.setObjectName("LoadingDialog")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(12)
+
+        self._spinner = _SpinnerWidget(self)
+        layout.addWidget(self._spinner, 0, Qt.AlignCenter)
+
+        self._label = QLabel(message, self)
+        self._label.setAlignment(Qt.AlignCenter)
+        self._label.setStyleSheet("color: #1a1a1a; font-weight: 500;")
+        self._label.setWordWrap(True)
+        layout.addWidget(self._label, 0, Qt.AlignCenter)
+
+        self.setStyleSheet(
+            "#LoadingDialog {"
+            "  background: rgba(255, 255, 255, 235);"
+            "  border: 1px solid rgba(0, 0, 0, 40);"
+            "  border-radius: 12px;"
+            "}"
+        )
+
+        self.adjustSize()
+
+    def set_message(self, message: str) -> None:
+        self._label.setText(message)
+        self.adjustSize()
+
+    def finish(self) -> None:
+        self.close()
+        self.deleteLater()
+
+    def closeEvent(self, event):  # noqa: D401 - Qt API compatibility
+        self._spinner.stop()
+        super().closeEvent(event)
+
+    def showEvent(self, event):  # noqa: D401 - Qt API compatibility
+        super().showEvent(event)
+        parent = self.parentWidget()
+        window = parent.window() if parent else None
+        target = window or parent
+        if target:
+            rect = target.frameGeometry()
+            self.move(
+                rect.center().x() - self.width() // 2,
+                rect.center().y() - self.height() // 2,
+            )
+
+
+def create_loading_dialog(parent: QWidget | None, message: str) -> LoadingDialog:
+    """Create and display a loading dialog with the provided message."""
+
+    dialog = LoadingDialog(message, parent)
+    dialog.show()
+    QApplication.processEvents()
+    return dialog
+
+
+@contextmanager
+def loading_dialog(parent: QWidget | None, message: str):
+    """Context manager that displays a loading dialog while running a block."""
+
+    dialog = create_loading_dialog(parent, message)
+    try:
+        yield dialog
+    finally:
+        dialog.finish()


### PR DESCRIPTION
## Summary
- add a reusable PyQt loading dialog with a spinner animation
- display loading indicators during Hacienda transmission, DTE creation, and email sending in the billing tab
- show loading feedback in the sales tab when generating documents or sending emails

## Testing
- python -m compileall utils/loading.py facturacion_tab.py sales_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68e3606446e48323b36e98a30d7afe72