### PR TITLE
Add standalone license verifier tool

### DIFF
--- a/installer/vertexdte.iss
+++ b/installer/vertexdte.iss
@@ -22,6 +22,7 @@ DisableProgramGroupPage=yes
 
 [Files]
 Source: "..\dist\InventarioFarmacia\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs replacesameversion
+ Excludes: "tools\verificador\*"
 Source: "..\svfe-api-firmador\*"; DestDir: "{app}\svfe-api-firmador"; Flags: recursesubdirs createallsubdirs replacesameversion; Excludes: "uploads\*"
 
 [Dirs]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ DEFAULT_EXCLUDED_DIR_NAMES = {
     'dist',
     'node_modules',
     'tests',
+    'verificador',
 }
 
 DEFAULT_EXCLUDED_FILE_NAMES = {

--- a/tools/verificador/README_admin.md
+++ b/tools/verificador/README_admin.md
@@ -1,0 +1,40 @@
+# Verificador de licencias de Vertex
+
+El verificador es una herramienta administrativa para generar y mantener licencias firmadas para los sistemas de inventario Vertex. **No forma parte del instalador del sistema de inventario ni debe distribuirse a los clientes.**
+
+## Operación general
+
+1. Configure la carpeta compartida SMB que contendrá las licencias firmadas (`licenses/`) y las solicitudes de alta (`requests/`).
+2. Ajuste las rutas en `admin_config.json` desde la aplicación (`Configuración...`).
+3. Genere el par de claves Ed25519 con el botón **Generar claves...**. La clave pública se comparte con los clientes; la privada nunca debe salir del equipo del administrador.
+4. Use **Actualizar** para cargar las solicitudes y licencias existentes, apruebe nuevas solicitudes y cambie estados según sea necesario. Cada cambio reescribe el archivo JSON con una firma Ed25519 del payload canónico.
+
+### Carpeta de claves
+
+La carpeta `tools/verificador/keys/` contiene la clave privada y pública del verificador. Debe mantenerse fuera del control de versiones por seguridad. Añada esta ruta a su `.git/info/exclude` o a las exclusiones locales de su cliente Git. No modifique `.gitignore` global del repositorio.
+
+## Formato de archivos
+
+Los archivos en `licenses/{device_id}.json` incluyen el payload canónico:
+
+```json
+{
+  "device_id": "...",
+  "status": "ACTIVE|BLOCKED|EXPIRED|TRIAL|GRACE",
+  "expires_at": "ISO8601|null",
+  "grace_until": "ISO8601|null",
+  "issued_at": "ISO8601"
+}
+```
+
+La aplicación firma el payload canonizado con `json.dumps(payload, separators=(",", ":"), sort_keys=True)` y guarda la firma como `signature` codificada en Base64. Los metadatos adicionales (`alias`, `notes`, etc.) se almacenan junto al payload pero no forman parte de la firma.
+
+## Modos de conexión
+
+* **Carpeta compartida**: accesos SMB configurables. Es el modo actualmente implementado.
+* **HTTP local**: reservado para una futura API; la interfaz permite seleccionarlo, pero aún no hay backend.
+
+## Exclusión de builds
+
+Los scripts de PyInstaller e Inno Setup del inventario excluyen `tools/verificador/**` para evitar que esta herramienta aparezca en los paquetes distribuidos a clientes.
+

--- a/tools/verificador/admin_config.json
+++ b/tools/verificador/admin_config.json
@@ -1,0 +1,8 @@
+{
+  "mode": "share",
+  "share_path": "\\\\PC_ADMIN\\LicenciasVertex\\",
+  "licenses_path": "\\\\PC_ADMIN\\LicenciasVertex\\licenses\\",
+  "requests_path": "\\\\PC_ADMIN\\LicenciasVertex\\requests\\",
+  "public_key_path": "tools/verificador/keys/license_pub.pem",
+  "private_key_path": "tools/verificador/keys/license_priv.pem"
+}

--- a/tools/verificador/license_backend.py
+++ b/tools/verificador/license_backend.py
@@ -1,0 +1,342 @@
+"""Backends para la herramienta de verificación de licencias de Vertex.
+
+Este módulo define la interfaz común de backends y la implementación por
+defecto basada en carpetas compartidas SMB. También deja un esqueleto para un
+backend HTTP local que se implementará en fases posteriores.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+
+@dataclass
+class AdminConfig:
+    """Configuración persistente del verificador."""
+
+    mode: str = "share"
+    share_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\"
+    licenses_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\licenses\\"
+    requests_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\requests\\"
+    public_key_path: str = "tools/verificador/keys/license_pub.pem"
+    private_key_path: str = "tools/verificador/keys/license_priv.pem"
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "mode": self.mode,
+            "share_path": self.share_path,
+            "licenses_path": self.licenses_path,
+            "requests_path": self.requests_path,
+            "public_key_path": self.public_key_path,
+            "private_key_path": self.private_key_path,
+        }
+
+    @classmethod
+    def from_path(cls, path: Path) -> "AdminConfig":
+        if not path.exists():
+            config = cls()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(config.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+            return config
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls(**data)
+
+    def save(self, path: Path) -> None:
+        path.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+@dataclass
+class LicenseRecord:
+    """Representa un archivo de licencia emitido."""
+
+    alias: str
+    device_id: str
+    status: str
+    expires_at: Optional[str]
+    grace_until: Optional[str]
+    issued_at: str
+    notes: str = ""
+    last_sync: Optional[str] = None
+    signature: Optional[str] = None
+    path: Optional[Path] = None
+    extra_fields: Dict[str, object] = field(default_factory=dict)
+
+    def canonical_payload(self) -> Dict[str, Optional[str]]:
+        return {
+            "device_id": self.device_id,
+            "status": self.status,
+            "expires_at": self.expires_at,
+            "grace_until": self.grace_until,
+            "issued_at": self.issued_at,
+        }
+
+
+@dataclass
+class LicenseRequest:
+    """Solicitud de alta generada por un cliente."""
+
+    device_id: str
+    alias: str = ""
+    notes: str = ""
+    requested_at: Optional[str] = None
+    path: Optional[Path] = None
+    raw_payload: Dict[str, object] = field(default_factory=dict)
+
+
+class LicenseBackend:
+    """Interfaz base para gestionar licencias."""
+
+    def __init__(self, config_path: Path) -> None:
+        self.config_path = config_path
+        self.config = AdminConfig.from_path(config_path)
+
+    # --- Métodos comunes ---
+    def reload_config(self) -> AdminConfig:
+        self.config = AdminConfig.from_path(self.config_path)
+        return self.config
+
+    def save_config(self, config: AdminConfig) -> None:
+        self.config = config
+        config.save(self.config_path)
+
+    # --- Operaciones abstractas ---
+    def list_licenses(self) -> List[LicenseRecord]:  # pragma: no cover - interfaz
+        raise NotImplementedError
+
+    def list_requests(self) -> List[LicenseRequest]:  # pragma: no cover - interfaz
+        raise NotImplementedError
+
+    def create_license(self, *, alias: str, device_id: str, status: str) -> LicenseRecord:  # pragma: no cover
+        raise NotImplementedError
+
+    def save_license(self, record: LicenseRecord) -> LicenseRecord:  # pragma: no cover
+        raise NotImplementedError
+
+    def remove_request(self, request: LicenseRequest) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    # --- Operaciones auxiliares ---
+    @staticmethod
+    def now_iso() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+
+class ShareBackend(LicenseBackend):
+    """Backend que trabaja directamente con una carpeta compartida SMB."""
+
+    def __init__(self, config_path: Path) -> None:
+        super().__init__(config_path)
+        self._licenses_dir = Path(self.config.licenses_path)
+        self._requests_dir = Path(self.config.requests_path)
+
+    # --- Utilidades internas ---
+    @property
+    def private_key_path(self) -> Path:
+        return Path(self.config.private_key_path)
+
+    @property
+    def public_key_path(self) -> Path:
+        return Path(self.config.public_key_path)
+
+    def ensure_directories(self) -> None:
+        self._licenses_dir.mkdir(parents=True, exist_ok=True)
+        self._requests_dir.mkdir(parents=True, exist_ok=True)
+        if self.public_key_path.parent != Path("."):
+            self.public_key_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.private_key_path.parent != Path("."):
+            self.private_key_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # --- Claves ---
+    def private_key(self) -> Optional[ed25519.Ed25519PrivateKey]:
+        if not self.private_key_path.exists():
+            return None
+        data = self.private_key_path.read_bytes()
+        return serialization.load_pem_private_key(data, password=None)
+
+    def public_key(self) -> Optional[ed25519.Ed25519PublicKey]:
+        if not self.public_key_path.exists():
+            return None
+        data = self.public_key_path.read_bytes()
+        return serialization.load_pem_public_key(data)
+
+    def generate_keys(self) -> None:
+        self.ensure_directories()
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        public_key = private_key.public_key()
+
+        priv_bytes = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pub_bytes = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+        self.private_key_path.write_bytes(priv_bytes)
+        self.public_key_path.write_bytes(pub_bytes)
+
+    # --- Lectura ---
+    def list_licenses(self) -> List[LicenseRecord]:
+        self.ensure_directories()
+        records: List[LicenseRecord] = []
+        if not self._licenses_dir.exists():
+            return records
+
+        for path in sorted(self._licenses_dir.glob("*.json")):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+
+            record = LicenseRecord(
+                alias=raw.get("alias", ""),
+                device_id=raw.get("device_id", path.stem),
+                status=raw.get("status", "UNKNOWN"),
+                expires_at=raw.get("expires_at"),
+                grace_until=raw.get("grace_until"),
+                issued_at=raw.get("issued_at", ""),
+                notes=raw.get("notes", ""),
+                last_sync=raw.get("last_sync"),
+                signature=raw.get("signature"),
+                path=path,
+                extra_fields={k: v for k, v in raw.items() if k not in {
+                    "alias",
+                    "device_id",
+                    "status",
+                    "expires_at",
+                    "grace_until",
+                    "issued_at",
+                    "notes",
+                    "last_sync",
+                    "signature",
+                }},
+            )
+            records.append(record)
+
+        return records
+
+    def list_requests(self) -> List[LicenseRequest]:
+        self.ensure_directories()
+        requests: List[LicenseRequest] = []
+        if not self._requests_dir.exists():
+            return requests
+
+        for path in sorted(self._requests_dir.glob("*.json")):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+
+            requests.append(
+                LicenseRequest(
+                    device_id=raw.get("device_id", path.stem),
+                    alias=raw.get("alias", ""),
+                    notes=raw.get("notes", ""),
+                    requested_at=raw.get("requested_at"),
+                    path=path,
+                    raw_payload=raw,
+                )
+            )
+
+        return requests
+
+    # --- Escritura ---
+    def create_license(self, *, alias: str, device_id: str, status: str) -> LicenseRecord:
+        issued_at = self.now_iso()
+        record = LicenseRecord(
+            alias=alias,
+            device_id=device_id,
+            status=status,
+            expires_at=None,
+            grace_until=None,
+            issued_at=issued_at,
+            notes="",
+            last_sync=None,
+            path=self._licenses_dir / f"{device_id}.json",
+        )
+        return self.save_license(record)
+
+    def save_license(self, record: LicenseRecord) -> LicenseRecord:
+        private_key = self.private_key()
+        if private_key is None:
+            raise RuntimeError(
+                "No se encontró la clave privada. Genere un par de claves antes de emitir licencias."
+            )
+
+        payload = record.canonical_payload()
+        canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        signature = private_key.sign(canonical.encode("utf-8"))
+        signature_b64 = base64.b64encode(signature).decode("ascii")
+
+        data = {
+            **payload,
+            "alias": record.alias,
+            "notes": record.notes,
+            "last_sync": record.last_sync,
+            **record.extra_fields,
+            "signature": signature_b64,
+        }
+
+        record.signature = signature_b64
+        if record.path is None:
+            record.path = self._licenses_dir / f"{record.device_id}.json"
+
+        record.path.parent.mkdir(parents=True, exist_ok=True)
+        record.path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        return record
+
+    def remove_request(self, request: LicenseRequest) -> None:
+        if request.path and request.path.exists():
+            try:
+                request.path.unlink()
+            except OSError:
+                pass
+
+    # --- Acciones de negocio ---
+    def update_status(self, record: LicenseRecord, status: str) -> LicenseRecord:
+        record.status = status
+        return self.save_license(record)
+
+    def set_expiration(self, record: LicenseRecord, expires_at: Optional[str]) -> LicenseRecord:
+        record.expires_at = expires_at
+        return self.save_license(record)
+
+    def set_grace_until(self, record: LicenseRecord, grace_until: Optional[str]) -> LicenseRecord:
+        record.grace_until = grace_until
+        return self.save_license(record)
+
+
+class HttpBackend(LicenseBackend):
+    """Futuro backend HTTP.
+
+    Esta clase servirá para comunicarse con una API local que exponga los mismos
+    flujos que el backend de carpetas compartidas. En esta fase no se implementa
+    la lógica, pero se documentan los métodos esperados para facilitar el
+    desarrollo posterior.
+    """
+
+    def list_licenses(self) -> List[LicenseRecord]:  # pragma: no cover - stub
+        raise NotImplementedError("HttpBackend aún no está implementado.")
+
+    def list_requests(self) -> List[LicenseRequest]:  # pragma: no cover - stub
+        raise NotImplementedError("HttpBackend aún no está implementado.")
+
+    def create_license(self, *, alias: str, device_id: str, status: str) -> LicenseRecord:  # pragma: no cover - stub
+        raise NotImplementedError("HttpBackend aún no está implementado.")
+
+    def save_license(self, record: LicenseRecord) -> LicenseRecord:  # pragma: no cover - stub
+        raise NotImplementedError("HttpBackend aún no está implementado.")
+
+    def remove_request(self, request: LicenseRequest) -> None:  # pragma: no cover - stub
+        raise NotImplementedError("HttpBackend aún no está implementado.")
+

--- a/tools/verificador/verificador.py
+++ b/tools/verificador/verificador.py
@@ -1,0 +1,645 @@
+"""Aplicación administrativa de verificación de licencias.
+
+Esta primera fase ofrece una interfaz PyQt5 con el backend de carpetas
+compartidas como fuente de verdad para las licencias firmadas.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from PyQt5.QtCore import (
+    QAbstractTableModel,
+    QDateTime,
+    QModelIndex,
+    Qt,
+    QSortFilterProxyModel,
+    QVariant,
+    pyqtSignal,
+)
+from PyQt5.QtWidgets import (
+    QAction,
+    QApplication,
+    QComboBox,
+    QDateTimeEdit,
+    QDialog,
+    QDialogButtonBox,
+    QDockWidget,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QStatusBar,
+    QTableView,
+    QTextEdit,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from license_backend import AdminConfig, HttpBackend, LicenseRecord, ShareBackend
+
+APP_ROOT = Path(__file__).resolve().parent
+CONFIG_PATH = APP_ROOT / "admin_config.json"
+LICENSE_STATUSES = ["ACTIVE", "BLOCKED", "EXPIRED", "TRIAL", "GRACE"]
+
+
+class LicenseTableModel(QAbstractTableModel):
+    headers = ["Alias", "Device ID", "Estado", "Expira", "Última sync", "Notas"]
+
+    def __init__(self, records: Optional[List[LicenseRecord]] = None, parent=None) -> None:
+        super().__init__(parent)
+        self._records: List[LicenseRecord] = records or []
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        return 0 if parent.isValid() else len(self._records)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        return 0 if parent.isValid() else len(self.headers)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid() or not (0 <= index.row() < len(self._records)):
+            return QVariant()
+
+        record = self._records[index.row()]
+
+        if role in (Qt.DisplayRole, Qt.EditRole):
+            column = index.column()
+            if column == 0:
+                return record.alias
+            if column == 1:
+                return record.device_id
+            if column == 2:
+                return record.status
+            if column == 3:
+                return record.expires_at or "—"
+            if column == 4:
+                return record.last_sync or "—"
+            if column == 5:
+                return record.notes
+
+        if role == Qt.TextAlignmentRole:
+            if index.column() in (2, 3, 4):
+                return Qt.AlignCenter
+
+        return QVariant()
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if role != Qt.DisplayRole:
+            return QVariant()
+        if orientation == Qt.Horizontal and 0 <= section < len(self.headers):
+            return self.headers[section]
+        return section + 1
+
+    def update_records(self, records: List[LicenseRecord]) -> None:
+        self.beginResetModel()
+        self._records = records
+        self.endResetModel()
+
+    def record_at(self, row: int) -> Optional[LicenseRecord]:
+        if 0 <= row < len(self._records):
+            return self._records[row]
+        return None
+
+
+class LicenseFilterProxy(QSortFilterProxyModel):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._filter_text = ""
+        self.setFilterCaseSensitivity(Qt.CaseInsensitive)
+
+    def setFilterText(self, text: str) -> None:
+        self._filter_text = text.strip().lower()
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # type: ignore[override]
+        if not self._filter_text:
+            return True
+        model = self.sourceModel()
+        if model is None:
+            return True
+        record = model.record_at(source_row)  # type: ignore[assignment]
+        if record is None:
+            return True
+        haystack = f"{record.alias} {record.device_id}".lower()
+        return self._filter_text in haystack
+
+
+class DateDialog(QDialog):
+    def __init__(self, title: str, label: str, parent=None, *, allow_clear: bool = True) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self._cleared = False
+        self.date_edit = QDateTimeEdit(self)
+        self.date_edit.setCalendarPopup(True)
+        self.date_edit.setDateTime(QDateTime.currentDateTime())
+
+        form = QFormLayout()
+        form.addRow(label, self.date_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        if allow_clear:
+            clear_btn = buttons.addButton("Sin fecha", QDialogButtonBox.ActionRole)
+            clear_btn.clicked.connect(self._clear)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+
+    def _clear(self) -> None:
+        self._cleared = True
+        self.accept()
+
+    def selected_iso(self) -> Optional[str]:
+        if self.result() != QDialog.Accepted:
+            return None
+        if self._cleared:
+            return None
+        dt = self.date_edit.dateTime().toPyDateTime()
+        return dt.isoformat()
+
+
+class NotesDialog(QDialog):
+    def __init__(self, notes: str, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Editar notas")
+        self.text = QTextEdit(self)
+        self.text.setPlainText(notes)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.text)
+        layout.addWidget(buttons)
+
+    def value(self) -> str:
+        return self.text.toPlainText().strip()
+
+
+class NewLicenseDialog(QDialog):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Nuevo sistema")
+        self.alias_edit = QLineEdit(self)
+        self.device_edit = QLineEdit(self)
+        self.status_combo = QComboBox(self)
+        self.status_combo.addItems(LICENSE_STATUSES)
+        self.status_combo.setCurrentText("ACTIVE")
+
+        form = QFormLayout()
+        form.addRow("Alias", self.alias_edit)
+        form.addRow("Device ID", self.device_edit)
+        form.addRow("Estado inicial", self.status_combo)
+
+        self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        self.buttons.accepted.connect(self._accept)
+        self.buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(self.buttons)
+
+    def _accept(self) -> None:
+        if not self.alias_edit.text().strip():
+            QMessageBox.warning(self, "Dato requerido", "Debe ingresar un alias.")
+            return
+        if not self.device_edit.text().strip():
+            QMessageBox.warning(self, "Dato requerido", "Debe ingresar el Device ID.")
+            return
+        self.accept()
+
+    @property
+    def alias(self) -> str:
+        return self.alias_edit.text().strip()
+
+    @property
+    def device_id(self) -> str:
+        return self.device_edit.text().strip()
+
+    @property
+    def status(self) -> str:
+        return self.status_combo.currentText()
+
+
+class ConfigDialog(QDialog):
+    def __init__(self, config: AdminConfig, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Configuración del verificador")
+        self._config = config
+
+        self.mode_combo = QComboBox(self)
+        self.mode_combo.addItem("Carpeta compartida", "share")
+        self.mode_combo.addItem("HTTP local", "http")
+        idx = max(0, self.mode_combo.findData(config.mode))
+        self.mode_combo.setCurrentIndex(idx)
+
+        self.share_edit = QLineEdit(config.share_path, self)
+        self.licenses_edit = QLineEdit(config.licenses_path, self)
+        self.requests_edit = QLineEdit(config.requests_path, self)
+        self.pub_key_edit = QLineEdit(config.public_key_path, self)
+        self.priv_key_edit = QLineEdit(config.private_key_path, self)
+
+        form = QFormLayout()
+        form.addRow("Modo", self.mode_combo)
+        form.addRow("Ruta compartida", self.share_edit)
+        form.addRow("Licencias", self.licenses_edit)
+        form.addRow("Solicitudes", self.requests_edit)
+        form.addRow("Clave pública", self.pub_key_edit)
+        form.addRow("Clave privada", self.priv_key_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+
+    def updated_config(self) -> AdminConfig:
+        config = AdminConfig(
+            mode=self.mode_combo.currentData(),
+            share_path=self.share_edit.text().strip() or self._config.share_path,
+            licenses_path=self.licenses_edit.text().strip() or self._config.licenses_path,
+            requests_path=self.requests_edit.text().strip() or self._config.requests_path,
+            public_key_path=self.pub_key_edit.text().strip() or self._config.public_key_path,
+            private_key_path=self.priv_key_edit.text().strip() or self._config.private_key_path,
+        )
+        return config
+
+
+class DetailPanel(QWidget):
+    activateRequested = pyqtSignal()
+    blockRequested = pyqtSignal()
+    graceRequested = pyqtSignal()
+    expirationRequested = pyqtSignal()
+    notesRequested = pyqtSignal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._record: Optional[LicenseRecord] = None
+
+        self.alias_label = QLabel("—")
+        self.device_label = QLabel("—")
+        self.status_label = QLabel("—")
+        self.expires_label = QLabel("—")
+        self.grace_label = QLabel("—")
+        self.issued_label = QLabel("—")
+        self.signature_label = QLabel("—")
+        self.notes_preview = QLabel("—")
+        self.notes_preview.setWordWrap(True)
+
+        form = QFormLayout()
+        form.addRow("Alias", self.alias_label)
+        form.addRow("Device ID", self.device_label)
+        form.addRow("Estado", self.status_label)
+        form.addRow("Expira", self.expires_label)
+        form.addRow("Grace hasta", self.grace_label)
+        form.addRow("Emitida", self.issued_label)
+        form.addRow("Firma", self.signature_label)
+        form.addRow("Notas", self.notes_preview)
+
+        self.activate_btn = QPushButton("Activar")
+        self.block_btn = QPushButton("Bloquear")
+        self.grace_btn = QPushButton("Poner en GRACE...")
+        self.expire_btn = QPushButton("Establecer expiración...")
+        self.notes_btn = QPushButton("Editar notas...")
+
+        self.activate_btn.clicked.connect(self.activateRequested.emit)
+        self.block_btn.clicked.connect(self.blockRequested.emit)
+        self.grace_btn.clicked.connect(self.graceRequested.emit)
+        self.expire_btn.clicked.connect(self.expirationRequested.emit)
+        self.notes_btn.clicked.connect(self.notesRequested.emit)
+
+        actions_layout = QVBoxLayout()
+        actions_layout.addWidget(self.activate_btn)
+        actions_layout.addWidget(self.block_btn)
+        actions_layout.addWidget(self.grace_btn)
+        actions_layout.addWidget(self.expire_btn)
+        actions_layout.addWidget(self.notes_btn)
+        actions_layout.addStretch(1)
+
+        wrapper = QVBoxLayout(self)
+        wrapper.addLayout(form)
+        wrapper.addSpacing(12)
+        wrapper.addLayout(actions_layout)
+        wrapper.addStretch(1)
+
+    def set_record(self, record: Optional[LicenseRecord]) -> None:
+        self._record = record
+        if record is None:
+            self.alias_label.setText("—")
+            self.device_label.setText("—")
+            self.status_label.setText("—")
+            self.expires_label.setText("—")
+            self.grace_label.setText("—")
+            self.issued_label.setText("—")
+            self.signature_label.setText("—")
+            self.notes_preview.setText("—")
+            for btn in (self.activate_btn, self.block_btn, self.grace_btn, self.expire_btn, self.notes_btn):
+                btn.setEnabled(False)
+            return
+
+        self.alias_label.setText(record.alias or "—")
+        self.device_label.setText(record.device_id)
+        self.status_label.setText(record.status)
+        self.expires_label.setText(record.expires_at or "—")
+        self.grace_label.setText(record.grace_until or "—")
+        self.issued_label.setText(record.issued_at or "—")
+        self.signature_label.setText(record.signature or "—")
+        self.notes_preview.setText(record.notes or "—")
+        for btn in (self.activate_btn, self.block_btn, self.grace_btn, self.expire_btn, self.notes_btn):
+            btn.setEnabled(True)
+
+
+class VerifierMainWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Verificador de licencias Vertex")
+        self.resize(1100, 700)
+
+        self.backend = ShareBackend(CONFIG_PATH)
+        self.records: List[LicenseRecord] = []
+        self._current_record: Optional[LicenseRecord] = None
+
+        self._setup_ui()
+        self._load_mode_from_config()
+        self.refresh()
+
+    # --- UI ---
+    def _setup_ui(self) -> None:
+        toolbar = QToolBar("Acciones", self)
+        toolbar.setMovable(False)
+        self.addToolBar(toolbar)
+
+        refresh_action = QAction("Actualizar", self)
+        refresh_action.triggered.connect(self.refresh)
+        toolbar.addAction(refresh_action)
+
+        new_action = QAction("Nuevo sistema...", self)
+        new_action.triggered.connect(self.create_new_license)
+        toolbar.addAction(new_action)
+
+        config_action = QAction("Configuración...", self)
+        config_action.triggered.connect(self.edit_config)
+        toolbar.addAction(config_action)
+
+        gen_keys_action = QAction("Generar claves...", self)
+        gen_keys_action.triggered.connect(self.generate_keys)
+        toolbar.addAction(gen_keys_action)
+
+        toolbar.addSeparator()
+
+        toolbar.addWidget(QLabel("Buscar:"))
+        self.search_edit = QLineEdit(self)
+        self.search_edit.setPlaceholderText("Alias o Device ID")
+        toolbar.addWidget(self.search_edit)
+
+        toolbar.addSeparator()
+        toolbar.addWidget(QLabel("Modo:"))
+        self.mode_combo = QComboBox(self)
+        self.mode_combo.addItem("Carpeta compartida", "share")
+        self.mode_combo.addItem("HTTP local", "http")
+        self.mode_combo.currentIndexChanged.connect(self._mode_changed)
+        toolbar.addWidget(self.mode_combo)
+
+        self.table_model = LicenseTableModel([])
+        self.proxy_model = LicenseFilterProxy(self)
+        self.proxy_model.setSourceModel(self.table_model)
+
+        self.table = QTableView(self)
+        self.table.setModel(self.proxy_model)
+        self.table.setSelectionBehavior(QTableView.SelectRows)
+        self.table.setSelectionMode(QTableView.SingleSelection)
+        self.table.doubleClicked.connect(self._row_double_clicked)
+        selection_model = self.table.selectionModel()
+        if selection_model is not None:
+            selection_model.selectionChanged.connect(self._selection_changed)
+        self.setCentralWidget(self.table)
+
+        self.detail_panel = DetailPanel(self)
+        self.detail_panel.activateRequested.connect(lambda: self._update_status("ACTIVE"))
+        self.detail_panel.blockRequested.connect(lambda: self._update_status("BLOCKED"))
+        self.detail_panel.graceRequested.connect(self._set_grace)
+        self.detail_panel.expirationRequested.connect(self._set_expiration)
+        self.detail_panel.notesRequested.connect(self._edit_notes)
+
+        dock = QDockWidget("Detalles", self)
+        dock.setWidget(self.detail_panel)
+        dock.setFeatures(QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable)
+        self.addDockWidget(Qt.RightDockWidgetArea, dock)
+
+        status = QStatusBar(self)
+        self.setStatusBar(status)
+
+        self.search_edit.textChanged.connect(self.proxy_model.setFilterText)
+
+    # --- Configuración ---
+    def _load_mode_from_config(self) -> None:
+        mode = self.backend.config.mode
+        idx = self.mode_combo.findData(mode)
+        if idx >= 0:
+            self.mode_combo.setCurrentIndex(idx)
+        else:
+            self.mode_combo.setCurrentIndex(0)
+
+    def _mode_changed(self) -> None:
+        mode = self.mode_combo.currentData()
+        config = self.backend.config
+        if config.mode != mode:
+            config.mode = mode
+            self.backend.save_config(config)
+        self._reload_backend()
+        self.refresh()
+
+    def _reload_backend(self) -> None:
+        try:
+            config = AdminConfig.from_path(CONFIG_PATH)
+        except Exception as exc:  # pragma: no cover - defensivo
+            QMessageBox.critical(self, "Error", f"No se pudo cargar la configuración: {exc}")
+            return
+
+        if config.mode == "share":
+            self.backend = ShareBackend(CONFIG_PATH)
+        else:
+            self.backend = HttpBackend(CONFIG_PATH)
+        self._update_status_bar()
+
+    def edit_config(self) -> None:
+        dialog = ConfigDialog(self.backend.config, self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+
+        config = dialog.updated_config()
+        try:
+            self.backend.save_config(config)
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo guardar la configuración: {exc}")
+            return
+
+        self._reload_backend()
+        idx = self.mode_combo.findData(config.mode)
+        if idx >= 0:
+            self.mode_combo.setCurrentIndex(idx)
+        self.refresh()
+
+    # --- Operaciones ---
+    def refresh(self) -> None:
+        try:
+            if isinstance(self.backend, ShareBackend):
+                self.records = self.backend.list_licenses()
+            else:
+                raise NotImplementedError
+        except NotImplementedError:
+            self.records = []
+            QMessageBox.information(
+                self,
+                "Modo no disponible",
+                "El backend HTTP aún no está implementado.",
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo cargar la información: {exc}")
+            self.records = []
+        finally:
+            self.table_model.update_records(self.records)
+            self.detail_panel.set_record(None)
+            self._current_record = None
+            self._update_status_bar()
+
+    def _update_status_bar(self, message: str = "") -> None:
+        if isinstance(self.backend, ShareBackend):
+            path = self.backend.config.licenses_path
+            text = f"Carpeta compartida: {path}"
+        else:
+            text = "HTTP local (pendiente de implementación)"
+        if message:
+            text = f"{text} | {message}"
+        self.statusBar().showMessage(text)
+
+    def _row_double_clicked(self, index: QModelIndex) -> None:
+        self._selection_changed()
+
+    def _selection_changed(self) -> None:
+        selection = self.table.selectionModel().selectedRows()
+        if not selection:
+            self.detail_panel.set_record(None)
+            self._current_record = None
+            return
+        proxy_index = selection[0]
+        source_index = self.proxy_model.mapToSource(proxy_index)
+        record = self.table_model.record_at(source_index.row())
+        self._current_record = record
+        self.detail_panel.set_record(record)
+
+    def create_new_license(self) -> None:
+        dialog = NewLicenseDialog(self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+
+        if not isinstance(self.backend, ShareBackend):
+            QMessageBox.warning(self, "Modo no disponible", "Solo puede crear licencias en modo carpeta compartida.")
+            return
+
+        try:
+            record = self.backend.create_license(
+                alias=dialog.alias,
+                device_id=dialog.device_id,
+                status=dialog.status,
+            )
+            self._update_status_bar(f"Licencia emitida para {record.device_id}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo crear la licencia: {exc}")
+        finally:
+            self.refresh()
+
+    def generate_keys(self) -> None:
+        if not isinstance(self.backend, ShareBackend):
+            QMessageBox.warning(self, "Modo no disponible", "La generación de claves solo está disponible en modo carpeta compartida.")
+            return
+        try:
+            self.backend.generate_keys()
+            self._update_status_bar("Claves generadas correctamente")
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudieron generar las claves: {exc}")
+
+    def _update_status(self, status: str) -> None:
+        if not isinstance(self.backend, ShareBackend):
+            QMessageBox.warning(self, "Modo no disponible", "El backend actual no permite modificar licencias.")
+            return
+        if not self._current_record:
+            return
+        try:
+            self.backend.update_status(self._current_record, status)
+            self._update_status_bar(f"Estado actualizado a {status}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo actualizar la licencia: {exc}")
+        finally:
+            self.refresh()
+
+    def _set_expiration(self) -> None:
+        if not isinstance(self.backend, ShareBackend) or not self._current_record:
+            return
+        dialog = DateDialog("Expiración", "Fecha y hora de expiración", self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        expires = dialog.selected_iso()
+        try:
+            self.backend.set_expiration(self._current_record, expires)
+            message = "Expiración eliminada" if expires is None else "Expiración actualizada"
+            self._update_status_bar(message)
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo actualizar la expiración: {exc}")
+        finally:
+            self.refresh()
+
+    def _set_grace(self) -> None:
+        if not isinstance(self.backend, ShareBackend) or not self._current_record:
+            return
+        dialog = DateDialog("Período de gracia", "Fin de GRACE", self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        grace = dialog.selected_iso()
+        try:
+            self.backend.set_grace_until(self._current_record, grace)
+            if grace:
+                self.backend.update_status(self._current_record, "GRACE")
+                message = "Período de gracia actualizado"
+            else:
+                message = "Período de gracia eliminado"
+            self._update_status_bar(message)
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudo actualizar la licencia: {exc}")
+        finally:
+            self.refresh()
+
+    def _edit_notes(self) -> None:
+        if not isinstance(self.backend, ShareBackend) or not self._current_record:
+            return
+        dialog = NotesDialog(self._current_record.notes, self)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        self._current_record.notes = dialog.value()
+        try:
+            self.backend.save_license(self._current_record)
+            self._update_status_bar("Notas guardadas")
+        except Exception as exc:
+            QMessageBox.critical(self, "Error", f"No se pudieron guardar las notas: {exc}")
+        finally:
+            self.refresh()
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    window = VerifierMainWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a PyQt5-based license verifier admin app under tools/verificador with share backend and configuration defaults
- document admin usage and key handling while persisting default configuration
- exclude tools/verificador from PyInstaller bundle and Inno Setup installer payload

## Testing
- python -m py_compile tools/verificador/license_backend.py tools/verificador/verificador.py


------
https://chatgpt.com/codex/tasks/task_e_68e49d9490b88323b0cbfa5300a73364