### PR TITLE
Ensure reception seal appears on credit and debit note PDFs

### DIFF
--- a/facturacion_tab.py
+++ b/facturacion_tab.py
@@ -5314,22 +5314,55 @@ class FacturacionTab(QWidget):
         codigo_gen = identificacion.get("codigoGeneracion")
         num_ctrl = identificacion.get("numeroControl")
         fec_emision = identificacion.get("fecEmi") or identificacion.get("fechaEmi")
-        def _render_note_pdf(output_path):
-            pdf_func(
-                venta_data,
-                detalles_pdf,
-                cliente or {},
-                distribuidor or {},
-                archivo=str(output_path),
-                codigo_generacion=codigo_gen,
-                numero_control=num_ctrl,
-                fecha_generacion=fec_emision,
+        def _normalize_sello(value):
+            if not value:
+                return ""
+            text = str(value).strip()
+            return text.upper() if text else ""
+
+        respuesta_info = nota_json.get("respuesta")
+        if not isinstance(respuesta_info, dict):
+            respuesta_info = {}
+        sello_recepcion = _normalize_sello(
+            nota_json.get("selloRecibido")
+            or respuesta_info.get("selloRecibido")
+            or respuesta_info.get("selloRecepcion")
+            or respuesta_info.get("sello")
+        )
+
+        if not sello_recepcion and nota_id:
+            try:
+                envio_info = self.manager.db.consultar_envio_dte(nota_id) or {}
+            except Exception:
+                envio_info = {}
+            sello_recepcion = _normalize_sello(
+                envio_info.get("selloRecibido")
+                or envio_info.get("selloRecepcion")
+                or envio_info.get("sello")
             )
+
+        def _make_note_renderer(sello_val: str):
+            def _render(output_path):
+                pdf_func(
+                    venta_data,
+                    detalles_pdf,
+                    cliente or {},
+                    distribuidor or {},
+                    archivo=str(output_path),
+                    codigo_generacion=codigo_gen,
+                    numero_control=num_ctrl,
+                    fecha_generacion=fec_emision,
+                    sello_recepcion=sello_val,
+                )
+
+            return _render
+
+        render_note_pdf = _make_note_renderer(sello_recepcion)
 
         resp = None
         try:
             with loading_dialog(self, "Creando DTE…"):
-                pdf_path = write_pdf_atomically(pdf_path, _render_note_pdf)
+                pdf_path = write_pdf_atomically(pdf_path, render_note_pdf)
                 _, token = sign_and_save(
                     nota_json, str(json_path), return_token=True
                 )
@@ -5345,6 +5378,29 @@ class FacturacionTab(QWidget):
             QMessageBox.critical(self, "Nota", str(exc))
             self.load_invoices()
             return
+
+        sello_resp = _normalize_sello(
+            (resp or {}).get("sello")
+            or (resp or {}).get("selloRecibido")
+            or (resp or {}).get("selloRecepcion")
+        )
+        if not sello_resp and nota_id:
+            try:
+                envio_info = self.manager.db.consultar_envio_dte(nota_id) or {}
+            except Exception:
+                envio_info = {}
+            sello_resp = _normalize_sello(
+                envio_info.get("selloRecibido")
+                or envio_info.get("selloRecepcion")
+                or envio_info.get("sello")
+            )
+        if sello_resp and sello_resp != sello_recepcion:
+            try:
+                render_note_pdf = _make_note_renderer(sello_resp)
+                pdf_path = write_pdf_atomically(pdf_path, render_note_pdf)
+                sello_recepcion = sello_resp
+            except Exception:
+                logger.exception("No se pudo regenerar la nota con el sello recibido.")
 
         # Mostrar previsualización del PDF generado
         try:

--- a/tests/test_nota_credito.py
+++ b/tests/test_nota_credito.py
@@ -906,6 +906,7 @@ def test_nota_credito_pdf(tmp_path):
     }
     codigo_generacion = "NC-TEST-1234567890"
     numero_control = "DTE-05-S001P001-000000000000001"
+    sello = "S" * 40
     generar_nota_credito_pdf(
         venta,
         detalles,
@@ -918,6 +919,7 @@ def test_nota_credito_pdf(tmp_path):
         codigo_generacion=codigo_generacion,
         numero_control=numero_control,
         fecha_generacion="01/02/2024, 12:00:00",
+        sello_recepcion=sello,
     )
     assert out.exists()
     with fitz.open(out) as doc:
@@ -929,6 +931,7 @@ def test_nota_credito_pdf(tmp_path):
     assert "Tipo: 03" in text
     assert "Código Generación: 123" in text
     assert "Motivo: Devolución" in text
+    assert f"Sello Recepción: {sello}" in text
 
 
 def test_nota_credito_direccion(tmp_path, monkeypatch):

--- a/tests/test_nota_debito_remision.py
+++ b/tests/test_nota_debito_remision.py
@@ -942,6 +942,7 @@ def test_nota_debito_pdf(tmp_path):
         "codigo_generacion": "abc",
         "fecha": "2024-01-01",
     }
+    sello = "A" * 40
     generar_nota_debito_pdf(
         venta,
         detalles,
@@ -954,6 +955,7 @@ def test_nota_debito_pdf(tmp_path):
         codigo_generacion="ND-TEST-1234567890",
         numero_control="DTE-06-S001P001-000000000000001",
         fecha_generacion="03/02/2024, 08:15:00",
+        sello_recepcion=sello,
     )
     assert out.exists()
     with fitz.open(out) as doc:
@@ -964,6 +966,7 @@ def test_nota_debito_pdf(tmp_path):
     assert "DOCUMENTO RELACIONADO" in text
     assert "Código Generación: abc" in text
     assert "Motivo: Intereses" in text
+    assert f"Sello Recepción: {sello}" in text
 
 
 def test_nota_remision_pdf(tmp_path):


### PR DESCRIPTION
## Summary
- reuse stored reception seals when rendering credit and debit note PDFs and regenerate them after transmission if a new seal is received
- extend credit and debit note PDF tests to assert that the reception seal text is rendered

## Testing
- pytest tests/test_nota_credito.py::test_nota_credito_pdf tests/test_nota_debito_remision.py::test_nota_debito_pdf

------
https://chatgpt.com/codex/tasks/task_e_68e49c3b752083239ad7c3e716a6a281