### PR TITLE
Add Inno Setup installer configuration and build script

### DIFF
--- a/build/make_installer.ps1
+++ b/build/make_installer.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [string]$AppVersion
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptRoot '..')
+
+if (-not $AppVersion) {
+    $versionFile = Join-Path $repoRoot 'VERSION'
+    if (Test-Path $versionFile) {
+        $AppVersion = (Get-Content $versionFile -TotalCount 1).Trim()
+    }
+    if (-not $AppVersion) {
+        $AppVersion = '0.0.0'
+    }
+}
+
+$python = Get-Command python -ErrorAction SilentlyContinue
+if (-not $python) {
+    throw 'Python no se encuentra en el PATH.'
+}
+
+Push-Location $repoRoot
+try {
+    $distDir = Join-Path $repoRoot 'dist'
+    $buildDir = Join-Path $distDir 'InventarioFarmacia'
+    if (Test-Path $buildDir) {
+        Remove-Item -Recurse -Force $buildDir
+    }
+
+    & $python.Path 'setup.py' '--mode' 'full' '--bundle' 'onedir'
+
+    if (-not (Test-Path (Join-Path $buildDir 'InventarioFarmacia.exe'))) {
+        throw 'La compilación de PyInstaller no generó InventarioFarmacia.exe en modo --onedir.'
+    }
+}
+finally {
+    Pop-Location
+}
+
+$signerDir = Join-Path $repoRoot 'svfe-api-firmador'
+if (-not (Test-Path $signerDir)) {
+    throw 'No se encontró la carpeta svfe-api-firmador requerida.'
+}
+
+$uploadsDir = Join-Path $signerDir 'uploads'
+if (Test-Path $uploadsDir) {
+    Write-Host 'La carpeta uploads existente no será empaquetada (se preservarán certificados).'
+} else {
+    Write-Host 'Creando carpeta uploads vacía para asegurar la estructura esperada.'
+    New-Item -ItemType Directory -Path $uploadsDir | Out-Null
+}
+
+$iscc = Get-Command ISCC.exe -ErrorAction SilentlyContinue
+if (-not $iscc) {
+    throw 'No se encontró ISCC.exe en el PATH. Instala Inno Setup o agrega su carpeta al PATH.'
+}
+
+$installerDir = Join-Path $repoRoot 'installer'
+$issFile = Join-Path $installerDir 'vertexdte.iss'
+if (-not (Test-Path $issFile)) {
+    throw 'No se encontró el script de Inno Setup installer/vertexdte.iss.'
+}
+
+$arguments = @($issFile, "/DAppVersion=$AppVersion")
+& $iscc.Path @arguments
+
+$expectedOutput = Join-Path $repoRoot 'build' 'installer' 'VertexDTE-Setup.exe'
+if (Test-Path $expectedOutput) {
+    Write-Host "Instalador generado en: $expectedOutput"
+} else {
+    Write-Warning 'La compilación de Inno Setup finalizó sin crear VertexDTE-Setup.exe.'
+}

--- a/installer/vertexdte.iss
+++ b/installer/vertexdte.iss
@@ -1,0 +1,41 @@
+; Vertex DTE installer generated with Inno Setup
+
+#ifndef AppVersion
+#define AppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{7ACDE88C-3C97-47F0-A0F1-8BFC734E7373}}
+AppName=Vertex DTE
+AppVersion={#AppVersion}
+DefaultDirName={autopf}\Vertex DTE
+UsePreviousAppDir=yes
+DirExistsWarning=no
+OutputDir=build\installer
+OutputBaseFilename=VertexDTE-Setup
+Compression=lzma2
+SolidCompression=yes
+CloseApplications=yes
+RestartApplications=no
+AppMutex=VertexDTE_Running
+DisableProgramGroupPage=yes
+
+[Files]
+Source: "..\dist\InventarioFarmacia\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion replacesameversion
+Source: "..\svfe-api-firmador\*"; DestDir: "{app}\svfe-api-firmador"; Flags: recursesubdirs createallsubdirs ignoreversion replacesameversion; Excludes: "uploads\*"
+
+[Dirs]
+Name: "{app}\svfe-api-firmador\uploads"; Flags: uninsneveruninstall
+
+[Tasks]
+Name: desktopicon; Description: "Crear acceso directo en el escritorio"; GroupDescription: "Accesos directos:"; Flags: unchecked
+
+[Icons]
+Name: "{autoprograms}\Vertex DTE"; Filename: "{app}\InventarioFarmacia.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\Vertex DTE"; Filename: "{app}\InventarioFarmacia.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+; No se ejecuta nada automáticamente tras la instalación.
+
+[UninstallDelete]
+; No eliminar %APPDATA%\VertexDTE ni la carpeta uploads.

--- a/setup.py
+++ b/setup.py
@@ -162,18 +162,29 @@ def collect_add_data(root: Path, *, config: BuildConfig) -> Iterable[str]:
     return entries
 
 
-def build(config: BuildConfig, additional_args: Optional[Sequence[str]] = None) -> None:
+def build(
+    config: BuildConfig,
+    *,
+    bundle_mode: str = "onefile",
+    additional_args: Optional[Sequence[str]] = None,
+) -> None:
     add_data = list(collect_add_data(ROOT, config=config))
     hidden_imports = list(collect_hidden_imports())
 
     args = [
         'main.py',
         '--name=InventarioFarmacia',
-        '--onefile',
         '--windowed',
         *[arg for item in add_data for arg in ('--add-data', item)],
         *[arg for module in hidden_imports for arg in ('--hidden-import', module)],
     ]
+
+    if bundle_mode == 'onefile':
+        args.append('--onefile')
+    elif bundle_mode == 'onedir':
+        args.append('--onedir')
+    else:
+        raise ValueError(f'Unsupported bundle mode: {bundle_mode}')
 
     if additional_args:
         args.extend(additional_args)
@@ -206,6 +217,12 @@ def parse_args() -> argparse.Namespace:
             'distribuir actualizaciones a clientes.'
         ),
     )
+    parser.add_argument(
+        '--bundle',
+        choices=('onefile', 'onedir'),
+        default='onefile',
+        help='Selecciona el modo de empaquetado de PyInstaller.',
+    )
     return parser.parse_args()
 
 
@@ -216,7 +233,7 @@ def main() -> None:
     else:
         config = BuildConfig.full()
 
-    build(config)
+    build(config, bundle_mode=args.bundle)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add an Inno Setup script that packages the onedir PyInstaller build and signer folder
- add a PowerShell helper that builds the app in onedir mode and invokes ISCC
- extend setup.py to support both onefile and onedir bundle modes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e4f92dc883239a6fab99e5ef27c5