### PR TITLE
Ensure note PDFs display full receptor information

### DIFF
--- a/factura_sv.py
+++ b/factura_sv.py
@@ -349,9 +349,16 @@ def generar_factura_electronica_pdf(
 
     emisor_line_count = 1 + len(emisor_lines)  # incluye encabezado
 
+    notas_tipo = ("nota de crédito", "nota de débito", "nota de remisión")
+    tipo_documento_normalizado = tipo_documento.lower().strip()
+    mostrar_datos_receptor_completos = (
+        tipo_documento == "Crédito Fiscal"
+        or tipo_documento_normalizado in notas_tipo
+    )
+
     receptor_line_count = 4  # encabezado + nombre + DUI + NIT
     receptor_extra = 1  # línea "Giro/Orden" o espaciado
-    if tipo_documento == "Crédito Fiscal":
+    if mostrar_datos_receptor_completos:
         receptor_extra += 1  # línea "Condición pago"
     receptor_line_count += receptor_extra
     receptor_line_count += 1  # Dirección
@@ -454,7 +461,7 @@ def generar_factura_electronica_pdf(
         text_y,
         receptor_col_width,
     )
-    if tipo_documento == "Crédito Fiscal":
+    if mostrar_datos_receptor_completos:
         draw_text_with_ellipsis(
             c,
             f"NRC: {cliente.get('nrc', '')}",
@@ -471,7 +478,7 @@ def generar_factura_electronica_pdf(
         text_y,
         receptor_col_width,
     )
-    if tipo_documento == "Crédito Fiscal":
+    if mostrar_datos_receptor_completos:
         draw_text_with_ellipsis(
             c,
             f"No. Remisión: {venta.get('no_remision', '')}",
@@ -480,7 +487,7 @@ def generar_factura_electronica_pdf(
             receptor_col_width,
         )
 
-    if tipo_documento == "Crédito Fiscal":
+    if mostrar_datos_receptor_completos:
         text_y -= line_h
         draw_text_with_ellipsis(
             c,

--- a/tests/test_factura_pdf.py
+++ b/tests/test_factura_pdf.py
@@ -3,7 +3,13 @@ import pytest
 import fitz
 from urllib.parse import urlparse, parse_qs
 import factura_sv
-from factura_sv import generar_factura_electronica_pdf, build_qr_url
+from factura_sv import (
+    generar_factura_electronica_pdf,
+    build_qr_url,
+    generar_nota_credito_pdf,
+    generar_nota_debito_pdf,
+    generar_nota_remision_pdf,
+)
 import utils.catalogos as catalogos
 
 
@@ -364,4 +370,55 @@ def test_direccion_as_text(tmp_path):
         sello_recepcion="0" * 40,
     )
     assert out.exists()
+
+
+@pytest.mark.parametrize(
+    "generator",
+    [
+        generar_nota_credito_pdf,
+        generar_nota_debito_pdf,
+        generar_nota_remision_pdf,
+    ],
+)
+def test_notas_pdf_includes_full_receptor_info(tmp_path, generator):
+    venta, detalles = _sample_data('Crédito Fiscal')
+    venta.update(
+        {
+            'no_remision': '12345',
+            'orden_no': 'A-1',
+            'condicion_pago': 'Contado',
+        }
+    )
+    cliente = {
+        'nombre': 'Cliente Nota',
+        'dui': '01234567-8',
+        'nrc': '123456-7',
+        'nit': '0614-290190-102-2',
+        'giro': 'Comercio',
+        'direccion': {
+            'departamento': '05',
+            'municipio': '24',
+            'complemento': 'Colonia Centro',
+        },
+    }
+    out = tmp_path / 'nota.pdf'
+    generator(
+        venta,
+        detalles,
+        cliente,
+        {},
+        archivo=str(out),
+        datos_negocio={},
+        codigo_generacion=str(uuid.uuid4()),
+        numero_control=uuid.uuid4().hex[:8].upper(),
+        fecha_generacion="01/01/2024",
+        sello_recepcion="0" * 40,
+    )
+    with fitz.open(out) as doc:
+        text = ''.join(p.get_text() for p in doc)
+
+    assert f"NRC: {cliente['nrc']}" in text
+    assert f"No. Remisión: {venta['no_remision']}" in text
+    assert f"Giro: {cliente['giro']}" in text
+    assert f"Condición pago: {venta['condicion_pago']}" in text
 


### PR DESCRIPTION
## Summary
- show the extended receptor fields on credit, debit, and remisión note PDFs just like invoices
- add regression coverage to confirm the note PDF generators include NRC, remisión, giro, and condición de pago

## Testing
- pytest tests/test_factura_pdf.py


------
https://chatgpt.com/codex/tasks/task_e_68e537dd3bc4832382c7eb472545148a