### PR TITLE
Normaliza rutas UNC en el verificador

### DIFF
--- a/tests/test_normalize_unc.py
+++ b/tests/test_normalize_unc.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tools.verificador.license_backend import normalize_unc
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (r"\\PC\Admin\LicenciasVertex\licenses", "\\\\PC\\Admin\\LicenciasVertex\\licenses"),
+        ("\\\\\\\\PC_ADMIN\\LicenciasVertex\\licenses\\\\", "\\\\PC_ADMIN\\LicenciasVertex\\licenses"),
+        ("/PC_ADMIN/LicenciasVertex/licenses", "\\\\PC_ADMIN\\LicenciasVertex\\licenses"),
+        ("\\PC_ADMIN\\LicenciasVertex\\licenses", "\\\\PC_ADMIN\\LicenciasVertex\\licenses"),
+        ('"\\\\PC_ADMIN\\LicenciasVertex\\licenses\\"', "\\\\PC_ADMIN\\LicenciasVertex\\licenses"),
+    ],
+)
+def test_normalize_unc(value: str, expected: str) -> None:
+    assert normalize_unc(value) == expected

--- a/tools/verificador/README_admin.md
+++ b/tools/verificador/README_admin.md
@@ -6,6 +6,7 @@ El verificador es una herramienta administrativa para generar y mantener licenci
 
 1. Configure la carpeta compartida SMB que contendrá las licencias firmadas (`licenses/`) y las solicitudes de alta (`requests/`).
 2. Ajuste las rutas en `admin_config.json` desde la aplicación (`Configuración...`).
+   *Para rutas UNC use el formato `\\Servidor\Recurso\Carpeta`. En JSON deben escribirse como `\\\\Servidor\\Recurso\\Carpeta`.*
 3. Genere el par de claves Ed25519 con el botón **Generar claves...**. La clave pública se comparte con los clientes; la privada nunca debe salir del equipo del administrador.
 4. Use **Actualizar** para cargar las solicitudes y licencias existentes, apruebe nuevas solicitudes y cambie estados según sea necesario. Cada cambio reescribe el archivo JSON con una firma Ed25519 del payload canónico.
 

--- a/tools/verificador/admin_config.json
+++ b/tools/verificador/admin_config.json
@@ -1,8 +1,8 @@
 {
   "mode": "share",
-  "share_path": "\\\\PC_ADMIN\\LicenciasVertex\\",
-  "licenses_path": "\\\\PC_ADMIN\\LicenciasVertex\\licenses\\",
-  "requests_path": "\\\\PC_ADMIN\\LicenciasVertex\\requests\\",
+  "share_path": "\\\\PC_ADMIN\\LicenciasVertex",
+  "licenses_path": "\\\\PC_ADMIN\\LicenciasVertex\\licenses",
+  "requests_path": "\\\\PC_ADMIN\\LicenciasVertex\\requests",
   "public_key_path": "tools/verificador/keys/license_pub.pem",
   "private_key_path": "tools/verificador/keys/license_priv.pem"
 }

--- a/tools/verificador/license_backend.py
+++ b/tools/verificador/license_backend.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import base64
 import json
+import ntpath
+import os
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -22,11 +25,19 @@ class AdminConfig:
     """Configuración persistente del verificador."""
 
     mode: str = "share"
-    share_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\"
-    licenses_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\licenses\\"
-    requests_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\requests\\"
+    share_path: str = r"\\\\PC_ADMIN\\LicenciasVertex"
+    licenses_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\licenses"
+    requests_path: str = r"\\\\PC_ADMIN\\LicenciasVertex\\requests"
     public_key_path: str = "tools/verificador/keys/license_pub.pem"
     private_key_path: str = "tools/verificador/keys/license_priv.pem"
