### PR TITLE
Ordenar compras recientes y registrar fecha detallada

### DIFF
--- a/dialogs/dialogs.py
+++ b/dialogs/dialogs.py
@@ -2395,8 +2395,9 @@ class RegisterPurchaseDialog(QDialog):
                 return
             item["producto_id"] = producto_id
 
-        fecha = QDate.currentDate().toString("yyyy-MM-dd")
-        if self.edit_mode and self._existing_fecha:
+        if not self.edit_mode or not self._existing_fecha:
+            fecha = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        else:
             fecha = self._existing_fecha
         total_general = sum(float(item.get("total", 0)) for item in self.compra_items)
         vendedor_id = self.vendedor_combo.currentData()

--- a/purchases_tab.py
+++ b/purchases_tab.py
@@ -323,6 +323,19 @@ class PurchasesTab(QWidget):
         vend_filter = self.vendedor_combo.currentData()
         search = self.search_bar.text().lower()
 
+        def _parse_fecha(value):
+            if isinstance(value, datetime):
+                return value
+            if isinstance(value, date):
+                return datetime.combine(value, datetime.min.time())
+            if isinstance(value, str):
+                for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
+                    try:
+                        return datetime.strptime(value, fmt)
+                    except ValueError:
+                        continue
+            return datetime.min
+
         rows = []
         for c in compras:
             fecha = c.get("fecha")
@@ -362,6 +375,8 @@ class PurchasesTab(QWidget):
                 except (TypeError, ValueError):
                     continue
             rows.append((c, dist, vend, comision_total, detalles_cache[c["id"]]))
+
+        rows.sort(key=lambda entry: _parse_fecha(entry[0].get("fecha")), reverse=True)
 
         # Mantener los detalles en caché para reutilizarlos al mostrar el
         # diálogo de detalle.  Esto evita consultas redundantes y nos


### PR DESCRIPTION
## Summary
- guarda las compras nuevas con fecha y hora exactas al registrarlas
- ordena la tabla de compras para mostrar primero las más recientes

## Testing
- pytest tests/test_date_parsing.py tests/test_update_compra.py *(falla: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e57bfafb548323982a021ec5432d24