+
+    def __post_init__(self) -> None:
+        if self.share_path:
+            self.share_path = normalize_unc(self.share_path)
+        if self.licenses_path:
+            self.licenses_path = normalize_unc(self.licenses_path)
+        if self.requests_path:
+            self.requests_path = normalize_unc(self.requests_path)
 
     def to_dict(self) -> Dict[str, str]:
         return {
@@ -147,8 +158,36 @@ class ShareBackend(LicenseBackend):
         return Path(self.config.public_key_path)
 
     def ensure_directories(self) -> None:
-        self._licenses_dir.mkdir(parents=True, exist_ok=True)
-        self._requests_dir.mkdir(parents=True, exist_ok=True)
+        normalized_licenses = validate_license_path(self.config.licenses_path)
+        normalized_requests = normalize_unc(self.config.requests_path)
+
+        if normalized_requests and _looks_like_unc(normalized_requests) and not UNC_PATTERN.match(normalized_requests):
+            raise InvalidLicensePathError(INVALID_LICENSE_PATH_MESSAGE)
+
+        licenses_dir = Path(normalized_licenses)
+        requests_dir = Path(normalized_requests)
+
+        if normalized_requests:
+            if not os.path.isdir(normalized_requests):
+                try:
+                    requests_dir.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:  # pragma: no cover - depende de FS
+                    raise InvalidLicensePathError(INVALID_LICENSE_PATH_MESSAGE) from exc
+
+        updated = False
+        if normalized_licenses != self.config.licenses_path:
+            self.config.licenses_path = normalized_licenses
+            updated = True
+        if normalized_requests and normalized_requests != self.config.requests_path:
+            self.config.requests_path = normalized_requests
+            updated = True
+
+        self._licenses_dir = licenses_dir
+        self._requests_dir = requests_dir
+
+        if updated:
+            self.config.save(self.config_path)
+
         if self.public_key_path.parent != Path("."):
             self.public_key_path.parent.mkdir(parents=True, exist_ok=True)
         if self.private_key_path.parent != Path("."):
@@ -252,6 +291,7 @@ class ShareBackend(LicenseBackend):
 
     # --- Escritura ---
     def create_license(self, *, alias: str, device_id: str, status: str) -> LicenseRecord:
+        self.ensure_directories()
         issued_at = self.now_iso()
         record = LicenseRecord(
             alias=alias,
@@ -267,6 +307,7 @@ class ShareBackend(LicenseBackend):
         return self.save_license(record)
 
     def save_license(self, record: LicenseRecord) -> LicenseRecord:
+        self.ensure_directories()
         private_key = self.private_key()
         if private_key is None:
             raise RuntimeError(
@@ -340,3 +381,62 @@ class HttpBackend(LicenseBackend):
     def remove_request(self, request: LicenseRequest) -> None:  # pragma: no cover - stub
         raise NotImplementedError("HttpBackend aún no está implementado.")
 
+UNC_PATTERN = re.compile(r"^\\\\[^\\]+\\[^\\]+(?:\\[^\\]+)*$")
+DRIVE_PATTERN = re.compile(r"^[A-Za-z]:\\")
+
+INVALID_LICENSE_PATH_MESSAGE = (
+    "Ruta de licencias inválida. Para recursos de red use formato UNC: "
+    "\\\\PC_ADMIN\\LicenciasVertex\\licenses. En JSON deben ir escapadas las barras."
+)
+
+
+class InvalidLicensePathError(ValueError):
+    """Señala una ruta de licencias inválida o inaccesible."""
+
+
+def _strip_quotes(value: str) -> str:
+    return value.strip("'\"")
+
+
+def normalize_unc(path: str) -> str:
+    """Normaliza rutas UNC o locales usando separadores de Windows."""
+
+    cleaned = _strip_quotes(path.strip())
+    cleaned = cleaned.replace("/", "\\")
+    if not cleaned:
+        return cleaned
+
+    if cleaned.startswith("\\"):
+        cleaned = "\\\\" + cleaned.lstrip("\\")
+
+    normalized = ntpath.normpath(cleaned)
+    if cleaned.startswith("\\"):
+        normalized = normalized.rstrip("\\")
+        if normalized == "\\\\":
+            return "\\\\"
+    return normalized
+
+
+def _looks_like_unc(path: str) -> bool:
+    return path.startswith("\\\\")
+
+
+def validate_license_path(path: str) -> str:
+    """Normaliza y valida la ruta de licencias configurada."""
+
+    normalized = normalize_unc(path)
+    if not normalized:
+        raise InvalidLicensePathError(INVALID_LICENSE_PATH_MESSAGE)
+
+    if _looks_like_unc(normalized):
+        if not UNC_PATTERN.match(normalized):
+            raise InvalidLicensePathError(INVALID_LICENSE_PATH_MESSAGE)
+    elif DRIVE_PATTERN.match(normalized):
+        normalized = normalized.rstrip("\\")
+    else:
+        raise InvalidLicensePathError(INVALID_LICENSE_PATH_MESSAGE)
+
+    if not os.path.isdir(normalized):
+        raise InvalidLicensePathError(INVALID_LICENSE_PATH_MESSAGE)
+
+    return normalized

--- a/tools/verificador/verificador.py
+++ b/tools/verificador/verificador.py
@@ -43,11 +43,24 @@ from PyQt5.QtWidgets import (
 )
 
 from api_server import VerifierApiServer
-from license_backend import AdminConfig, HttpBackend, LicenseRecord, ShareBackend
+from license_backend import (
+    AdminConfig,
+    HttpBackend,
+    InvalidLicensePathError,
+    LicenseRecord,
+    ShareBackend,
+    validate_license_path,
+)
 
 APP_ROOT = Path(__file__).resolve().parent
 CONFIG_PATH = APP_ROOT / "admin_config.json"
 LICENSE_STATUSES = ["ACTIVE", "BLOCKED", "EXPIRED", "TRIAL", "GRACE"]
+LICENSES_JSON_EXAMPLE = (
+    "{\n"
+    '  "mode": "share",\n'
+    '  "licenses_path": "\\\\PC_ADMIN\\LicenciasVertex\\licenses"\n'
+    "}"
+)
 
 LOGGER = logging.getLogger("verificador.ui")
 
@@ -238,6 +251,7 @@ class ConfigDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Configuración del verificador")
         self._config = config
+        self._result_config = config
 
         self.mode_combo = QComboBox(self)
         self.mode_combo.addItem("Carpeta compartida", "share")
@@ -250,6 +264,7 @@ class ConfigDialog(QDialog):
         self.requests_edit = QLineEdit(config.requests_path, self)
         self.pub_key_edit = QLineEdit(config.public_key_path, self)
         self.priv_key_edit = QLineEdit(config.private_key_path, self)
+        self.licenses_edit.setPlaceholderText("\\\\PC_ADMIN\\LicenciasVertex\\licenses")
 
         form = QFormLayout()
         form.addRow("Modo", self.mode_combo)
@@ -260,7 +275,7 @@ class ConfigDialog(QDialog):
         form.addRow("Clave privada", self.priv_key_edit)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
-        buttons.accepted.connect(self.accept)
+        buttons.accepted.connect(self._accept)
         buttons.rejected.connect(self.reject)
 
         layout = QVBoxLayout(self)
@@ -268,7 +283,10 @@ class ConfigDialog(QDialog):
         layout.addWidget(buttons)
 
     def updated_config(self) -> AdminConfig:
-        config = AdminConfig(
+        return self._result_config
+
+    def _build_config(self) -> AdminConfig:
+        return AdminConfig(
             mode=self.mode_combo.currentData(),
             share_path=self.share_edit.text().strip() or self._config.share_path,
             licenses_path=self.licenses_edit.text().strip() or self._config.licenses_path,
@@ -276,7 +294,23 @@ class ConfigDialog(QDialog):
             public_key_path=self.pub_key_edit.text().strip() or self._config.public_key_path,
             private_key_path=self.priv_key_edit.text().strip() or self._config.private_key_path,
         )
-        return config
+
+    def _accept(self) -> None:
+        try:
+            config = self._build_config()
+            if config.mode == "share":
+                normalized = validate_license_path(config.licenses_path)
+                config.licenses_path = normalized
+        except InvalidLicensePathError as exc:
+            QMessageBox.warning(
+                self,
+                "Ruta inválida",
+                f"{exc}\n\nEjemplo válido en JSON:\n{LICENSES_JSON_EXAMPLE}",
+            )
+            return
+
+        self._result_config = config
+        self.accept()
 
 
 class DetailPanel(QWidget):
@@ -527,6 +561,22 @@ class VerifierMainWindow(QMainWindow):
                 "Modo no disponible",
                 "El backend HTTP aún no está implementado.",
             )
+        except InvalidLicensePathError as exc:
+            self.records = []
+            dialog = QMessageBox(self)
+            dialog.setIcon(QMessageBox.Warning)
+            dialog.setWindowTitle("Ruta de licencias inválida")
+            dialog.setText(str(exc))
+            dialog.setInformativeText(
+                f"Ejemplo válido en JSON:\n{LICENSES_JSON_EXAMPLE}"
+            )
+            config_button = dialog.addButton(
+                "Abrir configuración...", QMessageBox.ActionRole
+            )
+            dialog.addButton(QMessageBox.Close)
+            dialog.exec_()
+            if dialog.clickedButton() == config_button:
+                self.edit_config()
         except Exception as exc:
             QMessageBox.critical(self, "Error", f"No se pudo cargar la información: {exc}")
             self.records = []


### PR DESCRIPTION
## Summary
- normalizar y validar rutas UNC/mapeadas al cargar la configuración del backend de licencias, corrigiendo entradas mal formadas y comprobando su existencia
- mostrar mensajes de ayuda en la interfaz cuando la ruta de licencias es inválida y ofrecer acceso directo a la configuración
- documentar el formato UNC correcto y añadir pruebas unitarias para la función de normalización

## Testing
- pytest tests/test_normalize_unc.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d566a32c83238e9818dfe0cd3e16